### PR TITLE
[orchestrator] refactor SKU specific portion of device ID

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -353,7 +353,7 @@ filegroup(
            EXT_SIGNED_PERSO_BINS,
 )
 
-_DISQUALIFIED_FOR_SIGNING = ["emulation"]
+_DISQUALIFIED_FOR_SIGNING = ["em00"]
 
 [
     offline_presigning_artifacts(

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -12,8 +12,8 @@ load(
 # individualization binaries that configure OTP with the constants defined in
 # these bazel targets.
 EARLGREY_OTP_CFGS = {
-    "sival": "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_consts",
-    "emulation": "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_consts",
+    "sv00": "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_consts",
+    "em00": "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_consts",
 } | EXT_EARLGREY_OTP_CFGS
 
 EXT_SIGNED_PERSO_BINS = []
@@ -24,7 +24,7 @@ EXT_SIGNED_PERSO_BINS = []
 EARLGREY_SKUS = {
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: None
     "emulation": {
-        "otp": "emulation",
+        "otp": "em00",
         "ca_data": "@//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
@@ -40,7 +40,7 @@ EARLGREY_SKUS = {
     },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     "emulation_dice_cwt": {
-        "otp": "emulation",
+        "otp": "em00",
         "ca_data": "@//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
@@ -56,7 +56,7 @@ EARLGREY_SKUS = {
     },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {
-        "otp": "emulation",
+        "otp": "em00",
         "ca_data": "@//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
@@ -74,7 +74,7 @@ EARLGREY_SKUS = {
         "orchestrator_cfg": "@//sw/host/provisioning/orchestrator/configs/skus:emulation_tpm.hjson",
     },
     "sival": {
-        "otp": "sival",
+        "otp": "sv00",
         "ca_data": "@//sw/device/silicon_creator/manuf/keys/sival:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -223,7 +223,7 @@ opentitan_test(
     deps = [
         ":flash_info_fields",
         # Testing emulation SKU only should be sufficient.
-        ":individualize_sw_cfg_emulation",
+        ":individualize_sw_cfg_em00",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -321,7 +321,7 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
-        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_sival",
+        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_sv00",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2326,7 +2326,7 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
         "//sw/device/silicon_creator/manuf/lib:individualize",
-        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_sival",
+        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_sv00",
         "//sw/device/silicon_creator/manuf/lib:otp_fields",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
@@ -8,7 +8,7 @@
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
-  otp: "emulation",
+  otp: "em00",
   perso_bin: "sw/device/silicon_creator/manuf/base/ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin",
   owner_fw_boot_str: "Bare metal PASS!"
   dice_ca: {

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation_dice_cwt.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation_dice_cwt.hjson
@@ -8,7 +8,7 @@
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
-  otp: "emulation",
+  otp: "em00",
   perso_bin: "sw/device/silicon_creator/manuf/base/ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin",
   owner_fw_boot_str: "Bare metal PASS!",
   dice_ca: {

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation_tpm.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation_tpm.hjson
@@ -8,7 +8,7 @@
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
-  otp: "emulation",
+  otp: "em00",
   perso_bin: "sw/device/silicon_creator/manuf/base/ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin",
   owner_fw_boot_str: "Bare metal PASS!"
   dice_ca: {

--- a/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
@@ -8,7 +8,7 @@
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
-  otp: "sival",
+  otp: "sv00",
   perso_bin: "sw/device/silicon_creator/manuf/base/binaries/ft_personalize_{sku}_{target}.signed.bin",
   # owner_fw_boot_str: "Bare metal PASS!"
   dice_ca: {

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -84,6 +84,12 @@ def main(args_in):
         help="SKU HJSON configuration file.",
     )
     parser.add_argument(
+        "--ast-cfg-version",
+        required=True,
+        type=int,
+        help="AST configuration version to be written to OTP.",
+    )
+    parser.add_argument(
         "--package",
         type=str,
         help="Override of package string that is in the SKU config.",
@@ -154,7 +160,8 @@ def main(args_in):
     sku_config_args = {}
     with open(sku_config_path, "r") as fp:
         sku_config_args = hjson.load(fp)
-    sku_config = SkuConfig(**sku_config_args)
+    sku_config = SkuConfig(ast_cfg_version=args.ast_cfg_version,
+                           **sku_config_args)
 
     # Override package ID if requested.
     if args.package:

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -24,9 +24,10 @@ class SkuConfig:
     si_creator: str  # valid: any SiliconCreator that exists in product database
     package: str  # valid: any package that exists in package database
     target_lc_state: str  # valid: must be in ["dev", "prod", "prod_end"]
-    otp: str  # valid: any string
+    otp: str  # valid: any 4 char string whose first char is alphabetic and last two are numeric
+    ast_cfg_version: int  # valid: any positive integer < 256 (to fit in one byte)
     perso_bin: str  # valid: any string
-    token_encrypt_key: str
+    token_encrypt_key: str  # valid: any file path that exists
     dice_ca: Optional[OrderedDict]  # valid: see CaConfig
     ext_ca: Optional[OrderedDict] = None  # valid: see CaConfig
     owner_fw_boot_str: str = None  # valid: any string
@@ -61,9 +62,9 @@ class SkuConfig:
             self.token_encrypt_key = resolve_runfile(self.token_encrypt_key)
 
     @staticmethod
-    def from_ids(product_id: int, si_creator_id: int,
-                 package_id: int) -> "SkuConfig":
-        """Creates a SKU configuration object from product, SiliconCreator, and package IDs."""
+    def from_ids(product_id: int, si_creator_id: int, package_id: int,
+                 otp: str, ast_cfg_version: int) -> "SkuConfig":
+        """Creates a SKU configuration object from various subcomponent IDs."""
         # Load product IDs database.
         product_ids_hjson = resolve_runfile(_PRODUCT_IDS_HJSON)
         product_ids = None
@@ -97,7 +98,8 @@ class SkuConfig:
                                si_creator=si_creator,
                                package=package,
                                target_lc_state="dev",
-                               otp="",
+                               otp=otp,
+                               ast_cfg_version=ast_cfg_version,
                                perso_bin="",
                                dice_ca=OrderedDict(),
                                ext_ca=OrderedDict(),
@@ -126,6 +128,21 @@ class SkuConfig:
             raise ValueError(
                 "Target LC state ({}) must be in [\"dev\", \"prod\", \"prod_end\"]"
                 .format(self.target_lc_state))
+        # Validate AST configuration version.
+        if self.ast_cfg_version < 0 or self.ast_cfg_version > 255:
+            raise ValueError("AST config version should be in range [0, 256).")
+        # Validate OTP string.
+        if len(self.otp) != 4:
+            raise ValueError("OTP must be a non-empty 4 character string.")
+        # Validate OTP ID string.
+        if not self.otp[0].isalpha() or not self.otp[1].isalpha():
+            raise ValueError(
+                "First two chars of OTP string must be alphabetic.")
+        # Validate OTP version.
+        try:
+            _ = int(self.otp[2:], 16)
+        except ValueError:
+            raise ValueError("OTP version should two digit hexstring.")
 
     def load_hw_ids(self) -> None:
         """Sets product, SiliconCreator, and package IDs."""
@@ -134,3 +151,6 @@ class SkuConfig:
         self.product_id = int(self._product_ids["product_ids"][self.product],
                               16)
         self.package_id = int(self._package_ids[self.package], 16)
+        # We process the OTP str into a two character ID and version number.
+        self.otp_id = self.otp[:2]
+        self.otp_version = int(self.otp[2:], 16)

--- a/sw/host/provisioning/orchestrator/tests/device_id_test.py
+++ b/sw/host/provisioning/orchestrator/tests/device_id_test.py
@@ -19,7 +19,7 @@ class TestDeviceId(unittest.TestCase):
         # Create SKU config object.
         with open(_SIVAL_SKU_CONFIG, "r") as fp:
             sku_config_args = hjson.load(fp)
-        self.sku_config = SkuConfig(**sku_config_args)
+        self.sku_config = SkuConfig(ast_cfg_version=7, **sku_config_args)
 
         # Create DIN object.
         self.din = DeviceIdentificationNumber(year=4,
@@ -114,15 +114,39 @@ class TestDeviceId(unittest.TestCase):
 
     def test_package_id_field(self):
         expected_field = 0x0
-        actual_field = (self.device_id.to_int() >> 128) & 0xffff
+        actual_field = (self.device_id.to_int() >> 128) & 0xff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
-                format_hex(actual_field, width=4),
-                format_hex(expected_field, width=4)))
+                format_hex(actual_field, width=2),
+                format_hex(expected_field, width=2)))
 
-    def test_sku_specific_reserved_field_0(self):
-        expected_field = 0
+    def test_ast_cfg_version_field(self):
+        expected_field = 0x7
+        actual_field = (self.device_id.to_int() >> 136) & 0xff
+        self.assertEqual(
+            actual_field, expected_field, "actual: {}, expected: {}.".format(
+                format_hex(actual_field, width=2),
+                format_hex(expected_field, width=2)))
+
+    def test_otp_id_field(self):
+        expected_field = bytes_to_int("ME".encode("utf-8"))
         actual_field = (self.device_id.to_int() >> 144) & 0xffff
+        self.assertEqual(
+            actual_field, expected_field, "actual: {}, expected: {}.".format(
+                format_hex(actual_field, width=2),
+                format_hex(expected_field, width=2)))
+
+    def test_otp_version_field(self):
+        expected_field = 0
+        actual_field = (self.device_id.to_int() >> 160) & 0xff
+        self.assertEqual(
+            actual_field, expected_field, "actual: {}, expected: {}.".format(
+                format_hex(actual_field, width=2),
+                format_hex(expected_field, width=2)))
+
+    def test_sku_specific_reserved_field0(self):
+        expected_field = 0
+        actual_field = (self.device_id.to_int() >> 168) & 0xffffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
                 format_hex(actual_field, width=4),
@@ -130,19 +154,27 @@ class TestDeviceId(unittest.TestCase):
 
     def test_sku_id_field(self):
         expected_field = bytes_to_int("LUME".encode("utf-8"))
-        actual_field = (self.device_id.to_int() >> 160) & 0xffffffff
+        actual_field = (self.device_id.to_int() >> 192) & 0xffffffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
                 format_hex(actual_field, width=8),
                 format_hex(expected_field, width=8)))
 
-    def test_sku_specific_reserved_field_1(self):
+    def test_sku_specific_reserved_field1(self):
         expected_field = 0
-        actual_field = (self.device_id.to_int() >> 224) & 0xffffffff
+        actual_field = (self.device_id.to_int() >> 224) & 0xffffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(
-                format_hex(actual_field, width=8),
-                format_hex(expected_field, width=8)))
+                format_hex(actual_field, width=4),
+                format_hex(expected_field, width=4)))
+
+    def test_sku_specific_version_field(self):
+        expected_field = 1
+        actual_field = (self.device_id.to_int() >> 248) & 0xff
+        self.assertEqual(
+            actual_field, expected_field, "actual: {}, expected: {}.".format(
+                format_hex(actual_field, width=4),
+                format_hex(expected_field, width=4)))
 
     def test_pretty_print(self):
         self.device_id.pretty_print()

--- a/sw/host/provisioning/orchestrator/tests/e2e.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e.sh
@@ -27,5 +27,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=${FPGA} \
+  --ast-cfg-version=0 \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/e2e_multistage.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_multistage.sh
@@ -31,6 +31,7 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=hyper310 \
+  --ast-cfg-version=0 \
   --non-interactive \
   --cp-only \
   --db-path=$TEST_TMPDIR/registry.sqlite
@@ -43,6 +44,7 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=hyper310 \
+  --ast-cfg-version=0 \
   --fpga-dont-clear-bitstream \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
@@ -29,6 +29,7 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --package=${PACKAGE} \
   --fpga=hyper310 \
+  --ast-cfg-version=0 \
   --enable-alerts \
   --use-ext-clk \
   --non-interactive \


### PR DESCRIPTION
This updates the SKU specific portion of the device ID to add the following subfields:
1. AST config version
2. OTP ID
3. OTP version
4. SKU specific version