### PR TITLE
[hw,clkmgr,rtl] Properly size the measurement counter

### DIFF
--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -392,7 +392,9 @@ rg_srcs = list(sorted({sig['src_name'] for sig
 % for i, src in enumerate(rg_srcs):
 <%
  freq = all_srcs[src]['freq']
- cnt = int(freq*2 / aon_freq)
+ # One bit margin, same bit width as in the reg top
+ bit_width = int(freq / aon_freq).bit_length() + 1
+ cnt = 2**bit_width
  sel_idx = f"Clk{Name.from_snake_case(src).as_camel_case()}Idx"
 %>
   clkmgr_meas_chk #(

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -549,7 +549,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(8),
+    .Cnt(16),
     .RefCnt(1)
   ) u_io_div4_meas (
     .clk_i,
@@ -576,7 +576,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(32),
+    .Cnt(64),
     .RefCnt(1)
   ) u_main_meas (
     .clk_i,
@@ -603,7 +603,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(32),
+    .Cnt(64),
     .RefCnt(1)
   ) u_usb_meas (
     .clk_i,

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -559,7 +559,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(960),
+    .Cnt(1024),
     .RefCnt(1)
   ) u_io_meas (
     .clk_i,
@@ -586,7 +586,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
+    .Cnt(512),
     .RefCnt(1)
   ) u_io_div2_meas (
     .clk_i,
@@ -613,7 +613,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(240),
+    .Cnt(256),
     .RefCnt(1)
   ) u_io_div4_meas (
     .clk_i,
@@ -640,7 +640,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(1000),
+    .Cnt(1024),
     .RefCnt(1)
   ) u_main_meas (
     .clk_i,
@@ -667,7 +667,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
+    .Cnt(512),
     .RefCnt(1)
   ) u_usb_meas (
     .clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -554,7 +554,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(960),
+    .Cnt(1024),
     .RefCnt(1)
   ) u_io_meas (
     .clk_i,
@@ -581,7 +581,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(240),
+    .Cnt(256),
     .RefCnt(1)
   ) u_io_div4_meas (
     .clk_i,
@@ -608,7 +608,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(1000),
+    .Cnt(1024),
     .RefCnt(1)
   ) u_main_meas (
     .clk_i,
@@ -635,7 +635,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
+    .Cnt(512),
     .RefCnt(1)
   ) u_usb_meas (
     .clk_i,


### PR DESCRIPTION
Darjeeling has different clock ratios. This causes the registers to have a different size than the counter of the measurement circuit. That happens because the threshold value is exactly a power of two, which requires one bit more.
Change the width of the counter do be able to hold the maximum value.
