### PR TITLE
[hw,pinmux,rtl] Only depend on USBDEV if USB wakeup is enabled

### DIFF
--- a/hw/ip_templates/pinmux/pinmux.core.tpl
+++ b/hw/ip_templates/pinmux/pinmux.core.tpl
@@ -19,7 +19,9 @@ filesets:
       - lowrisc:prim:pad_wrapper_pkg
       - lowrisc:prim:pad_attr
       - lowrisc:ip:jtag_pkg
+    % if enable_usb_wakeup:
       - lowrisc:ip:usbdev
+    % endif
       - ${instance_vlnv("lowrisc:ip:pinmux_reg:0.1")}
       - ${instance_vlnv("lowrisc:ip:pinmux_pkg:0.1")}
     files:

--- a/hw/top_darjeeling/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/pinmux.core
@@ -19,7 +19,6 @@ filesets:
       - lowrisc:prim:pad_wrapper_pkg
       - lowrisc:prim:pad_attr
       - lowrisc:ip:jtag_pkg
-      - lowrisc:ip:usbdev
       - lowrisc:opentitan:top_darjeeling_pinmux_reg:0.1
       - lowrisc:opentitan:top_darjeeling_pinmux_pkg:0.1
     files:


### PR DESCRIPTION
No need to pull in the USB device if the USB wakeup is not enabled in the IPGEN config.