### PR TITLE
[manuf] several orchestrator and provisioning enhancements

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -15,9 +15,9 @@
  * OTP the Direct Access Interface (DAI) operation time-out in micro seconds.
  *
  * It is not possible to predict the specific cycle count that a DAI operation
- * takes, thus arbitrary value of 100us is used.
+ * takes, thus arbitrary value of 10ms is used.
  */
-const uint16_t kOtpDaiTimeoutUs = 5000;
+const uint16_t kOtpDaiTimeoutUs = 10000;
 
 /**
  * Checks whether the DAI operation has finished.

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -84,6 +84,11 @@ def main(args_in):
         help="SKU HJSON configuration file.",
     )
     parser.add_argument(
+        "--package",
+        type=str,
+        help="Override of package string that is in the SKU config.",
+    )
+    parser.add_argument(
         "--test-unlock-token",
         required=True,
         type=parse_hexstring_to_int,
@@ -150,6 +155,12 @@ def main(args_in):
     with open(sku_config_path, "r") as fp:
         sku_config_args = hjson.load(fp)
     sku_config = SkuConfig(**sku_config_args)
+
+    # Override package ID if requested.
+    if args.package:
+        sku_config.package = args.package
+        sku_config.validate()
+        sku_config.load_hw_ids()
 
     # The device identification number is determined during CP by extracting data
     # from the device.

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -53,15 +53,10 @@ class SkuConfig:
         # Validate inputs.
         self.validate()
 
-        # Set product, SiliconCreator, and package IDs.
-        self.si_creator_id = int(
-            self._product_ids["si_creator_ids"][self.si_creator], 16)
-        self.product_id = int(self._product_ids["product_ids"][self.product],
-                              16)
+        # Load HW IDs.
+        self.load_hw_ids()
 
-        if self.package in self._package_ids:
-            self.package_id = int(self._package_ids[self.package], 16)
-
+        # Resolve LC token encryption key path.
         if self.token_encrypt_key:
             self.token_encrypt_key = resolve_runfile(self.token_encrypt_key)
 
@@ -131,3 +126,11 @@ class SkuConfig:
             raise ValueError(
                 "Target LC state ({}) must be in [\"dev\", \"prod\", \"prod_end\"]"
                 .format(self.target_lc_state))
+
+    def load_hw_ids(self) -> None:
+        """Sets product, SiliconCreator, and package IDs."""
+        self.si_creator_id = int(
+            self._product_ids["si_creator_ids"][self.si_creator], 16)
+        self.product_id = int(self._product_ids["product_ids"][self.product],
+                              16)
+        self.package_id = int(self._package_ids[self.package], 16)

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -91,6 +91,25 @@ sh_test(
     toolchains = ["@rules_python//python:current_py_toolchain"],
 )
 
+sh_test(
+    name = "e2e_multistage_test",
+    srcs = ["e2e_multistage.sh"],
+    data = [
+        ":orchestrator_hyper310_zip",
+        "@rules_python//python:current_py_toolchain",
+    ],
+    env = {
+        "PYTHON": "$(PYTHON3)",
+    },
+    tags = [
+        "changes_otp",
+        "exclusive",
+        "hyper310",
+        "manuf",
+    ],
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+)
+
 [
     sh_test(
         name = "e2e_{}_{}_test".format(sku, fpga),
@@ -152,21 +171,3 @@ sh_test(
         "cw340",
     ]
 ]
-
-# TODO: this test seems to work locally but fails in CI.
-# sh_test(
-#     name = "e2e_multistage_test",
-#     srcs = ["e2e_multistage.sh"],
-#     data = [
-#         ":orchestrator_zip",
-#         "@rules_python//python:current_py_toolchain",
-#     ],
-#     env = {
-#         "PYTHON": "$(PYTHON3)",
-#     },
-#     tags = [
-#         "hyper310",
-#         "manuf",
-#     ],
-#     toolchains = ["@rules_python//python:current_py_toolchain"],
-# )

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -69,6 +69,28 @@ orchestrator_cw340_test_settings_transition(
     target = "//sw/host/provisioning/orchestrator/src:orchestrator.zip",
 )
 
+sh_test(
+    name = "e2e_option_flags_test",
+    timeout = "moderate",
+    srcs = ["e2e_option_flags.sh"],
+    data = [
+        ":orchestrator_hyper310_zip",
+        "@//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
+        "@rules_python//python:current_py_toolchain",
+    ],
+    env = {
+        "PYTHON": "$(PYTHON3)",
+        "PACKAGE": "npcr11",
+    },
+    tags = [
+        "changes_otp",
+        "exclusive",
+        "hyper310",
+        "manuf",
+    ],
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+)
+
 [
     sh_test(
         name = "e2e_{}_{}_test".format(sku, fpga),

--- a/sw/host/provisioning/orchestrator/tests/e2e.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e.sh
@@ -21,14 +21,11 @@ ORCHESTRATOR_PATH=$TEST_TMPDIR/orchestrator.zip
 unset RUNFILES_DIR
 
 # Run tool. The path to the --sku-config parameter is relative to the
-# runfiles-dir. Note: "use-ext-clk" flag on FPGA does nothing, but this tests
-# the flag can be piped through to the test harness.
+# runfiles-dir.
 $PYTHON ${ORCHESTRATOR_PATH} \
   --sku-config=${SKU_CONFIG_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=${FPGA} \
-  --enable-alerts \
-  --use-ext-clk \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Test Description:
+#
+# This tests fuly provisioning an OpenTitan chip by executing both CP and FT
+# stages in a single execution of the orchestrator script.
+
+set -ex
+
+cp sw/host/provisioning/orchestrator/src/orchestrator.zip $TEST_TMPDIR
+
+ORCHESTRATOR_PATH=$TEST_TMPDIR/orchestrator.zip
+
+# This script is run by a Bazel sh_test rule, which sets RUNFILES_DIR to point
+# at the test's runfiles. However, if RUNFILES_DIR is set, orchestrator.zip will
+# inherit its value instead of setting it to the proper directory. This breaks
+# runfile resolution, so we unset this variable here.
+unset RUNFILES_DIR
+
+# Run tool. The path to the --sku-config parameter is relative to the
+# runfiles-dir. Note: "use-ext-clk" flag on FPGA does nothing, but this tests
+# the flag can be piped through to the test harness.
+$PYTHON ${ORCHESTRATOR_PATH} \
+  --sku-config=sw/host/provisioning/orchestrator/configs/skus/emulation.hjson \
+  --test-unlock-token="0x11111111_11111111_11111111_11111111" \
+  --test-exit-token="0x22222222_22222222_22222222_22222222" \
+  --package=${PACKAGE} \
+  --fpga=hyper310 \
+  --enable-alerts \
+  --use-ext-clk \
+  --non-interactive \
+  --cp-only \
+  --db-path=$TEST_TMPDIR/registry.sqlite


### PR DESCRIPTION
This PR contains several orchestrator.py script and provisioning enhancements, including:
1. enabling the overriding of the package ID via the orchestrator.py CLI,
2. removal of duplicate test behavior; specifically, the "enable-alerts" and "use-ext-clk" flags of the orchestrator.py script we being tested in several E2E tests instead of just one,
3. the multistage orchestrator.py E2E test was re-enabled, and
4. the OTP programming timeout was increased to 10ms