### PR TITLE
[prim,clkmgr,rtl] Simplify prim_clock_meas by removing RefCnt

### DIFF
--- a/hw/ip/prim/rtl/prim_clock_meas.sv
+++ b/hw/ip/prim/rtl/prim_clock_meas.sv
@@ -13,10 +13,9 @@
 `include "prim_assert.sv"
 
 module prim_clock_meas #(
-  // Maximum value of input clock counts over measurement period
+  // Maximum number of input clock counts over measurement period. Note that this is 1-based
+  // indexing (so a hardware counter would only count up to Cnt-1)
   parameter int Cnt = 16,
-  // Maximum value of reference clock counts over measurement period
-  parameter int RefCnt = 1,
   parameter bit ClkTimeOutChkEn = 1,
   parameter bit RefTimeOutChkEn = 1,
   localparam int CntWidth = prim_util_pkg::vbits(Cnt),
@@ -155,27 +154,10 @@ module prim_clock_meas #(
     .dst_pulse_o(valid_ref)
   );
 
-
-  if (RefCnt == 1) begin : gen_degenerate_case
-    // if reference count is one, cnt_ref is always 0.
-    // So there is no need to maintain a counter, and
-    // valid just becomes valid_ref
-    assign valid = valid_ref;
-  end else begin : gen_normal_case
-    logic [RefCntWidth-1:0] cnt_ref;
-    assign valid = valid_ref & (int'(cnt_ref) == RefCnt - 1);
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        cnt_ref <= '0;
-      end else if (!cnt_en && |cnt_ref) begin
-        cnt_ref <= '0;
-      end else if (cnt_en && valid) begin
-        cnt_ref <= '0;
-      end else if (cnt_en && valid_ref) begin
-        cnt_ref <= cnt_ref + 1'b1;
-      end
-    end
-  end
+  // There isn't really a reference counter (we just wait for the first edge on that clock). The
+  // valid signal is supposed to be saying that we have seen the synchronised version of the last
+  // edge we are waiting for, so it is always equal to valid_ref.
+  assign valid = valid_ref;
 
   logic cnt_ovfl;
   logic [CntWidth-1:0] cnt;

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -396,8 +396,7 @@ rg_srcs = list(sorted({sig['src_name'] for sig
  sel_idx = f"Clk{Name.from_snake_case(src).as_camel_case()}Idx"
 %>
   clkmgr_meas_chk #(
-    .Cnt(${cnt}),
-    .RefCnt(1)
+    .Cnt(${cnt})
   ) u_${src}_meas (
     .clk_i,
     .rst_ni,

--- a/hw/ip_templates/clkmgr/rtl/clkmgr_meas_chk.sv
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr_meas_chk.sv
@@ -9,8 +9,6 @@ module clkmgr_meas_chk
 #(
   // Maximum value of input clock counts over measurement period
   parameter int Cnt = 16,
-  // Maximum value of reference clock counts over measurement period
-  parameter int RefCnt = 1,
   localparam int CntWidth = prim_util_pkg::vbits(Cnt)
 ) (
   // the local operating clock
@@ -42,7 +40,6 @@ module clkmgr_meas_chk
 
   prim_clock_meas #(
     .Cnt(Cnt),
-    .RefCnt(RefCnt),
     .ClkTimeOutChkEn(1'b1),
     .RefTimeOutChkEn(1'b0)
   ) u_meas (

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -549,8 +549,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(8),
-    .RefCnt(1)
+    .Cnt(8)
   ) u_io_div4_meas (
     .clk_i,
     .rst_ni,
@@ -576,8 +575,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(32),
-    .RefCnt(1)
+    .Cnt(32)
   ) u_main_meas (
     .clk_i,
     .rst_ni,
@@ -603,8 +601,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(32),
-    .RefCnt(1)
+    .Cnt(32)
   ) u_usb_meas (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_meas_chk.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_meas_chk.sv
@@ -9,8 +9,6 @@ module clkmgr_meas_chk
 #(
   // Maximum value of input clock counts over measurement period
   parameter int Cnt = 16,
-  // Maximum value of reference clock counts over measurement period
-  parameter int RefCnt = 1,
   localparam int CntWidth = prim_util_pkg::vbits(Cnt)
 ) (
   // the local operating clock
@@ -42,7 +40,6 @@ module clkmgr_meas_chk
 
   prim_clock_meas #(
     .Cnt(Cnt),
-    .RefCnt(RefCnt),
     .ClkTimeOutChkEn(1'b1),
     .RefTimeOutChkEn(1'b0)
   ) u_meas (

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -559,8 +559,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(960),
-    .RefCnt(1)
+    .Cnt(960)
   ) u_io_meas (
     .clk_i,
     .rst_ni,
@@ -586,8 +585,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
-    .RefCnt(1)
+    .Cnt(480)
   ) u_io_div2_meas (
     .clk_i,
     .rst_ni,
@@ -613,8 +611,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(240),
-    .RefCnt(1)
+    .Cnt(240)
   ) u_io_div4_meas (
     .clk_i,
     .rst_ni,
@@ -640,8 +637,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(1000),
-    .RefCnt(1)
+    .Cnt(1000)
   ) u_main_meas (
     .clk_i,
     .rst_ni,
@@ -667,8 +663,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
-    .RefCnt(1)
+    .Cnt(480)
   ) u_usb_meas (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_meas_chk.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_meas_chk.sv
@@ -9,8 +9,6 @@ module clkmgr_meas_chk
 #(
   // Maximum value of input clock counts over measurement period
   parameter int Cnt = 16,
-  // Maximum value of reference clock counts over measurement period
-  parameter int RefCnt = 1,
   localparam int CntWidth = prim_util_pkg::vbits(Cnt)
 ) (
   // the local operating clock
@@ -42,7 +40,6 @@ module clkmgr_meas_chk
 
   prim_clock_meas #(
     .Cnt(Cnt),
-    .RefCnt(RefCnt),
     .ClkTimeOutChkEn(1'b1),
     .RefTimeOutChkEn(1'b0)
   ) u_meas (

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -554,8 +554,7 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(960),
-    .RefCnt(1)
+    .Cnt(960)
   ) u_io_meas (
     .clk_i,
     .rst_ni,
@@ -581,8 +580,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(240),
-    .RefCnt(1)
+    .Cnt(240)
   ) u_io_div4_meas (
     .clk_i,
     .rst_ni,
@@ -608,8 +606,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(1000),
-    .RefCnt(1)
+    .Cnt(1000)
   ) u_main_meas (
     .clk_i,
     .rst_ni,
@@ -635,8 +632,7 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(480),
-    .RefCnt(1)
+    .Cnt(480)
   ) u_usb_meas (
     .clk_i,
     .rst_ni,

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_meas_chk.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_meas_chk.sv
@@ -9,8 +9,6 @@ module clkmgr_meas_chk
 #(
   // Maximum value of input clock counts over measurement period
   parameter int Cnt = 16,
-  // Maximum value of reference clock counts over measurement period
-  parameter int RefCnt = 1,
   localparam int CntWidth = prim_util_pkg::vbits(Cnt)
 ) (
   // the local operating clock
@@ -42,7 +40,6 @@ module clkmgr_meas_chk
 
   prim_clock_meas #(
     .Cnt(Cnt),
-    .RefCnt(RefCnt),
     .ClkTimeOutChkEn(1'b1),
     .RefTimeOutChkEn(1'b0)
   ) u_meas (


### PR DESCRIPTION
This parameter is only ever set to 1: we don't do things like testing a clock that should be 50% faster by setting Cnt=30, RefCnt=20. Simplify the code slightly by getting rid of the support.

This commit also expands a comment explaining Cnt: my initial read suggested that this was the maximum value of a counter, which gives the wrong width if Cnt is a power of two.