### PR TITLE
[pentest] Fix masking off for AES-SCA

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.h
@@ -9,25 +9,6 @@
 #include "sw/device/lib/ujson/ujson.h"
 
 /**
- * The result of an AES SCA operation.
- */
-typedef enum aes_sca_error {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  aesScaOk = 0,
-  /**
-   * Indicates some unspecified failure.
-   */
-  aesScaAborted = 1,
-  /**
-   * Indicates that the attempted operation would attempt a read/write to an
-   * address that would go out of range.
-   */
-  aesScaOutOfRange = 2
-} aes_sca_error_t;
-
-/**
  * Simple serial 'a' (alternative batch encrypt) command handler.
  *
  * This command is designed to maximize the capture rate for side-channel


### PR DESCRIPTION
This PR consists of three different commits:

- The first two commits tidy up the code base and prepare it for the third commit
- The third commit makes sure that we correctly (i.e., after a `dif_aes_start`()) do a reseed.

Before this commit, turning off the masks for AES gave us the following TVLA figure:
![aes_masks_off_before](https://github.com/user-attachments/assets/d1e0a816-97aa-4407-855e-aa0d3b8a87c8)
As shown in the figure, leakage is only detected in the first AES rounds. However, with masking disabled, we expect leakage in all rounds.

With these changes, the masking off now works again:
![aes_masks_off_after](https://github.com/user-attachments/assets/32026223-7adf-40bc-bd94-a041cd788919)
