### PR TITLE
[bazel,airgapped] fetch earlgrey_1.0.0 bitstreams

### DIFF
--- a/rules/bitstreams.bzl
+++ b/rules/bitstreams.bzl
@@ -61,6 +61,7 @@ def _bitstreams_repo_impl(rctx):
         [
             rctx.path(rctx.attr.python_interpreter),
             rctx.attr._cache_manager,
+            "--branch=earlgrey_1.0.0",
             "--build-file=BUILD.bazel",
             "--bucket-url={}".format(rctx.attr.bucket_url),
             "--cache={}".format(cache_path),

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -61,6 +61,9 @@ parser.add_argument('--create-symlink', default=True,
 parser.add_argument('--latest-update',
                     default='latest.txt',
                     help='Last time the cache was updated')
+parser.add_argument('--branch',
+                    default="master",
+                    help='Upstream git branch to search for bitstreams.')
 parser.add_argument('--bucket-url', default=BUCKET_URL, help='GCP Bucket URL')
 parser.add_argument('--build-file',
                     default='BUILD.bazel',
@@ -160,7 +163,7 @@ class BitstreamCache(object):
         response = urllib.request.urlopen(url)
         return response.read()
 
-    def GetBitstreamsAvailable(self, refresh, load_latest_update=True):
+    def GetBitstreamsAvailable(self, branch, refresh, load_latest_update=True):
         """Inventory which bitstreams are available.
 
         Args:
@@ -208,7 +211,7 @@ class BitstreamCache(object):
             else:
                 break
 
-        latest = self.Get('master/latest.txt').decode('utf-8').split('\n')
+        latest = self.Get(f'{branch}/latest.txt').decode('utf-8').split('\n')
         self.available['latest'] = latest[1]
 
     def GetClosest(self, repodir, key):
@@ -539,7 +542,7 @@ def main(argv):
                     cache.NeedRefresh(args.refresh_time))
     # Do we need to load the latest_update file?
     load_latest_update = (desired_bitstream == 'latest')
-    cache.GetBitstreamsAvailable(need_refresh and not args.offline,
+    cache.GetBitstreamsAvailable(args.branch, need_refresh and not args.offline,
                                  load_latest_update)
 
     # If commanded to print bitstream availability, do so.

--- a/rules/scripts/bitstreams_workspace_test.py
+++ b/rules/scripts/bitstreams_workspace_test.py
@@ -201,7 +201,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
             name='cache.Get',
             side_effect=MOCKED_GET_RETURN,
         )
-        self.cache.GetBitstreamsAvailable(refresh=True)
+        self.cache.GetBitstreamsAvailable(branch="earlgrey_1.0.0", refresh=True)
         self.assertEqual(self.cache.Get.call_count, 2)
         self.assertEqual(self.cache.available, {
             "0": "master/bitstream-0.tar.gz",
@@ -257,7 +257,7 @@ class TestFetchAvailableBitstreams(unittest.TestCase):
             name='cache.Get',
             side_effect=MOCKED_GET_RETURN,
         )
-        self.cache.GetBitstreamsAvailable(refresh=True)
+        self.cache.GetBitstreamsAvailable(branch="earlgrey_1.0.0", refresh=True)
         self.assertEqual(self.cache.Get.call_count, 3)
         self.assertEqual(
             self.cache.available, {

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -167,7 +167,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   readonly LATEST_BISTREAM_HASH_FILE="${SYSTEM_BITSTREAM_CACHE}/latest.txt"
   # The revision named in latest.txt is not necessarily on disk. Induce the
   # cache backend to fetch the latest bitstreams.
-  BITSTREAM=latest ${BAZELISK} fetch @bitstreams//...
+  BITSTREAM="latest" ${BAZELISK} fetch @bitstreams//...
   cp "${LATEST_BISTREAM_HASH_FILE}" \
     "${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHE}/"
   LATEST_BISTREAM_HASH=$(cat "${LATEST_BISTREAM_HASH_FILE}")


### PR DESCRIPTION
Bitstream schemas can change on the main branch so we want to fetch the earlgrey_1.0.0 bitstreams in particular.