### PR TITLE
[topgen] Add support for instantiating uniquified ipgen IPs

### DIFF
--- a/hw/ip_templates/clkmgr/data/clkmgr.tpldesc.hjson
+++ b/hw/ip_templates/clkmgr/data/clkmgr.tpldesc.hjson
@@ -104,5 +104,11 @@
       type: "string"
       default: "lowrisc:constants:top_pkg"
     }
+    {
+      name: "module_instance_name"
+      desc: "instance name in case there are multiple clkmgr instances. Not yet implemented."
+      type: "string"
+      default: "clkmgr"
+    }
   ]
 }

--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.tpldesc.hjson
@@ -99,5 +99,11 @@
       type: "string"
       default: "lowrisc:constants:top_pkg"
     }
+    {
+      name: "module_instance_name"
+      desc: "instance name in case there are multiple flash_ctrl instances. Not yet implemented."
+      type: "string"
+      default: "flash_ctrl"
+    }
   ]
 }

--- a/hw/ip_templates/otp_ctrl/data/otp_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/otp_ctrl/data/otp_ctrl.tpldesc.hjson
@@ -15,5 +15,11 @@
       type: "object"
       default: {}
     }
+    {
+      name: "module_instance_name"
+      desc: "instance name in case there are multiple otp_ctrl instances. Not yet implemented."
+      type: "string"
+      default: "otp_ctrl"
+    }
   ]
 }

--- a/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
@@ -81,5 +81,11 @@
       type: "string"
       default: "lowrisc:systems:scan_role_pkg"
     }
+    {
+      name: "module_instance_name"
+      desc: "instance name in case there are multiple pinmux instances. Not yet implemented."
+      type: "string"
+      default: "pinmux"
+    }
   ]
 }

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
@@ -70,5 +70,11 @@
       type: "string"
       default: "lowrisc:constants:top_pkg"
     }
+    {
+      name: "module_instance_name"
+      desc: "instance name in case there are multiple pwrmgr instances. Not yet implemented."
+      type: "string"
+      default: "pwrmgr"
+    }
   ]
 }

--- a/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
@@ -135,5 +135,11 @@
       type: "string"
       default: "lowrisc:constants:top_pkg"
     }
+    {
+      name: "module_instance_name"
+      desc: "instance name in case there are multiple pwrmgr instances. Not yet implemented."
+      type: "string"
+      default: "pwrmgr"
+    }
   ]
 }

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1020,6 +1020,7 @@
     {
       name: otp_ctrl
       type: otp_ctrl
+      template_type: otp_ctrl
       clock_srcs:
       {
         clk_i: io_div4
@@ -2127,6 +2128,7 @@
     {
       name: alert_handler
       type: alert_handler
+      template_type: alert_handler
       clock_srcs:
       {
         clk_i: io_div4
@@ -2357,6 +2359,7 @@
     {
       name: pwrmgr_aon
       type: pwrmgr
+      template_type: pwrmgr
       clock_group: powerup
       clock_srcs:
       {
@@ -2721,6 +2724,7 @@
     {
       name: rstmgr_aon
       type: rstmgr
+      template_type: rstmgr
       clock_srcs:
       {
         clk_i:
@@ -2925,6 +2929,7 @@
     {
       name: clkmgr_aon
       type: clkmgr
+      template_type: clkmgr
       clock_srcs:
       {
         clk_i: io_div4
@@ -3260,6 +3265,7 @@
     {
       name: pinmux_aon
       type: pinmux
+      template_type: pinmux
       clock_srcs:
       {
         clk_i: io_div4
@@ -4553,6 +4559,7 @@
     {
       name: rv_plic
       type: rv_plic
+      template_type: rv_plic
       clock_srcs:
       {
         clk_i: main

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -313,6 +313,7 @@
     },
     { name: "otp_ctrl",
       type: "otp_ctrl",
+      template_type: "otp_ctrl",
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
@@ -349,6 +350,7 @@
     },
     { name: "alert_handler",
       type: "alert_handler",
+      template_type: "alert_handler",
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
@@ -368,6 +370,7 @@
     },
     { name: "pwrmgr_aon",
       type: "pwrmgr",
+      template_type: "pwrmgr",
       // TODO: RS, fix after pwrmgr fix is merged
       // param_decl: {
       //   PwrFsmWaitForExtRst: "1"
@@ -413,6 +416,7 @@
     },
     { name: "rstmgr_aon",
       type: "rstmgr",
+      template_type: "rstmgr",
       clock_srcs: {
         clk_i: {
           clock: "io_div4",
@@ -440,6 +444,7 @@
     },
     { name: "clkmgr_aon",
       type: "clkmgr",
+      template_type: "clkmgr",
       clock_srcs: {
         clk_i: "io_div4",
         clk_main_i: {
@@ -482,6 +487,7 @@
     },
     { name: "pinmux_aon",
       type: "pinmux",
+      template_type: "pinmux",
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "lc_io_div4",
@@ -646,6 +652,7 @@
     },
     { name: "rv_plic",
       type: "rv_plic",
+      template_type: "rv_plic",
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -8,6 +8,7 @@
     src: 158
     target: 1
     prio: 3
+    module_instance_name: rv_plic
     topname: darjeeling
   }
 }

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -329,7 +329,7 @@ module top_${top["name"]} #(
 ## Inter-module signal collection
 
 % for m in top["module"]:
-  % if m["type"] == "otp_ctrl":
+  % if m.get("template_type") == "otp_ctrl":
   // OTP HW_CFG Broadcast signals.
   // TODO(#6713): The actual struct breakout and mapping currently needs to
   // be performed by hand.
@@ -562,10 +562,10 @@ slice = f"{lo+w-1}:{lo}"
         % endif
       % endfor
     % endif
-    % if m["type"] == "rv_plic":
+    % if m.get("template_type") == "rv_plic":
       .intr_src_i (intr_vector),
     % endif
-    % if m["type"] == "pinmux":
+    % if m.get("template_type") == "pinmux":
 
       .periph_to_mio_i      (mio_d2p    ),
       .periph_to_mio_oe_i   (mio_en_d2p ),
@@ -586,7 +586,7 @@ slice = f"{lo+w-1}:{lo}"
       .dio_in_i,
 
     % endif
-    % if m["type"] == "alert_handler":
+    % if m.get("template_type") == "alert_handler":
       // alert signals
       .alert_rx_o  ( alert_rx ),
       .alert_tx_i  ( alert_tx ),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1505,6 +1505,7 @@
     {
       name: otp_ctrl
       type: otp_ctrl
+      template_type: otp_ctrl
       clock_srcs:
       {
         clk_i: io_div4
@@ -2613,6 +2614,7 @@
     {
       name: alert_handler
       type: alert_handler
+      template_type: alert_handler
       clock_srcs:
       {
         clk_i: io_div4
@@ -3252,6 +3254,7 @@
     {
       name: pwrmgr_aon
       type: pwrmgr
+      template_type: pwrmgr
       clock_group: powerup
       clock_srcs:
       {
@@ -3602,6 +3605,7 @@
     {
       name: rstmgr_aon
       type: rstmgr
+      template_type: rstmgr
       clock_srcs:
       {
         clk_i:
@@ -3806,6 +3810,7 @@
     {
       name: clkmgr_aon
       type: clkmgr
+      template_type: clkmgr
       clock_srcs:
       {
         clk_i: io_div4
@@ -4365,6 +4370,7 @@
     {
       name: pinmux_aon
       type: pinmux
+      template_type: pinmux
       clock_srcs:
       {
         clk_i: io_div4
@@ -5458,6 +5464,7 @@
     {
       name: flash_ctrl
       type: flash_ctrl
+      template_type: flash_ctrl
       clock_srcs:
       {
         clk_i: main
@@ -6269,6 +6276,7 @@
     {
       name: rv_plic
       type: rv_plic
+      template_type: rv_plic
       clock_srcs:
       {
         clk_i: main

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -394,6 +394,7 @@
     },
     { name: "otp_ctrl",
       type: "otp_ctrl",
+      template_type: "otp_ctrl",
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
@@ -427,6 +428,7 @@
     },
     { name: "alert_handler",
       type: "alert_handler",
+      template_type: "alert_handler",
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
@@ -467,6 +469,7 @@
     },
     { name: "pwrmgr_aon",
       type: "pwrmgr",
+      template_type: "pwrmgr",
       clock_group: "powerup",
       clock_srcs: {
         clk_i: "io_div4",
@@ -507,6 +510,7 @@
     },
     { name: "rstmgr_aon",
       type: "rstmgr",
+      template_type: "rstmgr",
       clock_srcs: {
         clk_i: {
           clock: "io_div4",
@@ -534,6 +538,7 @@
     },
     { name: "clkmgr_aon",
       type: "clkmgr",
+      template_type: "clkmgr",
       clock_srcs: {
         clk_i: "io_div4",
         clk_main_i: {
@@ -606,6 +611,7 @@
     },
     { name: "pinmux_aon",
       type: "pinmux",
+      template_type: "pinmux",
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "lc_io_div4",
@@ -735,6 +741,7 @@
     },
     { name: "flash_ctrl",
       type: "flash_ctrl",
+      template_type: "flash_ctrl",
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
@@ -781,6 +788,7 @@
     },
     { name: "rv_plic",
       type: "rv_plic",
+      template_type: "rv_plic",
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
@@ -8,6 +8,7 @@
     src: 186
     target: 1
     prio: 3
+    module_instance_name: rv_plic
     topname: earlgrey
   }
 }

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -328,7 +328,7 @@ module top_${top["name"]} #(
 ## Inter-module signal collection
 
 % for m in top["module"]:
-  % if m["type"] == "otp_ctrl":
+  % if m.get("template_type") == "otp_ctrl":
   // OTP HW_CFG* Broadcast signals.
   // TODO(#6713): The actual struct breakout and mapping currently needs to
   // be performed by hand.
@@ -581,10 +581,10 @@ slice = f"{lo+w-1}:{lo}"
         % endif
       % endfor
     % endif
-    % if m["type"] == "rv_plic":
+    % if m.get("template_type") == "rv_plic":
       .intr_src_i (intr_vector),
     % endif
-    % if m["type"] == "pinmux":
+    % if m.get("template_type") == "pinmux":
 
       .periph_to_mio_i      (mio_d2p    ),
       .periph_to_mio_oe_i   (mio_en_d2p ),
@@ -605,7 +605,7 @@ slice = f"{lo+w-1}:{lo}"
       .dio_in_i,
 
     % endif
-    % if m["type"] == "alert_handler":
+    % if m.get("template_type") == "alert_handler":
       // alert signals
       .alert_rx_o  ( alert_rx ),
       .alert_tx_i  ( alert_tx ),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -1282,6 +1282,7 @@
     {
       name: pwrmgr_aon
       type: pwrmgr
+      template_type: pwrmgr
       clock_srcs:
       {
         clk_i: io_div4
@@ -1609,6 +1610,7 @@
     {
       name: rstmgr_aon
       type: rstmgr
+      template_type: rstmgr
       clock_srcs:
       {
         clk_i: io_div4
@@ -1809,6 +1811,7 @@
     {
       name: clkmgr_aon
       type: clkmgr
+      template_type: clkmgr
       clock_srcs:
       {
         clk_i: io_div4
@@ -2135,6 +2138,7 @@
     {
       name: pinmux_aon
       type: pinmux
+      template_type: pinmux
       clock_srcs:
       {
         clk_i: io_div4
@@ -2771,6 +2775,7 @@
     {
       name: flash_ctrl
       type: flash_ctrl
+      template_type: flash_ctrl
       clock_srcs:
       {
         clk_i: main
@@ -3187,6 +3192,7 @@
     {
       name: rv_plic
       type: rv_plic
+      template_type: rv_plic
       clock_srcs:
       {
         clk_i: main

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -316,6 +316,7 @@
     },
     { name: "pwrmgr_aon",
       type: "pwrmgr",
+      template_type: "pwrmgr",
       clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon", clk_lc_i: "io_div4", clk_esc_i: "io_div4"},
       clock_group: "powerup",
       reset_connections: {
@@ -334,6 +335,7 @@
     },
     { name: "rstmgr_aon",
       type: "rstmgr",
+      template_type: "rstmgr",
       clock_srcs: {clk_i: "io_div4", clk_por_i: "io_div4", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
                    clk_io_div2_i: "io_div2", clk_io_div4_i: "io_div4"},
       clock_group: "powerup",
@@ -349,6 +351,7 @@
     },
     { name: "clkmgr_aon",
       type: "clkmgr",
+      template_type: "clkmgr",
       clock_srcs: {
         clk_i: "io_div4",
         clk_main_i: {
@@ -391,6 +394,7 @@
     },
     { name: "pinmux_aon",
       type: "pinmux",
+      template_type: "pinmux",
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "lc_io_div4",
@@ -442,6 +446,7 @@
     },
     { name: "flash_ctrl",
       type: "flash_ctrl",
+      template_type: "flash_ctrl",
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
@@ -471,6 +476,7 @@
     },
     { name: "rv_plic",
       type: "rv_plic",
+      template_type: "rv_plic",
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
@@ -8,6 +8,7 @@
     src: 88
     target: 1
     prio: 3
+    module_instance_name: rv_plic
     topname: englishbreakfast
   }
 }

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -856,6 +856,21 @@ def num_rom_ctrl(modules):
 
 def find_module(modules, type):
     '''Returns the first module of a given type
+    For ipgen modules the base template type is used for matching
+    '''
+    for m in modules:
+        if m.get('attr') == 'ipgen':
+            if m['template_type'] == type:
+                return m
+        else:
+            if m['type'] == type:
+                return m
+
+    return None
+
+
+def find_module_by_type(modules, type):
+    '''Returns the first module of a given type
     '''
     for m in modules:
         if m['type'] == type:

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -218,6 +218,9 @@ module_optional = {
     'incoming_alert': ['l', 'optional list of paths to incoming alert configurations for the '
                             'alert_handler'],
     'incoming_interrupt': ['g', 'Parsed incoming interrupts (generated)'],
+    'template_type': ['s', 'Base template type of ipgen IPs'],
+    'racl_group': ['s', 'Only valid for racl_ctrl IPs. Defines the RACL group this control IP is '
+                        'associated to'],
 }
 
 module_added = {


### PR DESCRIPTION
This PR adds basic support to render and instantiate uniquified IPs from ipgen. The change is done in the following way:

1. It is assumed that all ipgen IP templates support the `module_instance_name` parameter. This is not true for all IPs there. Though this parameter was added to all `*.tpldesc` files, even it is not used.
2. In topgen, when you instantiate an ipgen'ed (`attr: "ipen"`), you specify three different fields:
   1. `template_type`: This is the basic template type that is used to render the IP from.
   2. `type`: This is the uniquified type.
   3. `name`: This is the actual instance name used in the top-level SystemVerilog file.

Let's make an example: To render a uniquified `rv_plic` you would set the following parameters in the HJSON:
```hjson
{
  template_type: "rv_plic"
  type:          "my_fancy_plic"
  name:          "my_plic_name"
  ...
}
```

This would render and create new module `my_fancy_plic` and the instantiation would look like:
```SystemVerilog
my_fancy_plic #(
   ...
 ) u_my_plic_name (
   ...
 );
 ```

Note, currently, only the AC ranges, RACL Ctrl, and the PLIC support this kind of uniquification. The alert handler would support it in theory. However, here, the template needs a few modifications as the uniquication there does create wrong file names. 