### PR TITLE
[dd, prim_reg_cdc_arb] state signal width reduction

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -87,7 +87,7 @@ module prim_reg_cdc_arb #(
     SelHwReq
   } req_sel_e;
 
-  typedef enum logic [1:0] {
+  typedef enum logic {
     StIdle,
     StWait
   } state_e;


### PR DESCRIPTION
Removing unused upper bit of state_q/d signals