### PR TITLE
[ci] support merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ on:
   push:
     branches-ignore:
       - "backport-*"
+      - "gh-readonly-queue/*"
     tags:
       - "*"
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read
@@ -81,6 +85,7 @@ jobs:
     name: Lint (slow)
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -127,6 +132,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     env:
       BUCKET: gold-hybrid-255313-prod
     steps:
@@ -175,6 +181,7 @@ jobs:
     name: Airgapped build
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -233,6 +240,7 @@ jobs:
     name: Run OTBN smoke Test
     needs: quick_lint
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -266,6 +274,7 @@ jobs:
     name: Run OTBN crypto tests
     needs: quick_lint
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -282,6 +291,7 @@ jobs:
     name: Verilated English Breakfast
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
       - name: Prepare environment
@@ -312,6 +322,7 @@ jobs:
     name: Verilated Earl Grey
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
@@ -332,6 +343,7 @@ jobs:
     name: CW305's Bitstream
     runs-on: ubuntu-22.04-vivado
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
       - name: Prepare environment
@@ -440,6 +452,7 @@ jobs:
     name: CW310 Test ROM Tests
     needs: chip_earlgrey_cw310_hyperdebug
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_test_rom_fpga_tests_cw310
@@ -452,6 +465,7 @@ jobs:
     name: CW310 ROM Tests
     needs: chip_earlgrey_cw310_hyperdebug
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_rom_fpga_tests_cw310
@@ -465,6 +479,7 @@ jobs:
     name: CW310 ROM_EXT Tests
     needs: chip_earlgrey_cw310_hyperdebug
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_rom_ext_fpga_tests_cw310
@@ -477,6 +492,7 @@ jobs:
     name: CW310 SiVal Tests
     needs: chip_earlgrey_cw310_hyperdebug
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_sival_fpga_tests_cw310
@@ -489,6 +505,7 @@ jobs:
     name: CW310 SiVal ROM_EXT Tests
     needs: chip_earlgrey_cw310_hyperdebug
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_sival_rom_ext_fpga_tests_cw310
@@ -501,6 +518,7 @@ jobs:
     name: CW310 Manufacturing Tests
     needs: chip_earlgrey_cw310_hyperdebug
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_manuf_fpga_tests_cw310
@@ -514,6 +532,7 @@ jobs:
     name: CW340 Test ROM Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_test_rom_fpga_tests_cw340
@@ -526,6 +545,7 @@ jobs:
     name: CW340 ROM Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_rom_fpga_tests_cw340
@@ -538,6 +558,7 @@ jobs:
     name: CW340 ROM_EXT Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_rom_ext_fpga_tests_cw340
@@ -550,6 +571,7 @@ jobs:
     name: CW340 SiVal Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_sival_fpga_tests_cw340
@@ -562,6 +584,7 @@ jobs:
     name: CW340 SiVal ROM_EXT Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_sival_rom_ext_fpga_tests_cw340
@@ -574,6 +597,7 @@ jobs:
     name: CW340 Manufacturing Tests
     needs: chip_earlgrey_cw340
     uses: ./.github/workflows/fpga.yml
+    if: ${{ github.event_name != 'merge_group' }}
     secrets: inherit
     with:
       job_name: execute_manuf_fpga_tests_cw340
@@ -641,6 +665,7 @@ jobs:
     name: Build Docker Containers
     runs-on: ubuntu-22.04
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Developer Utility Container
@@ -665,6 +690,7 @@ jobs:
     runs-on: ubuntu-22.04-vivado
     timeout-minutes: 120
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -735,6 +761,7 @@ jobs:
     runs-on: ubuntu-22.04-vivado
     timeout-minutes: 120
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -760,6 +787,7 @@ jobs:
     name: QEMU smoketest
     runs-on: ubuntu-22.04-vivado
     needs: quick_lint
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -771,3 +799,24 @@ jobs:
       - name: Execute QEMU smoketest
         run: |
           ./bazelisk.sh test //sw/device/tests:rom_exit_immediately_sim_qemu_base
+
+  # We would like to gate PR on quick lint and merge queue on bitstream caching.
+  # GitHub requires a single job name to be used for branch protection rule, so we use 2 jobs with
+  # conditional names so the non-skipped ones woud be called "Merge blocker".
+  merge_blocker_pr:
+    name: Merge blocker${{ github.event_name != 'pull_request' && ' (skipped)' || '' }}
+    runs-on: ubuntu-latest
+    needs: quick_lint
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Complete
+        run: 'true'
+
+  merge_blocker_merge:
+    name: Merge blocker${{ github.event_name != 'merge_group' && ' (skipped)' || '' }}
+    runs-on: ubuntu-latest
+    needs: cache_bitstreams
+    if: ${{ github.event_name == 'merge_group' }}
+    steps:
+      - name: Complete
+        run: 'true'


### PR DESCRIPTION
With this change and merge queue enabled, PRs will only be merged to target branch once the bitstream is built and cached. This prevent RTL changes from causing all subsequent CI jobs to rebuild bitstream after merging and before bitstreams are built and cached.

This also has the advantage of reducing the likelihood of merge skews, if we move jobs from push to merge_group event. These are future possibilities, for now the merge queue is only gated on bitstream being built.

Implementation-wise, GitHub uses a single check name to gate both PR and merge queue, so I've created two dynamically named jobs to allow the PR to be gated only on `quick_lint` while the merge queue will be gate on bitstream being built and cached.