### PR TITLE
[hw,otp_ctrl,rtl] Parametrize the DFT config and response port

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -24,7 +24,10 @@ module prim_generic_otp
   parameter      MemInitFile   = "",
   // Vendor test partition offset and size (both in bytes)
   parameter  int VendorTestOffset = 0,
-  parameter  int VendorTestSize   = 0
+  parameter  int VendorTestSize   = 0,
+  // Type definitions of the config in response ports
+  parameter type CfgType_t        = prim_otp_cfg_pkg::otp_cfg_t,
+  parameter type CfgRspType_t     = prim_otp_cfg_pkg::otp_cfg_rsp_t
 ) (
   input                                  clk_i,
   input                                  rst_ni,
@@ -63,8 +66,8 @@ module prim_generic_otp
   output logic [IfWidth-1:0]              rdata_o,
   output err_e                            err_o,
   // DFT config and response port
-  input  prim_otp_cfg_pkg::otp_cfg_t      cfg_i,
-  output  prim_otp_cfg_pkg::otp_cfg_rsp_t cfg_rsp_o
+  input  CfgType_t                        cfg_i,
+  output CfgRspType_t                     cfg_rsp_o
 );
 
   import prim_mubi_pkg::MuBi4False;

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl.sv
@@ -806,16 +806,18 @@ end
 
   // SEC_CM: MACRO.MEM.CM, MACRO.MEM.INTEGRITY
   prim_otp #(
-    .Width            ( OtpWidth            ),
-    .Depth            ( OtpDepth            ),
-    .SizeWidth        ( OtpSizeWidth        ),
-    .PwrSeqWidth      ( OtpPwrSeqWidth      ),
-    .TestCtrlWidth    ( OtpTestCtrlWidth    ),
-    .TestStatusWidth  ( OtpTestStatusWidth  ),
-    .TestVectWidth    ( OtpTestVectWidth    ),
-    .MemInitFile      ( MemInitFile         ),
-    .VendorTestOffset ( VendorTestOffset    ),
-    .VendorTestSize   ( VendorTestSize      )
+    .Width            ( OtpWidth                        ),
+    .Depth            ( OtpDepth                        ),
+    .SizeWidth        ( OtpSizeWidth                    ),
+    .PwrSeqWidth      ( OtpPwrSeqWidth                  ),
+    .TestCtrlWidth    ( OtpTestCtrlWidth                ),
+    .TestStatusWidth  ( OtpTestStatusWidth              ),
+    .TestVectWidth    ( OtpTestVectWidth                ),
+    .MemInitFile      ( MemInitFile                     ),
+    .VendorTestOffset ( VendorTestOffset                ),
+    .VendorTestSize   ( VendorTestSize                  ),
+    .CfgType_t        ( prim_otp_cfg_pkg::otp_cfg_t     ),
+    .CfgRspType_t     ( prim_otp_cfg_pkg::otp_cfg_rsp_t )
   ) u_otp (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -806,16 +806,18 @@ end
 
   // SEC_CM: MACRO.MEM.CM, MACRO.MEM.INTEGRITY
   prim_otp #(
-    .Width            ( OtpWidth            ),
-    .Depth            ( OtpDepth            ),
-    .SizeWidth        ( OtpSizeWidth        ),
-    .PwrSeqWidth      ( OtpPwrSeqWidth      ),
-    .TestCtrlWidth    ( OtpTestCtrlWidth    ),
-    .TestStatusWidth  ( OtpTestStatusWidth  ),
-    .TestVectWidth    ( OtpTestVectWidth    ),
-    .MemInitFile      ( MemInitFile         ),
-    .VendorTestOffset ( VendorTestOffset    ),
-    .VendorTestSize   ( VendorTestSize      )
+    .Width            ( OtpWidth                        ),
+    .Depth            ( OtpDepth                        ),
+    .SizeWidth        ( OtpSizeWidth                    ),
+    .PwrSeqWidth      ( OtpPwrSeqWidth                  ),
+    .TestCtrlWidth    ( OtpTestCtrlWidth                ),
+    .TestStatusWidth  ( OtpTestStatusWidth              ),
+    .TestVectWidth    ( OtpTestVectWidth                ),
+    .MemInitFile      ( MemInitFile                     ),
+    .VendorTestOffset ( VendorTestOffset                ),
+    .VendorTestSize   ( VendorTestSize                  ),
+    .CfgType_t        ( prim_otp_cfg_pkg::otp_cfg_t     ),
+    .CfgRspType_t     ( prim_otp_cfg_pkg::otp_cfg_rsp_t )
   ) u_otp (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -806,16 +806,18 @@ end
 
   // SEC_CM: MACRO.MEM.CM, MACRO.MEM.INTEGRITY
   prim_otp #(
-    .Width            ( OtpWidth            ),
-    .Depth            ( OtpDepth            ),
-    .SizeWidth        ( OtpSizeWidth        ),
-    .PwrSeqWidth      ( OtpPwrSeqWidth      ),
-    .TestCtrlWidth    ( OtpTestCtrlWidth    ),
-    .TestStatusWidth  ( OtpTestStatusWidth  ),
-    .TestVectWidth    ( OtpTestVectWidth    ),
-    .MemInitFile      ( MemInitFile         ),
-    .VendorTestOffset ( VendorTestOffset    ),
-    .VendorTestSize   ( VendorTestSize      )
+    .Width            ( OtpWidth                        ),
+    .Depth            ( OtpDepth                        ),
+    .SizeWidth        ( OtpSizeWidth                    ),
+    .PwrSeqWidth      ( OtpPwrSeqWidth                  ),
+    .TestCtrlWidth    ( OtpTestCtrlWidth                ),
+    .TestStatusWidth  ( OtpTestStatusWidth              ),
+    .TestVectWidth    ( OtpTestVectWidth                ),
+    .MemInitFile      ( MemInitFile                     ),
+    .VendorTestOffset ( VendorTestOffset                ),
+    .VendorTestSize   ( VendorTestSize                  ),
+    .CfgType_t        ( prim_otp_cfg_pkg::otp_cfg_t     ),
+    .CfgRspType_t     ( prim_otp_cfg_pkg::otp_cfg_rsp_t )
   ) u_otp (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This parametrization allows the usage of prim_otp with different DFT config and response ports. One usage is for example when using macro tiling within the prim instance and have different instances with different configuration in the design. By passing the port type as a parameter we don't need to pull in all the tiling related parameters into the design.