### PR TITLE
[sram-exec] Avoid using compressed instructions when loading sp.

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/sram_start.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.S
@@ -133,7 +133,10 @@ sram_start:
 
 .L_crc_match:
   // Set up the stack.
+  .option push
+  .option norelax
   la  sp, _stack_end
+  .option pop
 
   /**
    * Setup the interrupt/exception handlers.


### PR DESCRIPTION
This changes solves an issue that caused larger programs to return the following linker error:

```
relocation truncated to fit: R_RISCV_GPREL_I against symbol `_stack_end' defined in .sram_start
```

Using the `norelax` option avoids the use of compressed instructions which was causing the `_stack_end` address calculation error.

Patch submitted by cfrantz@google.com.