### PR TITLE
[englishbreakfast] Switch to 256-bit seed for compile-time random consts

### DIFF
--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -7,11 +7,11 @@
 //
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
-//                --rnd_cnst_seed 4881560218908238235
+//                --rnd_cnst_seed 47496257290787239787852990649372780135330843464066774986444696694703339830170
 {
   name: englishbreakfast
   type: top
-  rnd_cnst_seed: 4881560218908238235
+  rnd_cnst_seed: 47496257290787239787852990649372780135330843464066774986444696694703339830170
   datawidth: "32"
   power:
   {
@@ -2849,7 +2849,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0x9e90f8e65f8cdc028e681edcb14cb2e8
+          default: 0x47699d7befa2eaca5e9e86b268b82b10
           randwidth: 128
         }
         {
@@ -2859,7 +2859,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0x1c9634b9fa84fec1ccc9e2525b4acfbe
+          default: 0xea8e913c65a10e10daa910cd93e9e8dd
           randwidth: 128
         }
         {
@@ -2869,7 +2869,7 @@
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
-          default: 0xf1354b0969540f0f285312fd274e1f6136763b10aef74fea8020040b2a0b515ed5e666d771ef5001237710feb20a90edffd46b00ce07c1b5411e793482c8143e
+          default: 0xe03e8ab0f1f4225b70de66ae2a2d2caf521284d078b2442c4dcdfffc136eaed4bf1a600233980bc4cf2116db51ec10b747b9011d99f556b893842a91cafc63cb
           randwidth: 512
         }
         {
@@ -2879,7 +2879,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x6ae2b721
+          default: 0x10b94460
           randwidth: 32
         }
         {
@@ -2889,7 +2889,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0x757edcd0d2e4d0b4eae27d831600b8e906756e1e
+          default: 0xf71768651ac5cb1d9df2183ee9a59d6a835250c2
           randwidth: 160
         }
         {
@@ -3391,7 +3391,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0xc5a44f9dc00a807e
+          default: 0x213905e9cb853bc8
           randwidth: 64
         }
         {
@@ -3401,7 +3401,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x80e79cf48b437e73292eb407c40d04ff2c3b476cf9368e136d55d650f912f1a882f89d5d877baf1bab18a819a58d9285
+          default: 0x87e1885e2ad14fb137023a9568a1503e71f9372f30eb59a0fe560ea0331dcde4b45a4bac25cc42b5bf4b059a767ef538
           randwidth: 384
         }
         {
@@ -3411,7 +3411,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x80d40cbf860e22779193a5f54b4d997d60d3f2b9a3c4af4754497f09bca214ba3bc1d6aa073e5c86ef8f254dedb29180
+          default: 0x10546c53c047bb1aa7b4d4a9ee362242b54a0af7ff4dd5f2eb321a7060245a0e668496cbc0cf65a0f675e37f9ed0e0f6
           randwidth: 384
         }
         {
@@ -3421,7 +3421,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0xff657fc29427d0f48aad106e3859890c0902355895a38418fa02e1245e46fac24fa1fc04
+          default: 0xc880914b8567e2fb12ce5455e5387cc149c106bd836a7311d59def2e2061b6069e362fb5
           randwidth: 288
         }
         {
@@ -3431,7 +3431,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0x9d12152e8b3c0f99008d951071673b882f61057f1e7b16685439498c5f34735a4f59705b7437751a369c0c64291b4b2c879a657a9b254a2076401d246d06698f5277010357433197483242189019932b7c9f274d08603a358545621f2a81500e923d51786c2d46021c6e445e589e72803f66418e6b6f6a170d565d8a82237d79949809330b4c530a9186846389133830048326963e4e1147555c07221421287e
+          default: 0x46c591b8e1e6f5887256151158d60027a8b0953562e404f68754d2967053193812226302b6920831d98657c8c1128105c48336a64909491073a9b89885b3f8a2374187257634139863e457f661f70213d6d37548f142c0e329d49132777420b3479629f039c1c762a01952f555a0f5f476e827d0d241799354a190c92524c3b851a96807b5e3c4b78849a0a440038127e9e464e5d1671735036066b9708432d
           randwidth: 1280
         }
       ]
@@ -3569,7 +3569,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xa84afd110e65e2c09d4012491ac45c2d
+          default: 0xf8b34d3a036354a7212f4ab685058803
           randwidth: 128
         }
         {
@@ -3579,7 +3579,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x7799e699c02a50aee3b25af703b953b
+          default: 0xba2f9679ea4623137127ec6ee39aa98b
           randwidth: 128
         }
         {
@@ -3589,7 +3589,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0x72c25acd
+          default: 0x7f39f9dd
           randwidth: 32
         }
         {
@@ -3599,7 +3599,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x70f1c20229aef41baec26351432b3283cb33fbbf
+          default: 0x9aec76abf040d80bf3b8ca4db75044f45e50d65a
           randwidth: 160
         }
         {
@@ -3831,7 +3831,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0xa055cd153e14afcf
+          default: 0x991516636bf59db6
           randwidth: 64
         }
         {
@@ -3841,7 +3841,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0xaf2b8b9ba0eeeeeab949b4462a2e7e3b
+          default: 0x8ccd043d5f2df70b7b0547c8245da916
           randwidth: 128
         }
         {
@@ -4015,7 +4015,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x88f2805b
+          default: 0x4b111053
           randwidth: 32
         }
         {
@@ -4025,7 +4025,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0xc19b5091071af9efd36fc952e8a99300af097756
+          default: 0xc506042fee9caa765fb937a168e84453c29db785
           randwidth: 160
         }
         {
@@ -4035,7 +4035,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0x6aeabf2275afc88a1d1273b99c6d2d23
+          default: 0xf341d8f69ffaf435e5d3c0ecdd694b90
           randwidth: 128
         }
         {
@@ -4045,7 +4045,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0x9f28888f3ef00fc7
+          default: 0xd7fb1168378c3136
           randwidth: 64
         }
         {

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -7,10 +7,10 @@
   type: "top",
 
   /////////////////////////////////////////////////////////////
-  // Seed for compile-time random constants                  //
+  // 256 bit seed for compile-time random constants          //
   // NOTE: REPLACE THIS WITH A NEW VALUE BEFORE THE TAPEOUT  //
   /////////////////////////////////////////////////////////////
-  rnd_cnst_seed: 4881560218908238235
+  rnd_cnst_seed: 47496257290787239787852990649372780135330843464066774986444696694703339830170
 
   // 32-bit datawidth
   datawidth: "32",

--- a/hw/top_englishbreakfast/dv/autogen/rstmgr_tgl_excl.cfg
+++ b/hw/top_englishbreakfast/dv/autogen/rstmgr_tgl_excl.cfg
@@ -10,7 +10,7 @@
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
 //                --rnd_cnst_seed \
-//                4881560218908238235
+//                47496257290787239787852990649372780135330843464066774986444696694703339830170
 
 //=========================================================
 // This file contains resets that are not used at top level

--- a/hw/top_englishbreakfast/rtl/autogen/chip_englishbreakfast_cw305.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/chip_englishbreakfast_cw305.sv
@@ -8,7 +8,7 @@
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
 //                --rnd_cnst_seed \
-//                4881560218908238235
+//                47496257290787239787852990649372780135330843464066774986444696694703339830170
 
 
 module chip_englishbreakfast_cw305 #(

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -8,7 +8,7 @@
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
 //                --rnd_cnst_seed \
-//                4881560218908238235
+//                47496257290787239787852990649372780135330843464066774986444696694703339830170
 
 module top_englishbreakfast #(
   // Manually defined parameters

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_pkg.sv
@@ -8,7 +8,7 @@
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
 //                --rnd_cnst_seed \
-//                4881560218908238235
+//                47496257290787239787852990649372780135330843464066774986444696694703339830170
 
 package top_englishbreakfast_pkg;
   /**

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_rnd_cnst_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_rnd_cnst_pkg.sv
@@ -8,7 +8,7 @@
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
 //                --rnd_cnst_seed \
-//                4881560218908238235
+//                47496257290787239787852990649372780135330843464066774986444696694703339830170
 
 
 package top_englishbreakfast_rnd_cnst_pkg;
@@ -18,28 +18,28 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'h9E90F8E6_5F8CDC02_8E681EDC_B14CB2E8
+    128'h47699D7B_EFA2EACA_5E9E86B2_68B82B10
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'h1C9634B9_FA84FEC1_CCC9E252_5B4ACFBE
+    128'hEA8E913C_65A10E10_DAA910CD_93E9E8DD
   };
 
   // Compile-time random bits for default seeds
   parameter flash_ctrl_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
-    256'hF1354B09_69540F0F_285312FD_274E1F61_36763B10_AEF74FEA_8020040B_2A0B515E,
-    256'hD5E666D7_71EF5001_237710FE_B20A90ED_FFD46B00_CE07C1B5_411E7934_82C8143E
+    256'hE03E8AB0_F1F4225B_70DE66AE_2A2D2CAF_521284D0_78B2442C_4DCDFFFC_136EAED4,
+    256'hBF1A6002_33980BC4_CF2116DB_51EC10B7_47B9011D_99F556B8_93842A91_CAFC63CB
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h6AE2B721
+    32'h10B94460
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'h757EDCD0_D2E4D0B4_EAE27D83_1600B8E9_06756E1E
+    160'hF7176865_1AC5CB1D_9DF2183E_E9A59D6A_835250C2
   };
 
   ////////////////////////////////////////////
@@ -47,34 +47,34 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'hC5A44F9D_C00A807E
+    64'h213905E9_CB853BC8
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h80E79CF4_8B437E73_292EB407_C40D04FF,
-    256'h2C3B476C_F9368E13_6D55D650_F912F1A8_82F89D5D_877BAF1B_AB18A819_A58D9285
+    128'h87E1885E_2AD14FB1_37023A95_68A1503E,
+    256'h71F9372F_30EB59A0_FE560EA0_331DCDE4_B45A4BAC_25CC42B5_BF4B059A_767EF538
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h80D40CBF_860E2277_9193A5F5_4B4D997D,
-    256'h60D3F2B9_A3C4AF47_54497F09_BCA214BA_3BC1D6AA_073E5C86_EF8F254D_EDB29180
+    128'h10546C53_C047BB1A_A7B4D4A9_EE362242,
+    256'hB54A0AF7_FF4DD5F2_EB321A70_60245A0E_668496CB_C0CF65A0_F675E37F_9ED0E0F6
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    32'hFF657FC2,
-    256'h9427D0F4_8AAD106E_3859890C_09023558_95A38418_FA02E124_5E46FAC2_4FA1FC04
+    32'hC880914B,
+    256'h8567E2FB_12CE5455_E5387CC1_49C106BD_836A7311_D59DEF2E_2061B606_9E362FB5
   };
 
   // Permutation applied to the output of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h9D12152E_8B3C0F99_008D9510_71673B88_2F61057F_1E7B1668_5439498C_5F34735A,
-    256'h4F59705B_7437751A_369C0C64_291B4B2C_879A657A_9B254A20_76401D24_6D06698F,
-    256'h52770103_57433197_48324218_9019932B_7C9F274D_08603A35_8545621F_2A81500E,
-    256'h923D5178_6C2D4602_1C6E445E_589E7280_3F66418E_6B6F6A17_0D565D8A_82237D79,
-    256'h94980933_0B4C530A_91868463_89133830_04832696_3E4E1147_555C0722_1421287E
+    256'h046C591B_8E1E6F58_87256151_158D6002_7A8B0953_562E404F_68754D29_67053193,
+    256'h81222630_2B692083_1D98657C_8C112810_5C48336A_64909491_073A9B89_885B3F8A,
+    256'h23741872_57634139_863E457F_661F7021_3D6D3754_8F142C0E_329D4913_2777420B,
+    256'h3479629F_039C1C76_2A01952F_555A0F5F_476E827D_0D241799_354A190C_92524C3B,
+    256'h851A9680_7B5E3C4B_78849A0A_44003812_7E9E464E_5D167173_5036066B_9708432D
   };
 
   ////////////////////////////////////////////
@@ -82,22 +82,22 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hA84AFD11_0E65E2C0_9D401249_1AC45C2D
+    128'hF8B34D3A_036354A7_212F4AB6_85058803
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h07799E69_9C02A50A_EE3B25AF_703B953B
+    128'hBA2F9679_EA462313_7127EC6E_E39AA98B
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'h72C25ACD
+    32'h7F39F9DD
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'h70F1C202_29AEF41B_AEC26351_432B3283_CB33FBBF
+    160'h9AEC76AB_F040D80B_F3B8CA4D_B75044F4_5E50D65A
   };
 
   ////////////////////////////////////////////
@@ -105,12 +105,12 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'hA055CD15_3E14AFCF
+    64'h99151663_6BF59DB6
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'hAF2B8B9B_A0EEEEEA_B949B446_2A2E7E3B
+    128'h8CCD043D_5F2DF70B_7B0547C8_245DA916
   };
 
   ////////////////////////////////////////////
@@ -118,22 +118,22 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h88F2805B
+    32'h4B111053
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'hC19B5091_071AF9EF_D36FC952_E8A99300_AF097756
+    160'hC506042F_EE9CAA76_5FB937A1_68E84453_C29DB785
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'h6AEABF22_75AFC88A_1D1273B9_9C6D2D23
+    128'hF341D8F6_9FFAF435_E5D3C0EC_DD694B90
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'h9F28888F_3EF00FC7
+    64'hD7FB1168_378C3136
   };
 
 endpackage : top_englishbreakfast_rnd_cnst_pkg

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -8,7 +8,7 @@
 // util/topgen.py -t hw/top_englishbreakfast/data/top_englishbreakfast.hjson \
 //                -o hw/top_englishbreakfast/ \
 //                --rnd_cnst_seed \
-//                4881560218908238235
+//                47496257290787239787852990649372780135330843464066774986444696694703339830170
 
 
 package top_racl_pkg;


### PR DESCRIPTION
Previously, we were still using a shorter seed and topgen/secure_prng.py kept complaining about this. We don't really care for English Breakfast as this is never going to be taped out anyway that constantly seeing the warning is kind of annoying.

Just in case someone cares: the number added now has been generated with randomness from /dev/random using the following command:

od -vAn -N32 -tuL < /dev/random

This gives a random 32-byte number in the form of 4 64-bit unsigned integers which can then be shifted and added together.