### PR TITLE
[tests,clkmgr_jitter] Fix jitter tests to track RTL changes

### DIFF
--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -9,6 +9,21 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
+  task check_jitter_regwen();
+    bit enable;
+    mubi4_t prev_value;
+    mubi4_t new_value;
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(enable)
+    new_value = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+    `uvm_info(`gfn, $sformatf("Check jitter regwen set to %b begin", enable), UVM_MEDIUM)
+    csr_wr(.ptr(ral.jitter_regwen), .value(enable));
+    csr_rd(.ptr(ral.jitter_enable), .value(prev_value));
+    csr_wr(.ptr(ral.jitter_enable), .value(new_value));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(MuBi4True));
+    `uvm_info(`gfn, "Check jitter regwen end", UVM_MEDIUM)
+  endtask : check_jitter_regwen
+
   task check_extclk_regwen();
     bit enable;
     int prev_value;
@@ -67,6 +82,7 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
     `uvm_info(`gfn, $sformatf("Will run %0d rounds", num_trans), UVM_MEDIUM)
     for (int i = 0; i < num_trans; ++i) begin
+      check_jitter_regwen();
       check_extclk_regwen();
       check_meas_ctrl_regwen();
       apply_reset("HARD");

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -188,8 +188,13 @@
             jitter_o clkmgr output to toggle. Verify this output is connected to AST's
             clk_src_sys_jen_i input using formal.
 
+            Test the following properties of jitter enable:
+            - The reset value of jitter_enable is off.
+            - Any write to jitter_enable turns jitter on.
+            - jitter_regwen has no impact on jitter_enable.
+
             X-ref with various specific jitter enable tests.
-            SiVal: This is a connectivity test only, not suitable for sival.
+            SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
             '''
       stage: V2
       si_stage: NA
@@ -211,7 +216,14 @@
       name: chip_sw_clkmgr_jitter_cycle_measurements
       desc: '''Verify jitter via clock cycle measurements after calibration.
             The clock count thresholds for main clk need to be set wider than when jitter is disabled.
-            SiVal: This is only useful on real silicon.
+            Check when jitter is enabled:
+            - Using jitter thresholds no errors are detected.
+            - Using normal thresholds results in recoverable errors.
+            - Don't test normal thresholds for FPGAs since they don't support jitter and no errors will occur.
+            Check when jitter is disabled:
+            - Using either sets of thresholds result in no errors.
+
+            SiVal: This is only useful on real silicon since FPGAs don't support jitter.
             Should be done after clock calibration.
             '''
       stage: V3

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -9,6 +9,21 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
+  task check_jitter_regwen();
+    bit enable;
+    mubi4_t prev_value;
+    mubi4_t new_value;
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(enable)
+    new_value = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(2));
+    `uvm_info(`gfn, $sformatf("Check jitter regwen set to %b begin", enable), UVM_MEDIUM)
+    csr_wr(.ptr(ral.jitter_regwen), .value(enable));
+    csr_rd(.ptr(ral.jitter_enable), .value(prev_value));
+    csr_wr(.ptr(ral.jitter_enable), .value(new_value));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(MuBi4True));
+    `uvm_info(`gfn, "Check jitter regwen end", UVM_MEDIUM)
+  endtask : check_jitter_regwen
+
   task check_extclk_regwen();
     bit enable;
     int prev_value;
@@ -67,6 +82,7 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
 
     `uvm_info(`gfn, $sformatf("Will run %0d rounds", num_trans), UVM_MEDIUM)
     for (int i = 0; i < num_trans; ++i) begin
+      check_jitter_regwen();
       check_extclk_regwen();
       check_meas_ctrl_regwen();
       apply_reset("HARD");

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -140,6 +140,24 @@ typedef enum dif_clkmgr_fatal_err_type {
 typedef uint32_t dif_clkmgr_fatal_err_codes_t;
 
 /**
+ * Check if jitter enable is locked.
+ * @param clkmgr Clock Manager Handle.
+ * @param[out] is_locked whether jitter is locked or not.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_jitter_enable_is_locked(const dif_clkmgr_t *clkmgr,
+                                                bool *is_locked);
+
+/**
+ * Lock jitter enable.
+ * @param clkmgr Clock Manager Handle.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_lock_jitter_enable(const dif_clkmgr_t *clkmgr);
+
+/**
  * Check if jitter is Enabled.
  * @param clkmgr Clock Manager Handle.
  * @param[out] is_enabled whether jitter is enabled or not.
@@ -150,14 +168,12 @@ dif_result_t dif_clkmgr_jitter_get_enabled(const dif_clkmgr_t *clkmgr,
                                            dif_toggle_t *state);
 
 /**
- * Enable or attempt to disable jitter.
+ * Enable jitter.
  * @param clkmgr Clock Manager Handle.
- * @param new_state whether to enable or disable jitter.
  * @returns The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_clkmgr_jitter_set_enabled(const dif_clkmgr_t *clkmgr,
-                                           dif_toggle_t new_state);
+dif_result_t dif_clkmgr_jitter_set_enabled(const dif_clkmgr_t *clkmgr);
 
 /**
  * Check if a Gateable Clock is Enabled or Disabled.
@@ -246,6 +262,24 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_hintable_clock_get_hint(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_hintable_clock_t clock,
     dif_toggle_t *state);
+
+/**
+ * Check if external clock control is locked.
+ * @param clkmgr Clock Manager Handle.
+ * @param[out] is_locked whether external clock control is locked or not.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_external_clock_control_is_locked(
+    const dif_clkmgr_t *clkmgr, bool *is_locked);
+
+/**
+ * Lock external clock control.
+ * @param clkmgr Clock Manager Handle.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_lock_external_clock_control(const dif_clkmgr_t *clkmgr);
 
 /**
  * Enable chip to use the external clock.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -851,6 +851,7 @@ opentitan_test(
     verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:clkmgr",

--- a/sw/device/tests/clkmgr_jitter_frequency_test.c
+++ b/sw/device/tests/clkmgr_jitter_frequency_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_sensor_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
@@ -28,6 +29,18 @@ OTTF_DEFINE_TEST_CONFIG();
  * - for simulation it requires overriding the hardware behavior via plusargs
  *   so it runs with calibrated USB clock, or the USB clock frequency will be
  *   incorrect.
+ *
+ * When jitter is enabled it checks that using jitter thresholds the checks
+ * pass, and with normal thresholds we encounter recoverable errors.
+ *
+ * When jitter is disabled it checks that either sets of thresholds cause
+ * no errors.
+ *
+ * The test flow depends on jitter enable status: once jitter is enabled it
+ * cannot be disabled.
+ *
+ * FPGA emulation platforms don't support jittery clocks so some of the
+ * checks are bypassed for them.
  */
 enum {
   kMeasurementsPerRound = 100,
@@ -35,6 +48,50 @@ enum {
 
 static dif_clkmgr_t clkmgr;
 static dif_pwrmgr_t pwrmgr;
+
+// Test with thresholds for jitter enabled expecting no failures, and then
+// with thresholds for jitter disabled expecting failures.
+static void test_clock_frequencies_with_jitter_enabled(uint32_t delay_micros) {
+  LOG_INFO("Testing frequencies with jitter enabled");
+  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+      &clkmgr, /*jitter_enabled=*/true, /*external_clk=*/false,
+      /*low_speed=*/false));
+  busy_spin_micros(delay_micros);
+  // This checks there are no errors.
+  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
+  CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
+  if (kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSilicon) {
+    // Set thresholds for jitter disabled expecting failures.
+    CHECK_STATUS_OK(
+        clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+            &clkmgr, /*jitter_enabled=*/false, /*external_clk=*/false,
+            /*low_speed=*/false));
+    busy_spin_micros(delay_micros);
+    dif_clkmgr_recov_err_codes_t err_codes;
+    CHECK_DIF_OK(dif_clkmgr_recov_err_code_get_codes(&clkmgr, &err_codes));
+    CHECK(err_codes != 0);
+  } else {
+    LOG_INFO("Testing with jitter enabled but no-jitter thresholds %s",
+             "is not viable for FPGAs");
+  }
+}
+
+static void test_clock_frequencies_with_jitter_disabled(uint32_t delay_micros) {
+  LOG_INFO("Testing frequencies with jitter disabled");
+  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+      &clkmgr, /*jitter_enabled=*/false, /*external_clk=*/false,
+      /*low_speed=*/false));
+  busy_spin_micros(delay_micros);
+  // This checks there are no errors.
+  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
+  CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
+  // Set thresholds for jitter disabled expecting failures.
+  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+      &clkmgr, /*jitter_enabled=*/true, /*external_clk=*/false,
+      /*low_speed=*/false));
+  busy_spin_micros(delay_micros);
+  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
+}
 
 bool test_main(void) {
   dif_sensor_ctrl_t sensor_ctrl;
@@ -57,14 +114,12 @@ bool test_main(void) {
 
   CHECK(UNWRAP(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) == true);
 
-  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
-      &clkmgr, /*jitter_enabled=*/true, /*external_clk=*/false,
-      /*low_speed=*/false));
-  busy_spin_micros(delay_micros);
-
-  // check results
-  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
-  CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
-
+  dif_toggle_t jitter_status;
+  CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(&clkmgr, &jitter_status));
+  if (jitter_status == kDifToggleDisabled) {
+    test_clock_frequencies_with_jitter_disabled(delay_micros);
+    CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr));
+  }
+  test_clock_frequencies_with_jitter_enabled(delay_micros);
   return true;
 }

--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -163,7 +163,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_clkmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
 
-  CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr));
 
   CHECK_DIF_OK(dif_flash_ctrl_init_state(
       &flash_state,

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -539,7 +539,7 @@ bool test_main(void) {
   init_units();
 
   set_edn_auto_mode();
-  CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr));
 
   // Enable both recoverable and fatal alerts
   CHECK_DIF_OK(dif_alert_handler_configure_alert(


### PR DESCRIPTION
Fix clkmgr jitter enable tests to match the change that any write to jitter enable will set it to mubi-true.