### PR TITLE
[hw,prim alert,rtl] Add flop repeater for alert signals

### DIFF
--- a/hw/ip/prim/prim_alert_repeater.core
+++ b/hw/ip/prim/prim_alert_repeater.core
@@ -1,0 +1,38 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:alert_repeater"
+description: "Flopped Alert repeater"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:alert
+      - lowrisc:prim:flop
+    files:
+      - rtl/prim_alert_repeater.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_alert_repeater.sv
+++ b/hw/ip/prim/rtl/prim_alert_repeater.sv
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Staged flop repeater to cut the crirtical path on alert signals when travelling
+// in the larger SoC. Both TX and RX are staged with a single flop stage.
+
+module prim_alert_repeater
+  import prim_alert_pkg::*;
+(
+  input                             clk_i,
+  input                             rst_ni,
+  // Input interface
+  input  prim_alert_pkg::alert_tx_t alert_tx_i
+  output prim_alert_pkg::alert_rx_t alert_rx_o,
+  // Flopped output interface
+  output prim_alert_pkg::alert_tx_t alert_staged_tx_o,
+  input  prim_alert_pkg::alert_rx_t alert_staged_rx_i
+);
+  prim_flop #(
+    .ResetValue(0)
+  ) u_tx_p (
+    .clk_i,
+    .rst_ni,
+    .d_i    (alert_tx_i.alert_p),
+    .q_o    (alert_staged_tx_o.alert_p)
+  );
+
+  prim_flop #(
+    .ResetValue(1)
+  ) u_tx_n (
+    .clk_i,
+    .rst_ni,
+    .d_i    (alert_tx_i.alert_n),
+    .q_o    (alert_staged_tx_o.alert_n)
+  );
+
+  prim_flop #(
+    .ResetValue(0)
+  ) u_rx_ping_p (
+    .clk_i,
+    .rst_ni,
+    .d_i    (alert_staged_rx_i.ping_p),
+    .q_o    (alert_rx_o.ping_p)
+  );
+
+  prim_flop #(
+    .ResetValue(1)
+  ) u_rx_ping_n (
+    .clk_i,
+    .rst_ni,
+    .d_i    (alert_staged_rx_i.ping_n),
+    .q_o    (alert_rx_o.ping_n)
+  );
+
+  prim_flop #(
+    .ResetValue(0)
+  ) u_rx_ack_p (
+    .clk_i,
+    .rst_ni,
+    .d_i    (alert_staged_rx_i.ack_p),
+    .q_o    (alert_rx_o.ack_p)
+  );
+
+  prim_flop #(
+    .ResetValue(1)
+  ) u_rx_ack_n (
+    .clk_i,
+    .rst_ni,
+    .d_i    (alert_staged_rx_i.ack_n),
+    .q_o    (alert_rx_o.ack_n)
+  );
+endmodule : prim_alert_repeater


### PR DESCRIPTION
Alerts are all collected by Darjeeling. IPs that are producing alerts are distributed in various places in the SoC, meaning there might a long distance to travel to Darjeeling. To cut the path, also when travelling across physical design partitions, it's necessary to flop signals, also alerts.

To make this easier, we add a repeater module tailored for alerts that flops both the TX and RX signal.