### PR TITLE
[RACL] Render RACL Roles in top_racl_pkg

### DIFF
--- a/util/topgen/templates/toplevel_racl_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg.sv.tpl
@@ -79,6 +79,16 @@ package top_racl_pkg;
   endfunction
 % endif
 
+% if racl_config.get('roles'):
+  /**
+   * RACL Roles
+   */
+<% racl_role_name_len = max((len(name) for name in racl_config.get('roles', {}).keys()), default=0) %>\
+  % for racl_role_name, racl_role in racl_config.get('roles', {}).items():
+  parameter role_t RACL_ROLE_${racl_role_name.upper().ljust(racl_role_name_len)} = ${racl_config['nr_role_bits']}'h${f"{racl_role['role_id']:x}"};
+  % endfor
+
+% endif
 % for racl_group, policies in racl_config['policies'].items():
 <% prefix = "" if len(racl_config['policies'].keys()) == 1 else f"{racl_group.upper()}_" %>\
   /**


### PR DESCRIPTION
This commit adds the racl roles as paramters to the top_racl_pkg.
These will be used later in a follow-up PR.

Example output:
```
  /**
   * RACL Roles
   */
  parameter role_t RACL_ROLE_ROT   = 4'h0;
  parameter role_t RACL_ROLE_ROLE1 = 4'h1;
  parameter role_t RACL_ROLE_SOC   = 4'h2;
```