### PR TITLE
[rom_ext, sival] Temporarily disable SPX signing of ROM_EXT

### DIFF
--- a/hw/top_earlgrey/data/otp/sival_skus/BUILD
+++ b/hw/top_earlgrey/data/otp/sival_skus/BUILD
@@ -42,11 +42,12 @@ otp_json(
                 # and not listed directly in this configuration.
                 "CREATOR_SW_CFG_AST_INIT_EN": otp_hex(CONST.MUBI4_TRUE),
                 "CREATOR_SW_CFG_ROM_EXT_SKU": otp_hex(0x0),
-                # Enable SPX+ signature verification. See the definitions of
+                # TODO(#26060): Temporarily disable SPX verification.
+                # Disable SPX+ signature verification. See the definitions of
                 # `kSigverifySpxDisabledOtp` in
                 # sw/device/silicon_creator/lib/sigverify/spx_verify.h for
-                # details on how to disable this feature.
-                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x0),
+                # details on how to enable this feature.
+                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x8d6c8c17),
                 # Enable flash data page scrambling and ECC.
                 "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
                 "CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG": otp_hex(0x0),

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -242,7 +242,8 @@ opentitan_binary(
     immutable_rom_ext_sections = SLOT_A_IMM_ROM_EXT_SECTIONS["main"],
     linker_script = ":ld_slot_a",
     manifest = ":manifest",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+    # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
+    #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -271,7 +272,8 @@ opentitan_binary(
     immutable_rom_ext_sections = SLOT_B_IMM_ROM_EXT_SECTIONS["main"],
     linker_script = ":ld_slot_b",
     manifest = ":manifest",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+    # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
+    #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -58,7 +58,8 @@ opentitan_binary(
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_a",
     linkopts = LINK_ORDER,
     manifest = ":manifest_sival",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+    # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
+    #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
@@ -85,7 +86,8 @@ opentitan_binary(
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_b",
     linkopts = LINK_ORDER,
     manifest = ":manifest_sival",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+    # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
+    #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",


### PR DESCRIPTION
See #26060 for the rationale and plan for re-enabling SPX signatures.