### PR TITLE
[rust] fix broken CI due to unformatted files

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -217,4 +217,9 @@ sh_test(
     env = {
         "SHELLCHECK": "$(location @shellcheck//:shellcheck)",
     },
+    tags = [
+        "external",
+        "no-cache",
+        "no-sandbox",
+    ],
 )

--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -528,9 +528,16 @@ rustfmt_fix = rule(
     executable = True,
 )
 
-rustfmt_test = rule(
+_rustfmt_test = rule(
     implementation = lambda ctx: _rustfmt_impl(ctx, check = True),
     attrs = rustfmt_attrs,
     executable = True,
     test = True,
 )
+
+def rustfmt_test(**kwargs):
+    tags = kwargs.get("tags", [])
+
+    # Note: the "external" tag is a workaround for bazelbuild#15516.
+    kwargs["tags"] = _ensure_tag(tags, "no-sandbox", "no-cache", "external")
+    _rustfmt_test(**kwargs)

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -12,7 +12,7 @@
 #![deny(unsafe_code)]
 
 use crate::with_unknown;
-use zerocopy::{KnownLayout, Immutable, IntoBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 // Currently, these definitions must be updated manually but they can be
 // generated using the following commands (requires bindgen):

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use std::cmp;
 use std::rc::Rc;
 use std::time::Duration;
-use zerocopy::{Immutable, IntoBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::io::gpio::GpioPin;
 use crate::io::i2c::{self, Bus, DeviceStatus, DeviceTransfer, I2cError, ReadStatus, Transfer};

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use std::mem::size_of;
 use std::rc::Rc;
 use std::time::Duration;
-use zerocopy::{Immutable, IntoBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::io::eeprom;
 use crate::io::gpio::GpioPin;


### PR DESCRIPTION
#25912 introduced some unformatted Rust files but due to broken Bazel rules they reuse previous results from cache and did not actually check in the CI.

This PR fixes those files and also fix the Bazel rules so they're no longer cached.