### PR TITLE
[hmac,dv] Reset S&R skip context

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -144,6 +144,7 @@ endtask : dut_init
 task hmac_base_vseq::apply_reset(string kind = "HARD");
   super.apply_reset(kind);
   cfg.hash_process_triggered = 0;
+  cfg.sar_skip_ctxt          = 0;
 endtask : apply_reset
 
 task hmac_base_vseq::hmac_init( bit sha_en             = 1'b1,


### PR DESCRIPTION
- reinitialize the Save and Restore skip context flag each time the HMAC is in reset.