### PR TITLE
[signing] Support sphincs+ PreHashedSha256 mode

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys/BUILD
@@ -16,7 +16,6 @@ package(default_visibility = ["//visibility:public"])
 
 key_ecdsa(
     name = "ecdsa_prod_0",
-    config = "EcdsaP256",
     method = "hsmtool",
     pub_key = "sv00-earlgrey-a1-root-ecdsa-prod-0.pub.der",
     type = "ProdKey",
@@ -24,7 +23,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "ecdsa_prod_1",
-    config = "EcdsaP256",
     method = "hsmtool",
     pub_key = "sv00-earlgrey-a1-root-ecdsa-prod-1.pub.der",
     type = "ProdKey",
@@ -32,7 +30,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "ecdsa_prod_2",
-    config = "EcdsaP256",
     method = "hsmtool",
     pub_key = "sv00-earlgrey-a1-root-ecdsa-prod-2.pub.der",
     type = "ProdKey",
@@ -40,7 +37,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "ecdsa_test_0",
-    config = "EcdsaP256",
     method = "hsmtool",
     pub_key = "sv00-earlgrey-a1-root-ecdsa-test-0.pub.der",
     type = "TestKey",
@@ -48,7 +44,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "ca_dice_0",
-    config = "EcdsaP256",
     method = "hsmtool",
     pub_key = "sv00-earlgrey-a1-ca-dice-0.pub.der",
     type = "TestKey",

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -42,10 +42,8 @@ key_sphincs_plus = rule(
             doc = "The type of the key. Can be TestKey, DevKey or ProdKey.",
             values = ["TestKey", "DevKey", "ProdKey"],
         ),
-        "config": attr.string(
-            default = "Sha2128s",
-            doc = "The config of the key. Can be Sha2128s[Q20][Prehash].",
-            values = ["Sha2128s", "Sha2128sQ20", "Sha2128sPrehash", "Sha2128sQ20Prehash"],
+        "config": attr.string_dict(
+            doc = "The config properties of the key.  `domain` can be `Pure` or `PreHashedSha256`.",
         ),
         "method": attr.string(
             doc = "Mechanism used to access the key. Can be local or hsmtool.",
@@ -70,10 +68,8 @@ key_ecdsa = rule(
             doc = "The type of the key. Can be TestKey, DevKey or ProdKey.",
             values = ["TestKey", "DevKey", "ProdKey"],
         ),
-        "config": attr.string(
-            default = "EcdsaP256",
-            doc = "The config of the key. Only EcdsaP256 is supported at the moment.",
-            values = ["EcdsaP256"],
+        "config": attr.string_dict(
+            doc = "The config properties of the key.  Currently, there are no properties for ECDSA keys.",
         ),
         # TODO(cfrantz, moidx, #22155): To support signing with opentitantool or
         # hsmtool, the `method` should be replaced with a `token` and `profile`

--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -10,7 +10,7 @@ load("//rules:host.bzl", "host_tools_transition")
 
 PreSigningBinaryInfo = provider(fields = ["files"])
 SigningToolInfo = provider(fields = ["tool", "data", "env", "location"])
-KeySetInfo = provider(fields = ["keys", "selected_key", "profile", "sign", "tool"])
+KeySetInfo = provider(fields = ["keys", "config", "selected_key", "profile", "sign", "tool"])
 
 KeyInfo = provider(
     """Key Information.
@@ -61,6 +61,8 @@ def key_from_dict(key, attr_name):
             label = key,
             file = ksi.keys[name],
             name = name,
+            info = None,
+            config = ksi.config[name],
         )
     elif KeyInfo in key:
         key_info = key[KeyInfo]
@@ -69,6 +71,7 @@ def key_from_dict(key, attr_name):
             file = None,
             name = name,
             info = key_info,
+            config = key_info.config,
         )
     elif DefaultInfo in key:
         key_file = key[DefaultInfo].files.to_list()
@@ -78,6 +81,7 @@ def key_from_dict(key, attr_name):
             label = key,
             file = key_file[0],
             name = name,
+            config = {},
         )
     return None
 
@@ -172,10 +176,8 @@ def _presigning_artifacts(ctx, opentitantool, src, manifest, ecdsa_key, rsa_key,
         info = getattr(ecdsa_key, "info", None)
         selected_ecdsa_key = getattr(ecdsa_key, "file", None)
         if info:
-            # Provider is KeyInfo; get the key file.
-            if info.private_key:
-                selected_ecdsa_key = ecdsa_key.info.private_key
-            elif info.pub_key:
+            # Provider is KeyInfo; get the public key file.
+            if info.pub_key:
                 selected_ecdsa_key = ecdsa_key.info.pub_key
             else:
                 fail("Expected an ECDSA key with a private_key or pub_key attributes.")
@@ -192,15 +194,16 @@ def _presigning_artifacts(ctx, opentitantool, src, manifest, ecdsa_key, rsa_key,
         inputs.append(rsa_key.file)
 
     spx_args = []
+    spx_domain = None
     if spx_key:
+        spx_domain = spx_key.config.get("domain", "Pure")
+
         # Check if the provider is KeyInfo or KeySetInfo
         info = getattr(spx_key, "info", None)
         selected_spx_key = getattr(spx_key, "file", None)
         if info:
-            # Provider is KeyInfo; get the key file.
-            if info.private_key:
-                selected_spx_key = spx_key.info.private_key
-            elif info.pub_key:
+            # Provider is KeyInfo; get the key public file.
+            if info.pub_key:
                 selected_spx_key = spx_key.info.pub_key
             else:
                 fail("Expected a SPHINCS+ key with a private_key or pub_key attributes.")
@@ -221,6 +224,7 @@ def _presigning_artifacts(ctx, opentitantool, src, manifest, ecdsa_key, rsa_key,
             "manifest",
             "update",
             "--manifest={}".format(manifest.path),
+            "--domain={}".format(spx_domain),
             "--output={}".format(pre.path),
             src.path,
         ] + ecdsa_or_rsa_args + spx_args,
@@ -269,32 +273,45 @@ def _presigning_artifacts(ctx, opentitantool, src, manifest, ecdsa_key, rsa_key,
     # Compute message to be signed with SPX+.
     spxmsg = None
     if spx_key:
-        spxmsg = ctx.actions.declare_file("{}.spx-message".format(basename))
-        ctx.actions.run(
-            outputs = [spxmsg],
-            inputs = [pre],
-            arguments = [
-                "--rcfile=",
-                "--quiet",
-                "image",
-                "spx-message",
-                "--output={}".format(spxmsg.path),
-                pre.path,
-            ],
-            executable = opentitantool,
-            mnemonic = "PreSigningSpxMessage",
-        )
-        signing_directives.append(struct(
-            command = "spx-sign",
-            id = None,
-            label = spx_key.name,
-            little_endian = False,
-            # TODO(cfrantz): Update the format/domain when we can support pre-hashed signing.
-            format = "PlainText",
-            domain = "Pure",
-            output = "{}.spx_sig".format(basename),
-            input = "{}.spx-message".format(basename),
-        ))
+        if spx_domain.lower() == "prehashedsha256":
+            spxmsg = digest
+            signing_directives.append(struct(
+                command = "spx-sign",
+                id = None,
+                label = spx_key.name,
+                # TODO(#25870): Set `little_endian` appropriately.
+                little_endian = True,
+                format = "Sha256Hash",
+                domain = spx_domain,
+                output = "{}.spx_sig".format(basename),
+                input = "{}.digest".format(basename),
+            ))
+        else:
+            spxmsg = ctx.actions.declare_file("{}.spx-message".format(basename))
+            ctx.actions.run(
+                outputs = [spxmsg],
+                inputs = [pre],
+                arguments = [
+                    "--rcfile=",
+                    "--quiet",
+                    "image",
+                    "spx-message",
+                    "--output={}".format(spxmsg.path),
+                    pre.path,
+                ],
+                executable = opentitantool,
+                mnemonic = "PreSigningSpxMessage",
+            )
+            signing_directives.append(struct(
+                command = "spx-sign",
+                id = None,
+                label = spx_key.name,
+                little_endian = False,
+                format = "PlainText",
+                domain = spx_domain,
+                output = "{}.spx_sig".format(basename),
+                input = "{}.spx-message".format(basename),
+            ))
 
     return struct(pre = pre, digest = digest, spxmsg = spxmsg, script = signing_directives)
 
@@ -347,19 +364,39 @@ def _local_sign(ctx, tool, digest, ecdsa_key, rsa_key, spxmsg = None, spx_key = 
     )
 
     spx_sig = None
-    if spxmsg and spx_key.file:
+    if spxmsg and spx_key:
+        info = getattr(spx_key, "info", None)
+        if info:
+            # Provider is KeyInfo; get the private key file.
+            private_key = info.private_key
+        elif spx_key.file:
+            private_key = spx_key.file
+        else:
+            fail("Expected either KeyInfo or KeySetInfo; got neither")
         spx_sig = ctx.actions.declare_file(paths.replace_extension(spxmsg.basename, ".spx_sig"))
+        domain = spx_key.config.get("domain", "Pure")
+
+        # TODO(#25870): Currently, opentitantool emits SHA256 digests in byte-reversed order,
+        # so for proper creation of PrehashedSha256 signatures, we need to reverse the input.
+        # The ROM erroneously uses the reversed representation, so when "byte-reversal-bug" is
+        # true, we should not reverse the bytes (since they're already reversed).
+        # This logic will change when we fix opentitantool to emit in the correct order.
+        rev = "true" if domain.lower() == "prehashedsha256" else "false"
+        if spx_key.config.get("byte-reversal-bug") == "true":
+            rev = "false"
         ctx.actions.run(
             outputs = [spx_sig],
-            inputs = [spxmsg, spx_key.file],
+            inputs = [spxmsg, private_key],
             arguments = [
                 "--rcfile=",
                 "--quiet",
                 "spx",
                 "sign",
+                "--input-bytes-reversed={}".format(rev),
+                "--domain={}".format(domain),
                 "--output={}".format(spx_sig.path),
                 spxmsg.path,
-                spx_key.file.path,
+                private_key.path,
             ],
             executable = tool.tool,
             mnemonic = "LocalSpxSign",
@@ -430,6 +467,19 @@ def _hsmtool_sign(ctx, tool, digest, ecdsa_key, rsa_key, spxmsg = None, spx_key 
 
     spx_sig = None
     if spxmsg and spx_key:
+        domain = spx_key.config.get("domain", "Pure")
+        if domain.lower() == "prehashedsha256":
+            args = [
+                # TODO(#25870): Set `little-endian` appropriately.
+                "--little-endian",
+                "--format=sha256-hash",
+                "--domain={}".format(domain),
+            ]
+        else:
+            args = [
+                "--format=plain-text",
+                "--domain={}".format(domain),
+            ]
         spx_sig = ctx.actions.declare_file(paths.replace_extension(spxmsg.basename, ".spx-sig"))
         ctx.actions.run(
             outputs = [spx_sig],
@@ -440,11 +490,10 @@ def _hsmtool_sign(ctx, tool, digest, ecdsa_key, rsa_key, spxmsg = None, spx_key 
                 "--profile={}".format(profile),
                 "spx",
                 "sign",
-                "--format=plain-text",
                 "--label={}".format(spx_key.name),
                 "--output={}".format(spx_sig.path),
                 spxmsg.path,
-            ],
+            ] + args,
             executable = tool.tool,
             execution_requirements = {
                 "no-sandbox": "",
@@ -855,11 +904,22 @@ signing_tool = rule(
 
 def _keyset(ctx):
     keys = {}
+    config = {}
     for k, v in ctx.attr.keys.items():
         keyfile = k.files.to_list()
+
+        # Parse the value (nickname and parameters) into a param dictionary
+        # so we keep the per-key configuration parameters in the KeySetInfo
+        # provider `config` field.
+        param = v.split(":")
+        if "=" not in param[0]:
+            param[0] = "name=" + param[0]
+        param = [p.split("=", 1) for p in param]
+        param = {p[0]: p[1] for p in param}
         if len(keyfile) != 1:
             fail("keyset key labels must resolve to exactly one file.")
-        keys[v] = keyfile[0]
+        keys[param["name"]] = keyfile[0]
+        config[param["name"]] = param
 
     tool = ctx.attr.tool[SigningToolInfo]
     if tool.location == "local" and ctx.attr.profile != "local":
@@ -875,7 +935,7 @@ def _keyset(ctx):
         sign = _local_sign
     else:
         sign = _hsmtool_sign
-    return [KeySetInfo(keys = keys, selected_key = selected_key, profile = ctx.attr.profile, sign = sign, tool = tool)]
+    return [KeySetInfo(keys = keys, config = config, selected_key = selected_key, profile = ctx.attr.profile, sign = sign, tool = tool)]
 
 keyset = rule(
     implementation = _keyset,
@@ -884,7 +944,7 @@ keyset = rule(
         "keys": attr.label_keyed_string_dict(
             allow_files = True,
             mandatory = True,
-            doc = "A mapping of key files to key names.  When a key file is a public key whose private component is held in an HSM, the name should be the same as the HSM label of that key.",
+            doc = "A mapping of key files to key names.  When a key file is a public key whose private component is held in an HSM, the name should be the same as the HSM label of that key.  Additional key parameters may be specified with colon-separated key=value pairs.",
         ),
         "profile": attr.string(
             mandatory = True,

--- a/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
@@ -32,7 +32,6 @@ filegroup(
 
 key_ecdsa(
     name = "app_prod_ecdsa",
-    config = "EcdsaP256",
     method = "local",
     private_key = "app_prod_ecdsa_p256.der",
     pub_key = "app_prod_ecdsa_p256.pub.der",

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
@@ -107,9 +107,7 @@ key_ecdsa(
 
 key_sphincs_plus(
     name = "app_dev_spx",
-    # TODO(cfrantz): Change this to Prehash after putting
-    # the prehash infrastructure in place.
-    config = {"domain": "Pure"},
+    config = {"domain": "PreHashedSha256"},
     method = "local",
     private_key = "app_dev_spx.pem",
     pub_key = "app_dev_spx.pub.pem",

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
@@ -82,7 +82,6 @@ filegroup(
 
 key_ecdsa(
     name = "app_prod_ecdsa",
-    config = "EcdsaP256",
     method = "local",
     private_key = "app_prod_ecdsa_p256.der",
     pub_key = "app_prod_ecdsa_p256.pub.der",
@@ -91,7 +90,7 @@ key_ecdsa(
 
 key_sphincs_plus(
     name = "app_prod_spx",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "local",
     private_key = "app_prod_spx.pem",
     pub_key = "app_prod_spx.pub.pem",
@@ -100,7 +99,6 @@ key_sphincs_plus(
 
 key_ecdsa(
     name = "app_dev_ecdsa",
-    config = "EcdsaP256",
     method = "local",
     private_key = "app_dev_ecdsa_p256.der",
     pub_key = "app_dev_ecdsa_p256.pub.der",
@@ -111,7 +109,7 @@ key_sphincs_plus(
     name = "app_dev_spx",
     # TODO(cfrantz): Change this to Prehash after putting
     # the prehash infrastructure in place.
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "local",
     private_key = "app_dev_spx.pem",
     pub_key = "app_dev_spx.pub.pem",
@@ -120,7 +118,6 @@ key_sphincs_plus(
 
 key_ecdsa(
     name = "app_test_ecdsa",
-    config = "EcdsaP256",
     method = "local",
     private_key = "app_test_ecdsa_p256.der",
     pub_key = "app_test_ecdsa_p256.pub.der",
@@ -129,7 +126,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "app_unauthorized_ecdsa",
-    config = "EcdsaP256",
     method = "local",
     private_key = "app_unauthorized_ecdsa_p256.der",
     pub_key = "app_unauthorized_ecdsa_p256.pub.der",

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -161,9 +161,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
               .tag = kTlvTagApplicationKey,
               .length = kTlvLenApplicationKeyHybrid,
           },
-      // TODO(cfrantz): Change this to Prehash after putting
-      // the prehash infrastructure in place.
-      .key_alg = kOwnershipKeyAlgHybridSpxPure,
+      .key_alg = kOwnershipKeyAlgHybridSpxPrehash,
       .key_domain = kOwnerAppDomainDev,
       .key_diversifier = {0},
       .usage_constraint = 0,

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/BUILD
@@ -8,7 +8,6 @@ package(default_visibility = ["//visibility:public"])
 
 key_ecdsa(
     name = "test_key_0_ecdsa_p256",
-    config = "EcdsaP256",
     method = "local",
     private_key = "test_key_0_ecdsa_p256.der",
     pub_key = "test_key_0_ecdsa_p256.pub.der",
@@ -17,7 +16,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "dev_key_0_ecdsa_p256",
-    config = "EcdsaP256",
     method = "local",
     private_key = "dev_key_0_ecdsa_p256.der",
     pub_key = "dev_key_0_ecdsa_p256.pub.der",
@@ -26,7 +24,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "prod_key_0_ecdsa_p256",
-    config = "EcdsaP256",
     method = "local",
     private_key = "prod_key_0_ecdsa_p256.der",
     pub_key = "prod_key_0_ecdsa_p256.pub.der",
@@ -35,7 +32,6 @@ key_ecdsa(
 
 key_ecdsa(
     name = "prod_key_1_ecdsa_p256",
-    config = "EcdsaP256",
     method = "local",
     private_key = "prod_key_1_ecdsa_p256.der",
     pub_key = "prod_key_1_ecdsa_p256.pub.der",

--- a/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
@@ -13,7 +13,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "test_key_0_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "local",
     private_key = "test_key_0_spx.pem",
     pub_key = "test_key_0_spx.pub.pem",
@@ -27,7 +27,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "dev_key_0_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "local",
     private_key = "dev_key_0_spx.pem",
     pub_key = "dev_key_0_spx.pub.pem",
@@ -41,7 +41,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "prod_key_0_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "local",
     private_key = "prod_key_0_spx.pem",
     pub_key = "prod_key_0_spx.pub.pem",
@@ -55,7 +55,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "prod_key_1_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "local",
     private_key = "prod_key_0_spx.pem",
     pub_key = "prod_key_0_spx.pub.pem",

--- a/sw/device/silicon_creator/rom/keys/real/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/spx/BUILD
@@ -13,7 +13,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "test_key_0_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "hsmtool",
     pub_key = "test_key_0_spx.pub.pem",
     type = "TestKey",
@@ -26,7 +26,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "dev_key_0_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "hsmtool",
     pub_key = "dev_key_0_spx.pub.pem",
     type = "TestKey",
@@ -39,7 +39,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "prod_key_0_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "hsmtool",
     pub_key = "prod_key_0_spx.pub.pem",
     type = "TestKey",
@@ -52,7 +52,7 @@ filegroup(
 
 key_sphincs_plus(
     name = "prod_key_1_spx_key",
-    config = "Sha2128s",
+    config = {"domain": "Pure"},
     method = "hsmtool",
     pub_key = "prod_key_1_spx.pub.pem",
     type = "TestKey",

--- a/sw/device/silicon_creator/rom/keys/unauthorized/ecdsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/unauthorized/ecdsa/BUILD
@@ -8,7 +8,6 @@ package(default_visibility = ["//visibility:public"])
 
 key_ecdsa(
     name = "unauthorized_key_0_ecdsa_p256",
-    config = "EcdsaP256",
     method = "local",
     private_key = "unauthorized_key_0_ecdsa_p256.der",
     pub_key = "unauthorized_key_0_ecdsa_p256.pub.der",

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -147,7 +147,7 @@ _KEYS = {
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
-    "dev_hybrid": {
+    "dev_hybrid_spx_prehashed": {
         "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_dev_ecdsa": "dev_key_0"},
         "spx": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_dev_spx": "dev_key_0"},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -159,7 +159,7 @@ _KEYS = {
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
-    "prod_hybrid": {
+    "prod_hybrid_spx_pure": {
         "ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
         "spx": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_spx": "prod_key_0"},
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -371,7 +371,7 @@ static rom_error_t rom_ext_spx_verify(
     const sigverify_spx_signature_t *signature, const sigverify_spx_key_t *key,
     uint32_t key_alg, const void *msg_prefix_1, size_t msg_prefix_1_len,
     const void *msg_prefix_2, size_t msg_prefix_2_len, const void *msg,
-    size_t msg_len, const hmac_digest_t *digest) {
+    size_t msg_len, hmac_digest_t digest) {
   /*
    * Shares for producing kErrorOk if SPHINCS+ verification succeeds.  The first
    * three shares are generated using the `sparse-fsm-encode` script while the
@@ -415,12 +415,13 @@ static rom_error_t rom_ext_spx_verify(
       break;
 
     case kOwnershipKeyAlgSpxPrehash:
+      util_reverse_bytes(digest.digest, sizeof(digest.digest));
       HARDENED_RETURN_IF_ERROR(
           spx_verify(signature->data, kSpxVerifyPrehashDomainSep,
                      kSpxVerifyPrehashDomainSepSize,
                      /*msg_prefix_2=*/NULL, /*msg_prefix_2_len=*/0,
                      /*msg_prefix_3=*/NULL, /*msg_prefix_3_len=*/0,
-                     (unsigned char *)digest->digest, sizeof(digest->digest),
+                     (unsigned char *)digest.digest, sizeof(digest.digest),
                      key->data, actual_root.data));
       break;
     default:
@@ -515,7 +516,7 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
         &ext_spx_signature->signature,
         &keyring.key[verify_key]->data.hybrid.spx, key_alg,
         &usage_constraints_from_hw, sizeof(usage_constraints_from_hw), NULL, 0,
-        digest_region.start, digest_region.length, &act_digest);
+        digest_region.start, digest_region.length, act_digest);
   } else {
     // TODO: consider whether an SPX+-only verify is sufficent.
     return kErrorOwnershipInvalidAlgorithm;

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -147,6 +147,9 @@ pub struct ManifestUpdateCommand {
     /// The signature domain (None, Pure, PreHashedSha256)
     #[arg(long, default_value_t = SpxDomain::default())]
     domain: SpxDomain,
+    /// Set to true if the firmware uses a byte-reversed representation of the hash.
+    #[arg(long, action = clap::ArgAction::Set, default_value = "false")]
+    spx_hash_reversed: bool,
     /// Filename to write the output to instead of updating the input file.
     #[arg(short, long)]
     output: Option<PathBuf>,
@@ -290,7 +293,12 @@ impl CommandDispatch for ManifestUpdateCommand {
                     image.map_signed_region(|buf| key.sign(self.domain, buf))??
                 }
                 SpxDomain::PreHashedSha256 => {
-                    let digest = image.compute_digest()?.to_le_bytes();
+                    let digest = image.compute_digest()?;
+                    let digest = if self.spx_hash_reversed {
+                        digest.to_le_bytes()
+                    } else {
+                        digest.to_be_bytes()
+                    };
                     key.sign(self.domain, &digest)?
                 }
             };

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -111,6 +111,8 @@ pub struct SpxSignResult {
 
 #[derive(Debug, Args)]
 pub struct SpxSignCommand {
+    #[arg(short='r', long, action = clap::ArgAction::Set, default_value = "false")]
+    input_bytes_reversed: bool,
     /// The signature domain (Raw, Pure, PreHashedSha256)
     #[arg(long, default_value_t = SpxDomain::default())]
     domain: SpxDomain,
@@ -130,7 +132,10 @@ impl CommandDispatch for SpxSignCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
-        let message = std::fs::read(&self.message)?;
+        let mut message = std::fs::read(&self.message)?;
+        if self.input_bytes_reversed {
+            message.reverse();
+        }
         let private_key = SpxSecretKey::read_pem_file(&self.private_key)?;
         let signature = private_key.sign(self.domain, &message)?;
         if let Some(output) = &self.output {
@@ -143,6 +148,8 @@ impl CommandDispatch for SpxSignCommand {
 
 #[derive(Debug, Args)]
 pub struct SpxVerifyCommand {
+    #[arg(short='r', long, action = clap::ArgAction::Set, default_value = "false")]
+    input_bytes_reversed: bool,
     /// The signature domain (Raw, Pure, PreHashedSha256)
     #[arg(long, default_value_t = SpxDomain::default())]
     domain: SpxDomain,
@@ -161,7 +168,10 @@ impl CommandDispatch for SpxVerifyCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
-        let message = std::fs::read(&self.message)?;
+        let mut message = std::fs::read(&self.message)?;
+        if self.input_bytes_reversed {
+            message.reverse();
+        }
         let public_key = SpxPublicKey::read_pem_file(&self.public_key)?;
         let signature = std::fs::read(&self.signature)?;
         public_key.verify(self.domain, &signature, &message)?;


### PR DESCRIPTION
1. Redefine the `config` field of `key_{ecdsa,sphicns_plus}` rules to be
   a dictionary of parameters.
2. Allow setting parameters in the key nickname field of `keyset` rules
   (e.g. `{"//key:label": "foo:domain=Pure"}`).
3. When generating pre-signing artifacts, use only the public key to
   prevent opentitantool from immediately signing the artifact.
4. In the `_local_sign` and `_hsmtool_sign` helper functions, construct
   appropriate command line arguments considering the signing mode and
   byte-reversal settings.
5. Fix the `image manifest update` command to use the normal SHA256 byte
   ordering.  Add a command line argument to reverse the hash to deal
   with existing implementations with a reversed hash.
6. Allow the `spx sign|verify` commands to optionally reverse their
   input.
7. Support verification of owner code using the SPHINCS+
   `PreHashedSha256` mode.  Since the OpenTitan HMAC peripheral
   produces hashes in "little-endian" order, reverse the bytes
   before verification so that the correct byte ordering is used.
8. Add a test for PreHashedSha256 mode using the fake app DEV key.