### PR TITLE
[opentitantool] Erase header of other slot during rescue

### DIFF
--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -98,15 +98,15 @@ impl CommandDispatch for Firmware {
             rescue.set_baud(rate)?;
         }
         rescue.wait()?;
-        rescue.update_firmware(self.slot, payload)?;
         if self.erase_other_slot {
-            // Erase the other slot by programming an empty blob.
+            // Invalidate the other slot by overwriting its header.
             if self.slot == BootSlot::SlotB {
-                rescue.update_firmware(BootSlot::SlotA, &[])?;
+                rescue.update_firmware(BootSlot::SlotA, &vec![0xFF; 2048])?;
             } else {
-                rescue.update_firmware(BootSlot::SlotB, &[])?;
+                rescue.update_firmware(BootSlot::SlotB, &vec![0xFF; 2048])?;
             }
         }
+        rescue.update_firmware(self.slot, payload)?;
         if self.rate.is_some() {
             rescue.set_baud(prev_baudrate)?;
         }


### PR DESCRIPTION
I believe I have seen cases where the slot not being flashed during rescue still booted afterwards, meaning that the previous code flashing a zero-length image to the other slot may be ineffective.  This PR changes the default behavior to flashing an 4kB image consisting entirely of 0xFF to the other slot, in order to make sure that the header of any previous image is overwritten and invalidated.