### PR TITLE
sphincsplus: accept PUB key as PEM encoded ASN.1 objects

### DIFF
--- a/sw/host/sphincsplus/BUILD
+++ b/sw/host/sphincsplus/BUILD
@@ -60,6 +60,7 @@ rust_library(
     deps = [
         ":bindgen_sha2_128s_simple",
         ":bindgen_shake_128s_simple",
+        "@crate_index//:asn1",
         "@crate_index//:pem-rfc7468",
         "@crate_index//:serde",
         "@crate_index//:strum",

--- a/sw/host/sphincsplus/key.rs
+++ b/sw/host/sphincsplus/key.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{DecodeKey, EncodeKey, SphincsPlus, SpxError};
+use asn1::{BitString, ObjectIdentifier, ParseResult};
 use pem_rfc7468::LineEnding;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -167,6 +168,9 @@ impl EncodeKey for SpxSecretKey {
 }
 
 impl SpxPublicKey {
+    const OID_SHA2_128S_SPX_PUBLIC_KEY: ObjectIdentifier =
+        asn1::oid!(2, 16, 840, 1, 101, 3, 4, 3, 35);
+
     /// Creates a SPHINCS+ public key from raw bytes.
     pub fn from_bytes(algorithm: SphincsPlus, bytes: &[u8]) -> Result<Self, SpxError> {
         if algorithm.public_key_len() != bytes.len() {
@@ -193,6 +197,35 @@ impl SpxPublicKey {
         let msg = domain.prepare(msg);
         self.algorithm.verify(&self.key, signature, &msg)
     }
+
+    fn parse_asn1_public_key(key: &[u8], label: &str) -> Result<Self, SpxError> {
+        // The PEM block is not a raw key, maybe it is an ASN.1 object.
+        let r: ParseResult<(ObjectIdentifier, &[u8])> = asn1::parse(key, |d| {
+            d.read_element::<asn1::Sequence>()?.parse(|d| {
+                let oid: ObjectIdentifier = d.read_element::<asn1::Sequence>()?.parse(|d| {
+                    let oid = d.read_element::<ObjectIdentifier>()?;
+                    Ok(oid)
+                })?;
+                let key = d.read_element::<BitString>()?.as_bytes();
+                Ok((oid, key))
+            })
+        });
+        let (oid, key) = match r {
+            Ok((oid, key)) => (oid, key),
+            Err(_) => return Err(SpxError::ParseError(format!("Not a RAW key {label:?}"))),
+        };
+
+        if oid == Self::OID_SHA2_128S_SPX_PUBLIC_KEY && key.len() == 32 {
+            Ok(SpxPublicKey {
+                algorithm: SphincsPlus::Sha2128sSimple,
+                key: key.to_vec(),
+            })
+        } else {
+            Err(SpxError::ParseError(format!(
+                "Not an expected SPX ASN.1: {label:?}"
+            )))
+        }
+    }
 }
 
 impl DecodeKey for SpxPublicKey {
@@ -210,7 +243,7 @@ impl DecodeKey for SpxPublicKey {
             return Err(SpxError::ParseError(format!("not a public key: {label:?}")));
         }
         if !algorithm.starts_with("RAW:") {
-            return Err(SpxError::ParseError(format!("not a RAW key: {label:?}")));
+            return Self::parse_asn1_public_key(&key, label);
         }
         let algorithm = algorithm[4..].replace('_', "-");
         let algorithm = SphincsPlus::from_str(&algorithm).map_err(SpxError::Strum)?;


### PR DESCRIPTION
Some HSMs distribute SPX pub keys as PEM encoded ANS.1 objects. The approach so far has been to manually extract the 32 byte key material from the object. This patch adds parsing code for processing the ANS.1 key files.

The supported algorithm is slh-dsa-sha2-128s-with-sha256, its OID is defined in
https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration#heading1725030685275_13

Tested on an opentitatn owner's firmware by passing to --spx-key first the raw SPX key and then the HSM generated PEM file, and observing the unchanged contents of the resulting image.

Signed-off-by: Vadim Bendebury <vbendeb@chromium.org>
(cherry picked from commit fb326fc736e955f3a6f2d8db44de03c430b9b9b1)