### PR TITLE
[rust] Remove missing module declarations

### DIFF
--- a/hw/top_darjeeling/sw/autogen/chip/mod.rs
+++ b/hw/top_darjeeling/sw/autogen/chip/mod.rs
@@ -3,5 +3,3 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod top_darjeeling;
-pub mod top_darjeeling_soc_dbg;
-pub mod top_darjeeling_soc_mbx;


### PR DESCRIPTION
As far as I can tell these modules do not exist but their declarations are causing failures.