### PR TITLE
[manuf] add debug prints to OTP provisioning process

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -184,6 +184,7 @@ cc_library(
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
     ],

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
@@ -22,7 +23,6 @@ enum {
   kValidAstCfgOtpAddrLow = OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_OFFSET,
   kInvalidAstCfgOtpAddrHigh =
       kValidAstCfgOtpAddrLow + OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE,
-
 };
 
 /**
@@ -82,6 +82,9 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
          kv[i].offset < kInvalidAstCfgOtpAddrHigh)) {
       continue;
     }
+    LOG_INFO(
+        "OTP Write: Partition (%d); Idx (%d); Offset (0x%x); Num Vals (%d)",
+        partition, i, kv[i].offset, kv[i].num_values);
     uint32_t offset;
     TRY(dif_otp_ctrl_relative_address(partition, kv[i].offset, &offset));
     switch (kv[i].type) {
@@ -267,7 +270,9 @@ status_t manuf_individualize_device_flash_data_default_cfg_check(
 
 status_t manuf_individualize_device_creator_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
+  LOG_INFO("Locking CreatorSwCfg partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg));
+  LOG_INFO("Done.");
   return OK_STATUS();
 }
 
@@ -310,7 +315,9 @@ status_t manuf_individualize_device_partition_expected_read(
 
 status_t manuf_individualize_device_owner_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
+  LOG_INFO("Locking OwnerSwCfg partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg));
+  LOG_INFO("Done.");
   return OK_STATUS();
 }
 
@@ -327,7 +334,9 @@ status_t manuf_individualize_device_rot_creator_auth_codesign(
   TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign,
                     kOtpKvRotCreatorAuthCodesign,
                     kOtpKvRotCreatorAuthCodesignSize));
+  LOG_INFO("Locking RotCreatorAuthCodesign partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+  LOG_INFO("Done.");
   return OK_STATUS();
 }
 
@@ -335,7 +344,9 @@ status_t manuf_individualize_device_rot_creator_auth_state(
     const dif_otp_ctrl_t *otp_ctrl) {
   TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState,
                     kOtpKvRotCreatorAuthState, kOtpKvRotCreatorAuthStateSize));
+  LOG_INFO("Locking RotCreatorAuthState partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState));
+  LOG_INFO("Done.");
   return OK_STATUS();
 }
 


### PR DESCRIPTION
This adds detailed log prints to each OTP write that happens during provisioning to enable easier triaging bugs.