### PR TITLE
[ci,bazel] Enable remote caching of FPGA & Verilator test results

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -158,3 +158,8 @@ cquery --output=files
 # This prevents having to build Verilator or an FPGA bitstream when not needed.
 # https://bazel.build/docs/user-manual#build-tests-only
 test --build_tests_only
+
+# We have Verilator DPIs that use pseudoterminals, so we need to be able to use
+# these when running sandboxed tests.
+test --sandbox_explicit_pseudoterminal
+run --sandbox_explicit_pseudoterminal

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,11 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --test_tag_filters=-slow_test --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test \
+            --build_tests_only \
+            --cache_test_results=no \
+            --test_tag_filters=-slow_test \
+            --target_pattern_file="$bazel_tests"
 
       - name: Run tests after ROM_EXT boot stage
         if: success() || failure()
@@ -72,7 +76,11 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --test_tag_filters=-slow_test --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test \
+            --build_tests_only \
+            --cache_test_results=no \
+            --test_tag_filters=-slow_test \
+            --target_pattern_file="$bazel_tests"
 
       - name: Compute bucket destination
         id: bucket_destination
@@ -128,7 +136,11 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --test_tag_filters=-slow_test --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test \
+            --build_tests_only \
+            --cache_test_results=no \
+            --test_tag_filters=-slow_test \
+            --target_pattern_file="$bazel_tests"
 
       - name: Run tests after ROM_EXT boot stage
         if: success() || failure()
@@ -139,7 +151,11 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --test_tag_filters=-slow_test --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test \
+            --build_tests_only \
+            --cache_test_results=no \
+            --test_tag_filters=-slow_test \
+            --target_pattern_file="$bazel_tests"
 
       - name: Compute bucket destination
         id: bucket_destination
@@ -198,7 +214,10 @@ jobs:
                                                                   | grep -v penetrationtests \
                                                                   > "$bazel_tests"
 
-          ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test \
+            --build_tests_only \
+            --cache_test_results=no \
+            --target_pattern_file="$bazel_tests"
 
       - name: Compute bucket destination
         id: bucket_destination
@@ -234,6 +253,7 @@ jobs:
             --define bitstream=gcp_splice \
             --test_tag_filters=-verilator,-dv,-broken \
             --build_tests_only \
+            --cache_test_results=no \
             --test_output=errors \
             //sw/device/silicon_creator/rom/e2e/...
       - name: Publish Bazel test results
@@ -256,7 +276,10 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Run the tests
         run: |
-          ./bazelisk.sh test --test_tag_filters=nightly //sw/otbn/crypto/...
+          ./bazelisk.sh test \
+            --cache_test_results=no \
+            --test_tag_filters=nightly \
+            //sw/otbn/crypto/...
       - name: Publish Bazel test results
         uses: ./.github/actions/publish-bazel-test-results
         if: ${{ !cancelled() }}
@@ -282,6 +305,7 @@ jobs:
             --define DISABLE_VERILATOR_BUILD=true \
             --define bitstream=gcp_splice \
             --build_tests_only \
+            --cache_test_results=no \
             --test_output=errors \
             --test_tag_filters="cw310_test_rom" \
             $(./bazelisk.sh query 'attr("tags", "[\[ ]pmod[,\]]", tests(//...))')
@@ -292,6 +316,7 @@ jobs:
             --define DISABLE_VERILATOR_BUILD=true \
             --define bitstream=gcp_splice \
             --build_tests_only \
+            --cache_test_results=no \
             --test_output=errors \
             --test_tag_filters=cw310_sival,-broken \
             $(./bazelisk.sh query 'attr("tags", "[\[ ]pmod[,\]]", tests(//...))')

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -292,7 +292,6 @@ def opentitan_test(
             # Tagging and timeout info always comes from a param block.
             tags = tparam.tags + extra_tags + skip_in_ci,
             timeout = tparam.timeout,
-            local = tparam.local,
             # Override parameters in the test rule.
             test_harness = tparam.test_harness,
             binaries = tparam.binaries,

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -218,7 +218,6 @@ fpga_cw340 = rule(
 def fpga_params(
         tags = [],
         timeout = "short",
-        local = True,
         test_harness = None,
         binaries = {},
         rom = None,
@@ -236,7 +235,6 @@ def fpga_params(
     Args:
       tags: The test tags to apply to the test rule.
       timeout: The timeout to apply to the test rule.
-      local: Whether to set the `local` flag on this test.
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binary labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
@@ -266,7 +264,6 @@ def fpga_params(
         # via the "_hacky_tags" macro in "rules/opentitan/defs.bzl".
         tags = ["exclusive"] + (["changes_otp"] if changes_otp else []) + tags,
         timeout = timeout,
-        local = local,
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -183,7 +183,6 @@ silicon = rule(
 def silicon_params(
         tags = [],
         timeout = "short",
-        local = True,
         rom_ext = None,
         test_harness = None,
         binaries = {},
@@ -198,7 +197,6 @@ def silicon_params(
     Args:
       tags: The test tags to apply to the test rule.
       timeout: The timeout to apply to the test rule.
-      local: Whether to set the `local` flag on this test.
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binary labels to substitution parameter names.
       rom_ext: Use an alternate ROM_EXT for this test.
@@ -213,7 +211,6 @@ def silicon_params(
     return struct(
         tags = ["silicon", "exclusive"] + (["changes_otp"] if changes_otp else []) + tags,
         timeout = timeout,
-        local = local,
         test_harness = test_harness,
         binaries = binaries,
         rom = None,

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -169,7 +169,6 @@ sim_dv = rule(
 def dv_params(
         tags = [],
         timeout = "short",
-        local = False,
         test_harness = None,
         binaries = None,
         rom = None,
@@ -184,7 +183,6 @@ def dv_params(
     Args:
       tags: The test tags to apply to the test rule.
       timeout: The timeout to apply to the test rule.
-      local: Whether to set the `local` flag on this test.
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binaries labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
@@ -199,7 +197,6 @@ def dv_params(
     return struct(
         tags = ["dv"] + tags,
         timeout = timeout,
-        local = local,
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -162,7 +162,6 @@ sim_verilator = rule(
 def verilator_params(
         tags = [],
         timeout = "moderate",
-        local = True,
         test_harness = None,
         binaries = {},
         rom = None,
@@ -177,7 +176,6 @@ def verilator_params(
     Args:
       tags: The test tags to apply to the test rule.
       timeout: The timeout to apply to the test rule.
-      local: Whether to set the `local` flag on this test.
       test_harness: Use an alternative test harness for this test.
       binaries: Dict of binaries labels to substitution parameter names.
       rom: Use an alternate ROM for this test.
@@ -192,7 +190,6 @@ def verilator_params(
     return struct(
         tags = ["verilator", "cpu:5"] + tags,
         timeout = timeout,
-        local = local,
         test_harness = test_harness,
         binaries = binaries,
         rom = rom,


### PR DESCRIPTION
In combination with the build determinism fixes from #25842, this PR aims to reduce CI runtime and FPGA runner utilisation by enabling the ability for FPGA and Verilator tests to be remotely cached. See the commit messages for more details on the individual changes.

Importantly, these changes will now mean that 
 - FPGA/Verilator tests will run in a sandboxed environment, and 
 - FPGA/Verilator tests will make use of remotely cached results where they exist, and the test previously passed, and the test itself has not changed / been rebuilt. 

Our CI bitstreams should have access to a remote cache which is written to by merge jobs, meaning that when a PR is merged, its successful FPGA/Verilator runs will be cached and can be re-used by subsequent PRs which do not modify the bitstream, testing infrastructure, or test itself. Tests that are built in some non-deterministic way will likely not be cached, however.

This PR also contains a commit to ensure that the nightly test runs do not make use of these cached results - this is to ensure that we collect FPGA test run data on a daily basis to enable us to spot e.g. flaky tests more easily, as flaky results would no longer as clearly appear in test runs on PRs.