### PR TITLE
[dv, rv_core_ibex] Fix broken rv_core_ibex_nmi_irq_test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5249,9 +5249,6 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
-    silicon = silicon_params(
-        tags = ["broken"],
-    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:alert_handler",

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -280,10 +280,9 @@ bool test_main(void) {
   init_peripherals();
 
   // Enable both NMIs.
+  // kDifRvCoreIbexNmiSourceAll = kDifRvCoreIbexNmiSourceWdog | kDifRvCoreIbexNmiSourceAlert
   CHECK_DIF_OK(
-      dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceWdog));
-  CHECK_DIF_OK(
-      dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceAlert));
+      dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceAll));
 
   // Execute both NMI tests several times back-to-back to verify that
   // the causes are successfully cleared in the NMI handlers.


### PR DESCRIPTION
dif_rv_core_ibex_enable_nmi does a write rather than set, so to enable both wdog and alert NMI, kDifRvCoreIbexNmiSourceAll(=wdog|alert) should be used.

With current called twice impl, as shown below, nmi_enable.wdog_en will be cleared by second call enabling NMISourceAlert.
![image](https://github.com/user-attachments/assets/50787d21-0913-41ca-a08f-bf4ecdbee8bf)