### PR TITLE
[bazel] Disable sandboxing for disassembly actions

### DIFF
--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -97,9 +97,6 @@ def obj_disassemble(ctx, **kwargs):
             src.path,
             output.path,
         ],
-        execution_requirements = {
-            "no-sandbox": "",
-        },
         command = "$1 -wx --disassemble --line-numbers --disassemble-zeroes --source --visualize-jumps $2 | expand > $3",
     )
     return output


### PR DESCRIPTION
It's not clear why sandboxing was disabled here but it seems unnecessary.