### PR TITLE
[ujson,perso_tlv,dice] Fix potential signed integer flow, and add buffer checks

### DIFF
--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -163,7 +163,7 @@ status_t ujson_parse_integer(ujson_t *uj, void *result, size_t rsz) {
     neg = true;
     ch = (char)TRY(ujson_getc(uj));
   }
-  int64_t value = 0;
+  uint64_t value = 0;
 
   if (!(ch >= '0' && ch <= '9')) {
     return NOT_FOUND();
@@ -179,8 +179,17 @@ status_t ujson_parse_integer(ujson_t *uj, void *result, size_t rsz) {
   }
   if (status_ok(s))
     TRY(ujson_ungetc(uj, ch));
-  if (neg)
-    value = -value;
+
+  if (neg) {
+    if (value > (uint64_t)INT64_MAX + 1) {
+      return OUT_OF_RANGE();
+    }
+
+    int64_t neg_value = -1 * (int64_t)value;
+    memcpy(result, &neg_value, rsz);
+    return OK_STATUS();
+  }
+
   memcpy(result, &value, rsz);
   return OK_STATUS();
 }

--- a/sw/device/lib/ujson/ujson_test.cc
+++ b/sw/device/lib/ujson/ujson_test.cc
@@ -159,6 +159,11 @@ TEST(UJson, ParseIntegerError) {
   ss.Reset("q");
   s = ujson_parse_integer(&uj, (void *)&t, sizeof(t));
   EXPECT_EQ(status_err(s), kNotFound);
+
+  // Negative number that can NOT be represented in a 64-bit signed integer.
+  ss.Reset("-9223372036854775809");
+  s = ujson_parse_integer(&uj, (void *)&t, sizeof(t));
+  EXPECT_EQ(status_err(s), kOutOfRange);
 }
 
 TEST(UJson, SerializeString) {

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -192,8 +192,7 @@ rom_error_t dice_cert_check_valid(const perso_tlv_cert_obj_t *cert_obj,
   // For X.509, we only check the serial_number but not public key contents.
   OT_DISCARD(pubkey);
 
-  size_t cert_size = cert_obj->cert_body_size;
-  return cert_x509_asn1_check_serial_number(cert_obj->cert_body_p, 0,
-                                            (uint8_t *)pubkey_id->digest,
-                                            cert_valid_output, &cert_size);
+  return cert_x509_asn1_check_serial_number(
+      cert_obj->cert_body_p, 0, (uint8_t *)pubkey_id->digest, cert_valid_output,
+      /*out_cert_size=*/NULL);
 }


### PR DESCRIPTION
This PR has three commits that:

1. Fixes a potential integer overflow in `ujson_parse_integer` by using an unsigned integer for parsing and adding a check before converting back to a signed integer.
2. Adds buffer size checks in `perso_tlv_data.c` to prevent potential memory corruption vulnerabilities.
3. Removes the unused cert_size output parameter in `dice_cert_check_valid`

