### PR TITLE
[racl] Expose TLUL User bits to the top-level

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -488,6 +488,13 @@
       desc:    "Number of scratch words maintained."
       default: "8"
     },
+    { name:    "TlulHostUserRsvdBits"
+      type:    "logic [tlul_pkg::RsvdWidth-1:0]"
+      default: "'0"
+      desc:    "TLUL user bits sent on outgoing transfers."
+      local:   "false"
+      expose:  "true"
+    },
   ],
   features: [
     {

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -46,8 +46,9 @@ module rv_core_ibex
       ibex_pkg::RndCnstIbexKeyDefault,
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonceDefault =
       ibex_pkg::RndCnstIbexNonceDefault,
-  parameter int unsigned            NEscalationSeverities = 4,
-  parameter int unsigned            WidthPingCounter = 16
+  parameter int unsigned                    NEscalationSeverities = 4,
+  parameter int unsigned                    WidthPingCounter      = 16,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -595,7 +596,7 @@ module rv_core_ibex
     .wdata_i      (32'b0),
     .wdata_intg_i (instr_wdata_intg),
     .be_i         (4'hF),
-    .user_rsvd_i  ('0),
+    .user_rsvd_i  (TlulHostUserRsvdBits),
     .valid_o      (instr_rvalid),
     .rdata_o      (instr_rdata),
     .rdata_intg_o (instr_rdata_intg),
@@ -649,7 +650,7 @@ module rv_core_ibex
     .wdata_i      (data_wdata),
     .wdata_intg_i (data_wdata_intg),
     .be_i         (data_be),
-    .user_rsvd_i  ('0),
+    .user_rsvd_i  (TlulHostUserRsvdBits),
     .valid_o      (data_rvalid),
     .rdata_o      (data_rdata),
     .rdata_intg_o (data_rdata_intg),

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -68,6 +68,13 @@
       local:   "false",
       expose:  "true"
     },
+    { name:    "TlulHostUserRsvdBits"
+      type:    "logic [tlul_pkg::RsvdWidth-1:0]"
+      default: "'0"
+      desc:    "TLUL user bits sent on outgoing transfers."
+      local:   "false"
+      expose:  "true"
+    },
   ]
   interrupt_list: [
   ],

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -15,10 +15,11 @@
 module rv_dm
   import rv_dm_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn           = {NumAlerts{1'b1}},
-  parameter logic [31:0]          IdcodeValue            = 32'h 0000_0001,
-  parameter bit                   UseDmiInterface        = 1'b0,
-  parameter bit                   SecVolatileRawUnlockEn = 0
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn           = {NumAlerts{1'b1}},
+  parameter logic [31:0]                    IdcodeValue            = 32'h 0000_0001,
+  parameter bit                             UseDmiInterface        = 1'b0,
+  parameter bit                             SecVolatileRawUnlockEn = 0,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
 ) (
   input  logic                clk_i,       // clock
   input  logic                clk_lc_i,    // only declared here so that the topgen
@@ -386,7 +387,7 @@ module rv_dm
     .wdata_i      (host_wdata),
     .wdata_intg_i ('0),
     .be_i         (host_be),
-    .user_rsvd_i  ('0),
+    .user_rsvd_i  (TlulHostUserRsvdBits),
     .valid_o      (host_r_valid),
     .rdata_o      (host_r_rdata),
     .rdata_intg_o (),

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4360,6 +4360,15 @@
           expose: "true"
           name_top: SecRvDmVolatileRawUnlockEn
         }
+        {
+          name: TlulHostUserRsvdBits
+          desc: TLUL user bits sent on outgoing transfers.
+          type: logic [tlul_pkg::RsvdWidth-1:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvDmTlulHostUserRsvdBits
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -9258,6 +9258,15 @@
           expose: "true"
           name_top: RvCoreIbexPipeLine
         }
+        {
+          name: TlulHostUserRsvdBits
+          desc: TLUL user bits sent on outgoing transfers.
+          type: logic [tlul_pkg::RsvdWidth-1:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexTlulHostUserRsvdBits
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -146,7 +146,8 @@ module top_darjeeling #(
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0],
   parameter int unsigned RvCoreIbexDmExceptionAddr =
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0],
-  parameter bit RvCoreIbexPipeLine = 1
+  parameter bit RvCoreIbexPipeLine = 1,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0
 ) (
   // Multiplexed I/O
   input        [11:0] mio_in_i,
@@ -2508,7 +2509,8 @@ module top_darjeeling #(
     .DmAddrMask(RvCoreIbexDmAddrMask),
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
-    .PipeLine(RvCoreIbexPipeLine)
+    .PipeLine(RvCoreIbexPipeLine),
+    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
   ) u_rv_core_ibex (
       // [95]: fatal_sw_err
       // [96]: recov_sw_err

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -54,6 +54,7 @@ module top_darjeeling #(
   parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
   parameter bit RvDmUseDmiInterface = 1,
   parameter bit SecRvDmVolatileRawUnlockEn = top_pkg::SecVolatileRawUnlockEn,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvDmTlulHostUserRsvdBits = '0,
   // parameters for rv_plic
   // parameters for aes
   parameter bit SecAesMasking = 1,
@@ -1673,7 +1674,8 @@ module top_darjeeling #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[51:51]),
     .IdcodeValue(RvDmIdcodeValue),
     .UseDmiInterface(RvDmUseDmiInterface),
-    .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn)
+    .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn),
+    .TlulHostUserRsvdBits(RvDmTlulHostUserRsvdBits)
   ) u_rv_dm (
       // [51]: fatal_fault
       .alert_tx_o  ( alert_tx[51:51] ),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6324,6 +6324,15 @@
           expose: "true"
           name_top: SecRvDmVolatileRawUnlockEn
         }
+        {
+          name: TlulHostUserRsvdBits
+          desc: TLUL user bits sent on outgoing transfers.
+          type: logic [tlul_pkg::RsvdWidth-1:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvDmTlulHostUserRsvdBits
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9262,6 +9262,15 @@
           expose: "true"
           name_top: RvCoreIbexPipeLine
         }
+        {
+          name: TlulHostUserRsvdBits
+          desc: TLUL user bits sent on outgoing transfers.
+          type: logic [tlul_pkg::RsvdWidth-1:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexTlulHostUserRsvdBits
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -141,7 +141,8 @@ module top_earlgrey #(
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0],
   parameter int unsigned RvCoreIbexDmExceptionAddr =
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0],
-  parameter bit RvCoreIbexPipeLine = 0
+  parameter bit RvCoreIbexPipeLine = 0,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0
 ) (
   // Multiplexed I/O
   input        [46:0] mio_in_i,
@@ -2728,7 +2729,8 @@ module top_earlgrey #(
     .DmAddrMask(RvCoreIbexDmAddrMask),
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
-    .PipeLine(RvCoreIbexPipeLine)
+    .PipeLine(RvCoreIbexPipeLine),
+    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
   ) u_rv_core_ibex (
       // [61]: fatal_sw_err
       // [62]: recov_sw_err

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -72,6 +72,7 @@ module top_earlgrey #(
   parameter logic [31:0] RvDmIdcodeValue = jtag_id_pkg::RV_DM_JTAG_IDCODE,
   parameter bit RvDmUseDmiInterface = 0,
   parameter bit SecRvDmVolatileRawUnlockEn = 1'b0,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvDmTlulHostUserRsvdBits = '0,
   // parameters for rv_plic
   // parameters for aes
   parameter bit SecAesMasking = 1,
@@ -2263,7 +2264,8 @@ module top_earlgrey #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[40:40]),
     .IdcodeValue(RvDmIdcodeValue),
     .UseDmiInterface(RvDmUseDmiInterface),
-    .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn)
+    .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn),
+    .TlulHostUserRsvdBits(RvDmTlulHostUserRsvdBits)
   ) u_rv_dm (
       // [40]: fatal_fault
       .alert_tx_o  ( alert_tx[40:40] ),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4397,6 +4397,15 @@
           expose: "true"
           name_top: RvCoreIbexPipeLine
         }
+        {
+          name: TlulHostUserRsvdBits
+          desc: TLUL user bits sent on outgoing transfers.
+          type: logic [tlul_pkg::RsvdWidth-1:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexTlulHostUserRsvdBits
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -81,7 +81,8 @@ module top_englishbreakfast #(
   parameter int unsigned RvCoreIbexDmAddrMask = 4095,
   parameter int unsigned RvCoreIbexDmHaltAddr = 0,
   parameter int unsigned RvCoreIbexDmExceptionAddr = 0,
-  parameter bit RvCoreIbexPipeLine = 0
+  parameter bit RvCoreIbexPipeLine = 0,
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0
 ) (
   // Multiplexed I/O
   input        [46:0] mio_in_i,
@@ -1269,7 +1270,8 @@ module top_englishbreakfast #(
     .DmAddrMask(RvCoreIbexDmAddrMask),
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
-    .PipeLine(RvCoreIbexPipeLine)
+    .PipeLine(RvCoreIbexPipeLine),
+    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
   ) u_rv_core_ibex (
       // [24]: fatal_sw_err
       // [25]: recov_sw_err


### PR DESCRIPTION
RACL uses the TLUL user bits to inject the role and CTN UID. To make these bits generically configurable, we need to expose them to the top-level interface. There, if RACL is used, they can be assigned to the right RACL roles. 

In this PR, we expose the user bits of the Ibex and RV DM host.