### PR TITLE
[rom_ext] Make the ROM_EXT protect itself in flash

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -212,7 +212,7 @@ enum module_ {
   X(kErrorOwnershipInvalidTag,        ERROR_(5, kModuleOwnership, kInvalidArgument)), \
   X(kErrorOwnershipInvalidTagLength,  ERROR_(6, kModuleOwnership, kInvalidArgument)), \
   X(kErrorOwnershipDuplicateItem,     ERROR_(7, kModuleOwnership, kAlreadyExists)), \
-  X(kErrorOwnershipFlashConfigLenth,  ERROR_(8, kModuleOwnership, kOutOfRange)), \
+  X(kErrorOwnershipFlashConfigLength, ERROR_(8, kModuleOwnership, kOutOfRange)), \
   X(kErrorOwnershipInvalidInfoPage,   ERROR_(9, kModuleOwnership, kInvalidArgument)), \
   X(kErrorOwnershipBadInfoPage,       ERROR_(10, kModuleOwnership, kInternal)), \
   X(kErrorOwnershipNoOwner,           ERROR_(11, kModuleOwnership, kInternal)), \
@@ -220,7 +220,8 @@ enum module_ {
   X(kErrorOwnershipInvalidDin,        ERROR_(13, kModuleOwnership, kInvalidArgument)), \
   X(kErrorOwnershipUnlockDenied,      ERROR_(14, kModuleOwnership, kPermissionDenied)), \
   X(kErrorOwnershipFlashConfigRomExt, ERROR_(15, kModuleOwnership, kInvalidArgument)), \
-  X(kErrorOwnershipInvalidAlgorithm,  ERROR_(16, kModuleOwnership, kInvalidArgument)), \
+  X(kErrorOwnershipFlashConfigBounds, ERROR_(16, kModuleOwnership, kInvalidArgument)), \
+  X(kErrorOwnershipInvalidAlgorithm,  ERROR_(17, kModuleOwnership, kInvalidArgument)), \
   /* Group all of the tag version error codes together */ \
   X(kErrorOwnershipOWNRVersion,       ERROR_(0x70, kModuleOwnership, kInvalidArgument)), \
   X(kErrorOwnershipAPPKVersion,       ERROR_(0x71, kModuleOwnership, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -108,6 +108,7 @@ cc_library(
         ":ownership_key",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:boot_log",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -24,6 +24,16 @@ owner_page_status_t owner_page_valid[2];
 enum {
   kFlashBankSize = FLASH_CTRL_PARAM_REG_PAGES_PER_BANK,
   kFlashPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+  kFlashTotalSize = 2 * kFlashBankSize,
+
+  kRomExtSizeInPages = CHIP_ROM_EXT_SIZE_MAX / kFlashPageSize,
+  kRomExtAStart = 0 / kFlashPageSize,
+  kRomExtAEnd = kRomExtAStart + kRomExtSizeInPages,
+  kRomExtBStart = kFlashBankSize + kRomExtAStart,
+  kRomExtBEnd = kRomExtBStart + kRomExtSizeInPages,
+
+  kRomExtRegions = 2,
+  kProtectSlots = 8,
 };
 
 hardened_bool_t owner_block_newversion_mode(void) {
@@ -81,9 +91,9 @@ void owner_config_default(owner_config_t *config) {
 }
 
 rom_error_t owner_block_parse(const owner_block_t *block,
+                              hardened_bool_t check_only,
                               owner_config_t *config,
                               owner_application_keyring_t *keyring) {
-  owner_config_default(config);
   if (block->header.tag != kTlvTagOwner)
     return kErrorOwnershipInvalidTag;
   if (block->header.length != sizeof(owner_block_t))
@@ -91,7 +101,10 @@ rom_error_t owner_block_parse(const owner_block_t *block,
   if (block->header.version.major != 0)
     return kErrorOwnershipOWNRVersion;
 
-  config->sram_exec = block->sram_exec_mode;
+  if (check_only == kHardenedBoolFalse) {
+    owner_config_default(config);
+    config->sram_exec = block->sram_exec_mode;
+  }
 
   uint32_t remain = sizeof(block->data);
   uint32_t offset = 0;
@@ -112,36 +125,45 @@ rom_error_t owner_block_parse(const owner_block_t *block,
         if (item->version.major != 0)
           return kErrorOwnershipAPPKVersion;
 
-        if (keyring->length < ARRAYSIZE(keyring->key)) {
-          keyring->key[keyring->length++] =
-              (const owner_application_key_t *)item;
+        if (check_only == kHardenedBoolFalse) {
+          if (keyring->length < ARRAYSIZE(keyring->key)) {
+            keyring->key[keyring->length++] =
+                (const owner_application_key_t *)item;
+          }
         }
         break;
       case kTlvTagFlashConfig:
         HARDENED_CHECK_EQ(tag, kTlvTagFlashConfig);
         if (item->version.major != 0)
           return kErrorOwnershipFLSHVersion;
-        if ((hardened_bool_t)config->flash != kHardenedBoolFalse)
-          return kErrorOwnershipDuplicateItem;
-        HARDENED_RETURN_IF_ERROR(
-            owner_block_flash_check((const owner_flash_config_t *)item));
-        config->flash = (const owner_flash_config_t *)item;
+        if (check_only == kHardenedBoolFalse) {
+          if ((hardened_bool_t)config->flash != kHardenedBoolFalse)
+            return kErrorOwnershipDuplicateItem;
+          config->flash = (const owner_flash_config_t *)item;
+        } else {
+          HARDENED_RETURN_IF_ERROR(
+              owner_block_flash_check((const owner_flash_config_t *)item));
+        }
         break;
       case kTlvTagInfoConfig:
         HARDENED_CHECK_EQ(tag, kTlvTagInfoConfig);
         if (item->version.major != 0)
           return kErrorOwnershipINFOVersion;
-        if ((hardened_bool_t)config->info != kHardenedBoolFalse)
-          return kErrorOwnershipDuplicateItem;
-        config->info = (const owner_flash_info_config_t *)item;
+        if (check_only == kHardenedBoolFalse) {
+          if ((hardened_bool_t)config->info != kHardenedBoolFalse)
+            return kErrorOwnershipDuplicateItem;
+          config->info = (const owner_flash_info_config_t *)item;
+        }
         break;
       case kTlvTagRescueConfig:
         HARDENED_CHECK_EQ(tag, kTlvTagRescueConfig);
         if (item->version.major != 0)
           return kErrorOwnershipRESQVersion;
-        if ((hardened_bool_t)config->rescue != kHardenedBoolFalse)
-          return kErrorOwnershipDuplicateItem;
-        config->rescue = (const owner_rescue_config_t *)item;
+        if (check_only == kHardenedBoolFalse) {
+          if ((hardened_bool_t)config->rescue != kHardenedBoolFalse)
+            return kErrorOwnershipDuplicateItem;
+          config->rescue = (const owner_rescue_config_t *)item;
+        }
         break;
       default:
         return kErrorOwnershipInvalidTag;
@@ -150,54 +172,62 @@ rom_error_t owner_block_parse(const owner_block_t *block,
   return kErrorOk;
 }
 
+// These functions aren't defined in owner_block.h because they aren't meant
+// to be public APIs.  They aren't static so we can access the symbols in the
+// unit test program.
+
+// Checks if the half-open range [start..end) overlaps with the ROM_EXT region.
+// The RomExt_Start/End constants are also expressed as half-open ranges.
+hardened_bool_t rom_ext_flash_overlap(uint32_t start, uint32_t end) {
+  return (start < kRomExtAEnd && end > kRomExtAStart) ||
+                 (start < kRomExtBEnd && end > kRomExtBStart)
+             ? kHardenedBoolTrue
+             : kHardenedBoolFalse;
+}
+
+// Checks if the half-open range [start..end) is exclusively within the ROM_EXT
+// region. The RomExt_Start/End constants are also expressed as half-open
+// ranges.
+hardened_bool_t rom_ext_flash_exclusive(uint32_t start, uint32_t end) {
+  return (kRomExtAStart <= start && start < kRomExtAEnd &&
+          kRomExtAStart < end && end <= kRomExtAEnd) ||
+                 (kRomExtBStart <= start && start < kRomExtBEnd &&
+                  kRomExtBStart < end && end <= kRomExtBEnd)
+             ? kHardenedBoolTrue
+             : kHardenedBoolFalse;
+}
+
 rom_error_t owner_block_flash_check(const owner_flash_config_t *flash) {
   size_t len = (flash->header.length - sizeof(owner_flash_config_t)) /
                sizeof(owner_flash_region_t);
-  if (len >= 8) {
-    return kErrorOwnershipFlashConfigLenth;
+  if (len > kProtectSlots - kRomExtRegions) {
+    return kErrorOwnershipFlashConfigLength;
   }
-
-  const uint32_t kRomExtAStart = 0 / kFlashPageSize;
-  const uint32_t kRomExtAEnd = CHIP_ROM_EXT_SIZE_MAX / kFlashPageSize;
-  const uint32_t kRomExtBStart = kFlashBankSize + kRomExtAStart;
-  const uint32_t kRomExtBEnd = kFlashBankSize + kRomExtAEnd;
 
   const owner_flash_region_t *config = flash->config;
   uint32_t crypt = 0;
   for (size_t i = 0; i < len; ++i, ++config, crypt += 0x11111111) {
     uint32_t start = config->start;
     uint32_t end = start + config->size;
-    if ((kRomExtAStart >= start && kRomExtAStart < end) ||
-        (kRomExtAEnd > start && kRomExtAEnd <= end) ||
-        (kRomExtBStart >= start && kRomExtBStart < end) ||
-        (kRomExtBEnd > start && kRomExtBEnd <= end)) {
-      uint32_t val = config->properties ^ crypt;
-      flash_ctrl_cfg_t cfg = {
-          .scrambling = bitfield_field32_read(val, FLASH_CONFIG_SCRAMBLE),
-          .ecc = bitfield_field32_read(val, FLASH_CONFIG_ECC),
-          .he = bitfield_field32_read(val, FLASH_CONFIG_HIGH_ENDURANCE),
-      };
-      flash_ctrl_cfg_t dfl = flash_ctrl_data_default_cfg_get();
-      // Any non-true value should be forced to false.
-      if (dfl.ecc != kMultiBitBool4True)
-        dfl.ecc = kMultiBitBool4False;
-      if (dfl.scrambling != kMultiBitBool4True)
-        dfl.scrambling = kMultiBitBool4False;
-
-      if (cfg.ecc != dfl.ecc || cfg.scrambling != dfl.scrambling) {
-        // The config region convering the ROM_EXT needs to match the
-        // default config's ECC and scrambling settings.
-        return kErrorOwnershipFlashConfigRomExt;
-      }
+    if (end > kFlashTotalSize) {
+      return kErrorOwnershipFlashConfigBounds;
+    }
+    // When checking the flash configuration, a region is a ROM_EXT region if
+    // it overlaps the ROM_EXT bounds.  It is an error to accept a new config
+    // with a flash region that overlaps the ROM_EXT.
+    if (rom_ext_flash_overlap(start, end) == kHardenedBoolTrue) {
+      return kErrorOwnershipFlashConfigRomExt;
     }
   }
   return kErrorOk;
 }
 
 rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
-                                    uint32_t config_side, uint32_t lockdown) {
+                                    uint32_t config_side,
+                                    uint32_t owner_lockdown) {
   if ((hardened_bool_t)flash == kHardenedBoolFalse)
     return kErrorOk;
+
   // TODO: Hardening: lockdown should be one of kBootSlotA, kBootSlotB or
   // kHardenedBoolFalse.
   uint32_t start = config_side == kBootSlotA   ? 0
@@ -208,8 +238,8 @@ rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
                                              : 0;
   size_t len = (flash->header.length - sizeof(owner_flash_config_t)) /
                sizeof(owner_flash_region_t);
-  if (len >= 8) {
-    return kErrorOwnershipFlashConfigLenth;
+  if (len > kProtectSlots - kRomExtRegions) {
+    return kErrorOwnershipFlashConfigLength;
   }
 
   const owner_flash_region_t *config = flash->config;
@@ -229,23 +259,42 @@ rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
           .erase = bitfield_field32_read(val, FLASH_CONFIG_ERASE),
       };
 
-      if (lockdown == config_side) {
-        if (bitfield_field32_read(val, FLASH_CONFIG_PROTECT_WHEN_PRIMARY) !=
-            kMultiBitBool4False) {
+      uint32_t pwp =
+          bitfield_field32_read(val, FLASH_CONFIG_PROTECT_WHEN_PRIMARY);
+      hardened_bool_t lock =
+          bitfield_field32_read(val, FLASH_CONFIG_LOCK) != kMultiBitBool4False
+              ? kHardenedBoolTrue
+              : kHardenedBoolFalse;
+      uint32_t region_start = config->start;
+      uint32_t region_end = region_start + config->size;
+
+      // When applying the flash configuration, a region is a ROM_EXT region if
+      // it is exclusively within the ROM_EXT bounds.  This sets the creator
+      // the lockdown policy for a region that is exclusively the creator
+      // region.
+      if (rom_ext_flash_exclusive(region_start, region_end) ==
+          kHardenedBoolTrue) {
+        // Flash region is a ROM_EXT region.  Do nothing.
+        // Some early configurations explicitly set parameters for the ROM_EXT
+        // region.  We ignore these regions in favor of the ROM_EXT setting
+        // its own protection parameters.
+        continue;
+      } else {
+        // Flash region is an owner region.
+        // If the config_side is the same as the owner lockdown side, and
+        // protect_when_primary is requested, deny write/erase to the region.
+        if (config_side == owner_lockdown && pwp != kMultiBitBool4False) {
           perm.write = kMultiBitBool4False;
           perm.erase = kMultiBitBool4False;
         }
-      }
-
-      hardened_bool_t lock = kHardenedBoolFalse;
-      if (lockdown != kHardenedBoolFalse) {
-        if (bitfield_field32_read(val, FLASH_CONFIG_LOCK) !=
-            kMultiBitBool4False) {
-          lock = kHardenedBoolTrue;
+        // If we aren't in a lockdown state, then do not lock the region
+        // configuration via the flash_ctrl regwen bits.
+        if (owner_lockdown == kHardenedBoolFalse) {
+          lock = kHardenedBoolFalse;
         }
       }
-      flash_ctrl_data_region_protect(i, config->start, config->size, perm, cfg,
-                                     lock);
+      flash_ctrl_data_region_protect(kRomExtRegions + i, config->start,
+                                     config->size, perm, cfg, lock);
     }
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -87,12 +87,15 @@ void owner_config_default(owner_config_t *config);
  * Parse an owner block, extracting pointers to keys and configuration items.
  *
  * @param block The owner block to parse.
+ * @param check_only Check the owner_block for validity, but do not parse into
+ *                   config and keyring structs.
  * @param config A pointer to a config struct holding pointers to config items.
  * @param keyring A pointer to a keyring struct holding application key
  * pointers.
  * @return error code.
  */
 rom_error_t owner_block_parse(const owner_block_t *block,
+                              hardened_bool_t check_only,
                               owner_config_t *config,
                               owner_application_keyring_t *keyring);
 
@@ -112,13 +115,14 @@ rom_error_t owner_block_flash_check(const owner_flash_config_t *flash);
  *
  * @param flash A pointer to a flash configuration struct.
  * @param config_side Which side of the flash to configure.
- * @param lockdown Apply any special lockdown configuration to the specified
- *                 side of the flash.  May use kHardenedBoolFalse to skip
- *                 lockdown.
+ * @param owner_lockdown Apply any special lockdown configuration to
+ *                       silicon_owner regions on the specified side of the
+ *                       flash.  May use kHardenedBoolFalse to skip lockdown.
  * @return error code.
  */
 rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
-                                    uint32_t config_side, uint32_t lockdown);
+                                    uint32_t config_side,
+                                    uint32_t owner_lockdown);
 
 /**
  * Apply the flash info configuration parameters from the owner block.

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -122,13 +123,14 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
     HARDENED_RETURN_IF_ERROR(boot_data_write(bootdata));
     return kErrorOwnershipBadInfoPage;
   }
-  HARDENED_RETURN_IF_ERROR(owner_block_parse(&owner_page[0], config, keyring));
+  HARDENED_RETURN_IF_ERROR(owner_block_parse(
+      &owner_page[0], /*check_only=*/kHardenedBoolFalse, config, keyring));
   HARDENED_RETURN_IF_ERROR(
       owner_block_flash_apply(config->flash, kBootSlotA,
-                              /*lockdown=*/kHardenedBoolFalse));
+                              /*owner_lockdown=*/kHardenedBoolFalse));
   HARDENED_RETURN_IF_ERROR(
       owner_block_flash_apply(config->flash, kBootSlotB,
-                              /*lockdown=*/kHardenedBoolFalse));
+                              /*owner_lockdown=*/kHardenedBoolFalse));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
   return kErrorOk;
 }
@@ -149,29 +151,28 @@ static rom_error_t unlocked_init(boot_data_t *bootdata, owner_config_t *config,
 
   if (owner_page_valid[0] == kOwnerPageStatusSealed) {
     // Configure the primary half of the flash as Owner Page 0 requests.
-    HARDENED_RETURN_IF_ERROR(
-        owner_block_parse(&owner_page[0], config, keyring));
+    HARDENED_RETURN_IF_ERROR(owner_block_parse(
+        &owner_page[0], /*check_only=*/kHardenedBoolFalse, config, keyring));
     HARDENED_RETURN_IF_ERROR(
         owner_block_flash_apply(config->flash, bootdata->primary_bl0_slot,
-                                /*lockdown=*/kHardenedBoolFalse));
+                                /*owner_lockdown=*/kHardenedBoolFalse));
   }
 
   if (owner_block_page1_valid_for_transfer(bootdata) == kHardenedBoolTrue) {
     // If we passed the validity test for Owner Page 1, test parse the config.
-    owner_config_t testcfg;
-    owner_application_keyring_t testring;
-    rom_error_t result = owner_block_parse(&owner_page[1], &testcfg, &testring);
+    rom_error_t result = owner_block_parse(
+        &owner_page[1], /*check_only=*/kHardenedBoolTrue, NULL, NULL);
     if (result == kErrorOk) {
       // Parse the configuration and add its keys to the keyring.
-      HARDENED_RETURN_IF_ERROR(
-          owner_block_parse(&owner_page[1], config, keyring));
+      HARDENED_RETURN_IF_ERROR(owner_block_parse(
+          &owner_page[1], /*check_only=*/kHardenedBoolFalse, config, keyring));
     } else {
       dbg_printf("error: owner page 1 invalid.\r\n");
     }
   }
   HARDENED_RETURN_IF_ERROR(
       owner_block_flash_apply(config->flash, secondary,
-                              /*lockdown=*/kHardenedBoolFalse));
+                              /*owner_lockdown=*/kHardenedBoolFalse));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
   return kErrorOk;
 }
@@ -271,14 +272,15 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   return error;
 }
 
-rom_error_t ownership_flash_lockdown(boot_data_t *bootdata,
-                                     uint32_t active_slot,
+rom_error_t ownership_flash_lockdown(boot_data_t *bootdata, boot_log_t *bootlog,
                                      const owner_config_t *config) {
   if (bootdata->ownership_state == kOwnershipStateLockedOwner) {
-    HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotA,
-                                                     /*lockdown=*/active_slot));
-    HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotB,
-                                                     /*lockdown=*/active_slot));
+    HARDENED_RETURN_IF_ERROR(
+        owner_block_flash_apply(config->flash, kBootSlotA,
+                                /*owner_lockdown=*/bootlog->bl0_slot));
+    HARDENED_RETURN_IF_ERROR(
+        owner_block_flash_apply(config->flash, kBootSlotB,
+                                /*owner_lockdown=*/bootlog->bl0_slot));
   } else {
     HARDENED_CHECK_NE(bootdata->ownership_state, kOwnershipStateLockedOwner);
   }

--- a/sw/device/silicon_creator/lib/ownership/ownership.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership.h
@@ -7,6 +7,7 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
@@ -25,8 +26,7 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
  * @param config The current owner configuration.
  * @return error state.
  */
-rom_error_t ownership_flash_lockdown(boot_data_t *bootdata,
-                                     uint32_t active_slot,
+rom_error_t ownership_flash_lockdown(boot_data_t *bootdata, boot_log_t *bootlog,
                                      const owner_config_t *config);
 
 /**

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -17,10 +17,8 @@
 rom_error_t ownership_activate(boot_data_t *bootdata,
                                hardened_bool_t write_both_pages) {
   // Check if page1 parses correctly.
-  owner_config_t config;
-  owner_application_keyring_t keyring;
-  HARDENED_RETURN_IF_ERROR(
-      owner_block_parse(&owner_page[1], &config, &keyring));
+  HARDENED_RETURN_IF_ERROR(owner_block_parse(
+      &owner_page[1], /*check_only*/ kHardenedBoolTrue, NULL, NULL));
 
   // Seal page one to this chip.
   ownership_seal_page(/*page=*/1);

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -58,6 +58,8 @@ opentitan_binary(
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )
 
@@ -398,15 +400,42 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_flash_permission_test
 # Note: rescue-after-activate tests that rescue correctly accesses regions with
 # different scrambling/ECC properties than the default flash configuration.
+_FLASH_PERMISSION_TESTS = {
+    "aa": {
+        "rom_ext_slot": "SlotA",
+        "owner_slot": "SlotA",
+        "rom_ext_offset": "0",
+    },
+    "ab": {
+        "rom_ext_slot": "SlotA",
+        "owner_slot": "SlotB",
+        "rom_ext_offset": "0",
+    },
+    "ba": {
+        "rom_ext_slot": "SlotB",
+        "owner_slot": "SlotA",
+        "rom_ext_offset": "0x80000",
+    },
+    "bb": {
+        "rom_ext_slot": "SlotB",
+        "owner_slot": "SlotB",
+        "rom_ext_offset": "0x80000",
+    },
+}
+
 [
     ownership_transfer_test(
-        name = "flash_permission_test_slot_{}".format(slot),
+        name = "flash_permission_test_slot_{}".format(name),
         srcs = ["flash_regions.c"],
         fpga = fpga_params(
+            assemble = "{rom_ext}@{rom_ext_offset} {firmware}@0x10000",
             binaries = {
                 ":flash_regions": "flash_regions",
             },
-            slot = "Slot{}".format(slot.upper()),
+            owner_slot = param["owner_slot"],
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+            rom_ext_offset = param["rom_ext_offset"],
+            rom_ext_slot = param["rom_ext_slot"],
             test_cmd = """
                 --clear-bitstream
                 --bootstrap={firmware}
@@ -418,7 +447,8 @@ ownership_transfer_test(
                 --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
                 --config-kind=with-flash-locked
                 --rescue-after-activate={flash_regions}
-                --rescue-slot={slot}
+                --rescue-slot={owner_slot}
+                --expected-rom-ext-slot={rom_ext_slot}
             """,
             test_harness = "//sw/host/tests/ownership:flash_permission_test",
         ),
@@ -428,9 +458,11 @@ ownership_transfer_test(
             "//sw/device/lib/base:status",
             "//sw/device/lib/dif:flash_ctrl",
             "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:boot_log",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
         ],
     )
-    for slot in ("a", "b")
+    for name, param in _FLASH_PERMISSION_TESTS.items()
 ]
 
 # Tests that a owner config with an improper flash configuration cannot be activated.

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -43,8 +43,9 @@ static top_earlgrey_plic_peripheral_t peripheral_serviced;
 static dif_aon_timer_irq_t irq_serviced;
 
 enum {
-  kFlashDataRegion = 0,
-  kRegionBasePageIndex = 256,  // First page in bank 1 (avoids program code.)
+  kFlashDataRegion = 2,  // The ROM_EXT protects itself using regions 0-1.
+  kRegionBasePageIndex =
+      256 + 32,  // First non-ROM_EXT page in bank 1 (avoids program code.)
   kPartitionId = 0,
   kRegionSize = 1,
   kNumWords = 128,

--- a/sw/device/tests/flash_ctrl_write_clear_test.c
+++ b/sw/device/tests/flash_ctrl_write_clear_test.c
@@ -38,6 +38,10 @@ enum {
   // The start page used by this test. Points to the start of the owner
   // partition in bank 1, otherwise known as owner partition B.
   kBank1StartPageNum = 256 + kRomExtPageCount,
+
+  // The ROM_EXT protects itself using regions 0-1.
+  kFlashRegionNum = 2,
+
 };
 
 // The `flash_word_verify()` function will need to be updated if this assertion
@@ -110,7 +114,7 @@ bool test_main(void) {
   }
 
   LOG_INFO("ECC enabled with high endurance disabled.");
-  flash_ctrl_write_clear_test(/*mp_region_index=*/0,
+  flash_ctrl_write_clear_test(/*mp_region_index=*/kFlashRegionNum,
                               (dif_flash_ctrl_data_region_properties_t){
                                   .base = kBank1StartPageNum,
                                   .size = 1,
@@ -124,7 +128,7 @@ bool test_main(void) {
                                   }});
 
   LOG_INFO("ECC enabled with high endurance enabled.");
-  flash_ctrl_write_clear_test(/*mp_region_index=*/1,
+  flash_ctrl_write_clear_test(/*mp_region_index=*/kFlashRegionNum,
                               (dif_flash_ctrl_data_region_properties_t){
                                   .base = kBank1StartPageNum + 1,
                                   .size = 1,

--- a/sw/device/tests/rv_core_ibex_mem_test.c
+++ b/sw/device/tests/rv_core_ibex_mem_test.c
@@ -60,6 +60,8 @@ enum {
 
   kFlashTestLoc = TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
                   kBank1StartPageNum * kFlashBytesPerPage,
+  // The ROM_EXT protects itself using regions 0-1.
+  kFlashRegionNum = 2,
 };
 
 // The flash test location is set to the encoding of `jalr x0, 0(x1)`
@@ -162,10 +164,10 @@ static void setup_flash(void) {
   dif_flash_ctrl_data_region_properties_t data_region = {
       .base = kBank1StartPageNum, .size = 0x1, .properties = region_properties};
 
-  CHECK_DIF_OK(
-      dif_flash_ctrl_set_data_region_properties(&flash_ctrl, 0, data_region));
-  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_enablement(&flash_ctrl, 0,
-                                                         kDifToggleEnabled));
+  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_properties(
+      &flash_ctrl, kFlashRegionNum, data_region));
+  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_enablement(
+      &flash_ctrl, kFlashRegionNum, kDifToggleEnabled));
 
   // Make flash executable
   CHECK_DIF_OK(

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -55,6 +55,12 @@ struct Opts {
     rescue_after_activate: Option<PathBuf>,
     #[arg(long, default_value = "SlotA", help = "Which slot to rescue into")]
     rescue_slot: BootSlot,
+    #[arg(
+        long,
+        default_value = "SlotA",
+        help = "Which slot the ROM_EXT is expected to execute from"
+    )]
+    expected_rom_ext_slot: BootSlot,
 
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Check the firmware boot in dual-owner mode")]
     dual_owner_boot_check: bool,
@@ -181,6 +187,13 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         /*customize=*/ |_| {},
     )?;
 
+    // The expected_rom_ext_slot is where we expect the ROM_EXT to execute.
+    let romext_region = match opts.expected_rom_ext_slot {
+        BootSlot::SlotA => ["RD-xx-xx-uu-uu-uu", "RD-WR-ER-uu-uu-uu"],
+        BootSlot::SlotB => ["RD-WR-ER-uu-uu-uu", "RD-xx-xx-uu-uu-uu"],
+        _ => return Err(anyhow!("Unknown boot slot {}", data.bl0_slot)),
+    };
+
     if opts.dual_owner_boot_check {
         log::info!("###### Boot in Dual-Owner Mode ######");
         // At this point, the device should be unlocked and should have accepted the owner
@@ -207,23 +220,25 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         // Note: when in an unlocked state, flash lockdown doesn't apply, so neither
         // the `protect_when_active` nor `lock` bits for individual regions will
         // affect the region config.
+
+        // The ROM_EXT always protects itself in regions 0 and 1.
         assert_eq!(
             region[0],
-            FlashRegion("data", 0, 0, 0, "xx-xx-xx-xx-xx-xx", "UN")
+            FlashRegion("data", 0, 0, 32, romext_region[0], "LK")
         );
         assert_eq!(
             region[1],
-            FlashRegion("data", 1, 0, 0, "xx-xx-xx-xx-xx-xx", "UN")
+            FlashRegion("data", 1, 256, 32, romext_region[1], "LK")
         );
         assert_eq!(
             region[2],
             FlashRegion("data", 2, 0, 0, "xx-xx-xx-xx-xx-xx", "UN")
         );
-        // Flash SideB is the next owner configuration.
         assert_eq!(
             region[3],
-            FlashRegion("data", 3, 256, 32, "RD-WR-ER-xx-xx-xx", "UN")
+            FlashRegion("data", 3, 0, 0, "xx-xx-xx-xx-xx-xx", "UN")
         );
+        // Flash SideB is the next owner configuration.
         assert_eq!(
             region[4],
             FlashRegion("data", 4, 288, 192, "RD-WR-ER-SC-EC-xx", "UN")
@@ -281,18 +296,14 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         return RomError(u32::from_str_radix(&capture[2], 16)?).into();
     }
     let region = FlashRegion::find_all(&capture[1])?;
-    // The rescue_slot shoudl be the active side and has protect_when_active = true.
-    let (romext_region, app_region) = match opts.rescue_slot {
-        BootSlot::SlotA => (
-            ["RD-xx-xx-xx-xx-xx", "RD-WR-ER-xx-xx-xx"],
-            ["RD-xx-xx-SC-EC-xx", "RD-WR-ER-SC-EC-xx"],
-        ),
-        BootSlot::SlotB => (
-            ["RD-WR-ER-xx-xx-xx", "RD-xx-xx-xx-xx-xx"],
-            ["RD-WR-ER-SC-EC-xx", "RD-xx-xx-SC-EC-xx"],
-        ),
+
+    // The rescue_slot should be the active side and has protect_when_active = true.
+    let app_region = match opts.rescue_slot {
+        BootSlot::SlotA => ["RD-xx-xx-SC-EC-xx", "RD-WR-ER-SC-EC-xx"],
+        BootSlot::SlotB => ["RD-WR-ER-SC-EC-xx", "RD-xx-xx-SC-EC-xx"],
         _ => return Err(anyhow!("Unknown boot slot {}", data.bl0_slot)),
     };
+
     //
     // Since we are in a locked ownership state, we expect the region configuration
     // to reflect both the `protect_when_active` and `lock` properties of the
@@ -302,24 +313,25 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
     } else {
         "UN"
     };
-    // Flash Slot A:
+    // The ROM_EXT always protects itself in regions 0 and 1.
     assert_eq!(
         region[0],
-        FlashRegion("data", 0, 0, 32, romext_region[0], locked)
+        FlashRegion("data", 0, 0, 32, romext_region[0], "LK")
     );
     assert_eq!(
         region[1],
-        FlashRegion("data", 1, 32, 192, app_region[0], locked)
+        FlashRegion("data", 1, 256, 32, romext_region[1], "LK")
     );
+    // Flash Slot A:
     assert_eq!(
         region[2],
-        FlashRegion("data", 2, 224, 32, "RD-WR-ER-xx-xx-HE", locked)
+        FlashRegion("data", 2, 32, 192, app_region[0], locked)
     );
-    // Flash Slot B:
     assert_eq!(
         region[3],
-        FlashRegion("data", 3, 256, 32, romext_region[1], locked)
+        FlashRegion("data", 3, 224, 32, "RD-WR-ER-xx-xx-HE", locked)
     );
+    // Flash Slot B:
     assert_eq!(
         region[4],
         FlashRegion("data", 4, 288, 192, app_region[1], locked)


### PR DESCRIPTION
Ownership flash lockdown was protecting and locking all regions in the same slot that booted the owner code.  However, the ROM_EXT and owner code don't have to boot from the same side of the flash.

1. Disallow ownership configurations that have flash regions that overlap with the ROM_EXT region.  It is an error to upload such a configuration, but if one already exists in the chip, the owner-specified ROM_EXT regions are ignored in favor of the self-protection.
2. Always protect the ROM_EXT by using flash regions 0 and 1.
3. Update the tests.

This is a cherry-pick & rewrite of #25892 for earlgrey_a1.
Fixes #25435.