### PR TITLE
[englishbreakfast] Redo topgen to fix merge skew

### DIFF
--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -1748,7 +1748,7 @@
           name: alert_dump
           desc: Alert handler crash dump information.
           struct: alert_crashdump
-          package: alert_pkg
+          package: alert_handler_pkg
           type: uni
           act: rcv
           width: 1
@@ -9504,7 +9504,7 @@
         name: alert_dump
         desc: Alert handler crash dump information.
         struct: alert_crashdump
-        package: alert_pkg
+        package: alert_handler_pkg
         type: uni
         act: rcv
         width: 1

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/rstmgr.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/rstmgr.hjson
@@ -233,7 +233,7 @@
       type:    "uni",
       name:    "alert_dump",
       act:     "rcv",
-      package: "alert_pkg",
+      package: "alert_handler_pkg",
       desc:    '''
         Alert handler crash dump information.
       '''

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/doc/interfaces.md
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/doc/interfaces.md
@@ -21,16 +21,16 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name   | Package::Struct                  | Type    | Act   |   Width | Description                                                                                                                  |
-|:------------|:---------------------------------|:--------|:------|--------:|:-----------------------------------------------------------------------------------------------------------------------------|
-| por_n       | logic                            | uni     | rcv   |       2 | Root power on reset signals from ast. There is one root reset signal for each core power domain.                             |
-| pwr         | pwr_rst                          | req_rsp | rsp   |       1 | Reset request signals from power manager. Power manager can request for specific domains of the lc/sys reset tree to assert. |
-| resets      | rstmgr_pkg::rstmgr_out           | uni     | req   |       1 | Leaf resets fed to the system.                                                                                               |
-| rst_en      | rstmgr_pkg::rstmgr_rst_en        | uni     | req   |       1 | Low-power-group outputs used by alert handler.                                                                               |
-| alert_dump  | alert_pkg::alert_crashdump       | uni     | rcv   |       1 | Alert handler crash dump information.                                                                                        |
-| cpu_dump    | rv_core_ibex_pkg::cpu_crash_dump | uni     | rcv   |       1 | Main processing element crash dump information.                                                                              |
-| sw_rst_req  | prim_mubi_pkg::mubi4             | uni     | req   |       1 | Software requested system reset to pwrmgr.                                                                                   |
-| tl          | tlul_pkg::tl                     | req_rsp | rsp   |       1 |                                                                                                                              |
+| Port Name   | Package::Struct                    | Type    | Act   |   Width | Description                                                                                                                  |
+|:------------|:-----------------------------------|:--------|:------|--------:|:-----------------------------------------------------------------------------------------------------------------------------|
+| por_n       | logic                              | uni     | rcv   |       2 | Root power on reset signals from ast. There is one root reset signal for each core power domain.                             |
+| pwr         | pwr_rst                            | req_rsp | rsp   |       1 | Reset request signals from power manager. Power manager can request for specific domains of the lc/sys reset tree to assert. |
+| resets      | rstmgr_pkg::rstmgr_out             | uni     | req   |       1 | Leaf resets fed to the system.                                                                                               |
+| rst_en      | rstmgr_pkg::rstmgr_rst_en          | uni     | req   |       1 | Low-power-group outputs used by alert handler.                                                                               |
+| alert_dump  | alert_handler_pkg::alert_crashdump | uni     | rcv   |       1 | Alert handler crash dump information.                                                                                        |
+| cpu_dump    | rv_core_ibex_pkg::cpu_crash_dump   | uni     | rcv   |       1 | Main processing element crash dump information.                                                                              |
+| sw_rst_req  | prim_mubi_pkg::mubi4               | uni     | req   |       1 | Software requested system reset to pwrmgr.                                                                                   |
+| tl          | tlul_pkg::tl                       | req_rsp | rsp   |       1 |                                                                                                                              |
 
 ## Security Alerts
 

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/README.md
@@ -32,7 +32,7 @@ All common types and methods defined at the package level can be found in
 `rstmgr_env_pkg`. Some of them in use are:
 ```systemverilog
   typedef logic [NumSwResets-1:0] sw_rst_t;
-  typedef logic [$bits(alert_pkg::alert_crashdump_t)-1:0] linearized_alert_dump_t;
+  typedef logic [$bits(alert_handler_pkg::alert_crashdump_t)-1:0] linearized_alert_dump_t;
   typedef virtual pwrmgr_rstmgr_sva_if #(.CHECK_RSTREQS(0)) parameterized_pwrmgr_rstmgr_sva_vif;
 ```
 The RSTMGR testbench instantiates (already handled in CIP base env) [tl_agent](../../../../dv/sv/tl_agent/README.md).

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -21,7 +21,7 @@ package rstmgr_env_pkg;
   import rstmgr_reg_pkg::NumHwResets;
   import rstmgr_reg_pkg::NumSwResets;
 
-  import alert_pkg::alert_crashdump_t;
+  import alert_handler_pkg::alert_crashdump_t;
   import rv_core_ibex_pkg::cpu_crash_dump_t;
 
   import sec_cm_pkg::*;

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_if.sv
@@ -24,7 +24,7 @@ interface rstmgr_if (
   rstmgr_pkg::rstmgr_cpu_t                              cpu_i;
 
   // Interface to alert handler
-  alert_pkg::alert_crashdump_t                          alert_dump_i;
+  alert_handler_pkg::alert_crashdump_t                          alert_dump_i;
 
   // Interface to cpu crash dump
   rv_core_ibex_pkg::cpu_crash_dump_t                    cpu_dump_i;

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_reset_race_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_reset_race_vseq.sv
@@ -29,7 +29,7 @@ class rstmgr_sw_rst_reset_race_vseq extends rstmgr_base_vseq;
     bit [NumSwResets-1:0] exp_ctrl_n;
     bit [NumSwResets-1:0] sw_rst_regwen = '1;
     int expected;
-    alert_pkg::alert_crashdump_t bogus_alert_dump = '1;
+    alert_handler_pkg::alert_crashdump_t bogus_alert_dump = '1;
     rv_core_ibex_pkg::cpu_crash_dump_t bogus_cpu_dump = '1;
     set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
 

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr.sv
@@ -48,7 +48,7 @@ module rstmgr
   output mubi4_t sw_rst_req_o,
 
   // Interface to alert handler
-  input alert_pkg::alert_crashdump_t alert_dump_i,
+  input alert_handler_pkg::alert_crashdump_t alert_dump_i,
 
   // Interface to cpu crash dump
   input rv_core_ibex_pkg::cpu_crash_dump_t cpu_dump_i,
@@ -911,7 +911,7 @@ module rstmgr
   assign dump_capture_halt = rst_hw_req;
 
   rstmgr_crash_info #(
-    .CrashDumpWidth($bits(alert_pkg::alert_crashdump_t))
+    .CrashDumpWidth($bits(alert_handler_pkg::alert_crashdump_t))
   ) u_alert_info (
     .clk_i(clk_por_i),
     .rst_ni(rst_por_ni),

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -288,8 +288,8 @@ module top_englishbreakfast #(
   logic intr_flash_ctrl_corr_err;
 
   // Alert list
-  prim_alert_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
-  prim_alert_pkg::alert_rx_t [alert_pkg::NAlerts-1:0]  alert_rx;
+  prim_alert_pkg::alert_tx_t [alert_handler_pkg::NAlerts-1:0]  alert_tx;
+  prim_alert_pkg::alert_rx_t [alert_handler_pkg::NAlerts-1:0]  alert_rx;
 
 
   // define inter-module signals
@@ -415,8 +415,8 @@ module top_englishbreakfast #(
   );
 
   // Wire up alert handler LPGs
-  prim_mubi_pkg::mubi4_t [alert_pkg::NLpg-1:0] lpg_cg_en;
-  prim_mubi_pkg::mubi4_t [alert_pkg::NLpg-1:0] lpg_rst_en;
+  prim_mubi_pkg::mubi4_t [alert_handler_pkg::NLpg-1:0] lpg_cg_en;
+  prim_mubi_pkg::mubi4_t [alert_handler_pkg::NLpg-1:0] lpg_rst_en;
 
 
   // peri_lc_io_div4_0
@@ -874,7 +874,7 @@ module top_englishbreakfast #(
       .pwr_o(pwrmgr_aon_pwr_rst_rsp),
       .resets_o(rstmgr_aon_resets),
       .rst_en_o(rstmgr_aon_rst_en),
-      .alert_dump_i(alert_pkg::ALERT_CRASHDUMP_DEFAULT),
+      .alert_dump_i(alert_handler_pkg::ALERT_CRASHDUMP_DEFAULT),
       .cpu_dump_i(rv_core_ibex_crash_dump),
       .sw_rst_req_o(rstmgr_aon_sw_rst_req),
       .tl_i(rstmgr_aon_tl_req),


### PR DESCRIPTION
alert_pkg changed to alert_handler_pkg after the CI run for the PR that added englishbreakfast's files.