### PR TITLE
[hw,darjeeling,rtl] Separate ROM ctrl cfg inputs

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -6903,7 +6903,9 @@
           width: 1
           inst_name: rom_ctrl0
           default: ""
-          top_signame: ast_rom_cfg
+          external: true
+          top_signame: rom_ctrl0_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -7087,7 +7089,9 @@
           width: 1
           inst_name: rom_ctrl1
           default: ""
-          top_signame: ast_rom_cfg
+          external: true
+          top_signame: rom_ctrl1_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -9638,22 +9642,6 @@
           conn_type: true
         }
         {
-          struct: rom_cfg
-          package: prim_rom_pkg
-          type: uni
-          name: rom_cfg
-          act: rcv
-          inst_name: ast
-          width: 1
-          default: ""
-          end_idx: -1
-          top_type: broadcast
-          top_signame: ast_rom_cfg
-          index: -1
-          external: true
-          conn_type: true
-        }
-        {
           struct: ast_obs_ctrl
           type: uni
           name: obs_ctrl
@@ -9679,11 +9667,6 @@
       ast.obs_ctrl:
       [
         otp_ctrl.obs_ctrl
-      ]
-      ast.rom_cfg:
-      [
-        rom_ctrl0.rom_cfg
-        rom_ctrl1.rom_cfg
       ]
       alert_handler.crashdump:
       [
@@ -10310,7 +10293,8 @@
       ast.lc_dft_en: ""
       ast.lc_hw_debug_en: ""
       ast.obs_ctrl: obs_ctrl
-      ast.rom_cfg: rom_cfg
+      rom_ctrl0.rom_cfg: rom_ctrl0_cfg
+      rom_ctrl1.rom_cfg: rom_ctrl1_cfg
       i2c0.ram_cfg: i2c_ram_1p_cfg
       i2c0.ram_cfg_rsp: i2c_ram_1p_cfg_rsp
       sram_ctrl_ret_aon.cfg: sram_ctrl_ret_aon_ram_1p_cfg
@@ -22013,7 +21997,9 @@
         width: 1
         inst_name: rom_ctrl0
         default: ""
-        top_signame: ast_rom_cfg
+        external: true
+        top_signame: rom_ctrl0_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -22087,7 +22073,9 @@
         width: 1
         inst_name: rom_ctrl1
         default: ""
-        top_signame: ast_rom_cfg
+        external: true
+        top_signame: rom_ctrl1_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -24693,22 +24681,6 @@
         conn_type: true
       }
       {
-        struct: rom_cfg
-        package: prim_rom_pkg
-        type: uni
-        name: rom_cfg
-        act: rcv
-        inst_name: ast
-        width: 1
-        default: ""
-        end_idx: -1
-        top_type: broadcast
-        top_signame: ast_rom_cfg
-        index: -1
-        external: true
-        conn_type: true
-      }
-      {
         struct: ast_obs_ctrl
         type: uni
         name: obs_ctrl
@@ -24790,14 +24762,26 @@
       {
         package: prim_rom_pkg
         struct: rom_cfg
-        signame: rom_cfg_i
+        signame: rom_ctrl0_cfg_i
         width: 1
         type: uni
         default: ""
         direction: in
-        conn_type: true
+        conn_type: false
         index: -1
-        netname: ast_rom_cfg
+        netname: rom_ctrl0_cfg
+      }
+      {
+        package: prim_rom_pkg
+        struct: rom_cfg
+        signame: rom_ctrl1_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: rom_ctrl1_cfg
       }
       {
         package: prim_ram_1p_pkg
@@ -26176,17 +26160,6 @@
         act: rcv
         suffix: ""
         default: ast_pkg::AST_OBS_CTRL_DEFAULT
-      }
-      {
-        package: prim_rom_pkg
-        struct: rom_cfg
-        signame: ast_rom_cfg
-        width: 1
-        type: uni
-        end_idx: -1
-        act: rcv
-        suffix: ""
-        default: prim_rom_pkg::ROM_CFG_DEFAULT
       }
       {
         package: alert_handler_pkg

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1068,15 +1068,6 @@
           package: "lc_ctrl_pkg",
         },
 
-        { struct:  "rom_cfg",
-          package: "prim_rom_pkg",
-          type:    "uni",
-          name:    "rom_cfg",
-          // The activity direction for a port inter-signal is "opposite" of
-          // what the external module actually needs.
-          act:     "rcv"
-        }
-
         { struct: "ast_obs_ctrl",
           type: "uni",
           name: "obs_ctrl",
@@ -1098,8 +1089,6 @@
   inter_module: {
     'connect': {
       'ast.obs_ctrl'            : ['otp_ctrl.obs_ctrl']
-      'ast.rom_cfg'             : ['rom_ctrl0.rom_cfg',
-                                   'rom_ctrl1.rom_cfg'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
       'alert_handler.esc_rx'    : ['rv_core_ibex.esc_rx',
                                    'lc_ctrl.esc_scrap_state0_rx',
@@ -1284,7 +1273,8 @@
         'ast.lc_dft_en'                        : '',
         'ast.lc_hw_debug_en'                   : '',
         'ast.obs_ctrl'                         : 'obs_ctrl',
-        'ast.rom_cfg'                          : 'rom_cfg',
+        'rom_ctrl0.rom_cfg'                    : 'rom_ctrl0_cfg',
+        'rom_ctrl1.rom_cfg'                    : 'rom_ctrl1_cfg',
         'i2c0.ram_cfg'                         : 'i2c_ram_1p_cfg',
         'i2c0.ram_cfg_rsp'                     : 'i2c_ram_1p_cfg_rsp',
         'sram_ctrl_ret_aon.cfg'                : 'sram_ctrl_ret_aon_ram_1p_cfg',

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -168,7 +168,8 @@ module top_darjeeling #(
   output lc_ctrl_pkg::lc_tx_t       ast_lc_dft_en_o,
   output lc_ctrl_pkg::lc_tx_t       ast_lc_hw_debug_en_o,
   input  ast_pkg::ast_obs_ctrl_t       obs_ctrl_i,
-  input  prim_rom_pkg::rom_cfg_t       rom_cfg_i,
+  input  prim_rom_pkg::rom_cfg_t       rom_ctrl0_cfg_i,
+  input  prim_rom_pkg::rom_cfg_t       rom_ctrl1_cfg_i,
   input  prim_ram_1p_pkg::ram_1p_cfg_t       i2c_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t       i2c_ram_1p_cfg_rsp_o,
   input  prim_ram_1p_pkg::ram_1p_cfg_t [SramCtrlRetAonNumRamInst-1:0] sram_ctrl_ret_aon_ram_1p_cfg_i,
@@ -496,7 +497,6 @@ module top_darjeeling #(
 
   // define inter-module signals
   ast_pkg::ast_obs_ctrl_t       ast_obs_ctrl;
-  prim_rom_pkg::rom_cfg_t       ast_rom_cfg;
   alert_handler_pkg::alert_crashdump_t       alert_handler_crashdump;
   prim_esc_pkg::esc_rx_t [3:0] alert_handler_esc_rx;
   prim_esc_pkg::esc_tx_t [3:0] alert_handler_esc_tx;
@@ -747,7 +747,6 @@ module top_darjeeling #(
   assign ast_lc_dft_en_o = lc_ctrl_lc_dft_en;
   assign ast_lc_hw_debug_en_o = lc_ctrl_lc_hw_debug_en;
   assign ast_obs_ctrl = obs_ctrl_i;
-  assign ast_rom_cfg = rom_cfg_i;
   assign pwrmgr_boot_status_o = pwrmgr_aon_boot_status;
 
   // define partial inter-module tie-off
@@ -2084,7 +2083,7 @@ module top_darjeeling #(
       .alert_rx_i  ( alert_rx[70:70] ),
 
       // Inter-module signals
-      .rom_cfg_i(ast_rom_cfg),
+      .rom_cfg_i(rom_ctrl0_cfg_i),
       .pwrmgr_data_o(pwrmgr_aon_rom_ctrl[0]),
       .keymgr_data_o(keymgr_dpe_rom_digest[0]),
       .kmac_data_o(kmac_app_req[2]),
@@ -2111,7 +2110,7 @@ module top_darjeeling #(
       .alert_rx_i  ( alert_rx[71:71] ),
 
       // Inter-module signals
-      .rom_cfg_i(ast_rom_cfg),
+      .rom_cfg_i(rom_ctrl1_cfg_i),
       .pwrmgr_data_o(pwrmgr_aon_rom_ctrl[1]),
       .keymgr_data_o(keymgr_dpe_rom_digest[1]),
       .kmac_data_o(kmac_app_req[3]),


### PR DESCRIPTION
Downstream, the DFT signals for both ROM ctrls are different. Let's add separate top-level inputs for that and let the AST connect to both in the uncore environment.