### PR TITLE
[Darjeeling] Configure Darjeeling clocks

### DIFF
--- a/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
@@ -601,7 +601,7 @@
           bits: "${min_msb}:${max_msb+1}",
           name: "LO",
           desc: "Min threshold for ${src} measurement",
-          resval: "${ratio - 10}"
+          resval: "${max(ratio - 10, 0)}"
         },
       ]
     },

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -38,25 +38,25 @@
       {
         name: main
         aon: no
-        freq: "100000000"
+        freq: "1000000000"
         ref: false
       }
       {
         name: io
         aon: no
-        freq: "96000000"
+        freq: "1000000000"
         ref: false
       }
       {
         name: usb
         aon: no
-        freq: "48000000"
+        freq: "1000000000"
         ref: false
       }
       {
         name: aon
         aon: yes
-        freq: "200000"
+        freq: "62500000"
         ref: true
       }
     ]
@@ -65,7 +65,7 @@
       {
         name: io_div2
         aon: no
-        freq: "48000000"
+        freq: "500000000"
         ref: false
         div: "2"
         src: io
@@ -73,7 +73,7 @@
       {
         name: io_div4
         aon: no
-        freq: "24000000"
+        freq: "250000000"
         ref: false
         div: "4"
         src: io

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -57,10 +57,10 @@
     // freq: Absolute frequency of clk in Hz
     // ref: indicates the clock is used as a reference for measurement.
     srcs: [
-      { name: "main", aon: "no",  freq: "100000000" }
-      { name: "io",   aon: "no",  freq: "96000000" }
-      { name: "usb",  aon: "no",  freq: "48000000" }
-      { name: "aon",  aon: "yes", freq: "200000", ref: true}
+      { name: "main", aon: "no",  freq: "1000000000" }
+      { name: "io",   aon: "no",  freq: "1000000000" }
+      { name: "usb",  aon: "no",  freq: "1000000000" }
+      { name: "aon",  aon: "yes", freq: "62500000", ref: true}
     ],
 
     // Derived clock source attributes
@@ -71,8 +71,8 @@
     // src:  From which clock source is the clock derived
     // div:  Ratio between derived clock and source clock
     derived_srcs: [
-      { name: "io_div2", aon: "no", div: 2, src: "io", freq: "48000000" }
-      { name: "io_div4", aon: "no", div: 4, src: "io", freq: "24000000" }
+      { name: "io_div2", aon: "no", div: 2, src: "io", freq: "500000000" }
+      { name: "io_div4", aon: "no", div: 4, src: "io", freq: "250000000" }
     ],
 
     // Clock Group attributes

--- a/hw/top_darjeeling/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_darjeeling/dv/autogen/tb__xbar_connect.sv
@@ -234,11 +234,11 @@ initial begin
     xbar_clk_rst_if.wait_for_reset(.wait_posedge(1'b0));
 
     clk_rst_if_main.set_active(.drive_rst_n_val(0));
-    clk_rst_if_main.set_freq_khz(100000000 / 1000);
+    clk_rst_if_main.set_freq_khz(1000000000 / 1000);
     clk_rst_if_usb.set_active(.drive_rst_n_val(0));
-    clk_rst_if_usb.set_freq_khz(48000000 / 1000);
+    clk_rst_if_usb.set_freq_khz(1000000000 / 1000);
     clk_rst_if_io_div4.set_active(.drive_rst_n_val(0));
-    clk_rst_if_io_div4.set_freq_khz(24000000 / 1000);
+    clk_rst_if_io_div4.set_freq_khz(250000000 / 1000);
 
   end
 end

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr.hjson
@@ -644,17 +644,17 @@
       storage_err_alert: "fatal_fault",
       fields: [
         {
-          bits: "7:0",
+          bits: "3:0",
           name: "HI",
           desc: "Max threshold for io_div4 measurement",
-          resval: "130"
+          resval: "14"
         },
 
         {
-          bits: "15:8",
+          bits: "7:4",
           name: "LO",
           desc: "Min threshold for io_div4 measurement",
-          resval: "110"
+          resval: "0"
         },
       ]
     },
@@ -698,17 +698,17 @@
       storage_err_alert: "fatal_fault",
       fields: [
         {
-          bits: "9:0",
+          bits: "5:0",
           name: "HI",
           desc: "Max threshold for main measurement",
-          resval: "510"
+          resval: "26"
         },
 
         {
-          bits: "19:10",
+          bits: "11:6",
           name: "LO",
           desc: "Min threshold for main measurement",
-          resval: "490"
+          resval: "6"
         },
       ]
     },
@@ -752,17 +752,17 @@
       storage_err_alert: "fatal_fault",
       fields: [
         {
-          bits: "8:0",
+          bits: "5:0",
           name: "HI",
           desc: "Max threshold for usb measurement",
-          resval: "250"
+          resval: "26"
         },
 
         {
-          bits: "17:9",
+          bits: "11:6",
           name: "LO",
           desc: "Min threshold for usb measurement",
-          resval: "230"
+          resval: "6"
         },
       ]
     },

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
@@ -11,28 +11,28 @@
       {
         name: main
         aon: false
-        freq: 100000000
+        freq: 1000000000
         ref: false
       }
       io:
       {
         name: io
         aon: false
-        freq: 96000000
+        freq: 1000000000
         ref: false
       }
       usb:
       {
         name: usb
         aon: false
-        freq: 48000000
+        freq: 1000000000
         ref: false
       }
       aon:
       {
         name: aon
         aon: true
-        freq: 200000
+        freq: 62500000
         ref: true
       }
     }
@@ -42,14 +42,14 @@
       {
         name: io_div2
         aon: false
-        freq: 48000000
+        freq: 500000000
         ref: false
         div: 2
         src:
         {
           name: io
           aon: no
-          freq: "96000000"
+          freq: "1000000000"
           ref: false
         }
       }
@@ -57,14 +57,14 @@
       {
         name: io_div4
         aon: false
-        freq: 24000000
+        freq: 250000000
         ref: false
         div: 4
         src:
         {
           name: io
           aon: no
-          freq: "96000000"
+          freq: "1000000000"
           ref: false
         }
       }

--- a/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
@@ -279,21 +279,21 @@ Configuration controls for io_div4 measurement.
 The threshold fields are made wider than required (by 1 bit) to ensure
 there is room to adjust for measurement inaccuracies.
 - Offset: `0x2c`
-- Reset default: `0x6e82`
-- Reset mask: `0xffff`
+- Reset default: `0xe`
+- Reset mask: `0xff`
 - Register enable: [`MEASURE_CTRL_REGWEN`](#measure_ctrl_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "HI", "bits": 8, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 8, "attr": ["rw"], "rotate": 0}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "HI", "bits": 4, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 4, "attr": ["rw"], "rotate": 0}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                           |
 |:------:|:------:|:-------:|:-------|:--------------------------------------|
-| 31:16  |        |         |        | Reserved                              |
-|  15:8  |   rw   |  0x6e   | LO     | Min threshold for io_div4 measurement |
-|  7:0   |   rw   |  0x82   | HI     | Max threshold for io_div4 measurement |
+|  31:8  |        |         |        | Reserved                              |
+|  7:4   |   rw   |   0x0   | LO     | Min threshold for io_div4 measurement |
+|  3:0   |   rw   |   0xe   | HI     | Max threshold for io_div4 measurement |
 
 ## MAIN_MEAS_CTRL_EN
 Enable for measurement control
@@ -319,21 +319,21 @@ Configuration controls for main measurement.
 The threshold fields are made wider than required (by 1 bit) to ensure
 there is room to adjust for measurement inaccuracies.
 - Offset: `0x34`
-- Reset default: `0x7a9fe`
-- Reset mask: `0xfffff`
+- Reset default: `0x19a`
+- Reset mask: `0xfff`
 - Register enable: [`MEASURE_CTRL_REGWEN`](#measure_ctrl_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "HI", "bits": 10, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 10, "attr": ["rw"], "rotate": 0}, {"bits": 12}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "HI", "bits": 6, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 6, "attr": ["rw"], "rotate": 0}, {"bits": 20}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                        |
 |:------:|:------:|:-------:|:-------|:-----------------------------------|
-| 31:20  |        |         |        | Reserved                           |
-| 19:10  |   rw   |  0x1ea  | LO     | Min threshold for main measurement |
-|  9:0   |   rw   |  0x1fe  | HI     | Max threshold for main measurement |
+| 31:12  |        |         |        | Reserved                           |
+|  11:6  |   rw   |   0x6   | LO     | Min threshold for main measurement |
+|  5:0   |   rw   |  0x1a   | HI     | Max threshold for main measurement |
 
 ## USB_MEAS_CTRL_EN
 Enable for measurement control
@@ -359,21 +359,21 @@ Configuration controls for usb measurement.
 The threshold fields are made wider than required (by 1 bit) to ensure
 there is room to adjust for measurement inaccuracies.
 - Offset: `0x3c`
-- Reset default: `0x1ccfa`
-- Reset mask: `0x3ffff`
+- Reset default: `0x19a`
+- Reset mask: `0xfff`
 - Register enable: [`MEASURE_CTRL_REGWEN`](#measure_ctrl_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "HI", "bits": 9, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 9, "attr": ["rw"], "rotate": 0}, {"bits": 14}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "HI", "bits": 6, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 6, "attr": ["rw"], "rotate": 0}, {"bits": 20}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                       |
 |:------:|:------:|:-------:|:-------|:----------------------------------|
-| 31:18  |        |         |        | Reserved                          |
-|  17:9  |   rw   |  0xe6   | LO     | Min threshold for usb measurement |
-|  8:0   |   rw   |  0xfa   | HI     | Max threshold for usb measurement |
+| 31:12  |        |         |        | Reserved                          |
+|  11:6  |   rw   |   0x6   | LO     | Min threshold for usb measurement |
+|  5:0   |   rw   |  0x1a   | HI     | Max threshold for usb measurement |
 
 ## RECOV_ERR_CODE
 Recoverable Error code

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -549,7 +549,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(240),
+    .Cnt(8),
     .RefCnt(1)
   ) u_io_div4_meas (
     .clk_i,
@@ -576,7 +576,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(1000),
+    .Cnt(32),
     .RefCnt(1)
   ) u_main_meas (
     .clk_i,
@@ -603,7 +603,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
+    .Cnt(32),
     .RefCnt(1)
   ) u_usb_meas (
     .clk_i,

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -80,10 +80,10 @@ package clkmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  q;
+      logic [3:0]  q;
     } lo;
     struct packed {
-      logic [7:0]  q;
+      logic [3:0]  q;
     } hi;
   } clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t;
 
@@ -93,10 +93,10 @@ package clkmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [9:0] q;
+      logic [5:0]  q;
     } lo;
     struct packed {
-      logic [9:0] q;
+      logic [5:0]  q;
     } hi;
   } clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t;
 
@@ -106,10 +106,10 @@ package clkmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [8:0]  q;
+      logic [5:0]  q;
     } lo;
     struct packed {
-      logic [8:0]  q;
+      logic [5:0]  q;
     } hi;
   } clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t;
 
@@ -216,18 +216,18 @@ package clkmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_alert_test_reg_t alert_test; // [92:89]
-    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [88:81]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [80:77]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [76:74]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [73:70]
-    clkmgr_reg2hw_measure_ctrl_regwen_reg_t measure_ctrl_regwen; // [69:69]
-    clkmgr_reg2hw_io_div4_meas_ctrl_en_reg_t io_div4_meas_ctrl_en; // [68:65]
-    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [64:49]
-    clkmgr_reg2hw_main_meas_ctrl_en_reg_t main_meas_ctrl_en; // [48:45]
-    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [44:25]
-    clkmgr_reg2hw_usb_meas_ctrl_en_reg_t usb_meas_ctrl_en; // [24:21]
-    clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t usb_meas_ctrl_shadowed; // [20:3]
+    clkmgr_reg2hw_alert_test_reg_t alert_test; // [70:67]
+    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [66:59]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [58:55]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [54:52]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [51:48]
+    clkmgr_reg2hw_measure_ctrl_regwen_reg_t measure_ctrl_regwen; // [47:47]
+    clkmgr_reg2hw_io_div4_meas_ctrl_en_reg_t io_div4_meas_ctrl_en; // [46:43]
+    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [42:35]
+    clkmgr_reg2hw_main_meas_ctrl_en_reg_t main_meas_ctrl_en; // [34:31]
+    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [30:19]
+    clkmgr_reg2hw_usb_meas_ctrl_en_reg_t usb_meas_ctrl_en; // [18:15]
+    clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t usb_meas_ctrl_shadowed; // [14:3]
     clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [2:0]
   } clkmgr_reg2hw_t;
 
@@ -305,11 +305,11 @@ package clkmgr_reg_pkg;
     4'b 0001, // index[ 8] CLKMGR_CLK_HINTS_STATUS
     4'b 0001, // index[ 9] CLKMGR_MEASURE_CTRL_REGWEN
     4'b 0001, // index[10] CLKMGR_IO_DIV4_MEAS_CTRL_EN
-    4'b 0011, // index[11] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
+    4'b 0001, // index[11] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
     4'b 0001, // index[12] CLKMGR_MAIN_MEAS_CTRL_EN
-    4'b 0111, // index[13] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
+    4'b 0011, // index[13] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
     4'b 0001, // index[14] CLKMGR_USB_MEAS_CTRL_EN
-    4'b 0111, // index[15] CLKMGR_USB_MEAS_CTRL_SHADOWED
+    4'b 0011, // index[15] CLKMGR_USB_MEAS_CTRL_SHADOWED
     4'b 0001, // index[16] CLKMGR_RECOV_ERR_CODE
     4'b 0001  // index[17] CLKMGR_FATAL_ERR_CODE
   };

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -178,7 +178,7 @@ module clkmgr_reg_top (
   logic io_div4_meas_ctrl_en_busy;
   logic io_div4_meas_ctrl_shadowed_re;
   logic io_div4_meas_ctrl_shadowed_we;
-  logic [15:0] io_div4_meas_ctrl_shadowed_qs;
+  logic [7:0] io_div4_meas_ctrl_shadowed_qs;
   logic io_div4_meas_ctrl_shadowed_busy;
   logic io_div4_meas_ctrl_shadowed_hi_storage_err;
   logic io_div4_meas_ctrl_shadowed_hi_update_err;
@@ -189,7 +189,7 @@ module clkmgr_reg_top (
   logic main_meas_ctrl_en_busy;
   logic main_meas_ctrl_shadowed_re;
   logic main_meas_ctrl_shadowed_we;
-  logic [19:0] main_meas_ctrl_shadowed_qs;
+  logic [11:0] main_meas_ctrl_shadowed_qs;
   logic main_meas_ctrl_shadowed_busy;
   logic main_meas_ctrl_shadowed_hi_storage_err;
   logic main_meas_ctrl_shadowed_hi_update_err;
@@ -200,7 +200,7 @@ module clkmgr_reg_top (
   logic usb_meas_ctrl_en_busy;
   logic usb_meas_ctrl_shadowed_re;
   logic usb_meas_ctrl_shadowed_we;
-  logic [17:0] usb_meas_ctrl_shadowed_qs;
+  logic [11:0] usb_meas_ctrl_shadowed_qs;
   logic usb_meas_ctrl_shadowed_busy;
   logic usb_meas_ctrl_shadowed_hi_storage_err;
   logic usb_meas_ctrl_shadowed_hi_update_err;
@@ -271,25 +271,25 @@ module clkmgr_reg_top (
   assign unused_io_div4_io_div4_meas_ctrl_en_wdata =
       ^io_div4_io_div4_meas_ctrl_en_wdata;
 
-  logic [7:0]  io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
-  logic [7:0]  io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
-  logic [15:0] io_div4_io_div4_meas_ctrl_shadowed_qs;
-  logic [15:0] io_div4_io_div4_meas_ctrl_shadowed_wdata;
+  logic [3:0]  io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
+  logic [3:0]  io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
+  logic [7:0] io_div4_io_div4_meas_ctrl_shadowed_qs;
+  logic [7:0] io_div4_io_div4_meas_ctrl_shadowed_wdata;
   logic io_div4_io_div4_meas_ctrl_shadowed_we;
   logic unused_io_div4_io_div4_meas_ctrl_shadowed_wdata;
   logic io_div4_io_div4_meas_ctrl_shadowed_re;
   logic io_div4_io_div4_meas_ctrl_shadowed_regwen;
 
   always_comb begin
-    io_div4_io_div4_meas_ctrl_shadowed_qs = 16'h6e82;
-    io_div4_io_div4_meas_ctrl_shadowed_qs[7:0] = io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
-    io_div4_io_div4_meas_ctrl_shadowed_qs[15:8] = io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
+    io_div4_io_div4_meas_ctrl_shadowed_qs = 8'he;
+    io_div4_io_div4_meas_ctrl_shadowed_qs[3:0] = io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
+    io_div4_io_div4_meas_ctrl_shadowed_qs[7:4] = io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
   end
 
   prim_reg_cdc #(
-    .DataWidth(16),
-    .ResetVal(16'h6e82),
-    .BitMask(16'hffff),
+    .DataWidth(8),
+    .ResetVal(8'he),
+    .BitMask(8'hff),
     .DstWrReq(0)
   ) u_io_div4_meas_ctrl_shadowed_cdc (
     .clk_src_i    (clk_i),
@@ -299,7 +299,7 @@ module clkmgr_reg_top (
     .src_regwen_i (measure_ctrl_regwen_qs),
     .src_we_i     (io_div4_meas_ctrl_shadowed_we),
     .src_re_i     (io_div4_meas_ctrl_shadowed_re),
-    .src_wd_i     (reg_wdata[15:0]),
+    .src_wd_i     (reg_wdata[7:0]),
     .src_busy_o   (io_div4_meas_ctrl_shadowed_busy),
     .src_qs_o     (io_div4_meas_ctrl_shadowed_qs), // for software read back
     .dst_update_i ('0),
@@ -357,25 +357,25 @@ module clkmgr_reg_top (
   assign unused_main_main_meas_ctrl_en_wdata =
       ^main_main_meas_ctrl_en_wdata;
 
-  logic [9:0]  main_main_meas_ctrl_shadowed_hi_qs_int;
-  logic [9:0]  main_main_meas_ctrl_shadowed_lo_qs_int;
-  logic [19:0] main_main_meas_ctrl_shadowed_qs;
-  logic [19:0] main_main_meas_ctrl_shadowed_wdata;
+  logic [5:0]  main_main_meas_ctrl_shadowed_hi_qs_int;
+  logic [5:0]  main_main_meas_ctrl_shadowed_lo_qs_int;
+  logic [11:0] main_main_meas_ctrl_shadowed_qs;
+  logic [11:0] main_main_meas_ctrl_shadowed_wdata;
   logic main_main_meas_ctrl_shadowed_we;
   logic unused_main_main_meas_ctrl_shadowed_wdata;
   logic main_main_meas_ctrl_shadowed_re;
   logic main_main_meas_ctrl_shadowed_regwen;
 
   always_comb begin
-    main_main_meas_ctrl_shadowed_qs = 20'h7a9fe;
-    main_main_meas_ctrl_shadowed_qs[9:0] = main_main_meas_ctrl_shadowed_hi_qs_int;
-    main_main_meas_ctrl_shadowed_qs[19:10] = main_main_meas_ctrl_shadowed_lo_qs_int;
+    main_main_meas_ctrl_shadowed_qs = 12'h19a;
+    main_main_meas_ctrl_shadowed_qs[5:0] = main_main_meas_ctrl_shadowed_hi_qs_int;
+    main_main_meas_ctrl_shadowed_qs[11:6] = main_main_meas_ctrl_shadowed_lo_qs_int;
   end
 
   prim_reg_cdc #(
-    .DataWidth(20),
-    .ResetVal(20'h7a9fe),
-    .BitMask(20'hfffff),
+    .DataWidth(12),
+    .ResetVal(12'h19a),
+    .BitMask(12'hfff),
     .DstWrReq(0)
   ) u_main_meas_ctrl_shadowed_cdc (
     .clk_src_i    (clk_i),
@@ -385,7 +385,7 @@ module clkmgr_reg_top (
     .src_regwen_i (measure_ctrl_regwen_qs),
     .src_we_i     (main_meas_ctrl_shadowed_we),
     .src_re_i     (main_meas_ctrl_shadowed_re),
-    .src_wd_i     (reg_wdata[19:0]),
+    .src_wd_i     (reg_wdata[11:0]),
     .src_busy_o   (main_meas_ctrl_shadowed_busy),
     .src_qs_o     (main_meas_ctrl_shadowed_qs), // for software read back
     .dst_update_i ('0),
@@ -443,25 +443,25 @@ module clkmgr_reg_top (
   assign unused_usb_usb_meas_ctrl_en_wdata =
       ^usb_usb_meas_ctrl_en_wdata;
 
-  logic [8:0]  usb_usb_meas_ctrl_shadowed_hi_qs_int;
-  logic [8:0]  usb_usb_meas_ctrl_shadowed_lo_qs_int;
-  logic [17:0] usb_usb_meas_ctrl_shadowed_qs;
-  logic [17:0] usb_usb_meas_ctrl_shadowed_wdata;
+  logic [5:0]  usb_usb_meas_ctrl_shadowed_hi_qs_int;
+  logic [5:0]  usb_usb_meas_ctrl_shadowed_lo_qs_int;
+  logic [11:0] usb_usb_meas_ctrl_shadowed_qs;
+  logic [11:0] usb_usb_meas_ctrl_shadowed_wdata;
   logic usb_usb_meas_ctrl_shadowed_we;
   logic unused_usb_usb_meas_ctrl_shadowed_wdata;
   logic usb_usb_meas_ctrl_shadowed_re;
   logic usb_usb_meas_ctrl_shadowed_regwen;
 
   always_comb begin
-    usb_usb_meas_ctrl_shadowed_qs = 18'h1ccfa;
-    usb_usb_meas_ctrl_shadowed_qs[8:0] = usb_usb_meas_ctrl_shadowed_hi_qs_int;
-    usb_usb_meas_ctrl_shadowed_qs[17:9] = usb_usb_meas_ctrl_shadowed_lo_qs_int;
+    usb_usb_meas_ctrl_shadowed_qs = 12'h19a;
+    usb_usb_meas_ctrl_shadowed_qs[5:0] = usb_usb_meas_ctrl_shadowed_hi_qs_int;
+    usb_usb_meas_ctrl_shadowed_qs[11:6] = usb_usb_meas_ctrl_shadowed_lo_qs_int;
   end
 
   prim_reg_cdc #(
-    .DataWidth(18),
-    .ResetVal(18'h1ccfa),
-    .BitMask(18'h3ffff),
+    .DataWidth(12),
+    .ResetVal(12'h19a),
+    .BitMask(12'hfff),
     .DstWrReq(0)
   ) u_usb_meas_ctrl_shadowed_cdc (
     .clk_src_i    (clk_i),
@@ -471,7 +471,7 @@ module clkmgr_reg_top (
     .src_regwen_i (measure_ctrl_regwen_qs),
     .src_we_i     (usb_meas_ctrl_shadowed_we),
     .src_re_i     (usb_meas_ctrl_shadowed_re),
-    .src_wd_i     (reg_wdata[17:0]),
+    .src_wd_i     (reg_wdata[11:0]),
     .src_busy_o   (usb_meas_ctrl_shadowed_busy),
     .src_qs_o     (usb_meas_ctrl_shadowed_qs), // for software read back
     .dst_update_i ('0),
@@ -1052,7 +1052,7 @@ module clkmgr_reg_top (
   logic io_div4_io_div4_meas_ctrl_shadowed_gated_we;
   assign io_div4_io_div4_meas_ctrl_shadowed_gated_we =
     io_div4_io_div4_meas_ctrl_shadowed_we & io_div4_io_div4_meas_ctrl_shadowed_regwen;
-  //   F[hi]: 7:0
+  //   F[hi]: 3:0
   logic async_io_div4_meas_ctrl_shadowed_hi_err_update;
   logic async_io_div4_meas_ctrl_shadowed_hi_err_storage;
 
@@ -1077,9 +1077,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(io_div4_meas_ctrl_shadowed_hi_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (8),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h82),
+    .RESVAL  (4'he),
     .Mubi    (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
@@ -1089,7 +1089,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (io_div4_io_div4_meas_ctrl_shadowed_re),
     .we     (io_div4_io_div4_meas_ctrl_shadowed_gated_we),
-    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[7:0]),
+    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[3:0]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1111,7 +1111,7 @@ module clkmgr_reg_top (
     .err_storage (async_io_div4_meas_ctrl_shadowed_hi_err_storage)
   );
 
-  //   F[lo]: 15:8
+  //   F[lo]: 7:4
   logic async_io_div4_meas_ctrl_shadowed_lo_err_update;
   logic async_io_div4_meas_ctrl_shadowed_lo_err_storage;
 
@@ -1136,9 +1136,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(io_div4_meas_ctrl_shadowed_lo_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (8),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h6e),
+    .RESVAL  (4'h0),
     .Mubi    (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
@@ -1148,7 +1148,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (io_div4_io_div4_meas_ctrl_shadowed_re),
     .we     (io_div4_io_div4_meas_ctrl_shadowed_gated_we),
-    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[15:8]),
+    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[7:4]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1210,7 +1210,7 @@ module clkmgr_reg_top (
   logic main_main_meas_ctrl_shadowed_gated_we;
   assign main_main_meas_ctrl_shadowed_gated_we =
     main_main_meas_ctrl_shadowed_we & main_main_meas_ctrl_shadowed_regwen;
-  //   F[hi]: 9:0
+  //   F[hi]: 5:0
   logic async_main_meas_ctrl_shadowed_hi_err_update;
   logic async_main_meas_ctrl_shadowed_hi_err_storage;
 
@@ -1235,9 +1235,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(main_meas_ctrl_shadowed_hi_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (10),
+    .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1fe),
+    .RESVAL  (6'h1a),
     .Mubi    (1'b0)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
@@ -1247,7 +1247,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (main_main_meas_ctrl_shadowed_re),
     .we     (main_main_meas_ctrl_shadowed_gated_we),
-    .wd     (main_main_meas_ctrl_shadowed_wdata[9:0]),
+    .wd     (main_main_meas_ctrl_shadowed_wdata[5:0]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1269,7 +1269,7 @@ module clkmgr_reg_top (
     .err_storage (async_main_meas_ctrl_shadowed_hi_err_storage)
   );
 
-  //   F[lo]: 19:10
+  //   F[lo]: 11:6
   logic async_main_meas_ctrl_shadowed_lo_err_update;
   logic async_main_meas_ctrl_shadowed_lo_err_storage;
 
@@ -1294,9 +1294,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(main_meas_ctrl_shadowed_lo_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (10),
+    .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1ea),
+    .RESVAL  (6'h6),
     .Mubi    (1'b0)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
@@ -1306,7 +1306,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (main_main_meas_ctrl_shadowed_re),
     .we     (main_main_meas_ctrl_shadowed_gated_we),
-    .wd     (main_main_meas_ctrl_shadowed_wdata[19:10]),
+    .wd     (main_main_meas_ctrl_shadowed_wdata[11:6]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1367,7 +1367,7 @@ module clkmgr_reg_top (
   logic usb_usb_meas_ctrl_shadowed_gated_we;
   assign usb_usb_meas_ctrl_shadowed_gated_we =
     usb_usb_meas_ctrl_shadowed_we & usb_usb_meas_ctrl_shadowed_regwen;
-  //   F[hi]: 8:0
+  //   F[hi]: 5:0
   logic async_usb_meas_ctrl_shadowed_hi_err_update;
   logic async_usb_meas_ctrl_shadowed_hi_err_storage;
 
@@ -1392,9 +1392,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(usb_meas_ctrl_shadowed_hi_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (9),
+    .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'hfa),
+    .RESVAL  (6'h1a),
     .Mubi    (1'b0)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
@@ -1404,7 +1404,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (usb_usb_meas_ctrl_shadowed_re),
     .we     (usb_usb_meas_ctrl_shadowed_gated_we),
-    .wd     (usb_usb_meas_ctrl_shadowed_wdata[8:0]),
+    .wd     (usb_usb_meas_ctrl_shadowed_wdata[5:0]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1426,7 +1426,7 @@ module clkmgr_reg_top (
     .err_storage (async_usb_meas_ctrl_shadowed_hi_err_storage)
   );
 
-  //   F[lo]: 17:9
+  //   F[lo]: 11:6
   logic async_usb_meas_ctrl_shadowed_lo_err_update;
   logic async_usb_meas_ctrl_shadowed_lo_err_storage;
 
@@ -1451,9 +1451,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(usb_meas_ctrl_shadowed_lo_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (9),
+    .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'he6),
+    .RESVAL  (6'h6),
     .Mubi    (1'b0)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
@@ -1463,7 +1463,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (usb_usb_meas_ctrl_shadowed_re),
     .we     (usb_usb_meas_ctrl_shadowed_gated_we),
-    .wd     (usb_usb_meas_ctrl_shadowed_wdata[17:9]),
+    .wd     (usb_usb_meas_ctrl_shadowed_wdata[11:6]),
 
     // from internal hardware
     .de     (1'b0),


### PR DESCRIPTION
This PR changes the Darjeeling clocks to:

* main: 1 GHz
* IO: 1 GHz
* USB (Not used): 1 GHz
* AON: 62.5 MHz

From IO, `clkmgr` derives a 500 MHz and 250 MHz Clock.

The `clkmgr` needed a tweak in the template. To measure the clock frequency, the clkmgr has some measurement circuitry. These regs are preloaded with defaults to (freq / f_aon) +- 10. For the 250 MHz IO_DIV4 clock, this ratio becomes 4 - 10, which is negative. This change ensures the lower value is clipped at 0.