### PR TITLE
[rom_ctrl, dv] Assertion coverage for rom_ctrl

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -127,9 +127,15 @@ function void rom_ctrl_common_vseq::sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_
       if (touching_req_fifo) begin
         if (!enable) begin
           `uvm_info(`gfn, "Doing FI on a request fifo. Disabling related assertions", UVM_HIGH)
-          $assertoff(0, "tb.dut");
+          $assertoff(0, "tb.dut.TlAccessChk_A");
+          $assertoff(0, "tb.dut.rom_tlul_assert_device.gen_device.respSzEqReqSz_A");
+          $assertoff(0, "tb.dut.rom_tlul_assert_device.gen_device.respMustHaveReq_A");
+          $assertoff(0, "tb.dut.rom_tlul_assert_device.gen_device.respOpcode_A");
         end else begin
-          $asserton(0, "tb.dut");
+          $asserton(0, "tb.dut.TlAccessChk_A");
+          $asserton(0, "tb.dut.rom_tlul_assert_device.gen_device.respSzEqReqSz_A");
+          $asserton(0, "tb.dut.rom_tlul_assert_device.gen_device.respMustHaveReq_A");
+          $asserton(0, "tb.dut.rom_tlul_assert_device.gen_device.respOpcode_A");
         end
       end
     end


### PR DESCRIPTION
There was some reported assertion coverage hole for rom_ctrl. All the assertions were basically related and they haven't seen the execution of them on a particular event. They should happen when we run a rom_ctrl_sec_cm test and inject errors in rom_ctrl's adapter fifos. Based on that an alert should fire, which was true. However, when we inject anything bad to the fifos, it fails some assertions in rom_ctrl and rom_tlul_assert_device. So, instead of turning all the assertions off for rom_ctrl (in rom_ctrl_commom_vseq), we just turn the affected assertions off. This resolves the assertion hole for rom_ctrl