### PR TITLE
[clkmgr] Align behavior of jitter_enable CSR

### DIFF
--- a/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
@@ -409,8 +409,7 @@
           name: "EN",
           resval: "1"
           desc: '''
-            When 1, the value of !!JITTER_ENABLE can be changed.  When 0, writes have no
-            effect.
+            This register has no effect.
           '''
         },
       ]
@@ -429,13 +428,14 @@
           name: "VAL",
           desc: '''
             Enable jittery clock.
-            A value of kMultiBitBool4False disables the jittery clock,
-            while all other values enable jittery clock.
+            At reset, this register reads as kMultiBitBool4False and the jittery clock is disabled.
+            Any write to the register turns the value to kMultiBitBool4True and enables the jittery clock.
+            The value written doesn't matter.
+            The value then remains kMultiBitBool4True until reset.
           ''',
           resval: false
-          // avoid writing random values to this register as it could trigger transient checks
-          // in mubi sync
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
+          // Exclude this register from any automated CSR tests as the behavior is non-standard.
+          tags: ["excl:CsrAllTests:CsrExclAll"]
         }
       ]
     },

--- a/hw/ip_templates/clkmgr/doc/registers.md.tpl
+++ b/hw/ip_templates/clkmgr/doc/registers.md.tpl
@@ -148,10 +148,10 @@ ${"###"} Fields
 {"reg": [{"name": "EN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                            |
-|:------:|:------:|:-------:|:-------|:-------------------------------------------------------------------------------------------------------|
-|  31:1  |        |         |        | Reserved                                                                                               |
-|   0    |  rw0c  |   0x1   | EN     | When 1, the value of [`JITTER_ENABLE`](#jitter_enable) can be changed.  When 0, writes have no effect. |
+|  Bits  |  Type  |  Reset  | Name   | Description                  |
+|:------:|:------:|:-------:|:-------|:-----------------------------|
+|  31:1  |        |         |        | Reserved                     |
+|   0    |  rw0c  |   0x1   | EN     | This register has no effect. |
 
 ${"##"} JITTER_ENABLE
 Enable jittery clock
@@ -165,10 +165,17 @@ ${"###"} Fields
 {"reg": [{"name": "VAL", "bits": 4, "attr": ["rw"], "rotate": 0}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                   |
-|:------:|:------:|:-------:|:-------|:------------------------------------------------------------------------------------------------------------------------------|
-|  31:4  |        |         |        | Reserved                                                                                                                      |
-|  3:0   |   rw   |   0x9   | VAL    | Enable jittery clock. A value of kMultiBitBool4False disables the jittery clock, while all other values enable jittery clock. |
+|  Bits  |  Type  |  Reset  | Name                       |
+|:------:|:------:|:-------:|:---------------------------|
+|  31:4  |        |         | Reserved                   |
+|  3:0   |   rw   |   0x9   | [VAL](#jitter_enable--val) |
+
+${"###"} JITTER_ENABLE . VAL
+Enable jittery clock.
+At reset, this register reads as kMultiBitBool4False and the jittery clock is disabled.
+Any write to the register turns the value to kMultiBitBool4True and enables the jittery clock.
+The value written doesn't matter.
+The value then remains kMultiBitBool4True until reset.
 
 ${"##"} CLK_ENABLES
 Clock enable for software gateable clocks.

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr.hjson
@@ -414,8 +414,7 @@
           name: "EN",
           resval: "1"
           desc: '''
-            When 1, the value of !!JITTER_ENABLE can be changed.  When 0, writes have no
-            effect.
+            This register has no effect.
           '''
         },
       ]
@@ -434,13 +433,14 @@
           name: "VAL",
           desc: '''
             Enable jittery clock.
-            A value of kMultiBitBool4False disables the jittery clock,
-            while all other values enable jittery clock.
+            At reset, this register reads as kMultiBitBool4False and the jittery clock is disabled.
+            Any write to the register turns the value to kMultiBitBool4True and enables the jittery clock.
+            The value written doesn't matter.
+            The value then remains kMultiBitBool4True until reset.
           ''',
           resval: false
-          // avoid writing random values to this register as it could trigger transient checks
-          // in mubi sync
-          tags: ["excl:CsrAllTests:CsrExclWrite"]
+          // Exclude this register from any automated CSR tests as the behavior is non-standard.
+          tags: ["excl:CsrAllTests:CsrExclAll"]
         }
       ]
     },

--- a/hw/top_earlgrey/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/doc/registers.md
@@ -148,10 +148,10 @@ Jitter write enable
 {"reg": [{"name": "EN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                            |
-|:------:|:------:|:-------:|:-------|:-------------------------------------------------------------------------------------------------------|
-|  31:1  |        |         |        | Reserved                                                                                               |
-|   0    |  rw0c  |   0x1   | EN     | When 1, the value of [`JITTER_ENABLE`](#jitter_enable) can be changed.  When 0, writes have no effect. |
+|  Bits  |  Type  |  Reset  | Name   | Description                  |
+|:------:|:------:|:-------:|:-------|:-----------------------------|
+|  31:1  |        |         |        | Reserved                     |
+|   0    |  rw0c  |   0x1   | EN     | This register has no effect. |
 
 ## JITTER_ENABLE
 Enable jittery clock
@@ -165,10 +165,17 @@ Enable jittery clock
 {"reg": [{"name": "VAL", "bits": 4, "attr": ["rw"], "rotate": 0}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                   |
-|:------:|:------:|:-------:|:-------|:------------------------------------------------------------------------------------------------------------------------------|
-|  31:4  |        |         |        | Reserved                                                                                                                      |
-|  3:0   |   rw   |   0x9   | VAL    | Enable jittery clock. A value of kMultiBitBool4False disables the jittery clock, while all other values enable jittery clock. |
+|  Bits  |  Type  |  Reset  | Name                       |
+|:------:|:------:|:-------:|:---------------------------|
+|  31:4  |        |         | Reserved                   |
+|  3:0   |   rw   |   0x9   | [VAL](#jitter_enable--val) |
+
+### JITTER_ENABLE . VAL
+Enable jittery clock.
+At reset, this register reads as kMultiBitBool4False and the jittery clock is disabled.
+Any write to the register turns the value to kMultiBitBool4True and enables the jittery clock.
+The value written doesn't matter.
+The value then remains kMultiBitBool4True until reset.
 
 ## CLK_ENABLES
 Clock enable for software gateable clocks.

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -874,7 +874,7 @@ module clkmgr_reg_top (
 
     // from register interface
     .we     (jitter_enable_we),
-    .wd     (jitter_enable_wd),
+    .wd     (prim_mubi_pkg::MuBi4True),
 
     // from internal hardware
     .de     (1'b0),
@@ -2826,6 +2826,11 @@ module clkmgr_reg_top (
 
 
   // Unused signal tieoff
+
+  // Any write to the jitter_enable CSR writes MuBi4True.
+  // The actual write data is ignored.
+  logic unused_jitter_enable_wd;
+  assign unused_jitter_enable_wd = ^jitter_enable_wd;
 
   // wdata / byte enable are not always fully used
   // add a blanket unused statement to handle lint waivers

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -88,8 +88,19 @@ dif_result_t dif_clkmgr_jitter_set_enabled(const dif_clkmgr_t *clkmgr,
     default:
       return kDifBadArg;
   }
-  mmio_region_write32(clkmgr->base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET,
-                      new_jitter_enable_val);
+
+  multi_bit_bool_t clk_jitter_enable_val =
+      mmio_region_read32(clkmgr->base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET);
+  if (clk_jitter_enable_val == kMultiBitBool4True &&
+      new_jitter_enable_val != kMultiBitBool4True) {
+    return kDifLocked;
+  }
+
+  if (new_jitter_enable_val == kMultiBitBool4True) {
+    mmio_region_write32(clkmgr->base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET,
+                        new_jitter_enable_val);
+  }
+
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -150,7 +150,7 @@ dif_result_t dif_clkmgr_jitter_get_enabled(const dif_clkmgr_t *clkmgr,
                                            dif_toggle_t *state);
 
 /**
- * Enable of Disable jitter.
+ * Enable or attempt to disable jitter.
  * @param clkmgr Clock Manager Handle.
  * @param new_state whether to enable or disable jitter.
  * @returns The result of the operation.

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -29,14 +29,13 @@ class ClkMgrTest : public Test, public MmioTest {
 
 class JitterEnableTest : public ClkMgrTest {};
 
-// SetEnabled uses EXPECT_WRITE32 instead of EXPECT_MASK32 because
-// dif_clkmgr_jitter_set_enabled doesn't perform a read, just a write.
 TEST_F(JitterEnableTest, SetEnabled) {
-  // Disable jitter.
-  EXPECT_WRITE32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4False);
+  // Attempt to disable jitter.
+  EXPECT_READ32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4False);
   EXPECT_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleDisabled));
 
   // Enable jitter.
+  EXPECT_READ32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4False);
   EXPECT_WRITE32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4True);
   EXPECT_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleEnabled));
 }

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -824,6 +824,13 @@ ${rdata_gen(f, r.name.lower() + "_" + f.name.lower())}\
 % endif
 
   // Unused signal tieoff
+% if lblock == "clkmgr":
+
+  // Any write to the jitter_enable CSR writes MuBi4True.
+  // The actual write data is ignored.
+  logic unused_jitter_enable_wd;
+  assign unused_jitter_enable_wd = ^jitter_enable_wd;
+% endif
 % if rb.all_regs:
 
   // wdata / byte enable are not always fully used
@@ -904,13 +911,16 @@ ${bits.msb}\
       we_expr = f'{clk_base_name}{reg_name}{gated_suffix}_{we_suffix}'
 
       # when async, pick from the cdc handled data
-      wd_expr = f'{finst_name}_wd'
-      if reg.async_clk:
-        if field.bits.msb == field.bits.lsb:
-          bit_sel = f'{field.bits.msb}'
-        else:
-          bit_sel = f'{field.bits.msb}:{field.bits.lsb}'
-        wd_expr = f'{clk_base_name}{reg_name}_wdata[{bit_sel}]'
+      if lblock == "clkmgr" and reg_name == "jitter_enable":
+        wd_expr = "prim_mubi_pkg::MuBi4True"
+      else:
+        wd_expr = f'{finst_name}_wd'
+        if reg.async_clk:
+          if field.bits.msb == field.bits.lsb:
+            bit_sel = f'{field.bits.msb}'
+          else:
+            bit_sel = f'{field.bits.msb}:{field.bits.lsb}'
+          wd_expr = f'{clk_base_name}{reg_name}_wdata[{bit_sel}]'
 
     else:
       we_expr = "1'b0"


### PR DESCRIPTION
This PR aligns RTL, block-level DV, DIF and doc to the modified behavior of the jitter_enable CSR. The corresponding ROM change is #26027.