### PR TITLE
[hw,rv_plic,rtl] Fix uniquified instance name in VLNVs

### DIFF
--- a/hw/ip_templates/rv_plic/rv_plic.core.tpl
+++ b/hw/ip_templates/rv_plic/rv_plic.core.tpl
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: ${instance_vlnv("lowrisc:ip:rv_plic:0.1")}
+name: ${instance_vlnv(f"lowrisc:ip:{module_instance_name}:0.1")}
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:
   files_rtl:
     depend:
-      - ${instance_vlnv("lowrisc:ip:rv_plic_component:0.1")}
+      - ${instance_vlnv(f"lowrisc:ip:{module_instance_name}_component:0.1")}
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
     files:

--- a/hw/ip_templates/rv_plic/rv_plic_component.core.tpl
+++ b/hw/ip_templates/rv_plic/rv_plic_component.core.tpl
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: ${instance_vlnv(f"lowrisc:ip:rv_plic_component:0.1")}
+name: ${instance_vlnv(f"lowrisc:ip:{module_instance_name}_component:0.1")}
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:


### PR DESCRIPTION
The `module_instance_name ` was missing in some VLNVs from the latest changes.