### PR TITLE
[hw,tlul_adapter_reg,rtl] Do not gate a_ready with a_valid

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -4331,7 +4331,7 @@ module adc_ctrl_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -1235,7 +1235,7 @@ module aon_timer_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -3345,7 +3345,7 @@ module pwm_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -7102,7 +7102,7 @@ module sysrst_ctrl_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -151,9 +151,7 @@ module tlul_adapter_reg
 
   tlul_pkg::tl_d2h_t tl_o_pre;
   assign tl_o_pre = '{
-    // busy is selected based on address
-    // thus if there is no valid transaction, we should ignore busy
-    a_ready:  ~(outstanding_q | tl_i.a_valid & busy_i),
+    a_ready:  ~(outstanding_q | busy_i),
     d_valid:  outstanding_q,
     d_opcode: rspop_q,
     d_param:  '0,

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -9878,7 +9878,7 @@ module usbdev_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -2043,7 +2043,7 @@ module clkmgr_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -42084,7 +42084,7 @@ module pinmux_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -2760,7 +2760,7 @@ module clkmgr_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -40159,7 +40159,7 @@ module pinmux_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -2232,7 +2232,7 @@ module clkmgr_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -37636,7 +37636,7 @@ module pinmux_reg_top (
 
   // register busy
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -884,7 +884,7 @@ ${rdata_gen(f, r.name.lower() + "_" + f.name.lower())}\
   assign reg_busy = shadow_busy;
   % else:
   logic reg_busy_sel;
-  assign reg_busy = reg_busy_sel | shadow_busy;
+  assign reg_busy = (reg_busy_sel | shadow_busy) & tl_i.a_valid;
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)


### PR DESCRIPTION
This creates a combinational path between the input and output TLUL port. This can be pretty long and impacts the synthesis in high-frequency designs.

Originally, the busy_i signal was gated with a_vali for cases where reg_tops have different clock domains. There, the busy input is a function from the request... At the moment, this causes assertions to fail, e.g., the `AReadyKnown` assertion in the PWM. This is an IP that uses 2 clock domains.