### PR TITLE
[dv,mem_bkdr_util] Temporarily fix otp_ctrl mem_bkdr functions

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This package has functions that perform mem_bkdr_util accesses to different partitions in OTP.
-// The functions take a handle to the otp_ctrl mem_bkdr_util class for reads and writes.
+// These functions end up performing reads and writes to the underlying simulated otp memory, so
+// the functions must get a handle to the mem_bkdr_util instance for otp_ctrl as an argument.
 
 package otp_ctrl_mem_bkdr_util_pkg;
 
@@ -166,9 +167,13 @@ package otp_ctrl_mem_bkdr_util_pkg;
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
+
+  // TODO(#25883): The size of these parameters depends on the top-level. This injected a fact about
+  // the top-level into the mem_bkdr_util class. For now, we're replacing "EnCsrngSwAppReadSize" with
+  // 1 as a short-term hack.
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
+      bit [1*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
       bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
   );

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This package has functions that perform mem_bkdr_util accesses to different partitions in OTP.
-// The functions take a handle to the otp_ctrl mem_bkdr_util class for reads and writes.
+// These functions end up performing reads and writes to the underlying simulated otp memory, so
+// the functions must get a handle to the mem_bkdr_util instance for otp_ctrl as an argument.
 
 package otp_ctrl_mem_bkdr_util_pkg;
 
@@ -166,9 +167,13 @@ package otp_ctrl_mem_bkdr_util_pkg;
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
+
+  // TODO(#25883): The size of these parameters depends on the top-level. This injected a fact about
+  // the top-level into the mem_bkdr_util class. For now, we're replacing "EnCsrngSwAppReadSize" with
+  // 1 as a short-term hack.
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
+      bit [1*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
       bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
   );

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This package has functions that perform mem_bkdr_util accesses to different partitions in OTP.
-// The functions take a handle to the otp_ctrl mem_bkdr_util class for reads and writes.
+// These functions end up performing reads and writes to the underlying simulated otp memory, so
+// the functions must get a handle to the mem_bkdr_util instance for otp_ctrl as an argument.
 
 package otp_ctrl_mem_bkdr_util_pkg;
 
@@ -166,9 +167,13 @@ package otp_ctrl_mem_bkdr_util_pkg;
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
+
+  // TODO(#25883): The size of these parameters depends on the top-level. This injected a fact about
+  // the top-level into the mem_bkdr_util class. For now, we're replacing "EnCsrngSwAppReadSize" with
+  // 1 as a short-term hack.
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
+      bit [1*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
       bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
   );


### PR DESCRIPTION
Put back the fix in otp_ctrl_mem_bkdr_util_pkg tadded in #25884.

otp_ctrl_mem_bkdr_util_pkg needs to be a template since it depends on the partitions. Until that is done this fix will do.