### PR TITLE
[assert] Add ASSERT_KNOWN asserts to multiple new outputs

### DIFF
--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -175,6 +175,9 @@ module i2c
   `ASSERT_KNOWN(IntrAcqStretchKnownO_A, intr_acq_stretch_o)
   `ASSERT_KNOWN(IntrUnexpStopKnownO_A, intr_unexp_stop_o)
   `ASSERT_KNOWN(IntrHostTimeoutKnownO_A, intr_host_timeout_o)
+  `ASSERT_KNOWN(LsioTriggerKnown_A, lsio_trigger_o)
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -3471,8 +3471,9 @@ module i2c_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // Address hit but failed the RACL check
-  assign racl_error_o = (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit but failed the RACL check
+  assign racl_error_o = tl_i.a_valid &
+                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -342,4 +342,18 @@ module mbx
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,
                                                  u_sysif.u_soc_regs,
                                                  alert_tx_o[0])
+  // All outputs should be known all the time after reset
+  `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
+  `ASSERT_KNOWN(IntrMbxReadyKnown_A, intr_mbx_ready_o)
+  `ASSERT_KNOWN(IntrMbxAbortKnown_A, intr_mbx_abort_o)
+  `ASSERT_KNOWN(IntrMbxErrorKnown_A, intr_mbx_error_o)
+  `ASSERT_KNOWN(DoeIntrSupportKnown_A, doe_intr_support_o)
+  `ASSERT_KNOWN(DoeIntrEnKnown_A, doe_intr_en_o)
+  `ASSERT_KNOWN(DoeIntrKnown_A, doe_intr_o)
+  `ASSERT_KNOWN(DoeAsyncMsgSupportKnown_A, doe_async_msg_support_o)
+  `ASSERT_KNOWN(CoreTlDValidKnownO_A, core_tl_d_o.d_valid)
+  `ASSERT_KNOWN(CoreTlAReadyKnownO_A, core_tl_d_o.a_ready)
+  `ASSERT_KNOWN(SocTlDValidKnownO_A, soc_tl_d_o.d_valid)
+  `ASSERT_KNOWN(SocTlAReadyKnownO_A, soc_tl_d_o.a_ready)
+
 endmodule

--- a/hw/ip/pwm/rtl/pwm.sv
+++ b/hw/ip/pwm/rtl/pwm.sv
@@ -99,6 +99,9 @@ module pwm
   `ASSERT_KNOWN(CioPWMKnownO_A, cio_pwm_o)
   `ASSERT(CioPWMEnIsOneO_A, (&cio_pwm_en_o) === 1'b1)
 
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
+
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
 endmodule : pwm

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -3164,8 +3164,9 @@ module pwm_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // Address hit but failed the RACL check
-  assign racl_error_o = (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit but failed the RACL check
+  assign racl_error_o = tl_i.a_valid &
+                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -602,6 +602,7 @@ module spi_host
   `ASSERT_KNOWN(CioSdEnKnownO_A, cio_sd_en_o)
   `ASSERT_KNOWN(IntrSpiEventKnownO_A, intr_spi_event_o)
   `ASSERT_KNOWN(IntrErrorKnownO_A, intr_error_o)
+  `ASSERT_KNOWN(LsioTriggerKnown_A, lsio_trigger_o)
 
   // passthrough_o.s is passed through to spi_device, it may contain unknown data,
   // but the unknown data won't be used based on the SPI protocol.

--- a/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
@@ -120,4 +120,8 @@ module tlul_adapter_reg_racl
   // Mask read data in case of a RACL violation
   assign rdata = racl_error_o ? '1 : rdata_i;
 
+  // Ensure that RACL signals are not undefined
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
+
 endmodule

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -135,6 +135,9 @@ module uart
   `ASSERT_KNOWN(RxBreakErrKnown_A, intr_rx_break_err_o)
   `ASSERT_KNOWN(RxTimeoutKnown_A, intr_rx_timeout_o)
   `ASSERT_KNOWN(RxParityErrKnown_A, intr_rx_parity_err_o)
+  `ASSERT_KNOWN(LsioTriggerKnown_A, lsio_trigger_o)
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
 
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1628,8 +1628,9 @@ module uart_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // Address hit but failed the RACL check
-  assign racl_error_o = (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit but failed the RACL check
+  assign racl_error_o = tl_i.a_valid &
+                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -318,6 +318,12 @@ module ${module_instance_name}
   // All outputs should be known value after reset
   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
 
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
+
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
+
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_ac_range_check_reg,
                                                  alert_tx_o[0])

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -339,6 +339,10 @@ num_regs = 6 + 4 * n_alerts + 4 * 7 + n_classes * 14
   // check whether all outputs have a good known state after reset
   `ASSERT_KNOWN(TlDValidKnownO_A,  tl_o.d_valid)
   `ASSERT_KNOWN(TlAReadyKnownO_A,  tl_o.a_ready)
+% if racl_support:
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
+% endif
   `ASSERT_KNOWN(IrqAKnownO_A,      intr_classa_o)
   `ASSERT_KNOWN(IrqBKnownO_A,      intr_classb_o)
   `ASSERT_KNOWN(IrqCKnownO_A,      intr_classc_o)

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -188,6 +188,11 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   // All outputs should be known value after reset
   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
 
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
+
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_policies_o)
+
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_racl_ctrl_reg,
                                                  alert_tx_o[0])

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -277,6 +277,10 @@ num_regs = src + ceil(src / 32) + target * ceil(src / 32) + 3 * target + 1
   // Assertions
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)
+% if racl_support:
+  `ASSERT_KNOWN(RaclErrorKnown_A, racl_error_o)
+  `ASSERT_KNOWN(RaclErrorLogKnown_A, racl_error_log_o)
+% endif
   `ASSERT_KNOWN(IrqKnownO_A, irq_o)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o)
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy.sv
@@ -443,6 +443,12 @@ module soc_proxy
     i2c_lsio_trigger_sync
   };
 
+  // All outputs should be known value after reset
+  `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
+  `ASSERT_KNOWN(DmaLsioTriggerKnown_A, dma_lsio_trigger_o)
+  `ASSERT_KNOWN(CoreTlDValidKnownO_A, core_tl_d_o.d_valid)
+  `ASSERT_KNOWN(CoreTlAReadyKnownO_A, core_tl_d_o.a_ready)
+
   // Assertions
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A,
                                                  u_reg,

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -730,8 +730,9 @@ ${finst_gen(sr, field, finst_name, fsig_name, fidx)}
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
 % if racl_support:
-  // Address hit but failed the RACL check
-  assign racl_error_o = (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit but failed the RACL check
+  assign racl_error_o = tl_i.a_valid &
+                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log


### PR DESCRIPTION
This adds ASSERT_KNOWN assertions to many outputs of the newly introduced signals.

It also uncovered a bug. The RACL error may be `'x` because the internal address hit depends on the incoming TLUL address, which might be `'x` at some cases. To fix this, the `a_valid` signal is factored in to the RACL error computation.