### PR TITLE
[hmac,dv] Disable S&R for stress reset and increase delay before reset

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
@@ -20,6 +20,6 @@ endfunction : new
 
 task hmac_stress_reset_vseq::body();
   for (int i = 1; i <= num_trans; i++) begin
-    run_seq_with_rand_reset_vseq(create_seq_by_name("hmac_long_msg_vseq"), 1, 100);
+    run_seq_with_rand_reset_vseq(create_seq_by_name("hmac_long_msg_vseq"), 1, 1_000);
   end
 endtask : body

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
@@ -9,6 +9,7 @@ class hmac_stress_reset_vseq extends hmac_base_vseq;
 
   // Standard SV/UVM methods
   extern function new(string name="");
+  extern task pre_body();
   extern task body();
 endclass : hmac_stress_reset_vseq
 
@@ -17,6 +18,12 @@ function hmac_stress_reset_vseq::new(string name="");
   super.new(name);
 endfunction : new
 
+task hmac_stress_reset_vseq::pre_body();
+  // TODO (#25809) - The S&R is causing troubles with this test, this flag will be removed later
+  // when reset is handled properly.
+  cfg.save_and_restore_pct = 0;
+  super.pre_body();
+endtask : pre_body
 
 task hmac_stress_reset_vseq::body();
   for (int i = 1; i <= num_trans; i++) begin


### PR DESCRIPTION
- The stress_reset test is currently failing when a reset is happening when the Save and Restore is in a particular state. This should be removed later when the reset will be handled properly in the env.
- Increase the time before reset to let the test doing something relevant and let some checks to happen.