### PR TITLE
[hw,ac_range_check,rtl] Add RACL checks to the AC Range Checks

### DIFF
--- a/hw/ip_templates/ac_range_check/ac_range_check.core.tpl
+++ b/hw/ip_templates/ac_range_check/ac_range_check.core.tpl
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:mubi
       - lowrisc:prim:all
+      - lowrisc:systems:top_racl_pkg
     files:
       - rtl/${module_instance_name}_reg_pkg.sv
       - rtl/${module_instance_name}_reg_top.sv

--- a/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
+<%
+import math
+%>\
 # AC Range Check register template
 {
   name:               "ac_range_check"
@@ -122,12 +125,22 @@
       swaccess: "ro"
       hwaccess: "hwo"
       fields: [
-        { bits: "22:18"
+<%
+  denied_ctn_uid_lsb = 14 + nr_role_bits
+  deny_range_index_lsb = denied_ctn_uid_lsb + nr_ctn_uid_bits
+  deny_range_index_size = math.ceil(math.log(num_ranges, 2))
+%>\
+        { bits: "${deny_range_index_lsb+deny_range_index_size-1}:${deny_range_index_lsb}"
           name: "deny_range_index"
           resval: 0x0
           desc: "Index of the range that caused the denied access."
         }
-        { bits: "17:14"
+        { bits: "${deny_range_index_lsb-1}:${denied_ctn_uid_lsb}"
+          name: "denied_ctn_uid"
+          resval: 0x0
+          desc: "Source CTN UID that was denied access."
+        }
+        { bits: "${denied_ctn_uid_lsb-1}:14"
           name: "denied_source_role"
           resval: 0x0
           desc: "Source RACL role that was denied access."

--- a/hw/ip_templates/ac_range_check/data/ac_range_check.tpldesc.hjson
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.tpldesc.hjson
@@ -21,5 +21,17 @@
       type:    "int",
       default: "32",
     }
+    {
+      name:    "nr_role_bits",
+      desc:    "Number of RACL bits",
+      type:    "int",
+      default: "4",
+    }
+    {
+      name:    "nr_ctn_uid_bits",
+      desc:    "Number of CTN UID bits",
+      type:    "int",
+      default: "5",
+    }
   ]
 }

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -572,6 +572,8 @@ def generate_ac_range_check(topcfg: Dict[str, object], out_path: Path) -> None:
     # Get the AC Range Check instance
     ac_ranges = lib.find_module(topcfg['module'], 'ac_range_check')
     params = {
+        "nr_role_bits": 4,
+        "nr_ctn_uid_bits": 5,
         "num_ranges": topcfg['ac_range_check']['num_ranges'],
         "module_instance_name": ac_ranges['type']
     }


### PR DESCRIPTION
This PR adds RACL checks to the AC ranges. Now that RACL is (partly) merged, we can enable the RACL checks first.

RACL error logging is not yet fully implemented as it depends on determining the failing range.