### PR TITLE
Properly uniquify defs.bzl in ipgen

### DIFF
--- a/hw/ip_templates/rv_plic/defs.bzl.tpl
+++ b/hw/ip_templates/rv_plic/defs.bzl.tpl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 load("//rules/opentitan:hw.bzl", "opentitan_ip")
 
-RV_PLIC = opentitan_ip(
-    name = "rv_plic",
-    hjson = "//hw/top_${topname}/ip_autogen/rv_plic:data/rv_plic.hjson",
+${module_instance_name.upper()} = opentitan_ip(
+    name = "${module_instance_name}",
+    hjson = "//hw/top_${topname}/ip_autogen/${module_instance_name}:data/${module_instance_name}.hjson",
 )

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -200,9 +200,9 @@ class IpTemplateRendererBase:
         """ Get the name of the file without a '.tpl' suffix. """
         assert filepath.suffix == '.tpl'
         filename = filepath.stem
-        # Do not render the module_instance_name into bazel BUILD file templates
+        # Do not render the module_instance_name into Bazel BUILD and defs.bzl file templates
         # Leave the filename as it is without the *.tpl suffix
-        if filename == "BUILD":
+        if filename in ['BUILD', 'defs.bzl']:
             return filename
         if "module_instance_name" in self.ip_config.param_values:
             filename = self.ip_config.param_values[


### PR DESCRIPTION
Do not render the module instance name into the `defs.bzl` filename and uniqify the `defs.bzl.tpl` of `rv_plic`.