### PR TITLE
[kmac, sival] Keymgr-state-agnostic `kmac_sideload_functest`

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -516,13 +516,8 @@ opentitan_test(
 opentitan_test(
     name = "kdf_kmac_sideload_functest_hardcoded",
     srcs = ["kdf_kmac_sideload_functest.c"],
-    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
     ),
     verilator = verilator_params(
         timeout = "long",
@@ -544,13 +539,8 @@ opentitan_test(
 opentitan_test(
     name = "kmac_sideload_functest_hardcoded",
     srcs = ["kmac_sideload_functest.c"],
-    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
     ),
     verilator = verilator_params(
         timeout = "long",

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -78,7 +78,7 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
                 .keyblob_length = 32,
                 .keyblob =
                     (uint32_t[]){
-                        0x00000002,
+                        0x00000000,
                         0xa0d0e9b4,
                         0x7e790e8b,
                         0x2ed764b2,
@@ -136,7 +136,7 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
                 .keyblob_length = 32,
                 .keyblob =
                     (uint32_t[]){
-                        0x0000000f,
+                        0x00000000,
                         0x1600a35a,
                         0x6f03675a,
                         0x6b0d549b,
@@ -218,7 +218,7 @@ static kdf_kmac_test_vector_t kKdfTestVectors[] = {
                 .keyblob_length = 32,
                 .keyblob =
                     (uint32_t[]){
-                        0x00000001,
+                        0x00000000,
                         0xe5f6db1d,
                         0x9acd8acd,
                         0x14b044d7,
@@ -426,12 +426,12 @@ bool test_main(void) {
   // Initialize keymgr and advance to CreatorRootKey state.
   dif_keymgr_t keymgr;
   dif_kmac_t kmac;
-  CHECK_STATUS_OK(keymgr_testutils_startup(&keymgr, &kmac));
+  CHECK_STATUS_OK(keymgr_testutils_initialize(&keymgr, &kmac));
 
-  CHECK_STATUS_OK(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  CHECK_STATUS_OK(keymgr_testutils_check_state(
-      &keymgr, kDifKeymgrStateOwnerIntermediateKey));
-  LOG_INFO("Keymgr entered OwnerIntKey State");
+  const char *state_name;
+  CHECK_STATUS_OK(keymgr_testutils_state_string_get(&keymgr, &state_name));
+
+  LOG_INFO("Keymgr entered %s State", state_name);
   LOG_INFO("Testing cryptolib KDF-KMAC driver with sideloaded key.");
 
   // Initialize the core with default parameters

--- a/sw/device/tests/crypto/kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kmac_sideload_functest.c
@@ -57,7 +57,7 @@ static kmac_test_vector_t kKmacTestVectors[] = {
                 .keyblob_length = 32,
                 .keyblob =
                     (uint32_t[]){
-                        0x00000001,
+                        0x00000000,
                         0x47464544,
                         0x4b4a4948,
                         0x4f4e4d4c,
@@ -112,7 +112,7 @@ static kmac_test_vector_t kKmacTestVectors[] = {
                 .keyblob_length = 32,
                 .keyblob =
                     (uint32_t[]){
-                        0x00000002,
+                        0x00000000,
                         0x11111111,
                         0x4b4a4948,
                         0x4f4e4d4c,
@@ -191,7 +191,7 @@ static kmac_test_vector_t kKmacTestVectors[] = {
                 .keyblob_length = 32,
                 .keyblob =
                     (uint32_t[]){
-                        0x00000001,
+                        0x00000000,
                         0x00000000,
                         0x00000000,
                         0x00000000,
@@ -371,12 +371,12 @@ bool test_main(void) {
   // Initialize keymgr and advance to CreatorRootKey state.
   dif_keymgr_t keymgr;
   dif_kmac_t kmac;
-  CHECK_STATUS_OK(keymgr_testutils_startup(&keymgr, &kmac));
+  CHECK_STATUS_OK(keymgr_testutils_initialize(&keymgr, &kmac));
 
-  CHECK_STATUS_OK(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  CHECK_STATUS_OK(keymgr_testutils_check_state(
-      &keymgr, kDifKeymgrStateOwnerIntermediateKey));
-  LOG_INFO("Keymgr entered OwnerIntKey State");
+  const char *state_name;
+  CHECK_STATUS_OK(keymgr_testutils_state_string_get(&keymgr, &state_name));
+
+  LOG_INFO("Keymgr entered %s State", state_name);
   LOG_INFO("Testing cryptolib KMAC driver with sideloaded key.");
 
   // Initialize the core with default parameters


### PR DESCRIPTION
This commit fixes the two `kmac_sideload_functest` tests that were failing due to a misconfigured key version parameter. Some ROMs set the max key version in the keymgr to 0, which causes sideloading to abort if any other version value is being programmed. Note that the proper functioning of valid/invalid keymgr version numbers is part of the `chip_sw_keymgr_derive_{sealing, attestation}` tests.

This bug has been mentioned as part of #21706.