### PR TITLE
[rom_ext] Update the ROM_EXT minor version

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -7,7 +7,7 @@
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "1",
+    MINOR = "102",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
Update the ROM_EXT minor version to `102`.  I'm using the offset 100 as a starting point to distinguish A1 development ROM_EXTs from ES development ROM_EXTs.