### PR TITLE
[tlul,rtl] Drop unused typedef from tlul_adapter_sram

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -251,10 +251,6 @@ module tlul_adapter_sram
   localparam int ReqFifoWidth = $bits(req_t) ;
   localparam int RspFifoWidth = $bits(rsp_t) ;
 
-  // An item in the SRAM request fifo is an SRAM request (of width SramReqWidth) plus, if
-  // DataXorAddr is true, some bits of the address that the request touches.
-  typedef logic [SramReqWidth-1:0] sram_req_fifo_item_t;
-
   // FIFO signal in case OutStand is greater than 1
   // If request is latched, {write, source} is pushed to req fifo.
   // Req fifo is popped when D channel is acknowledged (v & r)


### PR DESCRIPTION
This seemed sensible when I originally ported the code to use the shared fifo, but it turns out not to be needed. And Pirmin (quite reasonably) pointed out that the name is rather confusing. Forget about it!

(I mis-clicked when merging #25951. This PR tidies up again...)