### PR TITLE
[manuf] treat SimDv and Silicon platforms the same

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -228,7 +228,8 @@ static status_t provision(ujson_t *uj) {
   }
 
   // Enable external clock on silicon platforms if requested.
-  if (kDeviceType == kDeviceSilicon && in_data.use_ext_clk) {
+  if ((kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) &&
+      in_data.use_ext_clk) {
     TRY(dif_clkmgr_external_clock_set_enabled(&clkmgr,
                                               /*is_low_speed=*/true));
     IBEX_SPIN_FOR(did_extclk_settle(&clkmgr), kSettleDelayMicros);

--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -109,7 +109,7 @@ status_t manuf_individualize_device_hw_cfg(
     // empty. In this case we set the HW origin portion of the CP device ID.
     // Otherwise, we expect the CP device ID to be present and non-zero.
     if (flash_cp_device_id_empty) {
-      if (kDeviceType != kDeviceSilicon) {
+      if (kDeviceType != kDeviceSilicon && kDeviceType != kDeviceSimDV) {
         memset(&cp_device_id, 0, sizeof(cp_device_id));
         cp_device_id[0] = 0x00024001u;
       } else {


### PR DESCRIPTION
Some configuration settings are only toggled on specific platforms during individualization. This ensures SimDv and Silicon platforms are treated the same.