### PR TITLE
[hmac,dv] Split NIST test vectors to avoid timeout

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -18,6 +18,9 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   // continue hashing.
   int save_and_restore_pct;
 
+  // Flag to notify the scoreboard to treat the current digest as NIST
+  bit is_nist_test = 0;
+
   // TODO (#23562): will be removed when tackling this issue
   // Flag to notify the scoreboard to skip the current message writes and don't flush its variables
   bit sar_skip_ctxt = 0;
@@ -47,4 +50,6 @@ function void hmac_env_cfg::initialize(bit [TL_AW-1:0] csr_base_addr = '1);
 
   // Used to allow reset operations without waiting for CSR accesses to complete
   can_reset_with_csr_accesses = 1;
+
+  void'($value$plusargs("is_nist_test=%b", is_nist_test));
 endfunction : initialize

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -190,6 +190,19 @@ package hmac_env_pkg;
     endcase
   endfunction : get_key_length
 
+  function automatic key_length_e get_key_length_reg(int key_length);
+    key_length_e key_length_reg;
+    case (key_length)
+      128:     key_length_reg = Key_128;
+      256:     key_length_reg = Key_256;
+      384:     key_length_reg = Key_384;
+      512:     key_length_reg = Key_512;
+      1024:    key_length_reg = Key_1024;
+      default: key_length_reg = Key_None;
+    endcase
+    return key_length_reg;
+  endfunction : get_key_length_reg
+
   function automatic string get_digest_size(int digest_size_reg);
     case (digest_size_reg)
       'h01:    return "SHA2_256";    // SHA-2 256 digest
@@ -210,6 +223,39 @@ package hmac_env_pkg;
       default: return 0;
     endcase
   endfunction : get_block_size
+
+  // Extract NIST vector list name
+  function automatic string get_nist_list_name(string vector_list_path);
+    int last_slash   = -1;
+    int last_dot     = -1;
+    string list_name = "";
+
+    // Find the last slash and last dot positions in this string
+    for (int i=vector_list_path.len()-1; i>=0; i--) begin
+      if ((last_slash == -1) && (vector_list_path[i] == "/")) begin
+        last_slash = i;
+      end
+      if ((last_dot == -1) && (vector_list_path[i] == ".")) begin
+        last_dot = i;
+      end
+      if (last_dot != -1 && last_slash != -1) begin
+        break;
+      end
+    end
+
+    // Finally, extract the list name based on the last slash and last dot positions
+    list_name  = vector_list_path.substr(last_slash+1, last_dot-1);
+
+    // Check that vector list is not empty and that expected slash and dot were found
+    if (list_name == "" || last_dot == -1 || last_slash == -1) begin
+      `uvm_fatal($sformatf("%m"), $sformatf("Vector file name is incorrect: %0s", vector_list_path))
+    end else begin
+      `uvm_info("hmac_env_pkg", $sformatf("NIST list_name is %0s", list_name), UVM_DEBUG)
+    end
+
+    return list_name;
+  endfunction : get_nist_list_name
+
 
   typedef virtual hmac_if hmac_vif;
 

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -99,58 +99,53 @@
     {
       name: hmac_test_sha256_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
-      // Increase timeout for all test iterations to pass
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_000_000_000 +sha2_digest_size=SHA2_256"]
-      reseed: 5
+      run_opts: ["+is_nist_test=1 +test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=500_000_000 +sha2_digest_size=SHA2_256"]
+      reseed: 25
     }
 
     {
       name: hmac_test_sha384_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
-      // Increase timeout for all test iterations to pass
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_500_000_000 +sha2_digest_size=SHA2_384"]
-      reseed: 5
+      run_opts: ["+is_nist_test=1 +test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=750_000_000 +sha2_digest_size=SHA2_384"]
+      reseed: 50
     }
 
     {
       name: hmac_test_sha512_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
-      // Increase timeout for all test iterations to pass
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_500_000_000 +sha2_digest_size=SHA2_512"]
-      reseed: 5
+      run_opts: ["+is_nist_test=1 +test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=750_000_000 +sha2_digest_size=SHA2_512"]
+      reseed: 50
     }
 
     {
       name: hmac_test_hmac256_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_000_000_000 +sha2_digest_size=SHA2_256"]
-      reseed: 5
+      run_opts: ["+is_nist_test=1 +test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=500_000_000 +sha2_digest_size=SHA2_256"]
+      reseed: 50
     }
 
     {
       name: hmac_test_hmac384_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_000_000_000 +sha2_digest_size=SHA2_384"]
-      reseed: 5
+      run_opts: ["+is_nist_test=1 +test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=750_000_000 +sha2_digest_size=SHA2_384"]
+      reseed: 60
     }
 
     {
       name: hmac_test_hmac512_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_000_000_000 +sha2_digest_size=SHA2_512"]
-      reseed: 5
+      run_opts: ["+is_nist_test=1 +test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=750_000_000 +sha2_digest_size=SHA2_512"]
+      reseed: 75
     }
 
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
     }
 
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all_with_rand_reset
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
       reseed: 10
     }
   ]


### PR DESCRIPTION
- Split the NIST test vectors into shorter tests to avoid timeout issues. Linked to issue #23980.
- And move the NIST test vector checking from the sequence to the scoreboard to be more reusable (and UVM compliant). This addresses part of the issue #23288.
- Now, the seq is picking random vectors from the test vector file according to the desired configuartion. And the scoreboard is trying to find if one of the digest is matching. If yes, then the test is considered as passed and the coverage is collected. The NIST will be considred as covered if all of the vectors have been exercised.