### PR TITLE
[rom] Make the DEV key valid in TEST and RMA

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -64,6 +64,15 @@ def create_test_key(name, label):
 
 def create_dev_key(name, label):
     return create_key_(name, label, [
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.TEST_UNLOCKED1,
+        CONST.LCV.TEST_UNLOCKED2,
+        CONST.LCV.TEST_UNLOCKED3,
+        CONST.LCV.TEST_UNLOCKED4,
+        CONST.LCV.TEST_UNLOCKED5,
+        CONST.LCV.TEST_UNLOCKED6,
+        CONST.LCV.TEST_UNLOCKED7,
+        CONST.LCV.RMA,
         CONST.LCV.DEV,
     ])
 

--- a/sw/device/silicon_creator/rom/sigverify_otp_keys.c
+++ b/sw/device/silicon_creator/rom/sigverify_otp_keys.c
@@ -65,7 +65,7 @@ static rom_error_t key_is_valid_in_lc_state_rma(sigverify_key_type_t key_type) {
       return kErrorOk;
     case kSigverifyKeyTypeDev:
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
-      return kErrorSigverifyBadKey;
+      return kErrorOk;
     default:
       HARDENED_TRAP();
       OT_UNREACHABLE();
@@ -145,7 +145,7 @@ static rom_error_t key_is_valid_in_lc_state_test(
       return kErrorOk;
     case kSigverifyKeyTypeDev:
       HARDENED_CHECK_EQ(key_type, kSigverifyKeyTypeDev);
-      return kErrorSigverifyBadKey;
+      return kErrorOk;
     default:
       HARDENED_TRAP();
       OT_UNREACHABLE();


### PR DESCRIPTION
Make the DEV key valid in TEST and RMA. Because of the limited number of key slots in OTP, we allow the DEV key to be valid in DEV, TEST and RMA. This will allow a single set of keys (e.g. 3xPROD + 1xDEV) to be viable for devices provisioned to PROD and DEV mission mode states while still allowing the use of the DEV key for TEST and RMA states.