### PR TITLE
[test,do-not-merge] Experiment with FPGA test `--test_output=error` to see CI runtime reduction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,41 +39,6 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Show environment
         run: ./ci/scripts/show-env.sh
-      - name: Commit metadata
-        run: ./ci/scripts/lint-commits.sh "$GITHUB_BASE_REF"
-        if: ${{ github.event_name == 'pull_request' }}
-      - name: License headers
-        run: ./ci/scripts/check-licence-headers.sh "$GITHUB_BASE_REF"
-        if: ${{ github.event_name == 'pull_request' }}
-      - name: Executable bits
-        run: ./ci/scripts/exec-check.sh
-      - name: Non-ASCII characters
-        run: ./ci/scripts/check-ascii.sh
-      - name: Python (flake8)
-        run: ./ci/scripts/python-lint.sh "$GITHUB_BASE_REF"
-        if: ${{ github.event_name == 'pull_request' }}
-      - name: Python (mypy)
-        run: ./ci/scripts/mypy.sh
-      - name: Validate testplans with schema
-        run: ./ci/scripts/validate_testplans.sh
-      - name: C/C++ formatting
-        run: ./bazelisk.sh test //quality:clang_format_check
-      - name: Rust formatting
-        run: ./bazelisk.sh test //quality:rustfmt_check
-      - name: Shellcheck
-        run: ./bazelisk.sh test //quality:shellcheck_check
-      - name: Header guards
-        run: ./ci/scripts/include-guard.sh "$GITHUB_BASE_REF"
-        if: ${{ github.event_name == 'pull_request' }}
-      - name: Trailing whitespace
-        run: ./ci/scripts/whitespace.sh "$GITHUB_BASE_REF"
-        if: ${{ github.event_name == 'pull_request' }}
-      - name: Broken links
-        run: ./ci/scripts/check-links.sh
-      - name: Generated documentation
-        run: ./ci/scripts/check-cmdgen.sh
-      - name: Lock files
-        run: ./ci/scripts/check-lock-files.sh
 
   slow_lint:
     name: Lint (slow)

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -69,7 +69,7 @@ jobs:
               //sw/host/opentitantool:opentitantool -- \
               --interface=hyperdebug_dfu transport update-firmware || true
 
-      - name: Execute tests
+      - name: Execute tests (test_output=all)
         run: |
           . util/build_consts.sh
           module load "xilinx/vivado/${{ inputs.vivado_version }}"
@@ -82,7 +82,27 @@ jobs:
 
           # Run FPGA tests
           if [[ -s target_pattern_file.txt ]]; then
-            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt || {
+            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt all || {
+              res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}";
+            }
+          else
+            echo "No tests to run after filtering"
+          fi
+
+      - name: Execute tests (test_output=error)
+        run: |
+          . util/build_consts.sh
+          module load "xilinx/vivado/${{ inputs.vivado_version }}"
+
+          # Execute a query to find all targets that match the test tags and store them in a file.
+          ci/scripts/run-bazel-test-query.sh \
+            target_pattern_file.txt \
+            "${{ inputs.tag_filters }}",-manual,-broken,-skip_in_ci \
+            //... @manufacturer_test_hooks//...
+
+          # Run FPGA tests
+          if [[ -s target_pattern_file.txt ]]; then
+            ci/scripts/run-fpga-tests.sh "${{ inputs.interface }}" target_pattern_file.txt error || {
               res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}";
             }
           else

--- a/ci/scripts/get-bitstream-strategy.sh
+++ b/ci/scripts/get-bitstream-strategy.sh
@@ -52,12 +52,7 @@ else
   git diff --stat --name-only ${bitstream_commit}
   echo
   echo "Changed files after exclusions applied:"
-  # Use the cached bitstream if no changed files remain.
-  if git diff --exit-code --stat --name-only ${bitstream_commit} -- "${excluded_files[@]}"; then
-    bitstream_strategy=cached
-  else
-    bitstream_strategy=build
-  fi
+  bitstream_strategy=cached
 fi
 
 echo

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -9,12 +9,13 @@ set -e
 . util/build_consts.sh
 
 if [ $# == 0 ]; then
-    echo >&2 "Usage: run-fpga-tests.sh <fpga> <target_pattern_file>"
-    echo >&2 "E.g. ./run-fpga-tests.sh cw310 list_of_test.txt"
+    echo >&2 "Usage: run-fpga-tests.sh <fpga> <target_pattern_file> <test_output_type>"
+    echo >&2 "E.g. ./run-fpga-tests.sh cw310 list_of_test.txt all"
     exit 1
 fi
 fpga="$1"
 target_pattern_file="$2"
+test_output_type="$3"
 
 # Copy bitstreams and related files into the cache directory so Bazel will have
 # the corresponding targets in the @bitstreams workspace.
@@ -51,7 +52,7 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
     --define DISABLE_VERILATOR_BUILD=true \
     --nokeep_going \
     --test_timeout_filters=short,moderate \
-    --test_output=all \
+    --test_output="${test_output_type}" \
     --build_tests_only \
     --define "$fpga"=lowrisc \
     --flaky_test_attempts=2 \


### PR DESCRIPTION
This is a draft PR being used for testing of CI, do not merge it.

This PR doubles each FPGA test execution, to run once with `--test_output=all` (as normal) and once with `--test_output=error`. If the FPGA results are cached from a previous merge job to `master`, then the difference in time between the runs should just be the overhead incurred by outputting test outputs regardless of Bazel build/summary overheads.