### PR TITLE
[manuf] disable OTP checks during FT individualize

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -206,6 +206,15 @@ static status_t provision(ujson_t *uj) {
     LOG_INFO("External clock enabled.");
   }
 
+  // Turn off OTP runtime checks.
+  TRY(dif_otp_ctrl_configure(
+      &otp_ctrl,
+      (dif_otp_ctrl_config_t){
+          .check_timeout = 0,            // Disable the check timeout mechanism.
+          .integrity_period_mask = 0,    // Disable integrity checks.
+          .consistency_period_mask = 0,  // Disable consistency checks.
+      }));
+
   // Perform OTP writes.
   LOG_INFO("Writing HW_CFG* OTP partitions ...");
   TRY(manuf_individualize_device_hw_cfg(&flash_ctrl_state, &otp_ctrl,


### PR DESCRIPTION
This ensures all OTP consistency and integrity checks are disabled during FT individualization.