### PR TITLE
[orchestrator] fix confirmation requirement bug and enable classifying blind assembly parts

### DIFF
--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -19,16 +19,27 @@ _SKU_SPECIFIC_FORMAT_VERSION = 1
 
 @dataclass
 class DeviceIdentificationNumber:
-    """Class for storing Device Identification Number portion of Device ID."""
+    """Class for storing Device Identification Number portion of Device ID.
+
+    DINs for blind assembly parts have all values set to -1 or (UINT*_MAX).
+    """
     year: int = 0  # valid range: [0, 9]
     week: int = 0  # valid range: [0, 51]
     lot: int = 0  # valid range: [0, 999]
     wafer: int = 0  # valid range: [0,99]
     wafer_x_coord: int = 0  # valid range: [0, 999]
     wafer_y_coord: int = 0  # valid range: [0, 999]
+    blind_asm: bool = False  # boolean indicating if blind assembly part
 
     def __post_init__(self):
-        self.validate()
+        # Check if blind assembly part, if so, we skip field validation.
+        if (self.year == -1 and self.week == -1 and self.lot == -1 and
+                self.wafer == -1 and self.wafer_x_coord == -1 and
+                self.wafer_y_coord == -1):
+            self.blind_asm = True
+        else:
+            self.blind_asm = False
+            self.validate()
 
     def validate(self) -> None:
         """Validates this object's attributes."""
@@ -57,6 +68,10 @@ class DeviceIdentificationNumber:
                     self.wafer_y_coord))
 
     def to_int(self) -> int:
+        """Convert DIN to an int."""
+        # If blind assembly part, the DIN is UINT64_MAX.
+        if self.blind_asm:
+            return 2**64 - 1
         din = 0
         din |= util.bcd_encode(self.wafer_y_coord) << 44
         din |= util.bcd_encode(self.wafer_x_coord) << 32
@@ -80,6 +95,15 @@ class DeviceIdentificationNumber:
                                           wafer=wafer,
                                           wafer_x_coord=wafer_x_coord,
                                           wafer_y_coord=wafer_y_coord)
+
+    @staticmethod
+    def blind_asm() -> "DeviceIdentificationNumber":
+        return DeviceIdentificationNumber(year=-1,
+                                          week=-1,
+                                          lot=-1,
+                                          wafer=-1,
+                                          wafer_x_coord=-1,
+                                          wafer_y_coord=-1)
 
 
 class DeviceId():
@@ -199,7 +223,6 @@ class DeviceId():
                    f"{otp_version:02x}")
         except UnicodeDecodeError:
             otp = "Invalid"
-        print("HERE", otp)
 
         # Extract SKU config.
         sku_config = SkuConfig.from_ids(product_id, si_creator_id, package_id,

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -171,7 +171,7 @@ def main(args_in):
 
     # The device identification number is determined during CP by extracting data
     # from the device.
-    din = DeviceIdentificationNumber(0)
+    din = DeviceIdentificationNumber.blind_asm()
     device_id = DeviceId(sku_config, din)
 
     # TODO: Setup remote and/or local DB connections.

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -312,7 +312,8 @@ class OtDut():
                     f"Final (device) DeviceId: {device_id_in_otp.to_hexstr()}")
                 logging.error(
                     f"Final (host)   DeviceId: {self.device_id.to_hexstr()}")
-                confirm()
+                if self.require_confirmation:
+                    confirm()
                 self.device_id = device_id_in_otp
 
             logging.info("FT completed successfully.")

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -166,12 +166,12 @@ class OtDut():
                 # has already run through CP, and only needs to execute FT.
                 if chip_probe_data["cp_device_id"] == "":
                     logging.warning(
-                        "cp_device_id empty; setting default of all zeros.")
-                    din_from_device = DeviceIdentificationNumber(0)
+                        "cp_device_id empty; setting default DIN of all 0xFF.")
+                    din_from_device = DeviceIdentificationNumber.blind_asm()
                 else:
                     din_from_device = DeviceIdentificationNumber.from_int(
                         (int(chip_probe_data["cp_device_id"], 16) >> 32) &
-                        0xFFFFFFFFFFFFFFFF)
+                        (2**64 - 1))
             logging.info(
                 f"Updating device ID to: {chip_probe_data['cp_device_id']}")
             self.device_id.update_din(din_from_device)


### PR DESCRIPTION
Confirmation requirement should only be required when the `--non-interactive` mode CLI arg is NOT passed. This updates the script behavior to disble the confirmation requirement when said flag is passed and a host/device device ID mismatch occurs, which typically happens on parts that have had CP run, and later FT run, as opposed to running both stages back to back.

Additionally, this updates the DIN of blind assembly parts to all FF to provide a DIN for parts for which wafer information is missing.