### PR TITLE
[hw,alert_handler,rtl] Only read unused LPGs when there are more than 1

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_lpg_ctrl.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_lpg_ctrl.sv.tpl
@@ -71,18 +71,21 @@ module ${module_instance_name}_lpg_ctrl import ${module_instance_name}_pkg::*; (
     );
   end
 
-  // explicitly read all unused lpg triggers to avoid lint errors.
-  logic [NLpg-1:0] lpg_used;
-  logic unused_lpg_init_trig;
-  always_comb begin
-    lpg_used = '0;
-    unused_lpg_init_trig = 1'b0;
-    for (int j=0; j < NAlerts; j++) begin
-      lpg_used[LpgMap[j]] |= 1'b1;
-    end
-    for (int k=0; k < NLpg; k++) begin
-      if (!lpg_used) begin
-        unused_lpg_init_trig ^= ^lpg_init_trig[k];
+  if (NLpg > 1) begin : gen_read_unused_lpg
+    // explicitly read all unused lpg triggers to avoid lint errors.
+    // Only needed when there are at least two LPGs.
+    logic [NLpg-1:0] lpg_used;
+    logic unused_lpg_init_trig;
+    always_comb begin
+      lpg_used = '0;
+      unused_lpg_init_trig = 1'b0;
+      for (int j=0; j < NAlerts; j++) begin
+        lpg_used[LpgMap[j]] |= 1'b1;
+      end
+      for (int k=0; k < NLpg; k++) begin
+        if (!lpg_used) begin
+          unused_lpg_init_trig ^= ^lpg_init_trig[k];
+        end
       end
     end
   end

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_lpg_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_lpg_ctrl.sv
@@ -71,18 +71,21 @@ module alert_handler_lpg_ctrl import alert_handler_pkg::*; (
     );
   end
 
-  // explicitly read all unused lpg triggers to avoid lint errors.
-  logic [NLpg-1:0] lpg_used;
-  logic unused_lpg_init_trig;
-  always_comb begin
-    lpg_used = '0;
-    unused_lpg_init_trig = 1'b0;
-    for (int j=0; j < NAlerts; j++) begin
-      lpg_used[LpgMap[j]] |= 1'b1;
-    end
-    for (int k=0; k < NLpg; k++) begin
-      if (!lpg_used) begin
-        unused_lpg_init_trig ^= ^lpg_init_trig[k];
+  if (NLpg > 1) begin : gen_read_unused_lpg
+    // explicitly read all unused lpg triggers to avoid lint errors.
+    // Only needed when there are at least two LPGs.
+    logic [NLpg-1:0] lpg_used;
+    logic unused_lpg_init_trig;
+    always_comb begin
+      lpg_used = '0;
+      unused_lpg_init_trig = 1'b0;
+      for (int j=0; j < NAlerts; j++) begin
+        lpg_used[LpgMap[j]] |= 1'b1;
+      end
+      for (int k=0; k < NLpg; k++) begin
+        if (!lpg_used) begin
+          unused_lpg_init_trig ^= ^lpg_init_trig[k];
+        end
       end
     end
   end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_lpg_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_lpg_ctrl.sv
@@ -71,18 +71,21 @@ module alert_handler_lpg_ctrl import alert_handler_pkg::*; (
     );
   end
 
-  // explicitly read all unused lpg triggers to avoid lint errors.
-  logic [NLpg-1:0] lpg_used;
-  logic unused_lpg_init_trig;
-  always_comb begin
-    lpg_used = '0;
-    unused_lpg_init_trig = 1'b0;
-    for (int j=0; j < NAlerts; j++) begin
-      lpg_used[LpgMap[j]] |= 1'b1;
-    end
-    for (int k=0; k < NLpg; k++) begin
-      if (!lpg_used) begin
-        unused_lpg_init_trig ^= ^lpg_init_trig[k];
+  if (NLpg > 1) begin : gen_read_unused_lpg
+    // explicitly read all unused lpg triggers to avoid lint errors.
+    // Only needed when there are at least two LPGs.
+    logic [NLpg-1:0] lpg_used;
+    logic unused_lpg_init_trig;
+    always_comb begin
+      lpg_used = '0;
+      unused_lpg_init_trig = 1'b0;
+      for (int j=0; j < NAlerts; j++) begin
+        lpg_used[LpgMap[j]] |= 1'b1;
+      end
+      for (int k=0; k < NLpg; k++) begin
+        if (!lpg_used) begin
+          unused_lpg_init_trig ^= ^lpg_init_trig[k];
+        end
       end
     end
   end


### PR DESCRIPTION
If there is only 1 LPG, no need to read the unused one. The one LPGs is associated to all alerts.