### PR TITLE
[bazel,hw] improve hermeticity of bitstream builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -154,3 +154,7 @@ test --build_tests_only
 # these when running sandboxed tests.
 test --sandbox_explicit_pseudoterminal
 run --sandbox_explicit_pseudoterminal
+
+# Enable strict action env. This will prevent `PATH` and `LD_LIBRARY_PATH` from being passed into the sandbox
+# which would help the cacheability.
+build --incompatible_strict_action_env

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -109,17 +109,6 @@ runs:
     - uses: google-github-actions/setup-gcloud@v2
       if: github.event_name != 'pull_request'
 
-    # HACK: for pull request we don't really need gcloud (and it's ~0.5G to download), but not including
-    # it in the PATH cause environment variables to change and Verilator build to be uncached.
-    - name: Fake gcloud PATH
-      if: github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        LATEST=$(curl -sSfL https://raw.githubusercontent.com/google-github-actions/setup-cloud-sdk/main/data/versions.json | jq -r .[-1])
-        GCLOUD_PATH="${{ runner.tool_cache }}/gcloud/$LATEST/x64/bin"
-        mkdir -p "$GCLOUD_PATH"
-        echo "$GCLOUD_PATH" >> "$GITHUB_PATH"
-
     - name: Configure ~/.bazelrc
       if: inputs.configure-bazel == 'true'
       run: |

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@nonhermetic//:env.bzl", "ENV")
+load("@nonhermetic//:env.bzl", "BIN_PATHS", "ENV")
 
 """Rules for running FuseSoC.
 
@@ -91,9 +91,12 @@ def _fusesoc_build_impl(ctx):
         executable = ctx.executable._fusesoc,
         use_default_shell_env = False,
         env = dicts.add(
-            ENV,
+            # Verilator build doesn't need nonhermetic environment variables
+            ENV if ctx.attr.target == "synth" else {},
             {
                 "HOME": home_dir,
+                # Obtain the non-hermetic binary path and append Bazel's default PATH.
+                "PATH": BIN_PATHS["vivado" if ctx.attr.target == "synth" else "verilator"] + ":/bin:/usr/bin:/usr/local/bin",
             },
         ),
     )

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -5,7 +5,6 @@
 NONHERMETIC_ENV_VARS = [
     "PATH",
     "XILINX_VIVADO",
-    "XILINX_HLS",
     "XILINXD_LICENSE_FILE",
 ]
 

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 NONHERMETIC_ENV_VARS = [
-    "HOME",
     "PATH",
     "XILINX_VIVADO",
     "XILINX_HLS",
@@ -12,7 +11,8 @@ NONHERMETIC_ENV_VARS = [
 
 def _nonhermetic_repo_impl(rctx):
     env = "\n".join(["    \"{}\": \"{}\",".format(v, rctx.os.environ.get(v, "")) for v in NONHERMETIC_ENV_VARS])
-    rctx.file("env.bzl", "ENV = {{\n{}\n}}\n".format(env))
+    home = rctx.os.environ.get("HOME", "")
+    rctx.file("env.bzl", "ENV = {{\n{}\n}}\nHOME = \"{}\"".format(env, home))
     rctx.file("BUILD.bazel", "exports_files(glob([\"**\"]))\n")
 
 nonhermetic_repo = repository_rule(

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -3,15 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 NONHERMETIC_ENV_VARS = [
-    "PATH",
     "XILINX_VIVADO",
     "XILINXD_LICENSE_FILE",
+]
+
+# Binarys that Bazel rule may depend on from the PATH.
+NONHERMETIC_BINS = [
+    "verilator",
+    "vivado",
+    "updatemem",
 ]
 
 def _nonhermetic_repo_impl(rctx):
     env = "\n".join(["    \"{}\": \"{}\",".format(v, rctx.os.environ.get(v, "")) for v in NONHERMETIC_ENV_VARS])
     home = rctx.os.environ.get("HOME", "")
-    rctx.file("env.bzl", "ENV = {{\n{}\n}}\nHOME = \"{}\"".format(env, home))
+
+    bins = {name: rctx.which(name) for name in NONHERMETIC_BINS}
+    bin_paths = "\n".join(["    \"{}\": \"{}\",".format(name, rctx.path(path).dirname if path != None else "/no-such-path") for name, path in bins.items()])
+
+    rctx.file("env.bzl", "ENV = {{\n{}\n}}\nHOME = \"{}\"\nBIN_PATHS = {{\n{}\n}}\n".format(env, home, bin_paths))
     rctx.file("BUILD.bazel", "exports_files(glob([\"**\"]))\n")
 
 nonhermetic_repo = repository_rule(

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -14,6 +14,24 @@ NONHERMETIC_BINS = [
     "updatemem",
 ]
 
+"""Variables that describe non-hermetic parts of the environment.
+
+This repository provides 3 variables:
+    - `ENV`
+        - Dict of environment variables that may be needed for running non-hermetic tools.
+          Currently this only include those needed by Vivado.
+    - `HOME`
+        - Home directory of the user that invokes Bazel.
+          Currently this is used by hsmtool to access user's Google Cloud credentials.
+    - `BIN_PATHS`
+        - Map from a non-hermetic tool to the part of `$PATH` that contains it.
+          This allows actions to use a subset of `$PATH` when invoking the tool,
+          as `$PATH` may contain many unrelated tools.
+
+Together, these variables attempt to expose the least amount of environment information
+to Bazel rules as possible, thus improves reproducibility and cacheability.
+"""
+
 def _nonhermetic_repo_impl(rctx):
     env = "\n".join(["    \"{}\": \"{}\",".format(v, rctx.os.environ.get(v, "")) for v in NONHERMETIC_ENV_VARS])
     home = rctx.os.environ.get("HOME", "")

--- a/rules/opentitan/splice.bzl
+++ b/rules/opentitan/splice.bzl
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
 load("//rules/opentitan:providers.bzl", "get_one_binary_file")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 load("//rules/opentitan:util.bzl", "get_fallback")
-load("@nonhermetic//:env.bzl", "ENV")
+load("@nonhermetic//:env.bzl", "BIN_PATHS", "ENV")
 
 # Rules for memory splicing with Vivado.
 
@@ -65,7 +66,12 @@ def vivado_updatemem(ctx, name, src, instance, mmi, update, debug = False):
         execution_requirements = {
             "no-sandbox": "",
         },
-        env = ENV,
+        env = dicts.add(
+            ENV,
+            {
+                "PATH": BIN_PATHS["updatemem"] + ":/bin:/usr/bin:/usr/local/bin",
+            },
+        ),
     )
     return spliced
 

--- a/rules/opentitan/splice.bzl
+++ b/rules/opentitan/splice.bzl
@@ -30,9 +30,6 @@ def gen_vivado_mem_file(ctx, name, src, tool, swap_nibbles = True):
         arguments = [args],
         executable = tool,
         use_default_shell_env = True,
-        execution_requirements = {
-            "no-sandbox": "",
-        },
     )
     return update
 
@@ -63,9 +60,6 @@ def vivado_updatemem(ctx, name, src, instance, mmi, update, debug = False):
         arguments = [args],
         executable = "updatemem",
         use_default_shell_env = False,
-        execution_requirements = {
-            "no-sandbox": "",
-        },
         env = dicts.add(
             ENV,
             {

--- a/signing/tokens/BUILD
+++ b/signing/tokens/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@nonhermetic//:env.bzl", "ENV")
+load("@nonhermetic//:env.bzl", "HOME")
 load("//rules:signing.bzl", "signing_tool")
 
 package(default_visibility = ["//visibility:public"])
@@ -32,7 +32,7 @@ signing_tool(
     env = {
         # The Cloud KMS PKCS11 provider needs to know where the user's home
         # is in order to load the gclould credentials.
-        "HOME": ENV["HOME"],
+        "HOME": HOME,
         "HSMTOOL_MODULE": "$(location @cloud_kms_hsm//:libkmsp11)",
         "KMS_PKCS11_CONFIG": "$(location earlgrey_z1_sival.yaml)",
     },


### PR DESCRIPTION
* `HOME` is no longer used (except by hsmtool to find Google Cloud credentials)
* `XILINX_HLS` environment variable is removed (we don't use HLS anyway)
* Only relevant part of `PATH` is used, not the full path (this allows us to remove the CI hack)
* `updatemem` is now sandboxed