### PR TITLE
[bazel] Add QEMU execution environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,3 +733,19 @@ jobs:
       - name: Check for unrunnable tests
         run: ./ci/scripts/check-unrunnable-tests.sh
         continue-on-error: true
+
+  qemu_smoketest:
+    name: QEMU smoketest
+    runs-on: ubuntu-22.04-vivado
+    needs: quick_lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Execute QEMU smoketest
+        run: |
+          ./bazelisk.sh test //sw/device/tests:rom_exit_immediately_sim_qemu_base

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,6 +117,9 @@ use_repo(hyperdebug, "hyperdebug_firmware")
 lowrisc_rv32imcb_toolchain = use_extension("//third_party/lowrisc:extensions.bzl", "lowrisc_rv32imcb_toolchain")
 use_repo(lowrisc_rv32imcb_toolchain, "lowrisc_rv32imcb_toolchain")
 
+qemu = use_extension("//third_party/qemu:extensions.bzl", "qemu")
+use_repo(qemu, "qemu_opentitan")
+
 # Extension for linking in externally managed test and provisioning customizations
 # for both secure/non-secure manufacturer domains.
 hooks = use_extension("//rules:extensions.bzl", "hooks")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -720,6 +720,33 @@
         ]
       }
     },
+    "//third_party/qemu:extensions.bzl%qemu": {
+      "general": {
+        "bzlTransitiveDigest": "g1Q243UebtBr1HR+PUEPsoreMJlgLXsOR8F7g68e8dY=",
+        "usagesDigest": "Mt6r/irk2teAwjc3nVQbERYpoJwlTU+jRQ+xeX2YXTM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "qemu_opentitan": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "url": "https://github.com/lowRISC/qemu/releases/download/v9.1.0-2025-01-28/qemu-ot-earlgrey-v9.1.0-2025-01-28-x86_64-unknown-linux-gnu.tar.gz",
+              "build_file": "@@//third_party/qemu:BUILD.qemu_opentitan.bazel",
+              "sha256": "530bb7568f17ba3f9ba1245388c2625259d180188c8c5c9e15634b942ebeb108"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/riscv-compliance:extensions.bzl%riscv_compliance": {
       "general": {
         "bzlTransitiveDigest": "/XAyLWWZ++g8VnTDZr1+hVWcSk+BBt6WPMZ0yJ9hK8M=",

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -15,8 +15,10 @@ load(
     "fpga_cw340",
     "silicon",
     "sim_dv",
+    "sim_qemu",
     "sim_verilator",
 )
+load("//rules/opentitan:qemu.bzl", "qemu_cfg", "qemu_flash", "qemu_otp")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -93,6 +95,29 @@ fpga_cw310(
     base = ":fpga_cw310_test_rom",
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "test_key_0"},
     exec_env = "fpga_cw310_rom_with_fake_keys",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
+    rom = "//sw/device/silicon_creator/rom:mask_rom",
+)
+
+sim_qemu(
+    name = "sim_qemu_base",
+    design = "earlgrey",
+    exec_env = "sim_qemu_base",
+    libs = [
+        "//sw/device/lib/arch:boot_stage_rom_ext",
+        "//sw/device/lib/arch:sim_qemu",
+    ],
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    otp = "//hw/top_earlgrey/data/otp:img_rma",
+    rom_scramble_config = "//hw/top_earlgrey/data/autogen:top_earlgrey.gen.hjson",
+)
+
+sim_qemu(
+    name = "sim_qemu_rom_with_fake_keys",
+    testonly = True,
+    base = ":sim_qemu_base",
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "test_key_0"},
+    exec_env = "sim_qemu_rom_with_fake_keys",
     manifest = "//sw/device/silicon_creator/rom_ext:manifest",
     rom = "//sw/device/silicon_creator/rom:mask_rom",
 )

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -416,9 +416,13 @@ def _opentitan_test(ctx):
         p = None
 
     executable, runfiles = exec_env.test_dispatch(ctx, exec_env, p)
+    if ctx.attr.test_harness != None:
+        harness_runfiles = ctx.attr.test_harness[DefaultInfo].default_runfiles
+    else:
+        harness_runfiles = ctx.runfiles()
     return DefaultInfo(
         executable = executable,
-        runfiles = ctx.runfiles(files = runfiles),
+        runfiles = ctx.runfiles(files = runfiles).merge_all([harness_runfiles]),
     )
 
 opentitan_test = rv_rule(
@@ -431,6 +435,7 @@ opentitan_test = rv_rule(
         "test_harness": attr.label(
             executable = True,
             cfg = "exec",
+            allow_files = True,
         ),
         "binaries": attr.label_keyed_string_dict(
             allow_files = True,

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -109,6 +109,7 @@ EARLGREY_TEST_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     "//hw/top_earlgrey:sim_dv": None,
     "//hw/top_earlgrey:sim_verilator": None,
+    "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,
 }
 
 # The default set of test environments for Earlgrey.

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -55,6 +55,11 @@ load(
     _sim_verilator = "sim_verilator",
     _verilator_params = "verilator_params",
 )
+load(
+    "@lowrisc_opentitan//rules/opentitan:qemu.bzl",
+    _qemu_params = "qemu_params",
+    _sim_qemu = "sim_qemu",
+)
 
 # The following definition is used to clear the key set in the signing
 # configuration for execution environments (exec_env) and opentitan_test
@@ -83,6 +88,9 @@ verilator_params = _verilator_params
 
 sim_dv = _sim_dv
 dv_params = _dv_params
+
+sim_qemu = _sim_qemu
+qemu_params = _qemu_params
 
 ecdsa_key_for_lc_state = _ecdsa_key_for_lc_state
 ecdsa_key_by_name = _ecdsa_key_by_name
@@ -144,6 +152,8 @@ def _parameter_name(env, pname):
             pname = "dv"
         elif "silicon" in suffix:
             pname = "silicon"
+        elif "qemu" in suffix:
+            pname = "qemu"
         else:
             fail("Unable to identify parameter block name:", env)
     return pname
@@ -160,17 +170,17 @@ def _hacky_tags(env):
         # label name.
         subtag = suffix[5:]
         tags.append(subtag)
-        if subtag.startswith("cw305"):
-            tags.append("cw305")
-        elif subtag.startswith("cw310"):
-            tags.append("cw310")
-        elif subtag.startswith("hyper310"):
-            tags.append("hyper310")
-        elif subtag.startswith("cw340"):
-            tags.append("cw340")
-    if suffix.startswith("silicon"):
-        # We add the entire suffix for silicon exec environments to be able
-        # to filter tests by them. "silicon_creator" and
+
+        # Also add the kind of FPGA by itself (e.g. "hyper310" or "cw340").
+        fpga_kind = subtag.split("_")[0]
+        tags.append(fpga_kind)
+    if suffix.startswith("sim"):
+        # Add the kind of simulator by itself (e.g. "verilator" or "qemu").
+        sim_kind = suffix.split("_")[1]
+        tags.append(sim_kind)
+    if suffix.startswith("silicon") or suffix.startswith("sim"):
+        # We add the entire suffix for silicon and sim exec environments
+        # to be able to filter tests by them. "silicon_creator" and
         # "silicon_owner_sival_rom_ext" have different target configurations.
         tags.append(suffix)
     return tags
@@ -195,6 +205,7 @@ def opentitan_test(
         dv = _dv_params(),
         silicon = _silicon_params(),
         verilator = _verilator_params(),
+        qemu = _qemu_params(),
         data = [],
         run_in_ci = None,
         **kwargs):
@@ -224,6 +235,7 @@ def opentitan_test(
       dv: Execution overrides for a DV-based test.
       silicon: Execution overrides for a silicon-based test.
       verilator: Execution overrides for a verilator-based test.
+      qemu: Execution overrides for a QEUM-based test.
       run_in_ci: Override the automatic selection of execution environments to run in CI and run exactly those environments.
       kwargs: Additional execution overrides identified by the `exec_env` dict.
     """
@@ -233,6 +245,7 @@ def opentitan_test(
         "dv": dv,
         "silicon": silicon,
         "verilator": verilator,
+        "qemu": qemu,
     }
     test_parameters.update(kwargs)
     kwargs_unused = kwargs.keys()

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -28,12 +28,17 @@ SimVerilatorBinaryInfo = provider(
     doc = "Verilator Binary Info",
 )
 
+SimQemuBinaryInfo = provider(
+    doc = "QEMU Binary Info",
+)
+
 ALL_BINARY_PROVIDERS = [
     Cw310BinaryInfo,
     Cw340BinaryInfo,
     SiliconBinaryInfo,
     SimDvBinaryInfo,
     SimVerilatorBinaryInfo,
+    SimQemuBinaryInfo,
 ]
 
 PROVIDER_FIELDS = [

--- a/rules/opentitan/qemu.bzl
+++ b/rules/opentitan/qemu.bzl
@@ -1,0 +1,403 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "@lowrisc_opentitan//rules/opentitan:providers.bzl",
+    "SimQemuBinaryInfo",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:util.bzl",
+    "get_fallback",
+    "get_override",
+)
+load(
+    "//rules/opentitan:exec_env.bzl",
+    "ExecEnvInfo",
+    "common_test_setup",
+    "exec_env_as_dict",
+    "exec_env_common_attrs",
+)
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+
+_TEST_SCRIPT = """#!/bin/bash
+set -e
+
+# QEMU requires mutable flash and OTP files but Bazel only provides RO
+# files so we have to create copies unique to this test run.
+cp {otp} {mutable_otp} && chmod +w {mutable_otp}
+if [ ! -z {flash} ]; then
+    cp {flash} {mutable_flash} && chmod +w {mutable_flash}
+fi
+
+echo Invoking test: {test_harness} {args} "$@"
+{test_harness} {args} "$@"
+"""
+
+def qemu_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        test_harness = "//rules/scripts:qemu_pass",
+        binaries = {},
+        rom = None,
+        rom_ext = None,
+        otp = None,
+        bitstream = None,
+        test_cmd = "",
+        data = [],
+        defines = [],
+        icount = 6,
+        globals = {},
+        **kwargs):
+    extra_params = {
+        "icount": str(icount),
+        # We have to stringify this dictionary here because `_opentitan_test` only accepts
+        # a dict with string values, not more dicts.
+        "globals": json.encode(globals),
+    }
+
+    return struct(
+        tags = tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = rom,
+        rom_ext = rom_ext,
+        otp = otp,
+        bitstream = bitstream,
+        test_cmd = test_cmd,
+        data = data,
+        param = kwargs | extra_params,
+        defines = defines,
+    )
+
+def gen_cfg(ctx, **kwargs):
+    """Generate a QEMU `readconfig` INI file containing OpenTitan RTL secrets"""
+    name = get_override(ctx, "label.name", kwargs)
+    cfggen = get_override(ctx, "executable.cfggen", kwargs)
+
+    otp_sv = get_override(ctx, "file.otp_sv", kwargs)
+    lc_sv = get_override(ctx, "file.lc_sv", kwargs)
+    top_hjson = get_override(ctx, "file.top_hjson", kwargs)
+
+    top_name = get_override(ctx, "attr.top_name", kwargs)
+
+    out = ctx.actions.declare_file(name + ".ini")
+
+    ctx.actions.run(
+        inputs = [otp_sv, lc_sv, top_hjson],
+        outputs = [out],
+        executable = cfggen[DefaultInfo].files_to_run,
+        arguments = [
+            "--out",
+            out.path,
+            "--top",
+            top_name,
+            "--topcfg",
+            top_hjson.path,
+            "--otpconst",
+            otp_sv.path,
+            "--lifecycle",
+            lc_sv.path,
+            ".",
+        ],
+        mnemonic = "CfgGen",
+    )
+    return out
+
+qemu_cfg = rule(
+    implementation = lambda ctx: [DefaultInfo(files = depset([gen_cfg(ctx)]))],
+    attrs = {
+        "top_name": attr.string(),
+        "top_hjson": attr.label(allow_single_file = True),
+        "otp_sv": attr.label(allow_single_file = True),
+        "lc_sv": attr.label(allow_single_file = True),
+        "cfggen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:cfggen"),
+        ),
+    },
+)
+
+def gen_otp(ctx, **kwargs):
+    """Generate a QEMU-compatible OTP image"""
+    name = get_override(ctx, "label.name", kwargs)
+    out = ctx.actions.declare_file(name + ".raw")
+
+    vmem = get_override(ctx, "file.vmem", kwargs)
+    otptool = get_override(ctx, "executable.otptool", kwargs)
+
+    ctx.actions.run(
+        inputs = [vmem],
+        outputs = [out],
+        executable = otptool[DefaultInfo].files_to_run,
+        arguments = [
+            "-m",
+            vmem.path,
+            "-r",
+            out.path,
+            "-k",
+            "otp",
+        ],
+        mnemonic = "OtpGen",
+    )
+    return out
+
+qemu_otp = rule(
+    implementation = lambda ctx: [DefaultInfo(files = depset([gen_otp(ctx)]))],
+    attrs = {
+        "vmem": attr.label(allow_single_file = True),
+        "otptool": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:otptool"),
+        ),
+    },
+)
+
+# NOTE: currently only single-bank flash programs are supported.
+def gen_flash(ctx, **kwargs):
+    """\
+    Generate a QEMU-compatible flash image.
+
+    NOTE: currently only single-bank flash images are supported.
+    """
+    name = get_override(ctx, "label.name", kwargs)
+    out = ctx.actions.declare_file(name + ".qemu_bin")
+
+    firmware_bin = get_override(ctx, "file.firmware_bin", kwargs)
+    firmware_elf = get_override(ctx, "file.firmware_elf", kwargs)
+
+    flashgen = get_override(ctx, "executable.flashgen", kwargs)
+
+    ctx.actions.run(
+        inputs = [firmware_bin, firmware_elf],
+        outputs = [out],
+        executable = flashgen[DefaultInfo].files_to_run,
+        arguments = [
+            "-x",
+            firmware_bin.path,
+            "-X",
+            firmware_elf.path,
+            out.path,
+        ],
+        mnemonic = "FlashGen",
+    )
+    return out
+
+qemu_flash = rule(
+    implementation = lambda ctx: [DefaultInfo(files = depset([gen_flash(ctx)]))],
+    attrs = {
+        "firmware_bin": attr.label(
+            allow_single_file = True,
+            doc = "Binary firmware to be run after the ROM, usually signed",
+        ),
+        "firmware_elf": attr.label(
+            allow_single_file = True,
+            doc = "ELF version of the `firmware_bin` attribute for symbol tracking",
+        ),
+        "flashgen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:flashgen"),
+        ),
+    },
+)
+
+def _sim_qemu(ctx):
+    fields = exec_env_as_dict(ctx)
+    return ExecEnvInfo(
+        provider = SimQemuBinaryInfo,
+        test_dispatch = _test_dispatch,
+        transform = _transform,
+        cfggen = ctx.attr.cfggen,
+        otptool = ctx.attr.otptool,
+        flashgen = ctx.attr.flashgen,
+        otp_sv = ctx.file.otp_sv,
+        lc_sv = ctx.file.lc_sv,
+        top_hjson = ctx.file.top_hjson,
+        **fields
+    )
+
+sim_qemu = rule(
+    implementation = _sim_qemu,
+    attrs = exec_env_common_attrs() | {
+        "cfggen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:cfggen"),
+        ),
+        "otptool": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:otptool"),
+        ),
+        "flashgen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:flashgen"),
+        ),
+        "otp_sv": attr.label(
+            allow_single_file = True,
+            # TODO: should we really use Earl Grey as the default?
+            default = Label("//hw/top_earlgrey/ip_autogen/otp_ctrl:rtl/otp_ctrl_part_pkg.sv"),
+        ),
+        "lc_sv": attr.label(
+            allow_single_file = True,
+            default = Label("//hw/ip/lc_ctrl:rtl/lc_ctrl_state_pkg.sv"),
+        ),
+        "top_hjson": attr.label(
+            allow_single_file = True,
+            default = Label("//hw/top_earlgrey/data/autogen:top_earlgrey.gen.hjson"),
+        ),
+    },
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
+)
+
+def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):
+    if ctx.attr.kind == "rom":
+        default = elf
+        rom = elf
+    elif ctx.attr.kind == "ram":
+        default = elf
+        rom = None
+    elif ctx.attr.kind == "flash":
+        default = gen_flash(
+            ctx,
+            flashgen = exec_env.flashgen,
+            firmware_bin = signed_bin or binary,
+            firmware_elf = elf,
+        )
+        rom = exec_env.rom[SimQemuBinaryInfo].rom
+    else:
+        fail("Not implemented: kind == ", ctx.attr.kind)
+
+    otp = gen_otp(
+        ctx,
+        otptool = exec_env.otptool,
+        vmem = exec_env.otp,
+    )
+
+    qemu_cfg = gen_cfg(
+        ctx,
+        cfggen = exec_env.cfggen,
+        otp_sv = exec_env.otp_sv,
+        lc_sv = exec_env.lc_sv,
+        top_hjson = exec_env.top_hjson,
+        top_name = exec_env.design,
+    )
+
+    return {
+        "elf": elf,
+        "binary": binary,
+        "default": default,
+        "rom": rom,
+        "rom32": None,
+        "signed_bin": signed_bin,
+        "disassembly": disassembly,
+        "mapfile": mapfile,
+        "hashfile": None,
+        "qemu_cfg": qemu_cfg,
+        "otp": otp,
+    }
+
+def _test_dispatch(ctx, exec_env, firmware):
+    """Dispatch a test for the sim_qemu environment.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      firmware: A label with a SimQemuBinaryInfo provider attached.
+    Returns:
+      (File, List[File]) The test script and needed runfiles.
+    """
+
+    test_harness, data_labels, data_files, param, action_param = common_test_setup(ctx, exec_env, firmware)
+
+    data_files += [firmware.qemu_cfg, firmware.otp]
+    test_script_fmt = {}
+
+    # Get the pre-test_cmd args.
+    args = get_fallback(ctx, "attr.args", exec_env)
+    args = " ".join(args).format(**param)
+    args = ctx.expand_location(args, data_labels)
+
+    # Add arguments to pass directly to QEMU.
+    qemu_args = []
+
+    qemu_args += ["-display", "none"]
+    qemu_args += ["-M", "ot-{}".format(exec_env.design)]
+
+    # Provide top-specific files.
+    qemu_args += ["-readconfig", "{}".format(firmware.qemu_cfg.short_path)]
+    qemu_args += ["-object", "ot-rom_img,id=rom,file={}".format(firmware.rom.short_path)]
+
+    qemu_args += ["-drive", "if=pflash,file=otp_img.raw,format=raw"]
+    test_script_fmt |= {
+        "mutable_otp": "otp_img.raw",
+        "otp": firmware.otp.short_path,
+    }
+
+    if firmware.signed_bin != None and firmware.binary != None:
+        qemu_args += ["-drive", "if=mtd,bus=1,file=flash_img.bin,format=raw"]
+        test_script_fmt |= {
+            "flash": firmware.default.short_path,
+            "mutable_flash": "flash_img.bin",
+        }
+    else:
+        test_script_fmt |= {
+            "flash": "",
+            "mutable_flash": "",
+        }
+
+    # Forward UART0 to stdout.
+    qemu_args += ["-chardev", "stdio,id=serial0"]
+    qemu_args += ["-serial", "chardev:serial0"]
+
+    # Scale the Ibex clock by an `icount` factor.
+    qemu_args += ["-icount", "shift={}".format(param["icount"])]
+
+    # Quit QEMU immediately on rstmgr fatal resets by default.
+    qemu_args += ["-global", "ot-rstmgr.fatal_reset=1"]
+
+    # Add parameter-specified globals.
+    if param["globals"]:
+        globals = json.decode(param["globals"])
+        for key, val in globals.items():
+            qemu_args += ["-global", "{}={}".format(key, val)]
+
+    args += " " + " ".join(qemu_args)
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+
+    post_test_harness_path = ctx.executable.post_test_harness
+    post_test_cmd = ctx.attr.post_test_cmd.format(**param)
+
+    if post_test_harness_path != None:
+        data_files.append(post_test_harness_path)
+        post_test_harness_path = post_test_harness_path.short_path
+    else:
+        post_test_harness_path = ""
+
+    ctx.actions.write(
+        script,
+        _TEST_SCRIPT.format(
+            test_harness = test_harness.executable.short_path,
+            args = args,
+            post_test_harness = post_test_harness_path,
+            post_test_cmd = post_test_cmd,
+            **test_script_fmt
+        ),
+    )
+
+    return script, data_files

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
@@ -37,4 +37,11 @@ py_test(
 sh_binary(
     name = "modid_check",
     srcs = ["modid_check.sh"],
+)
+
+py_binary(
+    name = "qemu_pass",
+    srcs = ["qemu_pass.py"],
+    data = ["//third_party/qemu:qemu-system-riscv32"],
+    deps = ["@rules_python//python/runfiles"],
 )

--- a/rules/scripts/qemu_pass.py
+++ b/rules/scripts/qemu_pass.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""\
+This script executes QEMU (as provided by Bazel runfiles) and checks for
+`PASS!` to be printed from the UART. If QEMU also exited successfully, this
+script will exit with `0`.
+"""
+
+from python.runfiles import Runfiles
+import subprocess
+import sys
+
+
+def main() -> int:
+    r = Runfiles.Create()
+    qemu_bin = r.Rlocation("_main~qemu~qemu_opentitan/build/qemu-system-riscv32")
+
+    # Run the process capturing (then echoing) `stdout` and `stderr`.
+    proc = subprocess.run(
+        [qemu_bin] + sys.argv[1:],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    sys.stdout.write(proc.stdout or "")
+    sys.stderr.write(proc.stderr or "")
+
+    if proc.stdout.find("PASS!") != -1:
+        return proc.returncode
+    elif proc.returncode == 0:
+        # QEMU exited successfully but we didn't see `PASS!`, fail instead.
+        return 1
+    else:
+        return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -103,3 +103,16 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )
+
+cc_library(
+    name = "sim_qemu",
+    srcs = ["device_sim_qemu.c"],
+    deps = [
+        ":device",
+        "//hw/top:rv_core_ibex_c_regs",
+        "//hw/top:uart_c_regs",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+)

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -66,6 +66,11 @@ typedef enum device_type {
    * Silicon.
    */
   kDeviceSilicon = 5,
+  /**
+   * Represents the "QEMU" device, i.e. an emulation of OpenTitan written
+   * independently of the RTL.
+   */
+  kDeviceSimQemu = 6,
 } device_type_t;
 
 /**

--- a/sw/device/lib/arch/device_sim_qemu.c
+++ b/sw/device/lib/arch/device_sim_qemu.c
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated
+#include "rv_core_ibex_regs.h"                        // Generated
+#include "uart_regs.h"                                // Generated
+
+/**
+ * @file
+ * @brief Device-specific symbol definitions for the QEMU emulation.
+ */
+
+const device_type_t kDeviceType = kDeviceSimQemu;
+
+const uint64_t kClockFreqCpuMhz = 24;
+
+const uint64_t kClockFreqCpuHz = kClockFreqCpuMhz * 1000 * 1000;
+
+uint64_t to_cpu_cycles(uint64_t usec) { return usec * kClockFreqCpuMhz; }
+
+const uint64_t kClockFreqHiSpeedPeripheralHz = 24 * 1000 * 1000;  // 24MHz
+
+const uint64_t kClockFreqPeripheralHz = 6 * 1000 * 1000;  // 6MHz
+
+const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
+
+const uint64_t kClockFreqAonHz = 250 * 1000;  // 250kHz
+
+const uint64_t kUartBaudrate = 115200;
+
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
+
+const uint32_t kAstCheckPollCpuCycles =
+    CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
+
+// QEMU supports the DV_SIM register for terminating when a test status has been
+// written.
+const uintptr_t kDeviceTestStatusAddress =
+    TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
+    RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+// Although QEMU isn't an FPGA, there's no harm in us printing the version here.
+void device_fpga_version_print(void) {
+  uint32_t version = ibex_fpga_version();
+  //                       : M O R
+  const uint32_t kRom = 0x3a4d4f52;
+  uart_write_imm(kRom);
+  // The cast to unsigned int stops GCC from complaining about uint32_t
+  // being a `long unsigned int` while the %x specifier takes `unsigned int`.
+  const uint32_t kNewline = 0x0a0d;
+  uart_write_hex(version, sizeof(version), kNewline);
+}

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -17,6 +17,7 @@ load(
     "EARLGREY_TEST_ENVS",
     "fpga_params",
     "opentitan_test",
+    "qemu_params",
     "verilator_params",
 )
 
@@ -689,6 +690,12 @@ opentitan_test(
     name = "rstmgr_functest",
     srcs = ["rstmgr_functest.c"],
     exec_env = EARLGREY_TEST_ENVS,
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -13,6 +13,7 @@ load(
     "EARLGREY_TEST_ENVS",
     "fpga_params",
     "opentitan_test",
+    "qemu_params",
     "verilator_params",
 )
 load(
@@ -309,6 +310,9 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
+        timeout = "long",
+    ),
+    qemu = qemu_params(
         timeout = "long",
     ),
     # This test can take > 40 minutes, so mark it manual as it shouldn't run

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -200,6 +200,7 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+        "//hw/top_earlgrey:sim_qemu_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
     kind = "rom",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7337,3 +7337,28 @@ opentitan_test(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+cc_library(
+    name = "rom_exit_immediately_lib",
+    srcs = ["rom_exit_immediately.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/silicon_creator/lib/base:static_critical",
+    ],
+)
+
+opentitan_test(
+    name = "rom_exit_immediately",
+    exec_env = {
+        "//hw/top_earlgrey:sim_qemu_base": None,
+    },
+    kind = "rom",
+    linker_script = "//sw/device/lib/testing/test_rom:linker_script",
+    qemu = qemu_params(
+        # This test doesn't print `PASS!`, just check the exit code.
+        test_harness = "//third_party/qemu:qemu-system-riscv32",
+    ),
+    deps = [":rom_exit_immediately_lib"],
+)

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4094,9 +4094,13 @@ opentitan_test(
 opentitan_test(
     name = "sram_ctrl_execution_test",
     srcs = ["sram_ctrl_execution_test.c"],
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    exec_env = dicts.omit(
+        dicts.add(
+            EARLGREY_TEST_ENVS,
+            EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        ),
+        # TODO (#26100): QEMU's `flashgen.py` script does not like this test.
+        ["//hw/top_earlgrey:sim_qemu_rom_with_fake_keys"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -26,6 +26,7 @@ load(
     "fpga_params",
     "opentitan_binary",
     "opentitan_test",
+    "qemu_params",
     "silicon_params",
     "verilator_params",
 )
@@ -96,6 +97,11 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    qemu = qemu_params(
+        globals = {
+            "ot-aes.fast-mode": "false",
         },
     ),
     deps = [
@@ -3524,6 +3530,12 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
+        },
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -3572,6 +3584,12 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
         },
     ),
     deps = [
@@ -5148,6 +5166,12 @@ opentitan_test(
     ),
     fpga = fpga_params(
         timeout = "moderate",
+    ),
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
+        },
     ),
     silicon = silicon_params(
         tags = ["broken"],

--- a/sw/device/tests/rom_exit_immediately.S
+++ b/sw/device/tests/rom_exit_immediately.S
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "rv_core_ibex_regs.h"
+
+// This code can be used as the ROM in test environments to exit immediately.
+
+  .balign 4
+  .global _reset_start
+  .type _reset_start, @function
+_reset_start:
+
+// Write exit code 0 to `rv_core_ibex.sw_fatal_err`.
+li a0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR
+lui a1, 0xc0de0
+sw a1, RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET(a0)
+
+// Wait for shutdown.
+wfi

--- a/third_party/qemu/BUILD
+++ b/third_party/qemu/BUILD
@@ -1,0 +1,47 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("@ot_python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+py_binary(
+    name = "cfggen",
+    srcs = ["@qemu_opentitan//:scripts/opentitan/cfggen.py"],
+    deps = [
+        ":ot",
+        requirement("hjson"),
+    ],
+)
+
+py_binary(
+    name = "flashgen",
+    srcs = ["@qemu_opentitan//:scripts/opentitan/flashgen.py"],
+    deps = [
+        ":ot",
+        requirement("pyelftools"),
+    ],
+)
+
+py_binary(
+    name = "otptool",
+    srcs = ["@qemu_opentitan//:scripts/opentitan/otptool.py"],
+    deps = [":ot"],
+)
+
+py_library(
+    name = "ot",
+    srcs = ["@qemu_opentitan//:ot"],
+)
+
+alias(
+    name = "qemu-system-riscv32",
+    actual = "@qemu_opentitan//:build/qemu-system-riscv32",
+)
+
+alias(
+    name = "qemu-img",
+    actual = "@qemu_opentitan//:build/qemu-img",
+)

--- a/third_party/qemu/BUILD.qemu_opentitan.bazel
+++ b/third_party/qemu/BUILD.qemu_opentitan.bazel
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))
+
+filegroup(
+    name = "ot",
+    srcs = glob([
+        "python/qemu/ot/**",
+    ]),
+)

--- a/third_party/qemu/extensions.bzl
+++ b/third_party/qemu/extensions.bzl
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def qemu_opentitan_repos():
+    QEMU_VERSION = "v9.1.0-2025-01-28"
+
+    url = "/".join([
+        "https://github.com/lowRISC/qemu/releases/download",
+        QEMU_VERSION,
+        "qemu-ot-earlgrey-{}-x86_64-unknown-linux-gnu.tar.gz".format(QEMU_VERSION),
+    ])
+
+    http_archive(
+        name = "qemu_opentitan",
+        url = url,
+        build_file = Label(":BUILD.qemu_opentitan.bazel"),
+        sha256 = "530bb7568f17ba3f9ba1245388c2625259d180188c8c5c9e15634b942ebeb108",
+    )
+
+qemu = module_extension(
+    implementation = lambda _: qemu_opentitan_repos(),
+)


### PR DESCRIPTION
### Summary

This PR adds a `sim_qemu_rom_with_fake_keys` execution environment and CI job.

QEMU comes from the in-development Earl Grey branch of our fork: https://github.com/lowRISC/qemu/tree/dev/ot-earlgrey-1.0.0-updates

In the future when Earl Grey and Darjeeling coexist in the same QEMU binary, this execution environment should support both tops in Bazel.

### Execution environment

The exec env currently runs `qemu-system-riscv32` directly. A future PR will add QEMU support to `opentitantool`. Until then, the exec env does not support tests that require custom harnesses and the test won't quit when `FAIL!` is printed, it will have to timeout.

`qemu_params` supports the `icount: <int>` and `globals: { <key>: <val> }` parameters for changing the Ibex clock scaling factor and global parameter values respectively.

### File formats and python scripts

QEMU requires specific files for the flash image, OTP, and an INI describing configuration parameters for the top. These are generated with `flashgen.py`, `otptool.py`, and `cfggen.py` scripts pulled from the QEMU release.

These scripts require Python 3.12, however we don't want to update everything in the repo from 3.9 just yet. I have updated `rules_python` to the latest version 1.1.0 which allows us to add `python_version = "3.12"` to specific binaries. This caused some problems with aspects, see the commit message for details.

### CI tests

I have added a CI job for `sim_qemu` tests and added `sim_qemu_rom_with_fake_keys` to three. Two of these require specific `-global` settings, so it's good to know that works. After some unrelated changes to QEMU we can also show off a couple of tests which require different `icount` values to pass.

EDIT: we don't want to block OpenTitan CI on QEMU failures in case the RTL here changes but QEMU does not. I have made the CI non-blocking.