### PR TITLE
[hw,prim_subreg_shadow,rtl] Add Mubi Support to prim_subreg_shadow

### DIFF
--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -77,7 +77,8 @@ module prim_subreg_shadow
 
   prim_subreg_arb #(
     .DW       ( DW       ),
-    .SwAccess ( SwAccess )
+    .SwAccess ( SwAccess ),
+    .Mubi     ( Mubi     )
   ) wr_en_data_arb (
     .we      ( we      ),
     .wd      ( wd      ),
@@ -115,7 +116,8 @@ module prim_subreg_shadow
   prim_subreg #(
     .DW       ( DW             ),
     .SwAccess ( StagedSwAccess ),
-    .RESVAL   ( ~RESVAL        )
+    .RESVAL   ( ~RESVAL        ),
+    .Mubi     ( Mubi           )
   ) staged_reg (
     .clk_i    ( clk_i     ),
     .rst_ni   ( rst_ni    ),
@@ -140,7 +142,8 @@ module prim_subreg_shadow
   prim_subreg #(
     .DW       ( DW               ),
     .SwAccess ( InvertedSwAccess ),
-    .RESVAL   ( ~RESVAL          )
+    .RESVAL   ( ~RESVAL          ),
+    .Mubi     ( Mubi             )
   ) shadow_reg (
     .clk_i    ( clk_i           ),
     .rst_ni   ( rst_shadowed_ni ),
@@ -162,7 +165,8 @@ module prim_subreg_shadow
   prim_subreg #(
     .DW       ( DW       ),
     .SwAccess ( SwAccess ),
-    .RESVAL   ( RESVAL   )
+    .RESVAL   ( RESVAL   ),
+    .Mubi     ( Mubi     )
   ) committed_reg (
     .clk_i    ( clk_i        ),
     .rst_ni   ( rst_ni       ),
@@ -187,10 +191,5 @@ module prim_subreg_shadow
   assign qe = committed_qe;
   assign q  = committed_q;
   assign qs = committed_qs;
-
-  // prim_subreg_shadow does not support multi-bit software access yet
-  `ASSERT_NEVER(MubiIsNotYetSupported_A, Mubi)
-  logic unused_mubi;
-  assign unused_mubi = Mubi;
 
 endmodule


### PR DESCRIPTION
Shadowed subregs lacked support for Multibit values. This PR feeds the multibit parameter down to all prims that are used within this one. 

The reason why this is needed now is that `soc_dbg_ctrl` uses shadowed mubi registers.