### PR TITLE
[hw,soc_dbg_ctrl,rtl] Fix dependencies, improve type robustness, default values

### DIFF
--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_decode.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_decode.sv
@@ -23,6 +23,8 @@ module soc_dbg_ctrl_decode #(
   prim_mubi_pkg::mubi4_t valid, relocked;
 
   if (SyncDbgPolicy) begin : gen_dbg_policy_sync
+    logic [prim_mubi_pkg::MuBi4Width-1:0] logic_valid, logic_relocked;
+
     prim_flop_2sync #(
       .Width      ( prim_mubi_pkg::MuBi4Width   ),
       .ResetValue ( {prim_mubi_pkg::MuBi4False} )
@@ -30,7 +32,7 @@ module soc_dbg_ctrl_decode #(
       .clk_i  ( clk_i                      ),
       .rst_ni ( rst_ni                     ),
       .d_i    ( soc_dbg_policy_bus_i.valid ),
-      .q_o    ( valid                      )
+      .q_o    ( logic_valid                )
     );
 
     prim_flop_2sync #(
@@ -40,8 +42,12 @@ module soc_dbg_ctrl_decode #(
       .clk_i  ( clk_i                         ),
       .rst_ni ( rst_ni                        ),
       .d_i    ( soc_dbg_policy_bus_i.relocked ),
-      .q_o    ( relocked                      )
+      .q_o    ( logic_relocked                )
     );
+
+    // Cast from logic to the actual type to avoid strong SV type linting errors
+    assign valid    = prim_mubi_pkg::mubi4_t'(logic_valid);
+    assign relocked = prim_mubi_pkg::mubi4_t'(logic_relocked);
   end else begin: gen_dbg_policy_async
     assign valid    = soc_dbg_policy_bus_i.valid;
     assign relocked = soc_dbg_policy_bus_i.relocked;

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_pkg.sv
@@ -43,6 +43,16 @@ package soc_dbg_ctrl_pkg;
     prim_mubi_pkg::mubi4_t relocked;
   } soc_dbg_policy_t;
 
+  // TODO(#25880): This parameter is intended for DV so should be moved into a DV package file once
+  // that exists.
+  //
+  // Valid CAT 3 policy for DV purposes
+  parameter soc_dbg_policy_t SOC_DBG_POLICY_CAT3_VALID = '{
+    valid:    prim_mubi_pkg::MuBi4True,
+    category: DbgCategory3,
+    relocked: prim_mubi_pkg::MuBi4False
+  };
+
   // Encoding generated with:
   // $ ./util/design/sparse-fsm-encode.py -d 3 -m 6 -n 6 \
   //     -s 1870242553 --language=sv

--- a/hw/ip/soc_dbg_ctrl/soc_dbg_ctrl_decode.core
+++ b/hw/ip/soc_dbg_ctrl/soc_dbg_ctrl_decode.core
@@ -8,6 +8,8 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:soc_dbg_ctrl_pkg
+      - lowrisc:prim:flop_en
+      - lowrisc:prim:edge_detector
     files:
       - rtl/soc_dbg_ctrl_decode.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This PR just fixes some issues that showed up during integration:

* Add all dependencies to the decode module that is used out-of-tree
* Explicitly convert the logic from flops back to the MUBI types to avoid linting errors
* Provide a default valid CAT 3 policy used for DV