### PR TITLE
[keymgr, keymgr_dpe, rtl] keymgr_dpe correct KMAC input

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -10,13 +10,14 @@
 module keymgr_kmac_if
   import keymgr_pkg::*;
 #(
-  parameter rand_perm_t RndCnstRandPerm = RndCnstRandPermDefault
+  parameter rand_perm_t RndCnstRandPerm = RndCnstRandPermDefault,
+  parameter int MaxAdvDataWidth         = AdvDataWidth
 ) (
   input clk_i,
   input rst_ni,
 
   // data input interfaces
-  input [AdvDataWidth-1:0] adv_data_i,
+  input [MaxAdvDataWidth-1:0] adv_data_i,
   input [IdDataWidth-1:0] id_data_i,
   input [GenDataWidth-1:0] gen_data_i,
   input [3:0] inputs_invalid_i,
@@ -78,9 +79,9 @@ module keymgr_kmac_if
     StError   = 10'b0011101110
   } data_state_e;
 
-  localparam int AdvRem = AdvDataWidth % KmacDataIfWidth;
-  localparam int IdRem  = IdDataWidth  % KmacDataIfWidth;
-  localparam int GenRem = GenDataWidth % KmacDataIfWidth;
+  localparam int AdvRem = MaxAdvDataWidth % KmacDataIfWidth;
+  localparam int IdRem  = IdDataWidth     % KmacDataIfWidth;
+  localparam int GenRem = GenDataWidth    % KmacDataIfWidth;
 
   // the remainder must be in number of bytes
   `ASSERT_INIT(AdvRemBytes_A, AdvRem % 8 == 0)
@@ -88,7 +89,7 @@ module keymgr_kmac_if
   `ASSERT_INIT(GenRemBytes_A, GenRem % 8 == 0)
 
   // Number of kmac transactions required
-  localparam int AdvRounds = (AdvDataWidth + KmacDataIfWidth - 1) / KmacDataIfWidth;
+  localparam int AdvRounds = (MaxAdvDataWidth + KmacDataIfWidth - 1) / KmacDataIfWidth;
   localparam int IdRounds  = (IdDataWidth + KmacDataIfWidth - 1) / KmacDataIfWidth;
   localparam int GenRounds = (GenDataWidth + KmacDataIfWidth - 1) / KmacDataIfWidth;
   localparam int MaxRounds = KDFMaxWidth  / KmacDataIfWidth;

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
@@ -183,20 +183,18 @@ interface keymgr_dpe_if(input clk, input rst_n);
     rom_digests[i].valid = !bad_valid;
   endfunction
 
-  // randomize lc, flash input data
+  // randomize lc and input data
   task automatic drive_random_hw_input_data(int num_invalid_input = 0);
     // Firstly, decide which signals should be driven with invalid data. Store the choices we make
     // as a set of flags / counters.
     bit bad_keymgr_dpe_div = 1'b0;
     bit bad_otp_device_id = 1'b0;
-    int bad_flash_seeds = 0;
     bit [NumRomDigestInputs-1:0] bad_rom_data = '0, bad_rom_valid = '0;
 
     repeat (num_invalid_input) begin
       randcase
         1: bad_keymgr_dpe_div = 1'b1;
         1: bad_otp_device_id = 1'b1;
-        1: bad_flash_seeds++;
         1: bad_rom_data[$urandom % NumRomDigestInputs] = 1'b1;
         1: bad_rom_valid[$urandom % NumRomDigestInputs] = 1'b1;
       endcase
@@ -215,12 +213,6 @@ interface keymgr_dpe_if(input clk, input rst_n);
       begin
         #($urandom_range(1000, 0) * 1ns);
         set_random_otp_device_id(bad_otp_device_id);
-      end
-
-      // flash
-      begin
-        #($urandom_range(1000, 0) * 1ns);
-        set_random_flash(bad_flash_seeds);
       end
 
       // rom_digests

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -29,7 +29,8 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   typedef struct packed {
     // some portions are unused, which are 0s
-    bit [keymgr_pkg::AdvDataWidth-keymgr_pkg::KeyWidth-keymgr_pkg::SwBindingWidth-1:0] unused;
+    bit [keymgr_dpe_pkg::DpeAdvDataWidth-keymgr_pkg::KeyWidth-keymgr_pkg::SwBindingWidth-1:0]
+        unused;
     // SW_CDI_INPUT
     bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
     // OWNER SEED
@@ -38,7 +39,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   typedef struct packed {
     // some portions are unused, which are 0s
-    bit [keymgr_pkg::AdvDataWidth-keymgr_pkg::SwBindingWidth-1:0]  unused;
+    bit [keymgr_dpe_pkg::DpeAdvDataWidth-keymgr_pkg::SwBindingWidth-1:0]  unused;
     // SW_CDI_INPUT
     bit [keymgr_dpe_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
   } adv_owner_data_t;
@@ -91,7 +92,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
   // local queues to hold incoming packets pending comparison
   // store meaningful data, in non-working state, should not match to these data
-  bit [keymgr_pkg::AdvDataWidth-1:0] adv_data_a_array[
+  bit [keymgr_dpe_pkg::DpeAdvDataWidth-1:0] adv_data_a_array[
     keymgr_dpe_pkg::DpeNumSlots][
     keymgr_dpe_pkg::keymgr_dpe_exposed_working_state_e];
   bit [keymgr_pkg::IdDataWidth-1:0]  id_data_a_array[
@@ -1259,7 +1260,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     adv_creator_data_t exp, act;
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
-    if (exp_match) `DV_CHECK_EQ(byte_data_q.size, keymgr_pkg::AdvDataWidth / 8)
+    if (exp_match) `DV_CHECK_EQ(byte_data_q.size, keymgr_dpe_pkg::DpeAdvDataWidth / 8)
     act = {<<8{byte_data_q}};
     exp.DiversificationKey = cfg.keymgr_dpe_vif.otp_key.creator_seed;
 

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -70,9 +70,9 @@ package keymgr_dpe_pkg;
 
   // TODO(#354): Define further policy bits and extend this struct
   typedef struct packed {
-    logic allow_child;
-    logic exportable;
     logic retain_parent;
+    logic exportable;
+    logic allow_child;
   } keymgr_dpe_policy_t;
 
   // An internal secret key slot
@@ -95,9 +95,9 @@ package keymgr_dpe_pkg;
   } keymgr_dpe_key_update_e;
 
   localparam keymgr_dpe_policy_t DEFAULT_UDS_POLICY = '{
-    allow_child   : 1'b1,
+    retain_parent : 1'b0,
     exportable    : 1'b0,
-    retain_parent : 1'b0
+    allow_child   : 1'b1
   };
 
   // Keymgr_dpe requires more lc_en copies than keymgr

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_pkg.sv
@@ -12,6 +12,16 @@ package keymgr_dpe_pkg;
   parameter int DpeNumSlotsWidth = prim_util_pkg::vbits(DpeNumSlots);
   parameter int DpeNumBootStagesWidth = $clog2(DpeNumBootStages);
 
+  // keymgr and keymgr_dpe have different maximum KMAC input widths. The below widths correspond to
+  // the following inputs to advance to the creator root key state:
+  //   - Software binding
+  //   - Revision seed
+  //   - OTP device ID
+  //   - LC keymgr diversification value
+  //   - ROM digests
+  //   - Creator seed
+  parameter int DpeAdvDataWidth = SwBindingWidth + KeyWidth + otp_ctrl_pkg::DeviceIdWidth +
+      lc_ctrl_pkg::LcKeymgrDivWidth + KeyWidth*keymgr_dpe_reg_pkg::NumRomDigestInputs + KeyWidth;
 
   typedef logic [DpeNumSlotsWidth-1:0] keymgr_dpe_slot_idx_e;
 


### PR DESCRIPTION
This PR fixes the bug reported in #25994. It consists of three commits the first two being
preparatory bug fixes:

1. The `keymgr_dpe` DV was not compiling due to a spurious artifact.
2. All DV tests were failing because of wrongly ordered DPE policy bits.
3. The actual bugfix for #25994.