### PR TITLE
[manuf] add weak OTP operations hooks

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -54,7 +54,9 @@ status_t otp_ctrl_testutils_dai_access_error_check(
 }
 
 status_t otp_ctrl_testutils_wait_for_dai(const dif_otp_ctrl_t *otp_ctrl) {
+  TRY(otp_ctrl_testutils_wait_for_dai_pre_hook(otp_ctrl));
   IBEX_TRY_SPIN_FOR(dai_finished(otp_ctrl), kOtpDaiTimeoutUs);
+  TRY(otp_ctrl_testutils_wait_for_dai_post_hook(otp_ctrl));
   return OK_STATUS();
 }
 
@@ -69,9 +71,11 @@ status_t otp_ctrl_testutils_dai_read32(const dif_otp_ctrl_t *otp,
                                        dif_otp_ctrl_partition_t partition,
                                        uint32_t address, uint32_t *result) {
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
+  TRY(otp_ctrl_testutils_dai_read_pre_hook(otp));
   TRY(dif_otp_ctrl_dai_read_start(otp, partition, address));
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
   TRY(dif_otp_ctrl_dai_read32_end(otp, result));
+  TRY(otp_ctrl_testutils_dai_read_post_hook(otp));
   return OK_STATUS();
 }
 
@@ -83,9 +87,11 @@ status_t otp_ctrl_testutils_dai_read32_array(const dif_otp_ctrl_t *otp,
   for (uint32_t addr = start_address, i = 0; addr < stop_address;
        addr += sizeof(uint32_t), ++i) {
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_testutils_dai_read_pre_hook(otp));
     TRY(dif_otp_ctrl_dai_read_start(otp, partition, addr));
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
     TRY(dif_otp_ctrl_dai_read32_end(otp, &buffer[i]));
+    TRY(otp_ctrl_testutils_dai_read_post_hook(otp));
   }
   return OK_STATUS();
 }
@@ -94,9 +100,11 @@ status_t otp_ctrl_testutils_dai_read64(const dif_otp_ctrl_t *otp,
                                        dif_otp_ctrl_partition_t partition,
                                        uint32_t address, uint64_t *result) {
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
+  TRY(otp_ctrl_testutils_dai_read_pre_hook(otp));
   TRY(dif_otp_ctrl_dai_read_start(otp, partition, address));
   TRY(otp_ctrl_testutils_wait_for_dai(otp));
   TRY(dif_otp_ctrl_dai_read64_end(otp, result));
+  TRY(otp_ctrl_testutils_dai_read_post_hook(otp));
   return OK_STATUS();
 }
 
@@ -108,9 +116,11 @@ status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
   for (uint32_t addr = start_address, i = 0; addr < stop_address;
        addr += sizeof(uint64_t), ++i) {
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_testutils_dai_read_pre_hook(otp));
     TRY(dif_otp_ctrl_dai_read_start(otp, partition, addr));
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
     TRY(dif_otp_ctrl_dai_read64_end(otp, &buffer[i]));
+    TRY(otp_ctrl_testutils_dai_read_post_hook(otp));
   }
   return OK_STATUS();
 }
@@ -165,9 +175,13 @@ status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
     }
 
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_testutils_dai_write_pre_hook(otp));
     TRY(dif_otp_ctrl_dai_program32(otp, partition, addr, buffer[i]));
+    TRY(otp_ctrl_testutils_dai_write_post_hook(otp));
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_testutils_dai_write_pre_error_check_hook(otp));
     TRY(otp_ctrl_dai_write_error_check(otp));
+    TRY(otp_ctrl_testutils_dai_write_post_error_check_hook(otp));
 
     TRY(otp_ctrl_testutils_dai_read32(otp, partition, addr, &read_data));
     if (read_data != buffer[i]) {
@@ -185,9 +199,13 @@ status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
   for (uint32_t addr = start_address, i = 0; addr < stop_address;
        addr += sizeof(uint64_t), ++i) {
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_testutils_dai_write_pre_hook(otp));
     TRY(dif_otp_ctrl_dai_program64(otp, partition, addr, buffer[i]));
+    TRY(otp_ctrl_testutils_dai_write_post_hook(otp));
     TRY(otp_ctrl_testutils_wait_for_dai(otp));
+    TRY(otp_ctrl_testutils_dai_write_pre_error_check_hook(otp));
     TRY(otp_ctrl_dai_write_error_check(otp));
+    TRY(otp_ctrl_testutils_dai_write_post_error_check_hook(otp));
 
     uint64_t read_data;
     TRY(otp_ctrl_testutils_dai_read64(otp, partition, addr, &read_data));
@@ -195,5 +213,50 @@ status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
       return INTERNAL();
     }
   }
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_wait_for_dai_pre_hook(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_wait_for_dai_post_hook(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_dai_write_pre_hook(const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_dai_write_post_hook(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_dai_read_pre_hook(const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_dai_read_post_hook(const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_dai_write_pre_error_check_hook(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  return OK_STATUS();
+}
+
+OT_WEAK
+status_t otp_ctrl_testutils_dai_write_post_error_check_hook(
+    const dif_otp_ctrl_t *otp_ctrl) {
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -129,10 +129,10 @@ status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
  * @param otp otp_ctrl instance.
  * @param partition OTP partition.
  * @param start_address Address relative to the start of the `partition`. Must
- * be a 32bit aligned address.
+ *                      be a 32bit aligned address.
  * @param buffer The buffer containing the data to be written into OTP.
  * @param len The number of 32bit words to write into otp. `buffer` must have at
- * least `len` 32bit words.
+ *            least `len` 32bit words.
  * @return OK_STATUS on success.
  */
 OT_WARN_UNUSED_RESULT
@@ -159,5 +159,89 @@ status_t otp_ctrl_testutils_dai_write64(const dif_otp_ctrl_t *otp,
                                         dif_otp_ctrl_partition_t partition,
                                         uint32_t start_address,
                                         const uint64_t *buffer, size_t len);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately before
+ * spin looping on the DAI ready signal.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_wait_for_dai_pre_hook(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately after
+ * spin looping on the DAI ready signal.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_wait_for_dai_post_hook(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately before
+ * writing a 32 or 64 bit field.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_write_pre_hook(const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately after
+ * writing a 32 or 64 bit field.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_write_post_hook(const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately before
+ * reading a 32 or 64 bit field.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_read_pre_hook(const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately after
+ * reading a 32 or 64 bit field.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_read_post_hook(const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately before
+ * reading any DAI error state.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_write_pre_error_check_hook(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Weak function to enable tests to define logic that is run immediately after
+ * reading any DAI error state.
+ *
+ * @param otp otp_ctrl instance.
+ * @return OK_STATUS on success.
+ */
+OT_WARN_UNUSED_RESULT
+status_t otp_ctrl_testutils_dai_write_post_error_check_hook(
+    const dif_otp_ctrl_t *otp_ctrl);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_OTP_CTRL_TESTUTILS_H_

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -207,9 +207,9 @@ static status_t manuf_individualize_device_ast_cfg(
     }
     TRY(dif_otp_ctrl_relative_address(kDifOtpCtrlPartitionCreatorSwCfg, addr,
                                       &relative_addr));
-    TRY(otp_ctrl_testutils_dai_write32(otp_ctrl,
-                                       kDifOtpCtrlPartitionCreatorSwCfg,
-                                       relative_addr, &data, /*len=*/1));
+    TRY(otp_ctrl_testutils_dai_write32(
+        otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, relative_addr, &data,
+        /*len=*/1));
   }
   return OK_STATUS();
 }


### PR DESCRIPTION
This adds weak hook functions to OTP sub operations to enable tests, and provisioning firmware, to insert debug functionality before and after functions.