### PR TITLE
[rules] Rename and change semantic of `extra_bazel_features`

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -49,11 +49,13 @@ def ot_binary(ctx, **kwargs):
       (elf_file, map_file) File objects.
     """
     cc_toolchain = find_cc_toolchain(ctx)
+    transitive_features = [f for f in ctx.attr.transitive_features if not f.startswith("-")]
+    transitive_disabled_features = [f.removeprefix("-") for f in ctx.attr.transitive_features if f.startswith("-")]
     features = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
-        requested_features = get_override(ctx, "features", kwargs),
-        unsupported_features = get_override(ctx, "disabled_features", kwargs),
+        requested_features = get_override(ctx, "features", kwargs) + transitive_features,
+        unsupported_features = get_override(ctx, "disabled_features", kwargs) + transitive_disabled_features,
     )
 
     compilation_contexts = [
@@ -271,6 +273,22 @@ def _opentitan_binary(ctx):
     providers.append(OutputGroupInfo(**groups))
     return providers
 
+def _transitive_feature_transition_impl(settings, attr):
+    features = settings["//command_line_option:features"] + attr.transitive_features
+    return {
+        "//command_line_option:features": features,
+    }
+
+_transitive_feature_transition = transition(
+    implementation = _transitive_feature_transition_impl,
+    inputs = [
+        "//command_line_option:features",
+    ],
+    outputs = [
+        "//command_line_option:features",
+    ],
+)
+
 common_binary_attrs = {
     "srcs": attr.label_list(
         allow_files = True,
@@ -278,6 +296,7 @@ common_binary_attrs = {
     ),
     "deps": attr.label_list(
         providers = [CcInfo],
+        cfg = _transitive_feature_transition,
         doc = "The list of other libraries to be linked in to the binary target.",
     ),
     "linker_script": attr.label(
@@ -345,6 +364,10 @@ common_binary_attrs = {
     "immutable_rom_ext_sections": attr.label_list(
         providers = [CcInfo],
         doc = "The list of immutable ROM_EXT sections to be linked in to the binary target.  Only the deps matched with the specific exec_env will be kept.",
+    ),
+    "transitive_features": attr.string_list(
+        default = [],
+        doc = "List of features that will apply to this binary, and transitively to all `deps`.",
     ),
 }
 

--- a/rules/rv.bzl
+++ b/rules/rv.bzl
@@ -19,11 +19,9 @@ PER_DEVICE_DEPS = {
 }
 
 def _opentitan_transition_impl(settings, attr):
-    features = settings["//command_line_option:features"] + attr.extra_bazel_features
     return {
         "//command_line_option:platforms": attr.platform,
         "//command_line_option:copt": settings["//command_line_option:copt"],
-        "//command_line_option:features": features,
         "//hw/bitstream/universal:rom": "//hw/bitstream/universal:none",
         "//hw/bitstream/universal:otp": "//hw/bitstream/universal:none",
         "//hw/bitstream/universal:env": "//hw/bitstream/universal:none",
@@ -38,12 +36,10 @@ opentitan_transition = transition(
     #   present in the englishbreakfast rv32i implementation.
     inputs = [
         "//command_line_option:copt",
-        "//command_line_option:features",
     ],
     outputs = [
         "//command_line_option:platforms",
         "//command_line_option:copt",
-        "//command_line_option:features",
         "//hw/bitstream/universal:rom",
         "//hw/bitstream/universal:otp",
         "//hw/bitstream/universal:env",
@@ -59,8 +55,6 @@ def rv_rule(**kwargs):
     attrs = kwargs.pop("attrs", {})
     if "platform" not in attrs:
         attrs["platform"] = attr.string(default = OPENTITAN_PLATFORM)
-    if "extra_bazel_features" not in attrs:
-        attrs["extra_bazel_features"] = attr.string_list(default = [])
     attrs["_allowlist_function_transition"] = attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
     )

--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -100,12 +100,12 @@ ld_library(
 opentitan_binary(
     name = "main_binaries_slot_a",
     exec_env = DEFAULT_EXEC_ENV,
-    extra_bazel_features = [
+    linker_script = ":ld_slot_a",
+    manifest = "//hw/top_earlgrey:none_manifest",
+    transitive_features = [
         "minsize",
         "use_lld",
     ],
-    linker_script = ":ld_slot_a",
-    manifest = "//hw/top_earlgrey:none_manifest",
     deps = [
         ":main_lib",
         "//sw/device/lib/crt",
@@ -124,12 +124,12 @@ opentitan_binary(
 opentitan_binary(
     name = "main_binaries_slot_b",
     exec_env = DEFAULT_EXEC_ENV,
-    extra_bazel_features = [
+    linker_script = ":ld_slot_b",
+    manifest = "//hw/top_earlgrey:none_manifest",
+    transitive_features = [
         "minsize",
         "use_lld",
     ],
-    linker_script = ":ld_slot_b",
-    manifest = "//hw/top_earlgrey:none_manifest",
     deps = [
         ":main_lib",
         "//sw/device/lib/crt",
@@ -148,12 +148,12 @@ opentitan_binary(
 opentitan_binary(
     name = "main_binaries_slot_virtual",
     exec_env = DEFAULT_EXEC_ENV,
-    extra_bazel_features = [
+    linker_script = ":ld_slot_virtual",
+    manifest = "//hw/top_earlgrey:none_manifest",
+    transitive_features = [
         "minsize",
         "use_lld",
     ],
-    linker_script = ":ld_slot_virtual",
-    manifest = "//hw/top_earlgrey:none_manifest",
     deps = [
         ":main_lib",
         "//sw/device/lib/crt",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -223,6 +223,11 @@ manifest(d = {
     "security_version": ROM_EXT_VERSION.SECURITY,
 })
 
+ROM_EXT_FEATURES = [
+    "minsize",
+    "use_lld",
+]
+
 opentitan_binary(
     name = "rom_ext_slot_a",
     testonly = True,
@@ -235,15 +240,12 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
     immutable_rom_ext_sections = SLOT_A_IMM_ROM_EXT_SECTIONS["main"],
     linker_script = ":ld_slot_a",
     manifest = ":manifest",
     # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
     #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+    transitive_features = ROM_EXT_FEATURES,
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -265,15 +267,12 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
     immutable_rom_ext_sections = SLOT_B_IMM_ROM_EXT_SECTIONS["main"],
     linker_script = ":ld_slot_b",
     manifest = ":manifest",
     # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
     #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+    transitive_features = ROM_EXT_FEATURES,
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -295,13 +294,10 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
     immutable_rom_ext_sections = SLOT_VIRTUAL_IMM_ROM_EXT_SECTIONS["main"],
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest",
+    transitive_features = ROM_EXT_FEATURES,
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -323,13 +319,10 @@ opentitan_binary(
             "//hw/top_earlgrey:sim_verilator_base",
             "//hw/top_earlgrey:silicon_creator",
         ],
-        extra_bazel_features = [
-            "minsize",
-            "use_lld",
-        ],
         immutable_rom_ext_sections = imm_rom_ext_sections,
         linker_script = ":ld_slot_virtual",
         manifest = ":manifest",
+        transitive_features = ROM_EXT_FEATURES,
         deps = [
             ":rom_ext",
             "//sw/device/lib/crt",
@@ -356,12 +349,9 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
     linker_script = ":ld_slot_a",
     manifest = ":manifest_bad_address_translation",
+    transitive_features = ROM_EXT_FEATURES,
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -42,6 +42,11 @@ manifest(d = {
     "visibility": ["//visibility:private"],
 })
 
+ROM_EXT_FEATURES = [
+    "minsize",
+    "use_lld",
+]
+
 # To test that the prod-signed SiVAL ROM_EXT boots on the FPGA, you need a bitstream
 # with the sival keys pre-programmed into OTP.
 # You can manually create such a bitstream with:
@@ -58,14 +63,11 @@ manifest(d = {
             "//hw/top_earlgrey:sim_dv_base",
             "//hw/top_earlgrey:sim_verilator_base",
         ],
-        extra_bazel_features = [
-            "minsize",
-            "use_lld",
-        ],
         immutable_rom_ext_sections = imm_sections["main"],
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = LINK_ORDER,
         manifest = ":manifest_sival",
+        transitive_features = ROM_EXT_FEATURES,
         # TODO(#26060): Temporarily disable SPX signing of ROM_EXT.
         #spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
         deps = [
@@ -86,13 +88,10 @@ manifest(d = {
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:fpga_cw340",
         ],
-        extra_bazel_features = [
-            "minsize",
-            "use_lld",
-        ],
         immutable_rom_ext_sections = imm_sections["main"],
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = LINK_ORDER,
+        transitive_features = ROM_EXT_FEATURES,
         deps = [
             ":sival_owner",
             "//sw/device/lib/crt",


### PR DESCRIPTION
The `extra_bazel_features` attribute was added #25840 as an attribute to `rv_rule` to transitively add features to the rule. However this is too general because when applied to opentitan_binary, it will change the features not only for the rule, but all its dependencies such as exec_env, tools,  etc which may have unintended effects.

This commit keeps essentially the same logic but instead of applying it to `rv_rule`, it is now only an attribute of `opentitan_binary` and `opentitan_test` and it transitions only features for the `deps`. This attribute is also renamed to `transitive_features`. The rationale for the rename is that every bazel rule has an implicit `features` argument but it only applies to the target, not its dependencies. This attribute does the same but also applies transitively.