### PR TITLE
[prim,rtl] Remove ~under_rst from the expression for fifo_incr_wptr

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -176,7 +176,7 @@ module prim_fifo_sync #(
       .depth_o,
       .err_o
     );
-    assign fifo_incr_wptr = wvalid_i & wready_o & ~under_rst;
+    assign fifo_incr_wptr = wvalid_i & wready_o;
     assign fifo_incr_rptr = rvalid_o & rready_i & ~under_rst;
 
     logic [Depth-1:0][Width-1:0] storage;


### PR DESCRIPTION
This term can only be necessary if wready_o is true. But wready_o is driven by the following continuous assignment:

    assign wready_o = ~full_o & ~under_rst;

This commit doesn't add an assertion (to check the behaviour doesn't change) because the behaviour is internal to the module.