### PR TITLE
[membkdr] Provide a tile adapter to access internal rows

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
@@ -18,6 +18,7 @@ filesets:
       - lowrisc:ip:kmac_pkg
     files:
       - mem_bkdr_util_pkg.sv
+      - mem_bkdr_util_row_adapter.sv: {is_include_file: true}
       - mem_bkdr_util.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -30,7 +30,7 @@ class mem_bkdr_util extends uvm_object;
   // The depth of a single SRAM tile.
   protected uint32_t tile_depth;
 
-  // The width of the memory.
+  // The logical width of the memory in bits, not including extra bits added by the row adapter.
   protected uint32_t width;
 
   // The number of subword entries in the whole memory
@@ -38,6 +38,10 @@ class mem_bkdr_util extends uvm_object;
 
   // Indicates the error detection scheme implemented for this memory.
   protected err_detection_e err_detection_scheme = ErrDetectionNone;
+
+  // Adapter to access the underlying memory organization
+  // Integrators can provide a custom row adapter for their SRAM primitives
+  protected mem_bkdr_util_row_adapter row_adapter;
 
   // Convenience macro to check if ECC / parity is enabled.
   `define HAS_ECC (!(err_detection_scheme inside {ErrDetectionNone, ParityEven, ParityOdd}))
@@ -88,6 +92,9 @@ class mem_bkdr_util extends uvm_object;
   //
   // Optional arguments:
   //
+  //  row_adapter              Adapter to access the internal row of a memory. Integrators can
+  //                           provide a custom adapter for a different memory architecture.
+  //
   //  num_prince_rounds_half   The number of rounds of PRINCE used to scramble the memory. This is
   //                           used for scrambled memories. This defaults to 3.
   //
@@ -113,6 +120,7 @@ class mem_bkdr_util extends uvm_object;
   //                           memory.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
+               mem_bkdr_util_row_adapter row_adapter = null,
                uint32_t num_prince_rounds_half = 3,
                uint32_t extra_bits_per_subword = 0, uint32_t system_base_addr = 0,
                string tiling_path = "", string tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s",
@@ -120,12 +128,18 @@ class mem_bkdr_util extends uvm_object;
     super.new(name);
     `DV_CHECK_FATAL(!(n_bits % depth), "n_bits must be divisible by depth.")
 
+    if (row_adapter != null) begin
+      this.row_adapter = row_adapter;
+    end else begin
+      this.row_adapter = new();
+    end
+
     this.path                   = path;
     this.tiling_path            = tiling_path;
     this.depth                  = depth;
     this.tile_depth             = tile_depth;
     this.tiling_suffix_fmt_str  = tiling_suffix_fmt_str;
-    this.width                  = n_bits / depth;
+    this.width                  = (n_bits / depth) - this.row_adapter.get_num_extra_bits();
     this.err_detection_scheme   = err_detection_scheme;
     this.num_prince_rounds_half = num_prince_rounds_half;
 
@@ -296,12 +310,13 @@ class mem_bkdr_util extends uvm_object;
   virtual function uvm_hdl_data_t read(bit [bus_params_pkg::BUS_AW-1:0] addr);
     bit res;
     uint32_t index, ram_tile;
-    uvm_hdl_data_t data;
+    uvm_hdl_data_t encoded_row, data;
     if (!check_addr_valid(addr)) return 'x;
     index    = addr >> addr_lsb;
     ram_tile = index / tile_depth;
-    res      = uvm_hdl_read($sformatf("%0s[%0d]", get_full_path(ram_tile), index), data);
+    res      = uvm_hdl_read($sformatf("%0s[%0d]", get_full_path(ram_tile), index), encoded_row);
     `DV_CHECK_EQ(res, 1, $sformatf("uvm_hdl_read failed at index %0d", index))
+    data     = row_adapter.decode_row(encoded_row);
     return data;
   endfunction
 
@@ -410,11 +425,14 @@ class mem_bkdr_util extends uvm_object;
   // Updates the entire width of the memory at the given address, including the ECC bits.
   virtual function void write(bit [bus_params_pkg::BUS_AW-1:0] addr, uvm_hdl_data_t data);
     bit res;
+    uvm_hdl_data_t encoded_row;
     uint32_t index, ram_tile;
     if (!check_addr_valid(addr)) return;
-    index    = addr >> addr_lsb;
-    ram_tile = index / tile_depth;
-    res      = uvm_hdl_deposit($sformatf("%0s[%0d]", get_full_path(ram_tile), index), data);
+    index       = addr >> addr_lsb;
+    ram_tile    = index / tile_depth;
+    encoded_row = row_adapter.encode_row(data);
+    res         = uvm_hdl_deposit($sformatf("%0s[%0d]", get_full_path(ram_tile), index),
+                                  encoded_row);
     `DV_CHECK_EQ(res, 1, $sformatf("uvm_hdl_deposit failed at index %0d", index))
   endfunction
 
@@ -466,9 +484,14 @@ class mem_bkdr_util extends uvm_object;
 
   // this is used to write 32bit of data plus 7 raw integrity bits.
   virtual function void write39integ(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [38:0] data);
+    uvm_hdl_data_t rw_data;
     `_ACCESS_CHECKS(addr, 32) // this is essentially an aligned 32bit access.
     if (!check_addr_valid(addr)) return;
-    write(addr, data);
+    // Perform a read-modify-write to access the underlying memory architecture
+    rw_data = read(addr);
+    rw_data = row_adapter.write_row_data_39b(addr, data, rw_data);
+    // Note the write function takes care of interleaving, if used.
+    write(addr, rw_data);
   endfunction
 
   virtual function void write64(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [63:0] data);

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
@@ -40,5 +40,6 @@ package mem_bkdr_util_pkg;
   `include "dv_macros.svh"
 
   // sources
+  `include "mem_bkdr_util_row_adapter.sv"
   `include "mem_bkdr_util.sv"
 endpackage

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_row_adapter.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_row_adapter.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Provide an abstract way to access the memory rows
+//
+// Integrators can subclass this to provide a specfic way of accessing a memory row
+// and incorporate the phyical architecture.
+//
+class mem_bkdr_util_row_adapter;
+
+  // A row might have additional extra bits
+  protected uint32_t num_extra_bits = 0;
+
+  // Return the number of extra bits of this row architecture
+  function uint32_t get_num_extra_bits();
+    return num_extra_bits;
+  endfunction
+
+  // Translates a raw encoded UVM data row from the memory in a contiguous
+  // row of memory.
+  //
+  virtual function uvm_hdl_data_t decode_row(uvm_hdl_data_t read_data);
+    return read_data;
+  endfunction
+
+  // Translates a contiguous UVM data row to the internal organization of a row
+  // that can be written to the memory.
+  //
+  virtual function uvm_hdl_data_t encode_row(uvm_hdl_data_t write_data);
+    return write_data;
+  endfunction
+
+  // Writes a 39 bit word into a decoded row data depending on the memory architecture
+
+  // Given decoded `row_data`, a 39-bit `data` word to be written, and an address, return the
+  // decoded row data with the data word at the correct position for the memory architecture and
+  // the given address.
+  virtual function uvm_hdl_data_t write_row_data_39b(bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                     logic [38:0] data,
+                                                     uvm_hdl_data_t row_data);
+    row_data[38:0] = data;
+    return row_data;
+  endfunction
+
+  // Reads a 39 bit word from decoded row data depending on the memory architecture
+
+  // Given decoded `row_data` and an address, return the 39-bit data from the correct position
+  // for the memory architecture and the given address.
+  virtual function logic [38:0] read_row_data_39b(bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                                  uvm_hdl_data_t row_data);
+    logic data;
+    data = row_data[38:0];
+    return data;
+  endfunction
+
+endclass

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_bkdr_util.sv
@@ -19,10 +19,11 @@ class rom_ctrl_bkdr_util extends mem_bkdr_util;
   // secded package.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
-               bit [127:0] key, bit [63:0] nonce, int num_prince_rounds_half = 3,
-               int extra_bits_per_subword = 0, int unsigned system_base_addr = 0);
-    super.new(name, path, depth, n_bits, err_detection_scheme, num_prince_rounds_half,
-              extra_bits_per_subword, system_base_addr);
+               bit [127:0] key, bit [63:0] nonce, mem_bkdr_util_row_adapter row_adapter = null,
+               int num_prince_rounds_half = 3, int extra_bits_per_subword = 0,
+               int unsigned system_base_addr = 0);
+    super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter,
+              num_prince_rounds_half, extra_bits_per_subword, system_base_addr);
     // Remember the encryption configuration.
     m_key = key;
     m_nonce = nonce;

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
@@ -11,11 +11,12 @@ class sram_ctrl_bkdr_util extends mem_bkdr_util;
   // secded package.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
+               mem_bkdr_util_row_adapter row_adapter = null,
                int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0,
                string tiling_path = "", string tiling_suffix_fmt_str = ".gen_ram_inst[%0d].%s",
                uint32_t tile_depth = depth);
-    super.new(name, path, depth, n_bits, err_detection_scheme, num_prince_rounds_half,
+    super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter, num_prince_rounds_half,
               extra_bits_per_subword, system_base_addr, tiling_path, tiling_suffix_fmt_str,
               tile_depth);
   endfunction

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_bkdr_util.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_bkdr_util.sv
@@ -21,9 +21,10 @@ class flash_ctrl_bkdr_util extends mem_bkdr_util;
   // secded package.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
+               mem_bkdr_util_row_adapter row_adapter = null,
                int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0);
-    super.new(name, path, depth, n_bits, err_detection_scheme, num_prince_rounds_half,
+    super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter, num_prince_rounds_half,
               extra_bits_per_subword, system_base_addr);
     // Error detection scheme is assumed to be 76_68, otherwise, the overrides below won't work.
     `DV_CHECK_EQ_FATAL(err_detection_scheme, mem_bkdr_util_pkg::EccHamming_76_68)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.sv
@@ -21,9 +21,10 @@ class flash_ctrl_bkdr_util extends mem_bkdr_util;
   // secded package.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
+               mem_bkdr_util_row_adapter row_adapter = null,
                int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0);
-    super.new(name, path, depth, n_bits, err_detection_scheme, num_prince_rounds_half,
+    super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter, num_prince_rounds_half,
               extra_bits_per_subword, system_base_addr);
     // Error detection scheme is assumed to be 76_68, otherwise, the overrides below won't work.
     `DV_CHECK_EQ_FATAL(err_detection_scheme, mem_bkdr_util_pkg::EccHamming_76_68)

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.sv
@@ -21,9 +21,10 @@ class flash_ctrl_bkdr_util extends mem_bkdr_util;
   // secded package.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
+               mem_bkdr_util_row_adapter row_adapter = null,
                int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0);
-    super.new(name, path, depth, n_bits, err_detection_scheme, num_prince_rounds_half,
+    super.new(name, path, depth, n_bits, err_detection_scheme, row_adapter, num_prince_rounds_half,
               extra_bits_per_subword, system_base_addr);
     // Error detection scheme is assumed to be 76_68, otherwise, the overrides below won't work.
     `DV_CHECK_EQ_FATAL(err_detection_scheme, mem_bkdr_util_pkg::EccHamming_76_68)


### PR DESCRIPTION
This PR adds a custom row adapter that is being used by the memory backdoor util to access and manipulate rows of data. Integrators might are using SRAM primitives with a different internal organization than `Width x Depth`. They can provide a custom row adapter to the memory backdoor utility to for the needs of their memory prims.