### PR TITLE
[hmac,dv] Reset intr_test signal

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -553,6 +553,7 @@ function void hmac_scoreboard::reset(string kind = "HARD");
   hmac_fifo_depth = ral.status.fifo_depth.get_reset();
   hmac_start      = ral.cmd.hash_start.get_reset();
   sha_en          = ral.cfg.sha_en.get_reset();
+  intr_test       = ral.intr_test.get_reset();
   hmac_stopped    = 0;
   msg_q.delete();
   msg_part_q.delete();


### PR DESCRIPTION
- Reset expected intr_test signal to 0 when a reset is triggered, as this was obviously causing the SCB comparison to fail.