### PR TITLE
[hw,pinmux,lint] Read unused signals to avoid lint errors

### DIFF
--- a/hw/ip_templates/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip_templates/pinmux/data/pinmux.hjson.tpl
@@ -1136,7 +1136,7 @@
                   regwen_multi: "true",
                   cname:        "DETECTOR",
                   fields: [
-                    { bits: "${max(2 + n_mio_pads-1, n_dio_periph_in-1).bit_length()-1}:0",
+                    { bits: "${max(2 + n_mio_pads-1, n_dio_pads-1).bit_length()-1}:0",
                       name: "SEL",
                       resval: 0,
                       desc: '''Selects a specific MIO or DIO pad (depending on !!WKUP_DETECTOR configuration).

--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -492,6 +492,14 @@ module pinmux
     assign mio_to_periph_o[k] = mio_mux[reg2hw.mio_periph_insel[k].q];
   end
 
+% if n_dio_pads > n_mio_pads + 2:
+  // For configurations with NMioPads + 2 < NDioPads, mio_in is zero-extended to NDioPads bits for
+  // convenience. However, mio_periph_insel is sized to select the lowest NMioPads + 2 bits. Most
+  // of the zero bits cannot actually be selected. Tie them off to avoid lint warnings.
+  logic unused_mio_mux;
+  assign unused_mio_mux = ^{mio_mux[(AlignedMuxSize - 1):(NMioPads + 2)]};
+
+% endif
   //////////////////////
   // MIO Output Muxes //
   //////////////////////

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/pinmux.hjson
@@ -824,7 +824,7 @@
                   regwen_multi: "true",
                   cname:        "DETECTOR",
                   fields: [
-                    { bits: "5:0",
+                    { bits: "6:0",
                       name: "SEL",
                       resval: 0,
                       desc: '''Selects a specific MIO or DIO pad (depending on !!WKUP_DETECTOR configuration).

--- a/hw/top_darjeeling/ip_autogen/pinmux/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/pinmux/doc/registers.md
@@ -1752,7 +1752,7 @@ However, read/write accesses following a write will block until that write has c
 Pad selects for pad wakeup condition detectors.
 This register is NOT synced to the AON domain since the muxing mechanism is implemented in the same way as the pinmux muxing matrix.
 - Reset default: `0x0`
-- Reset mask: `0x3f`
+- Reset mask: `0x7f`
 - Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
@@ -1772,13 +1772,13 @@ This register is NOT synced to the AON domain since the muxing mechanism is impl
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "SEL", "bits": 6, "attr": ["rw"], "rotate": 0}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "SEL", "bits": 7, "attr": ["rw"], "rotate": 0}, {"bits": 25}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                              |
 |:------:|:------:|:-------:|:----------------------------------|
-|  31:6  |        |         | Reserved                          |
-|  5:0   |   rw   |   0x0   | [SEL](#wkup_detector_padsel--sel) |
+|  31:7  |        |         | Reserved                          |
+|  6:0   |   rw   |   0x0   | [SEL](#wkup_detector_padsel--sel) |
 
 ### WKUP_DETECTOR_PADSEL . SEL
 Selects a specific MIO or DIO pad (depending on [`WKUP_DETECTOR`](#wkup_detector) configuration).

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
@@ -316,6 +316,12 @@ module pinmux
     assign mio_to_periph_o[k] = mio_mux[reg2hw.mio_periph_insel[k].q];
   end
 
+  // For configurations with NMioPads + 2 < NDioPads, mio_in is zero-extended to NDioPads bits for
+  // convenience. However, mio_periph_insel is sized to select the lowest NMioPads + 2 bits. Most
+  // of the zero bits cannot actually be selected. Tie them off to avoid lint warnings.
+  logic unused_mio_mux;
+  assign unused_mio_mux = ^{mio_mux[(AlignedMuxSize - 1):(NMioPads + 2)]};
+
   //////////////////////
   // MIO Output Muxes //
   //////////////////////

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -166,7 +166,7 @@ package pinmux_reg_pkg;
   } pinmux_reg2hw_wkup_detector_cnt_th_mreg_t;
 
   typedef struct packed {
-    logic [5:0]  q;
+    logic [6:0]  q;
   } pinmux_reg2hw_wkup_detector_padsel_mreg_t;
 
   typedef struct packed {
@@ -256,21 +256,21 @@ package pinmux_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    pinmux_reg2hw_alert_test_reg_t alert_test; // [2601:2600]
-    pinmux_reg2hw_mio_periph_insel_mreg_t [3:0] mio_periph_insel; // [2599:2584]
-    pinmux_reg2hw_mio_outsel_mreg_t [11:0] mio_outsel; // [2583:2548]
-    pinmux_reg2hw_mio_pad_attr_mreg_t [11:0] mio_pad_attr; // [2547:2260]
-    pinmux_reg2hw_dio_pad_attr_mreg_t [72:0] dio_pad_attr; // [2259:508]
-    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [11:0] mio_pad_sleep_status; // [507:496]
-    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [11:0] mio_pad_sleep_en; // [495:484]
-    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [11:0] mio_pad_sleep_mode; // [483:460]
-    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [72:0] dio_pad_sleep_status; // [459:387]
-    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [72:0] dio_pad_sleep_en; // [386:314]
-    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [72:0] dio_pad_sleep_mode; // [313:168]
-    pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [167:160]
-    pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [159:120]
-    pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [119:56]
-    pinmux_reg2hw_wkup_detector_padsel_mreg_t [7:0] wkup_detector_padsel; // [55:8]
+    pinmux_reg2hw_alert_test_reg_t alert_test; // [2609:2608]
+    pinmux_reg2hw_mio_periph_insel_mreg_t [3:0] mio_periph_insel; // [2607:2592]
+    pinmux_reg2hw_mio_outsel_mreg_t [11:0] mio_outsel; // [2591:2556]
+    pinmux_reg2hw_mio_pad_attr_mreg_t [11:0] mio_pad_attr; // [2555:2268]
+    pinmux_reg2hw_dio_pad_attr_mreg_t [72:0] dio_pad_attr; // [2267:516]
+    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [11:0] mio_pad_sleep_status; // [515:504]
+    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [11:0] mio_pad_sleep_en; // [503:492]
+    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [11:0] mio_pad_sleep_mode; // [491:468]
+    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [72:0] dio_pad_sleep_status; // [467:395]
+    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [72:0] dio_pad_sleep_en; // [394:322]
+    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [72:0] dio_pad_sleep_mode; // [321:176]
+    pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [175:168]
+    pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [167:128]
+    pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [127:64]
+    pinmux_reg2hw_wkup_detector_padsel_mreg_t [7:0] wkup_detector_padsel; // [63:8]
     pinmux_reg2hw_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
   } pinmux_reg2hw_t;
 

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -3382,29 +3382,29 @@ module pinmux_reg_top (
   logic [7:0] wkup_detector_cnt_th_7_qs;
   logic wkup_detector_cnt_th_7_busy;
   logic wkup_detector_padsel_0_we;
-  logic [5:0] wkup_detector_padsel_0_qs;
-  logic [5:0] wkup_detector_padsel_0_wd;
+  logic [6:0] wkup_detector_padsel_0_qs;
+  logic [6:0] wkup_detector_padsel_0_wd;
   logic wkup_detector_padsel_1_we;
-  logic [5:0] wkup_detector_padsel_1_qs;
-  logic [5:0] wkup_detector_padsel_1_wd;
+  logic [6:0] wkup_detector_padsel_1_qs;
+  logic [6:0] wkup_detector_padsel_1_wd;
   logic wkup_detector_padsel_2_we;
-  logic [5:0] wkup_detector_padsel_2_qs;
-  logic [5:0] wkup_detector_padsel_2_wd;
+  logic [6:0] wkup_detector_padsel_2_qs;
+  logic [6:0] wkup_detector_padsel_2_wd;
   logic wkup_detector_padsel_3_we;
-  logic [5:0] wkup_detector_padsel_3_qs;
-  logic [5:0] wkup_detector_padsel_3_wd;
+  logic [6:0] wkup_detector_padsel_3_qs;
+  logic [6:0] wkup_detector_padsel_3_wd;
   logic wkup_detector_padsel_4_we;
-  logic [5:0] wkup_detector_padsel_4_qs;
-  logic [5:0] wkup_detector_padsel_4_wd;
+  logic [6:0] wkup_detector_padsel_4_qs;
+  logic [6:0] wkup_detector_padsel_4_wd;
   logic wkup_detector_padsel_5_we;
-  logic [5:0] wkup_detector_padsel_5_qs;
-  logic [5:0] wkup_detector_padsel_5_wd;
+  logic [6:0] wkup_detector_padsel_5_qs;
+  logic [6:0] wkup_detector_padsel_5_wd;
   logic wkup_detector_padsel_6_we;
-  logic [5:0] wkup_detector_padsel_6_qs;
-  logic [5:0] wkup_detector_padsel_6_wd;
+  logic [6:0] wkup_detector_padsel_6_qs;
+  logic [6:0] wkup_detector_padsel_6_wd;
   logic wkup_detector_padsel_7_we;
-  logic [5:0] wkup_detector_padsel_7_qs;
-  logic [5:0] wkup_detector_padsel_7_wd;
+  logic [6:0] wkup_detector_padsel_7_qs;
+  logic [6:0] wkup_detector_padsel_7_wd;
   logic wkup_cause_we;
   logic [7:0] wkup_cause_qs;
   logic wkup_cause_busy;
@@ -33951,9 +33951,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_0_gated_we;
   assign wkup_detector_padsel_0_gated_we = wkup_detector_padsel_0_we & wkup_detector_regwen_0_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
@@ -33983,9 +33983,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_1_gated_we;
   assign wkup_detector_padsel_1_gated_we = wkup_detector_padsel_1_we & wkup_detector_regwen_1_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
@@ -34015,9 +34015,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_2_gated_we;
   assign wkup_detector_padsel_2_gated_we = wkup_detector_padsel_2_we & wkup_detector_regwen_2_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
@@ -34047,9 +34047,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_3_gated_we;
   assign wkup_detector_padsel_3_gated_we = wkup_detector_padsel_3_we & wkup_detector_regwen_3_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
@@ -34079,9 +34079,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_4_gated_we;
   assign wkup_detector_padsel_4_gated_we = wkup_detector_padsel_4_we & wkup_detector_regwen_4_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
@@ -34111,9 +34111,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_5_gated_we;
   assign wkup_detector_padsel_5_gated_we = wkup_detector_padsel_5_we & wkup_detector_regwen_5_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
@@ -34143,9 +34143,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_6_gated_we;
   assign wkup_detector_padsel_6_gated_we = wkup_detector_padsel_6_we & wkup_detector_regwen_6_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
@@ -34175,9 +34175,9 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_7_gated_we;
   assign wkup_detector_padsel_7_gated_we = wkup_detector_padsel_7_we & wkup_detector_regwen_7_qs;
   prim_subreg #(
-    .DW      (6),
+    .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h0),
+    .RESVAL  (7'h0),
     .Mubi    (1'b0)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
@@ -38695,28 +38695,28 @@ module pinmux_reg_top (
 
   assign wkup_detector_padsel_0_we = addr_hit[494] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_0_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_1_we = addr_hit[495] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_1_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_2_we = addr_hit[496] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_2_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_3_we = addr_hit[497] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_3_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_4_we = addr_hit[498] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_4_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_5_we = addr_hit[499] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_5_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_6_we = addr_hit[500] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_6_wd = reg_wdata[6:0];
   assign wkup_detector_padsel_7_we = addr_hit[501] & reg_we & !reg_error;
 
-  assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
+  assign wkup_detector_padsel_7_wd = reg_wdata[6:0];
   assign wkup_cause_we = addr_hit[502] & reg_we & !reg_error;
 
 
@@ -42038,35 +42038,35 @@ module pinmux_reg_top (
         reg_rdata_next = DW'(wkup_detector_cnt_th_7_qs);
       end
       addr_hit[494]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_0_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_0_qs;
       end
 
       addr_hit[495]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_1_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_1_qs;
       end
 
       addr_hit[496]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_2_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_2_qs;
       end
 
       addr_hit[497]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_3_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_3_qs;
       end
 
       addr_hit[498]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_4_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_4_qs;
       end
 
       addr_hit[499]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_5_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_5_qs;
       end
 
       addr_hit[500]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_6_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_6_qs;
       end
 
       addr_hit[501]: begin
-        reg_rdata_next[5:0] = wkup_detector_padsel_7_qs;
+        reg_rdata_next[6:0] = wkup_detector_padsel_7_qs;
       end
 
       addr_hit[502]: begin


### PR DESCRIPTION
Depending on the pin config of the pinmux, some signals of the MUX might be unused (It is aligned to the largest DIO size). Read the unused signals to avoid linting errors.