### PR TITLE
[opentitantool] Eliminate use of min_specialization 

### DIFF
--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -78,6 +78,7 @@ rust_library(
         "@crate_index//:der",
         "@crate_index//:directories",
         "@crate_index//:ecdsa",
+        "@crate_index//:erased-serde",
         "@crate_index//:hex",
         "@crate_index//:indexmap",
         "@crate_index//:log",

--- a/sw/host/hsmtool/src/commands/ecdsa/export.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/export.rs
@@ -7,7 +7,6 @@ use cryptoki::object::{Attribute, ObjectHandle};
 use cryptoki::session::Session;
 use p256::ecdsa::{SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -74,7 +73,7 @@ impl Dispatch for Export {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Ec.try_into()?));

--- a/sw/host/hsmtool/src/commands/ecdsa/generate.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/generate.rs
@@ -8,7 +8,6 @@ use cryptoki::session::Session;
 use p256::elliptic_curve::pkcs8;
 use p256::elliptic_curve::pkcs8::der::Encode;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::str::FromStr;
 
@@ -64,7 +63,7 @@ impl Dispatch for Generate {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         helper::no_object_exists(session, self.id.as_deref(), self.label.as_deref())?;
         let id = AttrData::Str(self.id.as_ref().cloned().unwrap_or_else(helper::random_id));

--- a/sw/host/hsmtool/src/commands/ecdsa/import.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/import.rs
@@ -6,7 +6,6 @@ use anyhow::{bail, Context, Result};
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -76,7 +75,7 @@ impl Dispatch for Import {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         helper::no_object_exists(session, self.id.as_deref(), self.label.as_deref())?;
         let mut public_attrs =

--- a/sw/host/hsmtool/src/commands/ecdsa/mod.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/mod.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -33,7 +32,7 @@ impl Dispatch for Ecdsa {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         match self {
             Ecdsa::Generate(x) => x.run(context, hsm, session),
             Ecdsa::Export(x) => x.run(context, hsm, session),

--- a/sw/host/hsmtool/src/commands/ecdsa/sign.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/sign.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, Result};
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -44,7 +43,7 @@ impl Dispatch for Sign {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Ec.try_into()?));

--- a/sw/host/hsmtool/src/commands/ecdsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/verify.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, Result};
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -44,7 +43,7 @@ impl Dispatch for Verify {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Ec.try_into()?));

--- a/sw/host/hsmtool/src/commands/exec.rs
+++ b/sw/host/hsmtool/src/commands/exec.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::{Annotate, Document};
+use serde_annotate::Document;
 use std::any::Any;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -18,10 +18,10 @@ pub struct Exec {
     file: PathBuf,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub struct ExecResult {
     pub command: String,
-    pub result: Box<dyn Annotate>,
+    pub result: Box<dyn erased_serde::Serialize>,
 }
 
 #[derive(Debug, Error)]
@@ -38,7 +38,7 @@ impl Dispatch for Exec {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let commands = std::fs::read_to_string(&self.file)?;
         let commands = serde_annotate::from_str::<Vec<Box<dyn Dispatch>>>(&commands)?;
 

--- a/sw/host/hsmtool/src/commands/mod.rs
+++ b/sw/host/hsmtool/src/commands/mod.rs
@@ -26,7 +26,7 @@ pub trait Dispatch {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>>;
+    ) -> Result<Box<dyn erased_serde::Serialize>>;
 
     fn leaf(&self) -> &dyn Dispatch
     where
@@ -58,7 +58,7 @@ impl Dispatch for Commands {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         match self {
             Commands::Ecdsa(x) => x.run(context, hsm, session),
             Commands::Exec(x) => x.run(context, hsm, session),
@@ -122,7 +122,7 @@ impl Default for BasicResult {
 }
 
 impl BasicResult {
-    pub fn from_error(e: &anyhow::Error) -> Box<dyn Annotate> {
+    pub fn from_error(e: &anyhow::Error) -> Box<dyn erased_serde::Serialize> {
         Box::new(BasicResult {
             success: false,
             id: AttrData::None,
@@ -145,7 +145,7 @@ pub fn print_result(
     format: Format,
     color: Option<bool>,
     quiet: bool,
-    result: Result<Box<dyn Annotate>>,
+    result: Result<Box<dyn erased_serde::Serialize>>,
 ) -> Result<()> {
     let (doc, result) = match result {
         Ok(value) => {

--- a/sw/host/hsmtool/src/commands/object/destroy.rs
+++ b/sw/host/hsmtool/src/commands/object/destroy.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::{BasicResult, Dispatch};
@@ -28,7 +27,7 @@ impl Dispatch for Destroy {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let attr = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         let objects = session.find_objects(&attr)?;

--- a/sw/host/hsmtool/src/commands/object/list.rs
+++ b/sw/host/hsmtool/src/commands/object/list.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::str::FromStr;
 
@@ -38,7 +37,7 @@ impl Dispatch for List {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let search = self
             .search

--- a/sw/host/hsmtool/src/commands/object/mod.rs
+++ b/sw/host/hsmtool/src/commands/object/mod.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -35,7 +34,7 @@ impl Dispatch for Object {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         match self {
             Object::Destroy(x) => x.run(context, hsm, session),
             Object::List(x) => x.run(context, hsm, session),

--- a/sw/host/hsmtool/src/commands/object/read.rs
+++ b/sw/host/hsmtool/src/commands/object/read.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ impl Dispatch for Read {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let attr = helper::search_spec_ex(
             self.id.as_deref(),

--- a/sw/host/hsmtool/src/commands/object/show.rs
+++ b/sw/host/hsmtool/src/commands/object/show.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::collections::HashSet;
 
@@ -53,7 +52,7 @@ impl Dispatch for Show {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let attr = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         let objects = session.find_objects(&attr)?;

--- a/sw/host/hsmtool/src/commands/object/update.rs
+++ b/sw/host/hsmtool/src/commands/object/update.rs
@@ -5,7 +5,6 @@
 use anyhow::{bail, Result};
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -31,7 +30,7 @@ impl Dispatch for Update {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let attr = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         let objects = session.find_objects(&attr)?;

--- a/sw/host/hsmtool/src/commands/object/write.rs
+++ b/sw/host/hsmtool/src/commands/object/write.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -37,7 +36,7 @@ impl Dispatch for Write {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
 
         let mut attr = AttributeMap::default();

--- a/sw/host/hsmtool/src/commands/rsa/decrypt.rs
+++ b/sw/host/hsmtool/src/commands/rsa/decrypt.rs
@@ -7,7 +7,6 @@ use cryptoki::mechanism::Mechanism;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ impl Dispatch for Decrypt {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Rsa.try_into()?));

--- a/sw/host/hsmtool/src/commands/rsa/encrypt.rs
+++ b/sw/host/hsmtool/src/commands/rsa/encrypt.rs
@@ -7,7 +7,6 @@ use cryptoki::mechanism::Mechanism;
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ impl Dispatch for Encrypt {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Rsa.try_into()?));

--- a/sw/host/hsmtool/src/commands/rsa/export.rs
+++ b/sw/host/hsmtool/src/commands/rsa/export.rs
@@ -7,7 +7,6 @@ use cryptoki::object::{Attribute, ObjectHandle};
 use cryptoki::session::Session;
 use rsa::{RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -74,7 +73,7 @@ impl Dispatch for Export {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Rsa.try_into()?));

--- a/sw/host/hsmtool/src/commands/rsa/generate.rs
+++ b/sw/host/hsmtool/src/commands/rsa/generate.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use cryptoki::mechanism::Mechanism;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::str::FromStr;
 
@@ -65,7 +64,7 @@ impl Dispatch for Generate {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         helper::no_object_exists(session, self.id.as_deref(), self.label.as_deref())?;
         let id = AttrData::Str(self.id.as_ref().cloned().unwrap_or_else(helper::random_id));

--- a/sw/host/hsmtool/src/commands/rsa/import.rs
+++ b/sw/host/hsmtool/src/commands/rsa/import.rs
@@ -6,7 +6,6 @@ use anyhow::{bail, Context, Result};
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -78,7 +77,7 @@ impl Dispatch for Import {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         helper::no_object_exists(session, self.id.as_deref(), self.label.as_deref())?;
         let mut public_attrs =

--- a/sw/host/hsmtool/src/commands/rsa/mod.rs
+++ b/sw/host/hsmtool/src/commands/rsa/mod.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -37,7 +36,7 @@ impl Dispatch for Rsa {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         match self {
             Rsa::Decrypt(x) => x.run(context, hsm, session),
             Rsa::Encrypt(x) => x.run(context, hsm, session),

--- a/sw/host/hsmtool/src/commands/rsa/sign.rs
+++ b/sw/host/hsmtool/src/commands/rsa/sign.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, Result};
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -44,7 +43,7 @@ impl Dispatch for Sign {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Rsa.try_into()?));

--- a/sw/host/hsmtool/src/commands/rsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/rsa/verify.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, Result};
 use cryptoki::object::Attribute;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -44,7 +43,7 @@ impl Dispatch for Verify {
         _context: &dyn Any,
         _hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let session = session.ok_or(HsmError::SessionRequired)?;
         let mut attrs = helper::search_spec(self.id.as_deref(), self.label.as_deref())?;
         attrs.push(Attribute::KeyType(KeyType::Rsa.try_into()?));

--- a/sw/host/hsmtool/src/commands/spx/export.rs
+++ b/sw/host/hsmtool/src/commands/spx/export.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -40,7 +39,7 @@ impl Dispatch for Export {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let spx = hsm.spx.as_deref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
         self.export(spx)?;

--- a/sw/host/hsmtool/src/commands/spx/generate.rs
+++ b/sw/host/hsmtool/src/commands/spx/generate.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ impl Dispatch for Generate {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 

--- a/sw/host/hsmtool/src/commands/spx/import.rs
+++ b/sw/host/hsmtool/src/commands/spx/import.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -31,7 +30,7 @@ impl Dispatch for Import {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 

--- a/sw/host/hsmtool/src/commands/spx/list.rs
+++ b/sw/host/hsmtool/src/commands/spx/list.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -35,7 +34,7 @@ impl Dispatch for List {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 

--- a/sw/host/hsmtool/src/commands/spx/mod.rs
+++ b/sw/host/hsmtool/src/commands/spx/mod.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -35,7 +34,7 @@ impl Dispatch for Spx {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         match self {
             Spx::Generate(x) => x.run(context, hsm, session),
             Spx::Export(x) => x.run(context, hsm, session),

--- a/sw/host/hsmtool/src/commands/spx/sign.rs
+++ b/sw/host/hsmtool/src/commands/spx/sign.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use sphincsplus::SpxDomain;
 use std::any::Any;
 use std::path::PathBuf;
@@ -39,7 +38,7 @@ impl Dispatch for Sign {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 

--- a/sw/host/hsmtool/src/commands/spx/verify.rs
+++ b/sw/host/hsmtool/src/commands/spx/verify.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use sphincsplus::SpxDomain;
 use std::any::Any;
 use std::path::PathBuf;
@@ -38,7 +37,7 @@ impl Dispatch for Verify {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 

--- a/sw/host/hsmtool/src/commands/token.rs
+++ b/sw/host/hsmtool/src/commands/token.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -45,7 +44,7 @@ impl Dispatch for List {
         _context: &dyn Any,
         hsm: &Module,
         _session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         let mut response = Box::<ListResponse>::default();
         for slot in hsm.pkcs11.get_slots_with_token()? {
             let info = hsm.pkcs11.get_token_info(slot)?;
@@ -67,7 +66,7 @@ impl Dispatch for Token {
         context: &dyn Any,
         hsm: &Module,
         session: Option<&Session>,
-    ) -> Result<Box<dyn Annotate>> {
+    ) -> Result<Box<dyn erased_serde::Serialize>> {
         match self {
             Token::List(x) => x.run(context, hsm, session),
         }

--- a/sw/host/hsmtool/src/hsmtool.rs
+++ b/sw/host/hsmtool/src/hsmtool.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(min_specialization)]
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use cryptoki::session::UserType;

--- a/sw/host/hsmtool/src/lib.rs
+++ b/sw/host/hsmtool/src/lib.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(min_specialization)]
 pub mod commands;
 pub mod error;
 pub mod extra;

--- a/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
+++ b/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
@@ -31,7 +31,7 @@ use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Error, Fields, Ident, 
 ///         &self,
 ///         context: &dyn std::any::Any,
 ///         backend: &mut dyn opentitanlib::transport::Transport
-///     ) -> anyhow::Result<Option<Box<dyn serde_annotate::Annotate>>> {
+///     ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
 ///         match self {
 ///             Hello::World(ref __field) => __field.run(context, backend),
 ///             Hello::People(ref __field) => __field.run(context, backend),
@@ -78,7 +78,7 @@ fn dispatch_enum(name: &Ident, e: &DataEnum) -> Result<TokenStream> {
                     &self,
                     context: &dyn std::any::Any,
                     backend: &opentitanlib::app::TransportWrapper,
-                ) -> anyhow::Result<Option<Box<dyn serde_annotate::Annotate>>> {
+                ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
                     match self {
                         #(#arms),*
                     }

--- a/sw/host/opentitanlib/src/app/command.rs
+++ b/sw/host/opentitanlib/src/app/command.rs
@@ -5,7 +5,6 @@
 use crate::app::TransportWrapper;
 use anyhow::Result;
 pub use opentitantool_derive::*;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 /// The `CommandDispatch` trait should be implemented for all leaf structures
@@ -21,5 +20,5 @@ pub trait CommandDispatch {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>>;
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>>;
 }

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -26,7 +26,7 @@ use crate::transport::{
 
 use anyhow::{bail, ensure, Result};
 use indicatif::{ProgressBar, ProgressStyle};
-use serde_annotate::Annotate;
+
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::hash_map::Entry;
@@ -887,7 +887,7 @@ impl TransportWrapper {
     }
 
     /// Invoke non-standard functionality of some Transport implementations.
-    pub fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
+    pub fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         self.transport.dispatch(action)
     }
 

--- a/sw/host/opentitanlib/src/lib.rs
+++ b/sw/host/opentitanlib/src/lib.rs
@@ -4,8 +4,6 @@
 
 // Stabilised in Rust 1.74, can be removed when we upgrade.
 #![feature(io_error_other)]
-// Used for serde_annotate.
-#![feature(min_specialization)]
 
 pub mod app;
 pub mod backend;

--- a/sw/host/opentitanlib/src/test_utils/bootstrap.rs
+++ b/sw/host/opentitanlib/src/test_utils/bootstrap.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::path::{Path, PathBuf};
 
 use crate::app::{StagedProgressBar, TransportWrapper};
@@ -22,7 +21,10 @@ pub struct Bootstrap {
 }
 
 impl Bootstrap {
-    pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Annotate>>> {
+    pub fn init(
+        &self,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if let Some(bootstrap) = &self.bootstrap {
             self.load(transport, bootstrap)?;
         }

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use clap::Args;
 use directories::ProjectDirs;
 use log::LevelFilter;
-use serde_annotate::Annotate;
 use std::env::ArgsOs;
 use std::ffi::OsString;
 use std::io::ErrorKind;
@@ -107,7 +106,10 @@ impl InitializeTest {
 
     // Print the result of a command.
     // If there is an error and `RUST_BACKTRACE=1`, print a backtrace.
-    pub fn print_result(operation: &str, result: Result<Option<Box<dyn Annotate>>>) -> Result<()> {
+    pub fn print_result(
+        operation: &str,
+        result: Result<Option<Box<dyn erased_serde::Serialize>>>,
+    ) -> Result<()> {
         match result {
             Ok(Some(value)) => {
                 log::info!("{}: success.", operation);

--- a/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_bitstream.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -32,7 +31,10 @@ pub struct LoadBitstream {
 }
 
 impl LoadBitstream {
-    pub fn init(&self, transport: &TransportWrapper) -> Result<Option<Box<dyn Annotate>>> {
+    pub fn init(
+        &self,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Clear out existing bitstream, if requested.
         if self.clear_bitstream {
             log::info!("Clearing bitstream.");
@@ -50,7 +52,7 @@ impl LoadBitstream {
         &self,
         transport: &TransportWrapper,
         file: &Path,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         log::info!("Loading bitstream: {:?}", file);
         let payload = std::fs::read(file)?;
         let progress = StagedProgressBar::new();

--- a/sw/host/opentitanlib/src/transport/chip_whisperer/mod.rs
+++ b/sw/host/opentitanlib/src/transport/chip_whisperer/mod.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, Result};
-use serde_annotate::Annotate;
 use serialport::SerialPortType;
 use std::any::Any;
 use std::cell::RefCell;
@@ -139,7 +138,7 @@ impl<B: Board + 'static> Transport for ChipWhisperer<B> {
         Ok(Rc::clone(inner.spi.as_ref().unwrap()))
     }
 
-    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
+    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
             // Program the FPGA bitstream.
             log::info!("Programming the FPGA bitstream.");

--- a/sw/host/opentitanlib/src/transport/ftdi/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ftdi/mod.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
@@ -126,7 +125,7 @@ impl<C: Chip> Transport for Ftdi<C> {
         Ok(Rc::clone(inner.spi.as_ref().unwrap()))
     }
 
-    fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
+    fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         Err(TransportError::UnsupportedOperation.into())
     }
 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/dfu.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/dfu.rs
@@ -7,7 +7,6 @@
 use anyhow::{anyhow, bail, Result};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::cell::RefCell;
 use std::cmp::Ordering;
@@ -93,7 +92,7 @@ impl Transport for HyperdebugDfu {
         Ok(Capabilities::new(Capability::NONE))
     }
 
-    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
+    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if let Some(update_firmware_action) = action.downcast_ref::<UpdateFirmware>() {
             update_firmware(
                 &mut self.usb_backend.borrow_mut(),
@@ -178,7 +177,7 @@ pub fn update_firmware(
     force: bool,
     usb_vid: u16,
     usb_pid: u16,
-) -> Result<Option<Box<dyn Annotate>>> {
+) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
     let firmware: &[u8] = if let Some(vec) = firmware.as_ref() {
         validate_firmware_image(vec)?;
         vec

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -5,7 +5,6 @@
 use anyhow::{bail, ensure, Context, Result};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use serde_annotate::Annotate;
 use serialport::TTYPort;
 use std::any::Any;
 use std::cell::Cell;
@@ -763,7 +762,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
         )?))
     }
 
-    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
+    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if let Some(update_firmware_action) = action.downcast_ref::<UpdateFirmware>() {
             let usb_vid = self.inner.usb_device.borrow().get_vendor_id();
             let usb_pid = self.inner.usb_device.borrow().get_product_id();

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -153,7 +153,7 @@ pub trait Transport {
     }
 
     /// Invoke non-standard functionality of some Transport implementations.
-    fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn serde_annotate::Annotate>>> {
+    fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         Err(TransportError::UnsupportedOperation.into())
     }
 

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -5,7 +5,6 @@
 use anyhow::{ensure, Context, Result};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -122,7 +121,7 @@ impl Transport for Verilator {
         })))
     }
 
-    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Annotate>>> {
+    fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if let Some(watch) = action.downcast_ref::<Watch>() {
             let subprocess = self.subprocess.as_ref().unwrap();
             let deadline = Instant::now() + watch.timeout.unwrap_or(Watch::FOREVER);

--- a/sw/host/opentitantool/src/command/bfv.rs
+++ b/sw/host/opentitantool/src/command/bfv.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{Context, Result};
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -26,7 +25,7 @@ impl CommandDispatch for BfvCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         for value in &self.bfv {
             // Decode status.
             let string_bfv = if value.starts_with("0x") {

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{ensure, Result};
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ impl BootstrapCommand {
     fn bootstrap_using_direct_emulator_integration(
         &self,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         ensure!(
             !(self.filename.len() > 1 || self.filename[0].contains('@')),
             "The `emulator` protocol does not support image assembly"
@@ -61,7 +60,7 @@ impl CommandDispatch for BootstrapCommand {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if self.bootstrap_options.protocol == BootstrapProtocol::Emulator {
             return self.bootstrap_using_direct_emulator_integration(transport);
         }

--- a/sw/host/opentitantool/src/command/certificate.rs
+++ b/sw/host/opentitantool/src/command/certificate.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::{self, File};
 use std::io::Write;
@@ -74,7 +73,7 @@ impl CommandDispatch for CodegenCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let (template_name, codegen) = match self.cert_format {
             CertFormat::X509 => {
                 let template = load_template(&self.template)?;
@@ -144,7 +143,7 @@ impl CommandDispatch for GenCertCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Load template.
         let template = load_template(&self.template)?;
         // Load data.
@@ -195,7 +194,7 @@ impl CommandDispatch for ParseCertificate {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let cert = fs::read(&self.certificate).context("could not read certificate from file")?;
         let cert = x509::parse_certificate(&cert)?;
         Ok(Some(Box::new(cert)))
@@ -218,7 +217,7 @@ impl CommandDispatch for SubstCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Load template.
         let template = load_template(&self.template)?;
         // Load data.

--- a/sw/host/opentitantool/src/command/clear_bitstream.rs
+++ b/sw/host/opentitantool/src/command/clear_bitstream.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -20,7 +19,7 @@ impl CommandDispatch for ClearBitstream {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.dispatch(&fpga::ClearBitstream)
     }
 }

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -5,7 +5,6 @@
 use anyhow::{anyhow, Result};
 use clap::Args;
 use regex::Regex;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::File;
 use std::time::Duration;
@@ -58,7 +57,7 @@ impl CommandDispatch for Console {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // We need the UART for the console command to operate.
         transport.capabilities()?.request(Capability::UART).ok()?;
 

--- a/sw/host/opentitantool/src/command/ecdsa.rs
+++ b/sw/host/opentitantool/src/command/ecdsa.rs
@@ -52,7 +52,7 @@ impl CommandDispatch for EcdsaKeyShowCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
 
         // The OTP creation tool is written in python and parses arbitrary
@@ -94,7 +94,7 @@ impl CommandDispatch for EcdsaKeyGenerateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let private_key = EcdsaPrivateKey::new();
         let mut der_file = self.output_dir.to_owned();
         der_file.push(&self.basename);
@@ -123,7 +123,7 @@ impl CommandDispatch for EcdsaKeyExportCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
         let key = EcdsaRawPublicKey::try_from(&key)?;
 
@@ -229,7 +229,7 @@ impl CommandDispatch for EcdsaSignCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let private_key = EcdsaPrivateKey::load(&self.private_key)?;
         let digest = if let Some(input) = &self.input {
             let bytes = std::fs::read(input)?;
@@ -269,7 +269,7 @@ impl CommandDispatch for EcdsaVerifyCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
         let digest = if let Some(digest_file) = &self.digest_file {
             let bytes = std::fs::read(digest_file)?;

--- a/sw/host/opentitantool/src/command/emulator.rs
+++ b/sw/host/opentitantool/src/command/emulator.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -28,7 +27,7 @@ impl CommandDispatch for EmuGetState {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::EMULATOR)
@@ -77,7 +76,7 @@ impl CommandDispatch for EmuStart {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::EMULATOR)
@@ -103,7 +102,7 @@ impl CommandDispatch for EmuStop {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::EMULATOR)

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::borrow::Borrow;
 use std::collections::HashMap;
@@ -40,7 +39,7 @@ impl CommandDispatch for GpioRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         let value = gpio_pin.read()?;
@@ -66,7 +65,7 @@ impl CommandDispatch for GpioWrite {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
 
@@ -90,7 +89,7 @@ impl CommandDispatch for GpioSetMode {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         gpio_pin.set_mode(self.mode)?;
@@ -113,7 +112,7 @@ impl CommandDispatch for GpioSetPullMode {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         gpio_pin.set_pull_mode(self.pull_mode)?;
@@ -145,7 +144,7 @@ impl CommandDispatch for GpioSet {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
 
@@ -177,7 +176,7 @@ impl CommandDispatch for GpioAnalogRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         let volts = gpio_pin.analog_read()?;
@@ -202,7 +201,7 @@ impl CommandDispatch for GpioAnalogWrite {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
 
@@ -223,7 +222,7 @@ impl CommandDispatch for GpioApplyStrapping {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         transport.pin_strapping(&self.name)?.apply()?;
         Ok(None)
@@ -262,7 +261,7 @@ impl CommandDispatch for GpioMonitoringStart {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::GPIO | Capability::GPIO_MONITORING)
@@ -325,7 +324,7 @@ impl CommandDispatch for GpioMonitoringRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::GPIO | Capability::GPIO_MONITORING)
@@ -378,7 +377,7 @@ impl CommandDispatch for GpioMonitoringVcd {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::GPIO | Capability::GPIO_MONITORING)
@@ -525,7 +524,7 @@ impl CommandDispatch for GpioRemoveStrapping {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         transport.pin_strapping(&self.name)?.remove()?;
         Ok(None)
@@ -543,7 +542,7 @@ impl CommandDispatch for GpioMonitoring {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         self.command.run(context, transport)
     }
 }
@@ -591,7 +590,7 @@ impl CommandDispatch for GpioBitbang {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::GPIO_BITBANGING)
@@ -652,7 +651,7 @@ impl CommandDispatch for GpioDacBang {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::GPIO_BITBANGING)

--- a/sw/host/opentitantool/src/command/hello.rs
+++ b/sw/host/opentitantool/src/command/hello.rs
@@ -9,7 +9,6 @@
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -33,7 +32,7 @@ impl CommandDispatch for HelloWorld {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Is the world cruel or not?
         let msg = if self.cruel {
             "Hello cruel World!"
@@ -55,7 +54,7 @@ impl CommandDispatch for HelloPeople {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // The `hello people` command produces no result.
         Ok(None)
     }
@@ -86,7 +85,7 @@ impl CommandDispatch for GoodbyeCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         Ok(Some(Box::new(GoodbyeMessage {
             message: "Goodbye!".to_owned(),
         })))

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{bail, Result};
 use clap::{Args, Subcommand, ValueEnum};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::convert::From;
 use std::time::Duration;
@@ -34,7 +33,7 @@ impl CommandDispatch for I2cRawRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport, "DEFAULT")?;
@@ -59,7 +58,7 @@ impl CommandDispatch for I2cRawWrite {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport, "DEFAULT")?;
@@ -89,7 +88,7 @@ impl CommandDispatch for I2cRawWriteRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport, "DEFAULT")?;
@@ -131,7 +130,7 @@ impl CommandDispatch for I2cSetMode {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport, "DEFAULT")?;
@@ -219,7 +218,7 @@ impl CommandDispatch for I2cGetDeviceStatus {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport, "DEFAULT")?;
@@ -248,7 +247,7 @@ impl CommandDispatch for I2cPrepareRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport, "DEFAULT")?;
@@ -272,7 +271,7 @@ impl CommandDispatch for I2cTpm {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let ready_pin = match &self.gsc_ready {
             Some(pin) => Some((transport.gpio_pin(pin)?, transport.gpio_monitoring()?)),
@@ -312,7 +311,7 @@ impl CommandDispatch for I2cCommand {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // None of the I2C commands care about the prior context, but they do
         // care about the `bus` parameter in the current node.
         self.command.run(self, transport)

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -50,7 +50,7 @@ impl CommandDispatch for AssembleCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let mut image = ImageAssembler::with_params(self.size, self.mirror);
         // Filter out empty arguments that could appear e.g. because of bazel
         // and also trim extra spaces if necessary.
@@ -91,7 +91,7 @@ impl CommandDispatch for ManifestShowCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let result = image
             .subimages()?
@@ -180,7 +180,7 @@ impl CommandDispatch for ManifestUpdateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let mut image = image::Image::read_from_file(&self.image)?;
         let mut update_length = self.update_length;
 
@@ -363,7 +363,7 @@ impl CommandDispatch for ManifestVerifyCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let digest = image.compute_digest()?;
 
@@ -411,7 +411,7 @@ impl CommandDispatch for DigestCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let digest = image.compute_digest()?;
         if let Some(bin) = &self.bin {
@@ -437,7 +437,7 @@ impl CommandDispatch for SpxMessageCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let image = image::Image::read_from_file(&self.image)?;
         let mut output = File::create(&self.output)?;
         // Note: the closure returns a Result R, and map_signed region

--- a/sw/host/opentitantool/src/command/lc.rs
+++ b/sw/host/opentitantool/src/command/lc.rs
@@ -2,14 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::Any;
-use std::time::Duration;
-
 use anyhow::{ensure, Result};
 use clap::{Args, Subcommand};
 use hex::decode;
 use humantime::parse_duration;
-use serde_annotate::Annotate;
+use std::any::Any;
+use std::time::Duration;
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
@@ -92,7 +90,7 @@ impl CommandDispatch for LcStateRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
 
@@ -142,7 +140,7 @@ impl CommandDispatch for LcRegRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
 
@@ -178,7 +176,7 @@ impl CommandDispatch for LcDeviceIdRead {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
         transport.reset_target(self.reset_delay, true)?;
@@ -233,7 +231,7 @@ impl CommandDispatch for RawUnlock {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
         transport.reset_target(self.reset_delay, true)?;
@@ -297,7 +295,7 @@ impl CommandDispatch for Transition {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
         transport.reset_target(self.reset_delay, true)?;
@@ -378,7 +376,7 @@ impl CommandDispatch for Status {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
         transport.reset_target(self.reset_delay, true)?;
@@ -429,7 +427,7 @@ impl CommandDispatch for TransitionCount {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
         transport.reset_target(self.reset_delay, true)?;
@@ -466,7 +464,7 @@ impl CommandDispatch for VolatileRawUnlock {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Set the TAP straps for the lifecycle controller and reset.
         transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
         transport.reset_target(self.reset_delay, true)?;

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs;
 use std::path::PathBuf;
@@ -33,7 +32,7 @@ impl CommandDispatch for LoadBitstream {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         log::info!("Loading bitstream: {:?}", self.filename);
         let bitstream = fs::read(&self.filename)?;
         let progress = StagedProgressBar::new();

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -33,7 +33,7 @@ pub mod xmodem;
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
+
 use std::any::Any;
 use std::time::Duration;
 
@@ -59,7 +59,7 @@ impl CommandDispatch for NoOp {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if let Some(d) = self.delay {
             std::thread::sleep(d);
         }

--- a/sw/host/opentitantool/src/command/otp.rs
+++ b/sw/host/opentitantool/src/command/otp.rs
@@ -2,16 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use serde_annotate::{serialize, Base};
 use std::any::Any;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-
-use anyhow::Result;
-
-use serde_annotate::{serialize, Annotate, Base};
-
-use clap::{Args, Subcommand};
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
@@ -37,7 +34,7 @@ impl CommandDispatch for AlertDigest {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // From kErrorOk in ROM.
         const ERROR_OK: u32 = 0x739;
 

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::{Args, Subcommand, ValueEnum};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
@@ -51,7 +50,7 @@ impl CommandDispatch for OwnershipConfigCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         GlobalFlags::set_debug(self.debug);
         let mut config = if self.basic {
             OwnerBlock::basic()
@@ -115,7 +114,7 @@ impl CommandDispatch for OwnershipUnlockCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let unlock = self
             .params
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
@@ -149,7 +148,7 @@ impl CommandDispatch for OwnershipActivateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let activate = self
             .params
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -63,7 +63,7 @@ impl CommandDispatch for Firmware {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let image = Image::read_from_file(&self.filename)?;
         let payload = if self.raw {
             image.bytes()
@@ -125,7 +125,7 @@ impl CommandDispatch for GetBootLog {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let uart = self.params.create(transport)?;
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
@@ -159,7 +159,7 @@ impl CommandDispatch for GetBootSvc {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let uart = self.params.create(transport)?;
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
@@ -193,7 +193,7 @@ impl CommandDispatch for GetDeviceId {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let uart = self.params.create(transport)?;
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
@@ -246,7 +246,7 @@ impl CommandDispatch for SetNextBl0Slot {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let uart = self.params.create(transport)?;
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
@@ -291,7 +291,7 @@ impl CommandDispatch for OwnershipUnlock {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let unlock = self
             .unlock
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
@@ -340,7 +340,7 @@ impl CommandDispatch for OwnershipActivate {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let activate = self
             .activate
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
@@ -380,7 +380,7 @@ impl CommandDispatch for SetOwnerConfig {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let data = std::fs::read(&self.input)?;
         let uart = self.params.create(transport)?;
         let rescue = RescueSerial::new(uart);
@@ -419,7 +419,7 @@ impl CommandDispatch for GetOwnerConfig {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let page = match self.page {
             0 => RescueSerial::GET_OWNER_PAGE0,
             1 => RescueSerial::GET_OWNER_PAGE1,
@@ -462,7 +462,7 @@ impl CommandDispatch for EraseOwner {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         if self.really {
             let uart = self.params.create(transport)?;
             let rescue = RescueSerial::new(uart);

--- a/sw/host/opentitantool/src/command/rsa.rs
+++ b/sw/host/opentitantool/src/command/rsa.rs
@@ -5,7 +5,6 @@
 use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
 use regex::Regex;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs::File;
 use std::io::Write;
@@ -66,7 +65,7 @@ impl CommandDispatch for RsaKeyShowCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
 
         Ok(Some(Box::new(RsaKeyInfo {
@@ -95,7 +94,7 @@ impl CommandDispatch for RsaKeyGenerateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let private_key = RsaPrivateKey::new()?;
         let mut der_file = self.output_dir.to_owned();
         der_file.push(&self.basename);
@@ -180,7 +179,7 @@ impl CommandDispatch for RsaKeyExportCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
 
         let output_path = match &self.output_file {
@@ -281,7 +280,7 @@ impl CommandDispatch for RsaSignCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let digest = if let Some(input) = &self.input {
             let bytes = std::fs::read(input)?;
             Sha256Digest::try_from(bytes.as_slice())?
@@ -316,7 +315,7 @@ impl CommandDispatch for RsaVerifyCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = RsaPublicKey::from_pkcs1_der_file(&self.der_file)?;
         let digest = Sha256Digest::from_str(&self.digest)?;
         let signature = Signature::from_str(&self.signature)?;

--- a/sw/host/opentitantool/src/command/sam3x.rs
+++ b/sw/host/opentitantool/src/command/sam3x.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -20,7 +19,7 @@ impl CommandDispatch for Reset {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         log::info!("Resetting the SAM3X chip");
         transport.dispatch(&chip_whisperer::ResetSam3x {})
     }
@@ -35,7 +34,7 @@ impl CommandDispatch for GetFwVersion {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.dispatch(&chip_whisperer::GetSam3xFwVersion {})
     }
 }

--- a/sw/host/opentitantool/src/command/set_pll.rs
+++ b/sw/host/opentitantool/src/command/set_pll.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -20,7 +19,7 @@ impl CommandDispatch for SetPll {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         log::info!("Programming the CDCE906 PLL chip with defaults");
         transport.dispatch(&chip_whisperer::SetPll {})
     }

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -38,7 +38,7 @@ impl CommandDispatch for SpiSfdp {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport, "BOOTSTRAP")?;
@@ -80,7 +80,7 @@ impl CommandDispatch for SpiReadId {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport, "BOOTSTRAP")?;
@@ -138,7 +138,7 @@ impl CommandDispatch for SpiRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport, "BOOTSTRAP")?;
@@ -204,7 +204,7 @@ impl CommandDispatch for SpiErase {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport, "BOOTSTRAP")?;
@@ -259,7 +259,7 @@ impl CommandDispatch for SpiProgram {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport, "BOOTSTRAP")?;
@@ -292,7 +292,7 @@ impl CommandDispatch for SpiTpm {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let ready_pin = match &self.gsc_ready {
             Some(pin) => Some((transport.gpio_pin(pin)?, transport.gpio_monitoring()?)),
@@ -324,7 +324,7 @@ impl CommandDispatch for SpiRawRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi_bus = context.params.create(transport, "BOOTSTRAP")?;
@@ -349,7 +349,7 @@ impl CommandDispatch for SpiRawWrite {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi_bus = context.params.create(transport, "BOOTSTRAP")?;
@@ -375,7 +375,7 @@ impl CommandDispatch for SpiRawWriteRead {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi_bus = context.params.create(transport, "BOOTSTRAP")?;
@@ -403,7 +403,7 @@ impl CommandDispatch for SpiRawTransceive {
         &self,
         context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi_bus = context.params.create(transport, "BOOTSTRAP")?;
@@ -445,7 +445,7 @@ impl CommandDispatch for SpiCommand {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // None of the SPI commands care about the prior context, but they do
         // care about the `bus` parameter in the current node.
         self.command.run(self, transport)

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -34,7 +34,7 @@ impl CommandDispatch for SpxKeyShowCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let key = SpxPublicKey::read_pem_file(&self.key_file)?;
         let bytes = key.as_bytes();
 
@@ -82,7 +82,7 @@ impl CommandDispatch for SpxKeyGenerateCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let (private_key, public_key) = SpxSecretKey::new_keypair(self.algorithm)?;
         let mut file = self.output_dir.to_owned();
         file.push(&self.basename);
@@ -132,7 +132,7 @@ impl CommandDispatch for SpxSignCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let mut message = std::fs::read(&self.message)?;
         if self.spx_hash_reversal_bug {
             message.reverse();
@@ -169,7 +169,7 @@ impl CommandDispatch for SpxVerifyCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let mut message = std::fs::read(&self.message)?;
         if self.spx_hash_reversal_bug {
             message.reverse();

--- a/sw/host/opentitantool/src/command/status_cmd.rs
+++ b/sw/host/opentitantool/src/command/status_cmd.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -45,7 +44,7 @@ impl CommandDispatch for ListCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let records = load_elf(&self.elf_file)?;
         if self.raw_records {
             return Ok(Some(Box::new(records)));
@@ -90,7 +89,7 @@ impl CommandDispatch for LintCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // We group filenames by Module ID, coming from all ELF files at once
         let mut mod_id_map: HashMap<String, HashSet<ModuleIdProvenance>> = HashMap::new();
 
@@ -155,7 +154,7 @@ impl CommandDispatch for DecodeCommand {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Decode status.
         let status = Status::from_u32(self.raw_status)?;
         // Find filenames

--- a/sw/host/opentitantool/src/command/tpm.rs
+++ b/sw/host/opentitantool/src/command/tpm.rs
@@ -38,7 +38,7 @@ impl CommandDispatch for TpmReadRegister {
         &self,
         context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let tpm = context.downcast_ref::<Box<dyn tpm::Driver>>().unwrap();
         let length = self
             .length
@@ -102,7 +102,7 @@ impl CommandDispatch for TpmWriteRegister {
         &self,
         context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let tpm = context.downcast_ref::<Box<dyn tpm::Driver>>().unwrap();
         if let Some(hexdata) = &self.hexdata {
             tpm.write_register(self.register, &hex::decode(hexdata)?)?;
@@ -133,7 +133,7 @@ impl CommandDispatch for TpmExecuteCommand {
         &self,
         context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let tpm = context.downcast_ref::<Box<dyn tpm::Driver>>().unwrap();
         let resp = tpm.execute_command(&hex::decode(&self.hexdata)?)?;
         Ok(Some(Box::new(TpmExecuteCommandResponse {

--- a/sw/host/opentitantool/src/command/transport.rs
+++ b/sw/host/opentitantool/src/command/transport.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use regex::Regex;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fs;
@@ -35,7 +34,7 @@ impl CommandDispatch for TransportInit {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         // Configure all GPIO pins to default direction and level, according to
         // configuration files provided, and configures SPI port mode/speed, etc.
         // Also apply an optional, named gpio strap while performing pin initialization.
@@ -61,7 +60,7 @@ impl CommandDispatch for TransportSetJtagPins {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         transport
             .capabilities()?
             .request(Capability::GPIO | Capability::JTAG)
@@ -97,7 +96,7 @@ impl CommandDispatch for TransportUpdateFirmware {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let firmware = match self.filename.as_ref() {
             Some(name) => Some(fs::read(name)?),
             None => None,
@@ -127,7 +126,7 @@ impl CommandDispatch for VerilatorWatch {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let watch = Watch {
             regex: Regex::new(&self.regex)?,
             timeout: self.timeout,
@@ -153,7 +152,7 @@ impl CommandDispatch for TransportQuery {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let value = transport.query_provides(&self.key)?;
         Ok(Some(Box::new(TransportQueryResult {
             key: self.key.clone(),
@@ -170,7 +169,7 @@ impl CommandDispatch for TransportQueryAll {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let value: HashMap<String, String> = transport.provides_map()?.clone();
         Ok(Some(Box::new(value)))
     }

--- a/sw/host/opentitantool/src/command/update_usr_access.rs
+++ b/sw/host/opentitantool/src/command/update_usr_access.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 use std::fs;
 use std::path::PathBuf;
@@ -33,7 +32,7 @@ impl CommandDispatch for UpdateUsrAccess {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let mut bs = fs::read(&self.input)?;
 
         let usr_access_val = match self.usr_access {

--- a/sw/host/opentitantool/src/command/version.rs
+++ b/sw/host/opentitantool/src/command/version.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use clap::Args;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -47,7 +46,7 @@ impl CommandDispatch for Version {
         &self,
         _context: &dyn Any,
         _transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         Ok(Some(Box::<VersionResponse>::default()))
     }
 }

--- a/sw/host/opentitantool/src/command/xmodem.rs
+++ b/sw/host/opentitantool/src/command/xmodem.rs
@@ -5,7 +5,6 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use opentitanlib::io::uart::UartParams;
-use serde_annotate::Annotate;
 use std::any::Any;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -25,7 +24,7 @@ impl CommandDispatch for XmodemSend {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let payload = std::fs::read(&self.filename)?;
         let xmodem = Xmodem::new();
         let uart = self.params.create(transport)?;
@@ -48,7 +47,7 @@ impl CommandDispatch for XmodemRecv {
         &self,
         _context: &dyn Any,
         transport: &TransportWrapper,
-    ) -> Result<Option<Box<dyn Annotate>>> {
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         let uart = self.params.create(transport)?;
         uart.clear_rx_buffer()?;
         let xmodem = Xmodem::new();

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(min_specialization)]
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use directories::ProjectDirs;
 use log::LevelFilter;
-use serde_annotate::Annotate;
 use serde_annotate::ColorProfile;
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsString;
@@ -180,7 +178,10 @@ fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
 
 // Print the result of a command.
 // If there is an error and `RUST_BACKTRACE=1`, print a backtrace.
-fn print_command_result(opts: &Opts, result: Result<Option<Box<dyn Annotate>>>) -> Result<()> {
+fn print_command_result(
+    opts: &Opts,
+    result: Result<Option<Box<dyn erased_serde::Serialize>>>,
+) -> Result<()> {
     match result {
         Ok(Some(value)) => {
             log::info!("Command result: success.");

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "indexmap 2.0.0",
  "indicatif",
  "indoc",
+ "inventory",
  "itertools",
  "libloading 0.8.3",
  "log",
@@ -1387,9 +1388,12 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.12"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
+checksum = "3b31349d02fe60f80bbbab1a9402364cad7460626d6030494b08ac4a2075bf81"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ipnet"

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -44,6 +44,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 humantime = "2.1.0"
 humantime-serde = "1.1"
 indicatif = "0.17.6"
+inventory = "0.3.17"
 itertools = "0.13.0"
 log = "0.4"
 memchr = "2.6.4"

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -242,6 +242,12 @@ alias(
 )
 
 alias(
+    name = "inventory",
+    actual = "@crate_index__inventory-0.3.17//:inventory",
+    tags = ["manual"],
+)
+
+alias(
     name = "itertools",
     actual = "@crate_index__itertools-0.13.0//:itertools",
     tags = ["manual"],

--- a/third_party/rust/crates/BUILD.inventory-0.3.17.bazel
+++ b/third_party/rust/crates/BUILD.inventory-0.3.17.bazel
@@ -30,6 +30,15 @@ rust_library(
     ),
     crate_root = "src/lib.rs",
     edition = "2021",
+    proc_macro_deps = select({
+        "@rules_rust//rust/platform:wasm32-unknown-unknown": [
+            "@crate_index__rustversion-1.0.14//:rustversion",  # cfg(target_family = "wasm")
+        ],
+        "@rules_rust//rust/platform:wasm32-wasi": [
+            "@crate_index__rustversion-1.0.14//:rustversion",  # cfg(target_family = "wasm")
+        ],
+        "//conditions:default": [],
+    }),
     rustc_flags = ["--cap-lints=allow"],
     tags = [
         "cargo-bazel",
@@ -72,5 +81,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.3.12",
+    version = "0.3.17",
 )

--- a/third_party/rust/crates/BUILD.typetag-0.2.13.bazel
+++ b/third_party/rust/crates/BUILD.typetag-0.2.13.bazel
@@ -78,7 +78,7 @@ rust_library(
     version = "0.2.13",
     deps = [
         "@crate_index__erased-serde-0.3.31//:erased_serde",
-        "@crate_index__inventory-0.3.12//:inventory",
+        "@crate_index__inventory-0.3.17//:inventory",
         "@crate_index__once_cell-1.18.0//:once_cell",
         "@crate_index__serde-1.0.189//:serde",
     ],

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -330,6 +330,7 @@ _NORMAL_DEPENDENCIES = {
             "humantime-serde": "@crate_index__humantime-serde-1.1.1//:humantime_serde",
             "indexmap": "@crate_index__indexmap-2.0.0//:indexmap",
             "indicatif": "@crate_index__indicatif-0.17.6//:indicatif",
+            "inventory": "@crate_index__inventory-0.3.17//:inventory",
             "itertools": "@crate_index__itertools-0.13.0//:itertools",
             "libloading": "@crate_index__libloading-0.8.3//:libloading",
             "log": "@crate_index__log-0.4.20//:log",
@@ -501,6 +502,7 @@ _CONDITIONS = {
     "cfg(target_arch = \"wasm32\")": ["@rules_rust//rust/platform:wasm32-unknown-unknown", "@rules_rust//rust/platform:wasm32-wasi"],
     "cfg(target_env = \"msvc\")": ["@rules_rust//rust/platform:aarch64-pc-windows-msvc", "@rules_rust//rust/platform:i686-pc-windows-msvc", "@rules_rust//rust/platform:x86_64-pc-windows-msvc"],
     "cfg(target_env = \"sgx\")": [],
+    "cfg(target_family = \"wasm\")": ["@rules_rust//rust/platform:wasm32-unknown-unknown", "@rules_rust//rust/platform:wasm32-wasi"],
     "cfg(target_feature = \"atomics\")": [],
     "cfg(target_os = \"android\")": ["@rules_rust//rust/platform:aarch64-linux-android", "@rules_rust//rust/platform:armv7-linux-androideabi", "@rules_rust//rust/platform:i686-linux-android", "@rules_rust//rust/platform:x86_64-linux-android"],
     "cfg(target_os = \"fuchsia\")": ["@rules_rust//rust/platform:aarch64-fuchsia", "@rules_rust//rust/platform:x86_64-fuchsia"],
@@ -1909,12 +1911,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_index__inventory-0.3.12",
-        sha256 = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e",
+        name = "crate_index__inventory-0.3.17",
+        sha256 = "3b31349d02fe60f80bbbab1a9402364cad7460626d6030494b08ac4a2075bf81",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/inventory/0.3.12/download"],
-        strip_prefix = "inventory-0.3.12",
-        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.inventory-0.3.12.bazel"),
+        urls = ["https://static.crates.io/crates/inventory/0.3.17/download"],
+        strip_prefix = "inventory-0.3.17",
+        build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.inventory-0.3.17.bazel"),
     )
 
     maybe(

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -103,7 +103,7 @@ def rust_repos(rules_rust = None, serde_annotate = None):
     http_archive_or_local(
         name = "lowrisc_serde_annotate",
         local = serde_annotate,
-        sha256 = "7d6db7c811469f3abd6b58745bd2b8ebb7596a68974739da51bc8b6568c8002a",
-        strip_prefix = "serde-annotate-0.0.11",
-        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.11.tar.gz",
+        sha256 = "7300ed093fa3de679512ffdab7d0f1824be2b11f499bb852df29c3ae12e1348d",
+        strip_prefix = "serde-annotate-0.0.12",
+        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.12.tar.gz",
     )


### PR DESCRIPTION
Update serde_annotate to 0.0.12 and change all uses of `dyn Annotate` to `dyn erased_serde::Serialize`.