### PR TITLE
[racl] Follow-up fixes to TLUL adapter and reg_top

### DIFF
--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -12,7 +12,7 @@ module i2c
   parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
   parameter int unsigned          InputDelayCycles     = 0,
   parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = 1'b1,
+  parameter bit                   RaclErrorRsp         = EnableRacl,
   parameter int unsigned          RaclPolicySelVec[32] = '{32{0}}
 ) (
   input                                    clk_i,

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -3471,9 +3471,9 @@ module i2c_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit but failed the RACL check
-  assign racl_error_o = tl_i.a_valid &
-                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                     (reg_we & ~|racl_addr_hit_write));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -15,7 +15,7 @@ module mbx
   parameter bit          DoeIrqSupport            = 1'b1,
   parameter bit          DoeAsyncMsgSupport       = 1'b1,
   parameter bit          EnableRacl               = 1'b0,
-  parameter bit          RaclErrorRsp             = 1'b1,
+  parameter bit          RaclErrorRsp             = EnableRacl,
   parameter int unsigned RaclPolicySelVecSoc[4]   = '{4{0}},
   parameter int unsigned RaclPolicySelWinSocWDATA = 0,
   parameter int unsigned RaclPolicySelWinSocRDATA = 0

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -518,9 +518,9 @@ module mbx_soc_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit but failed the RACL check
-  assign racl_error_o = tl_i.a_valid &
-                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                     (reg_we & ~|racl_addr_hit_write));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip/pwm/rtl/pwm.sv
+++ b/hw/ip/pwm/rtl/pwm.sv
@@ -9,7 +9,7 @@ module pwm
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
   parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = 1'b1,
+  parameter bit                   RaclErrorRsp         = EnableRacl,
   parameter int unsigned          RaclPolicySelVec[23] = '{23{0}},
   parameter int                   PhaseCntDw           = 16,
   parameter int                   BeatCntDw            = 27

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -3164,9 +3164,9 @@ module pwm_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit but failed the RACL check
-  assign racl_error_o = tl_i.a_valid &
-                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                     (reg_we & ~|racl_addr_hit_write));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -14,7 +14,7 @@ module spi_host
   parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
   parameter int unsigned          NumCS         = 1,
   parameter bit          EnableRacl             = 1'b0,
-  parameter bit          RaclErrorRsp           = 1'b1,
+  parameter bit          RaclErrorRsp           = EnableRacl,
   parameter int unsigned RaclPolicySelVec[12]   = '{12{0}},
   parameter int unsigned RaclPolicySelWinRXDATA = 0,
   parameter int unsigned RaclPolicySelWinTXDATA = 0

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -1781,9 +1781,9 @@ module spi_host_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit but failed the RACL check
-  assign racl_error_o = tl_i.a_valid &
-                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                     (reg_we & ~|racl_addr_hit_write));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
@@ -69,11 +69,14 @@ module tlul_adapter_reg_racl
       .out_o( racl_role_vec )
     );
 
-    logic rd_req, racl_read_allowed, racl_write_allowed;
-    assign rd_req             = tl_i.a_opcode == tlul_pkg::Get;
+    logic req, rd_req, wr_req, racl_read_allowed, racl_write_allowed;
+    assign req                = tl_i.a_valid & tl_o.a_ready;
+    assign rd_req             = req & (tl_i.a_opcode == tlul_pkg::Get);
+    assign wr_req             = req & (tl_i.a_opcode == tlul_pkg::PutFullData |
+                                       tl_i.a_opcode == tlul_pkg::PutPartialData);
     assign racl_read_allowed  = (|(racl_policies_i[RaclPolicySelVec].read_perm  & racl_role_vec));
     assign racl_write_allowed = (|(racl_policies_i[RaclPolicySelVec].write_perm & racl_role_vec));
-    assign racl_error_o       = (rd_req & ~racl_read_allowed) | (~rd_req & ~racl_write_allowed);
+    assign racl_error_o       = (rd_req & ~racl_read_allowed) | (wr_req & ~racl_write_allowed);
 
     tlul_request_loopback #(
       .ErrorRsp(RaclErrorRsp)

--- a/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
@@ -12,15 +12,15 @@ module tlul_adapter_reg_racl
   import tlul_pkg::*;
   import prim_mubi_pkg::mubi4_t;
 #(
-  parameter  bit CmdIntgCheck      = 0,     // 1: Enable command integrity check
-  parameter  bit EnableRspIntgGen  = 0,     // 1: Generate response integrity
-  parameter  bit EnableDataIntgGen = 0,     // 1: Generate response data integrity
-  parameter  int RegAw             = 8,     // Width of register address
-  parameter  int RegDw             = 32,    // Shall be matched with TL_DW
-  parameter  int AccessLatency     = 0,     // 0: same cycle, 1: next cycle
-  parameter  bit EnableRacl        = 0,     // 1: Enable RACL checks on access
-  parameter  bit RaclErrorRsp      = 1,     // 1: Return TLUL error on RACL errors
-  parameter  int RaclPolicySelVec  = 0,     // RACL policy for this reg adapter
+  parameter  bit CmdIntgCheck      = 0,           // 1: Enable command integrity check
+  parameter  bit EnableRspIntgGen  = 0,           // 1: Generate response integrity
+  parameter  bit EnableDataIntgGen = 0,           // 1: Generate response data integrity
+  parameter  int RegAw             = 8,           // Width of register address
+  parameter  int RegDw             = 32,          // Shall be matched with TL_DW
+  parameter  int AccessLatency     = 0,           // 0: same cycle, 1: next cycle
+  parameter  bit EnableRacl        = 0,           // 1: Enable RACL checks on access
+  parameter  bit RaclErrorRsp      = EnableRacl,  // 1: Return TLUL error on RACL errors
+  parameter  int RaclPolicySelVec  = 0,           // RACL policy for this reg adapter
   localparam int RegBw             = RegDw/8
 ) (
   input clk_i,

--- a/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
@@ -95,11 +95,14 @@ module tlul_adapter_sram_racl
       .out_o( racl_role_vec )
     );
 
-    logic rd_req, racl_read_allowed, racl_write_allowed;
-    assign rd_req             = tl_i.a_opcode == tlul_pkg::Get;
+    logic req, rd_req, wr_req, racl_read_allowed, racl_write_allowed;
+    assign req                = tl_i.a_valid & tl_o.a_ready;
+    assign rd_req             = req & (tl_i.a_opcode == tlul_pkg::Get);
+    assign wr_req             = req & (tl_i.a_opcode == tlul_pkg::PutFullData |
+                                       tl_i.a_opcode == tlul_pkg::PutPartialData);
     assign racl_read_allowed  = (|(racl_policies_i[RaclPolicySelVec].read_perm  & racl_role_vec));
     assign racl_write_allowed = (|(racl_policies_i[RaclPolicySelVec].write_perm & racl_role_vec));
-    assign racl_error_o       = (rd_req & ~racl_read_allowed) | (~rd_req & ~racl_write_allowed);
+    assign racl_error_o       = (rd_req & ~racl_read_allowed) | (wr_req & ~racl_write_allowed);
 
     tlul_request_loopback #(
       .ErrorRsp(RaclErrorRsp)

--- a/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
@@ -22,25 +22,26 @@ module tlul_adapter_sram_racl
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter int SramAw            = 12,
-  parameter int SramDw            = 32, // Must be multiple of the TL width
-  parameter int Outstanding       = 1,  // Only one request is accepted
-  parameter int SramBusBankAW     = 12, // SRAM bus address width of the SRAM bank. Only used
-                                        // when DataXorAddr=1.
-  parameter bit ByteAccess        = 1,  // 1: Enables sub-word write transactions. Note that this
-                                        //    results in read-modify-write operations for integrity
-                                        //    re-generation if EnableDataIntgPt is set to 1.
-  parameter bit ErrOnWrite        = 0,  // 1: Writes not allowed, automatically error
-  parameter bit ErrOnRead         = 0,  // 1: Reads not allowed, automatically error
-  parameter bit CmdIntgCheck      = 0,  // 1: Enable command integrity check
-  parameter bit EnableRspIntgGen  = 0,  // 1: Generate response integrity
-  parameter bit EnableDataIntgGen = 0,  // 1: Generate response data integrity
-  parameter bit EnableDataIntgPt  = 0,  // 1: Passthrough command/response data integrity
-  parameter bit SecFifoPtr        = 0,  // 1: Duplicated fifo pointers
-  parameter bit EnableReadback    = 0,  // 1: Readback and check written/read data.
-  parameter bit DataXorAddr       = 0,  // 1: XOR data and address for address protection
-  parameter bit EnableRacl        = 0,  // 1: Enable RACL checks on access
-  parameter bit RaclErrorRsp      = 1,  // 1: Return TLUL error on RACL errors
-  parameter int RaclPolicySelVec  = 0,  // RACL policy for this SRAM adapter
+  parameter int SramDw            = 32,         // Must be multiple of the TL width
+  parameter int Outstanding       = 1,          // Only one request is accepted
+  parameter int SramBusBankAW     = 12,         // SRAM bus address width of the SRAM bank. Only
+                                                // used when DataXorAddr=1.
+  parameter bit ByteAccess        = 1,          // 1: Enables sub-word write transactions. Note that
+                                                //    this results in read-modify-write operations
+                                                //    for integrity re-generation if
+                                                //    EnableDataIntgPt is set to 1.
+  parameter bit ErrOnWrite        = 0,          // 1: Writes not allowed, automatically error
+  parameter bit ErrOnRead         = 0,          // 1: Reads not allowed, automatically error
+  parameter bit CmdIntgCheck      = 0,          // 1: Enable command integrity check
+  parameter bit EnableRspIntgGen  = 0,          // 1: Generate response integrity
+  parameter bit EnableDataIntgGen = 0,          // 1: Generate response data integrity
+  parameter bit EnableDataIntgPt  = 0,          // 1: Passthrough command/response data integrity
+  parameter bit SecFifoPtr        = 0,          // 1: Duplicated fifo pointers
+  parameter bit EnableReadback    = 0,          // 1: Readback and check written/read data.
+  parameter bit DataXorAddr       = 0,          // 1: XOR data and address for address protection
+  parameter bit EnableRacl        = 0,          // 1: Enable RACL checks on access
+  parameter bit RaclErrorRsp      = EnableRacl, // 1: Return TLUL error on RACL errors
+  parameter int RaclPolicySelVec  = 0,          // RACL policy for this SRAM adapter
   localparam int WidthMult        = SramDw / top_pkg::TL_DW,
   localparam int IntgWidth        = tlul_pkg::DataIntgWidth * WidthMult,
   localparam int DataOutW         = EnableDataIntgPt ? SramDw + IntgWidth : SramDw

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -11,7 +11,7 @@ module uart
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
   parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = 1'b1,
+  parameter bit                   RaclErrorRsp         = EnableRacl,
   parameter int unsigned          RaclPolicySelVec[13] = '{13{0}}
 ) (
   input           clk_i,

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1628,9 +1628,9 @@ module uart_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit but failed the RACL check
-  assign racl_error_o = tl_i.a_valid &
-                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                     (reg_we & ~|racl_addr_hit_write));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -7,7 +7,8 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter bit                   RaclErrorRsp = 1'b1,
+  parameter bit                   EnableRacl   = 1'b0,
+  parameter bit                   RaclErrorRsp = EnableRacl,
   parameter int unsigned          RaclPolicySelVec[${3 + 5*num_ranges}] = '{${3 + 5*num_ranges}{0}}
 ) (
   input  logic                                      clk_i,

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -13,7 +13,7 @@ module ${module_instance_name}
 #(
 % if racl_support:
   parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = 1'b1,
+  parameter bit                   RaclErrorRsp         = EnableRacl,
 <% 
 num_regs = 6 + 4 * n_alerts + 4 * 7 + n_classes * 14
 %>\

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -25,8 +25,8 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   // and routing the source clocks / resets to the PLIC).
   parameter logic [NumSrc-1:0]    LevelEdgeTrig = '0, // 0: level, 1: edge
 % if racl_support:
-  parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = 1'b1,
+  parameter bit                   EnableRacl    = 1'b0,
+  parameter bit                   RaclErrorRsp  = EnableRacl,
 <% 
 from math import ceil
 num_regs = src + ceil(src / 32) + target * ceil(src / 32) + 3 * target + 1

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -730,9 +730,9 @@ ${finst_gen(sr, field, finst_name, fsig_name, fidx)}
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
 % if racl_support:
-  // A valid address hit but failed the RACL check
-  assign racl_error_o = tl_i.a_valid &
-                        (|addr_hit) & ~(|(addr_hit & (racl_addr_hit_read | racl_addr_hit_write)));
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                     (reg_we & ~|racl_addr_hit_write));
   assign racl_error_log_o.racl_role  = racl_role;
 
   if (EnableRacl) begin : gen_racl_log


### PR DESCRIPTION
This PR is a follow up to the review in https://github.com/lowRISC/opentitan/pull/26004#pullrequestreview-2579395912:

It adds:
1. Proper qualification of the read and write request with the necessary TLUL signals for the reg and sram adapter
2. Properly qualify the error log computation in the reg_top with the access control signal coming from the reg_adapter.