### PR TITLE
[doc,docker] update util/container to Ubuntu 22.04 and stop mentioning 20.04

### DIFF
--- a/doc/getting_started/README.md
+++ b/doc/getting_started/README.md
@@ -44,7 +44,7 @@ You can then **skip to step 4** (building software).
 If you do have Linux, you are still welcome to try the Docker container.
 However, as the container option is currently experimental, we recommend following the steps below to build manually if you plan on being a long-term user or contributor for the project.
 
-Our continuous integration setup runs on Ubuntu 20.04 LTS, which gives us the most confidence that this distribution works out of the box.
+Our continuous integration setup runs on Ubuntu 22.04 LTS, which gives us the most confidence that this distribution works out of the box.
 We do our best to support other distributions, but cannot guarantee they can be used "out of the box" and they might require updates of packages.
 Please file a [GitHub issue](https://github.com/lowRISC/opentitan/issues) if you need help or would like to propose a change to increase compatibility with other distributions.
 

--- a/sw/device/silicon_creator/rom/doc/e2e_tests.md
+++ b/sw/device/silicon_creator/rom/doc/e2e_tests.md
@@ -1,5 +1,5 @@
 # ROM E2E Regressions setup
-This guide will help you to setup an environment to run the ROM E2E tests in an Ubuntu 20.04 machine.
+This guide will help you to setup an environment to run the ROM E2E tests in an Ubuntu 22.04 machine.
 
 ## Introduction
 The [ROM](../README.md) is the first boot stage of secure boot flow and by nature, it cannot be updated after manufacturing.

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -16,7 +16,7 @@ ARG BAZELISK_VERSION=v1.24.1
 ARG CLANG_VERSION=16
 
 # Main container image.
-FROM ubuntu:20.04 AS opentitan
+FROM ubuntu:22.04 AS opentitan
 ARG VERILATOR_VERSION
 ARG VERIBLE_VERSION
 ARG RISCV_TOOLCHAIN_TAR_VERSION
@@ -73,7 +73,7 @@ RUN /tmp/get-toolchain.py -r ${RISCV_TOOLCHAIN_TAR_VERSION} \
 # build. These are kept intentionally since we plan to use them in the future, e.g.
 # `llvm-remark-size-diff` and `llvm-tli-checker`.
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add \
-    && add-apt-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VERSION} main" \
+    && add-apt-repository "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${CLANG_VERSION} main" \
     && apt update \
     && apt install -y clang-${CLANG_VERSION} lldb-${CLANG_VERSION} lld-${CLANG_VERSION} \
         clangd-${CLANG_VERSION} clang-tidy-${CLANG_VERSION} clang-format-${CLANG_VERSION} \

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -1,6 +1,6 @@
 # Docker Container
 
-Docker container based on Ubuntu 20.04 LTS containing various hardware and
+Docker container based on Ubuntu 22.04 LTS containing various hardware and
 software development tools for OpenTitan, as listed in the
 [OpenTitan documentation](../../doc/getting_started/README.md).
 


### PR DESCRIPTION
Getting this fixed so people don't have new Ubuntu 20.04 installations anymore.

We'll need to deprecate the support of Ubuntu 20.04 before it goes EOL this April.