### PR TITLE
[ci] Bump verilator test runner to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
 
   verilator_earlgrey:
     name: Verilated Earl Grey
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: quick_lint
     timeout-minutes: 240
     steps:


### PR DESCRIPTION
This was using an older `ubuntu-20.04` runner. Update to using `ubuntu-22.04` as `ubuntu-20.04` will begin deprecation on 2025-02-01 and be fully deprecated by 2025-04-01.