### PR TITLE
[topgen] Uniquification folllow-up

### DIFF
--- a/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
@@ -137,9 +137,9 @@
     }
     {
       name: "module_instance_name"
-      desc: "instance name in case there are multiple pwrmgr instances. Not yet implemented."
+      desc: "instance name in case there are multiple rstmgr instances. Not yet implemented."
       type: "string"
-      default: "pwrmgr"
+      default: "rstmgr"
     }
   ]
 }

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -850,7 +850,8 @@ def _process_top(
             # of as soon as we don't arbitrarily template IP description Hjson
             # files any more.
             if ip_name in ipgen_list and not ip_desc_file.is_file():
-                ipgen_module = lib.find_module_by_type(topcfg['module'], ip_name)
+                ipgen_module = lib.find_module(topcfg['module'], ip_name,
+                                               use_base_template_type=False)
                 template_type = ipgen_module['template_type']
                 log.info(
                     f"To-be-generated Hjson {ip_desc_file} does not yet exist. "

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -854,27 +854,19 @@ def num_rom_ctrl(modules):
     return num
 
 
-def find_module(modules, type):
+def find_module(modules, type, use_base_template_type=True):
     '''Returns the first module of a given type
-    For ipgen modules the base template type is used for matching
+    If use_base_template_type is set to True, ipgen-based modules are
+    matched based on the base template type. If set to False, the
+    uniquified type is matched,
     '''
     for m in modules:
-        if m.get('attr') == 'ipgen':
+        if m.get('attr') == 'ipgen' and use_base_template_type:
             if m['template_type'] == type:
                 return m
         else:
             if m['type'] == type:
                 return m
-
-    return None
-
-
-def find_module_by_type(modules, type):
-    '''Returns the first module of a given type
-    '''
-    for m in modules:
-        if m['type'] == type:
-            return m
 
     return None
 


### PR DESCRIPTION
This PR is a follow-up from https://github.com/lowRISC/opentitan/pull/25966 and post-merge fixes 2 review comments:

1. Properly use the rstmgr default in their module instance name template
2. Merge `find_module` and `find_module_by_type` by adding a new parameter `use_base_template_type`