### PR TITLE
[ci] re-enable ROM E2E tests on `earlgrey_1.0.0`

### DIFF
--- a/ci/fpga-job.yml
+++ b/ci/fpga-job.yml
@@ -81,10 +81,6 @@ jobs:
         //... @manufacturer_test_hooks//...
       # Run FPGA tests.
       if [ -s "${{ parameters.target_pattern_file }}" ]; then
-        # Disable ROM e2e test cases. These are not needed in this branch as we
-        # have sufficient coverage from //sw/device/silicon_creator/... unittests
-        # and functests.
-        echo "-//sw/device/silicon_creator/rom/e2e/..." >> "${{ parameters.target_pattern_file }}"
         ci/scripts/run-fpga-tests.sh "${{ parameters.interface }}" "${{ parameters.target_pattern_file }}" || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
       else
         echo "No tests to run after filtering"

--- a/ci/verify-fpga-jobs.yml
+++ b/ci/verify-fpga-jobs.yml
@@ -40,12 +40,6 @@ jobs:
       # - then sort by the target name
       # - then keep all duplicated lines
       pattern_files=$(find $(Pipeline.Workspace)/verify_fpga_jobs -name target_pattern_file.txt)
-      # Filter -//sw/device/silicon_creator/rom/e2e/... occurrences as these
-      # are tests patterns that are harcoded across all FPGA jobs to skip
-      # the ROM E2E tests in CI. See ci/fpga-job.yml for more details.
-      awk '!/-\/\/sw\/device\/silicon_creator\/rom\/e2e\/.../ {
-              print(gensub(/.*\/(.+)\/target_pattern_file.txt/, "\\1", "g", FILENAME) " " $0)
-          }' $pattern_files | sort -k2 | uniq -D -f1 > duplicates.txt
       if [ -s duplicates.txt ]; then
         echo "The following tests ran in two or more jobs:"
         cat duplicates.txt


### PR DESCRIPTION
These renanble the ROM E2E tests on the `earlgrey_1.0.0` branch (thus reverting #25302), to prepare for a ROM release.