### PR TITLE
Revert "[bazel] Disable sandboxing for disassembly actions"

### DIFF
--- a/rules/opentitan/transform.bzl
+++ b/rules/opentitan/transform.bzl
@@ -97,6 +97,9 @@ def obj_disassemble(ctx, **kwargs):
             src.path,
             output.path,
         ],
+        execution_requirements = {
+            "no-sandbox": "",
+        },
         command = "$1 -wx --disassemble --line-numbers --disassemble-zeroes --source --visualize-jumps $2 | expand > $3",
     )
     return output


### PR DESCRIPTION
This reverts commit bd84812874efbf4c574322c816a3e5bf204ee887.

Please don't merge this!

I've just created this to investigate a CI failure.