### PR TITLE
[silicon_creator] remove duplicate function prototype

### DIFF
--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -31,37 +31,6 @@ OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_app_load(void);
 
 /**
- * Generate an attestation public key from a keymgr-derived secret.
- *
- * This routine triggers the key manager to sideload key material into OTBN,
- * and also loads in an extra seed to XOR with the key material. The final
- * private key is:
- *   d = (additional_seed ^ keymgr_seed) mod n
- * ...where n is the P256 curve order. The public key is d*G, where G is the
- * P256 base point.
- *
- * The extra seed is expected to be the output from a specially seeded DRBG, and
- * is provisioned into flash at manufacturing time. It must be fully independent
- * from the key manager seed.
- *
- * Expects the OTBN boot-services program to already be loaded; see
- * `otbn_boot_app_load`.
- *
- * @param additional_seed_idx The attestation key generation seed index to load.
- *                            The index corresponds to the seed offset in flash
- *                            info page `kFlashCtrlInfoPageAttestationKeySeeds`.
- * @param key_type Keymgr key type to generate, attestation or sealing.
- * @param diversification Salt and version information for key manager.
- * @param[out] public_key Attestation public key.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-rom_error_t otbn_boot_attestation_keygen(
-    uint32_t additional_seed_idx, sc_keymgr_key_type_t key_type,
-    sc_keymgr_diversification_t diversification,
-    ecdsa_p256_public_key_t *public_key);
-
-/**
  * Generate a deterministic ECC P256 attestation public key from a
  * keymgr-derived secret.
  *


### PR DESCRIPTION
This removes a duplicate function prototype for the `otbn_boot_attestation_keygen()` that is unneeded.