### PR TITLE
[opentitantool] Ship updated firmware for HyperDebug

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -358,7 +358,7 @@
     },
     "//third_party/hyperdebug:extensions.bzl%hyperdebug": {
       "general": {
-        "bzlTransitiveDigest": "3loY09fIwvLLGCrs/lE9Nt6Xix9Rw7i7fe+dxmoegxw=",
+        "bzlTransitiveDigest": "vOmsyCkbVFm3k5qp3LoDFkrmuO5HnpUMu366SFU26Yo=",
         "usagesDigest": "K8zzt/ed9B09EhnXxX3ZDGxVJrCxWeFKaYd/lNFhIlU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -369,9 +369,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "urls": [
-                "https://github.com/lowRISC/hyperdebug-firmware/releases/download/20241211_02/hyperdebug-firmware.tar.gz"
+                "https://github.com/lowRISC/hyperdebug-firmware/releases/download/20250131_01/hyperdebug-firmware.tar.gz"
               ],
-              "sha256": "8b72dfe4ecb6a2258228e62c2246c5beffe8339d440a592c483534fa3f54d679",
+              "sha256": "8595340b347531438ce07f7d678ec24038b4fa2edd7f4a620bd8c5130d72c2ce",
               "build_file": "@@//third_party/hyperdebug:BUILD"
             }
           }

--- a/third_party/hyperdebug/extensions.bzl
+++ b/third_party/hyperdebug/extensions.bzl
@@ -11,7 +11,7 @@ hyperdebug = module_extension(
 def _hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20241211_02/hyperdebug-firmware.tar.gz"],
-        sha256 = "8b72dfe4ecb6a2258228e62c2246c5beffe8339d440a592c483534fa3f54d679",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20250131_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "8595340b347531438ce07f7d678ec24038b4fa2edd7f4a620bd8c5130d72c2ce",
         build_file = "@lowrisc_opentitan//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Support 48Mhz clock generation, and bugfixes

Add ability to change HyperDebug core clock frequency.  Choosing 96 MHz will allow any PWM capable pin to produce a 48 MHz clock suitable for driving a NuvoTitan chip.  (CN10.31 is the only pin that can output 96 MHz.)

Also included are a few bugfixes to HyperDebug polling the "GSC ready" signal when passing through TPM operations.

Relevant CLs:
d090a07063 chip/stm32: Avoid stuck UART to USB forwarding
b3c959b5c5 board/hyperdebug: Avoid clobbering CCR_CFGR register
765b8a9d2b chip/stm32: Wait for core voltage to stabilize on STM32L4/5
6e9f274d2c board/hyperdebug: Improve GSC ready pulse detection
843d7ee9a6 board/hyperdebug: Expect GSC ready pulse after transaction
1b9f351528 board/hyperdebug: Properly set system timer tick rate
3962928140 board/hyperdebug: Allow runtime changes to system clock
821e9349d2 chip/stm32: Consolidate clock enums
e7f8842e93 chip/stm32: Rename STM32_HSE_CLOCK to CONFIG_STM32_CLOCK_HSE_HZ
a8fc0258fe board/hyperdebug: Fast clock output on CN10.31
6265770002 board/hyperdebug: Add support for PWM via low power timers
195271c11d board/hyperdebug: Refactor PWM
fbf583383f board/hyperdebug: Fix off-by-one and rounding errors