### PR TITLE
[reggen] Render the number of registers

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -14,6 +14,9 @@ package adc_ctrl_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 32;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -15,6 +15,9 @@ package aes_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 34;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -12,6 +12,9 @@ package aon_timer_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 6;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 14;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -13,6 +13,9 @@ package csrng_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 24;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -13,6 +13,9 @@ package dma_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 9;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 63;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -16,6 +16,9 @@ package edn_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 18;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -13,6 +13,9 @@ package entropy_src_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 57;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -10,13 +10,13 @@ module gpio
   import gpio_pkg::*;
   import gpio_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn          = {NumAlerts{1'b1}},
-  parameter bit                   GpioAsHwStrapsEn      = 1,
+  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                   GpioAsHwStrapsEn          = 1,
   // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
-  parameter bit                   GpioAsyncOn          = 1,
-  parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = 1'b1,
-  parameter int unsigned          RaclPolicySelVec[18] = '{18{0}}
+  parameter bit                   GpioAsyncOn               = 1,
+  parameter bit                   EnableRacl                = 1'b0,
+  parameter bit                   RaclErrorRsp              = 1'b1,
+  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_pkg.sv
@@ -12,6 +12,9 @@ package gpio_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 18;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -10,7 +10,7 @@ module gpio_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[18] = '{18{0}}
+    parameter int unsigned RaclPolicySelVec[gpio_reg_pkg::NumRegs] = '{gpio_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -14,6 +14,9 @@ package hmac_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 13;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 59;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -9,11 +9,11 @@
 module i2c
   import i2c_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
-  parameter int unsigned          InputDelayCycles     = 0,
-  parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[32] = '{32{0}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter int unsigned          InputDelayCycles          = 0,
+  parameter bit                   EnableRacl                = 1'b0,
+  parameter bit                   RaclErrorRsp              = EnableRacl,
+  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input                                    clk_i,
   input                                    rst_ni,

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -14,6 +14,9 @@ package i2c_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 32;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -10,7 +10,7 @@ module i2c_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[32] = '{32{0}}
+    parameter int unsigned RaclPolicySelVec[i2c_reg_pkg::NumRegs] = '{i2c_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -16,6 +16,9 @@ package keymgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 63;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -17,6 +17,9 @@ package keymgr_dpe_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 53;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -18,6 +18,9 @@ package kmac_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 12;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 57;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -24,6 +24,10 @@ package lc_ctrl_reg_pkg;
   parameter int RegsAw = 8;
   parameter int DmiAw = 12;
 
+  // Number of registers for every interface
+  parameter int NumRegsRegs = 35;
+  parameter int NumRegsDmi = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -8,17 +8,17 @@ module mbx
   import tlul_pkg::*;
   import mbx_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
-  parameter int unsigned CfgSramAddrWidth         = 32,
-  parameter int unsigned CfgSramDataWidth         = 32,
-  parameter int unsigned CfgObjectSizeWidth       = 11,
-  parameter bit          DoeIrqSupport            = 1'b1,
-  parameter bit          DoeAsyncMsgSupport       = 1'b1,
-  parameter bit          EnableRacl               = 1'b0,
-  parameter bit          RaclErrorRsp             = EnableRacl,
-  parameter int unsigned RaclPolicySelVecSoc[4]   = '{4{0}},
-  parameter int unsigned RaclPolicySelWinSocWdata = 0,
-  parameter int unsigned RaclPolicySelWinSocRdata = 0
+  parameter logic [NumAlerts-1:0] AlertAsyncOn           = {NumAlerts{1'b1}},
+  parameter int unsigned CfgSramAddrWidth                = 32,
+  parameter int unsigned CfgSramDataWidth                = 32,
+  parameter int unsigned CfgObjectSizeWidth              = 11,
+  parameter bit          DoeIrqSupport                   = 1'b1,
+  parameter bit          DoeAsyncMsgSupport              = 1'b1,
+  parameter bit          EnableRacl                      = 1'b0,
+  parameter bit          RaclErrorRsp                    = EnableRacl,
+  parameter int unsigned RaclPolicySelVecSoc[NumRegsSoc] = '{NumRegsSoc{0}},
+  parameter int unsigned RaclPolicySelWinSocWdata        = 0,
+  parameter int unsigned RaclPolicySelWinSocRdata        = 0
 ) (
   input  logic                                      clk_i,
   input  logic                                      rst_ni,

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -13,6 +13,10 @@ package mbx_reg_pkg;
   parameter int CoreAw = 7;
   parameter int SocAw = 5;
 
+  // Number of registers for every interface
+  parameter int NumRegsCore = 17;
+  parameter int NumRegsSoc = 4;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -10,7 +10,7 @@ module mbx_soc_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[4] = '{4{0}}
+    parameter int unsigned RaclPolicySelVec[mbx_reg_pkg::NumRegsSoc] = '{mbx_reg_pkg::NumRegsSoc{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/mbx/rtl/mbx_sysif.sv
+++ b/hw/ip/mbx/rtl/mbx_sysif.sv
@@ -4,17 +4,18 @@
 
 module mbx_sysif
   import tlul_pkg::*;
+  import mbx_reg_pkg::*;
 #(
-  parameter int unsigned CfgSramAddrWidth         = 32,
-  parameter int unsigned CfgSramDataWidth         = 32,
+  parameter int unsigned CfgSramAddrWidth                = 32,
+  parameter int unsigned CfgSramDataWidth                = 32,
   // PCIe capabilities
-  parameter bit          DoeIrqSupport            = 1'b1,
-  parameter bit          DoeAsyncMsgSupport       = 1'b1,
-  parameter bit          EnableRacl               = 1'b0,
-  parameter bit          RaclErrorRsp             = 1'b1,
-  parameter int unsigned RaclPolicySelVecSoc[4]   = '{4{0}},
-  parameter int unsigned RaclPolicySelWinSocWdata = 0,
-  parameter int unsigned RaclPolicySelWinSocRdata = 0
+  parameter bit          DoeIrqSupport                   = 1'b1,
+  parameter bit          DoeAsyncMsgSupport              = 1'b1,
+  parameter bit          EnableRacl                      = 1'b0,
+  parameter bit          RaclErrorRsp                    = 1'b1,
+  parameter int unsigned RaclPolicySelVecSoc[NumRegsSoc] = '{NumRegsSoc{0}},
+  parameter int unsigned RaclPolicySelWinSocWdata        = 0,
+  parameter int unsigned RaclPolicySelWinSocRdata        = 0
 ) (
   input  logic                           clk_i,
   input  logic                           rst_ni,

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -12,6 +12,9 @@ package otbn_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 16;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 11;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -13,6 +13,9 @@ package pattgen_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 6;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 12;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/pwm/rtl/pwm.sv
+++ b/hw/ip/pwm/rtl/pwm.sv
@@ -7,12 +7,12 @@
 module pwm
   import pwm_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
-  parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[23] = '{23{0}},
-  parameter int                   PhaseCntDw           = 16,
-  parameter int                   BeatCntDw            = 27
+  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                   EnableRacl                = 1'b0,
+  parameter bit                   RaclErrorRsp              = EnableRacl,
+  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
+  parameter int                   PhaseCntDw                = 16,
+  parameter int                   BeatCntDw                 = 27
 ) (
   input                       clk_i,
   input                       rst_ni,

--- a/hw/ip/pwm/rtl/pwm_reg_pkg.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_pkg.sv
@@ -13,6 +13,9 @@ package pwm_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 23;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -10,7 +10,7 @@ module pwm_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[23] = '{23{0}}
+    parameter int unsigned RaclPolicySelVec[pwm_reg_pkg::NumRegs] = '{pwm_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
@@ -13,6 +13,10 @@ package rom_ctrl_reg_pkg;
   parameter int RegsAw = 7;
   parameter int RomAw = 1;
 
+  // Number of registers for every interface
+  parameter int NumRegsRegs = 18;
+  parameter int NumRegsRom = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -15,6 +15,9 @@ package rv_core_ibex_reg_pkg;
   // Address widths within the block
   parameter int CfgAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegsCfg = 25;
+
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
   //////////////////////////////////////////////

--- a/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_reg_pkg.sv
@@ -15,6 +15,11 @@ package rv_dm_reg_pkg;
   parameter int MemAw = 12;
   parameter int DbgAw = 9;
 
+  // Number of registers for every interface
+  parameter int NumRegsRegs = 3;
+  parameter int NumRegsMem = 281;
+  parameter int NumRegsDbg = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -14,6 +14,9 @@ package rv_timer_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 9;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 10;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/spi_device/lint/spi_device.vbl
+++ b/hw/ip/spi_device/lint/spi_device.vbl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for spi_device
+
+# waive long line violations in generated code
+waive --rule=line-length --location="spi_device_reg_top.sv"

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -8,9 +8,7 @@
 `include "prim_assert.sv"
 
 module spi_device
-  import spi_device_reg_pkg::NumAlerts;
-  import spi_device_reg_pkg::SPI_DEVICE_EGRESS_BUFFER_IDX;
-  import spi_device_reg_pkg::SPI_DEVICE_INGRESS_BUFFER_IDX;
+  import spi_device_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
   parameter spi_device_pkg::sram_type_e SramType       = spi_device_pkg::DefaultSramType,

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -35,6 +35,9 @@ package spi_device_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 13;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 73;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -10,7 +10,7 @@ module spi_device_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[73] = '{73{0}}
+    parameter int unsigned RaclPolicySelVec[spi_device_reg_pkg::NumRegs] = '{spi_device_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -67,6 +67,9 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
+    files:
+      - lint/spi_device.vbl
+    file_type: veribleLintWaiver
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/spi_host/lint/spi_host.vbl
+++ b/hw/ip/spi_host/lint/spi_host.vbl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for spi_host
+
+# waive long line violations in generated code
+waive --rule=line-length --location="spi_host_reg_top.sv"

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -11,13 +11,13 @@
 module spi_host
   import spi_host_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
-  parameter int unsigned          NumCS         = 1,
-  parameter bit          EnableRacl             = 1'b0,
-  parameter bit          RaclErrorRsp           = EnableRacl,
-  parameter int unsigned RaclPolicySelVec[12]   = '{12{0}},
-  parameter int unsigned RaclPolicySelWinRXDATA = 0,
-  parameter int unsigned RaclPolicySelWinTXDATA = 0
+  parameter logic [NumAlerts-1:0] AlertAsyncOn     = {NumAlerts{1'b1}},
+  parameter int unsigned          NumCS            = 1,
+  parameter bit          EnableRacl                = 1'b0,
+  parameter bit          RaclErrorRsp              = EnableRacl,
+  parameter int unsigned RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
+  parameter int unsigned RaclPolicySelWinRXDATA    = 0,
+  parameter int unsigned RaclPolicySelWinTXDATA    = 0
 ) (
   input              clk_i,
   input              rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -16,6 +16,9 @@ package spi_host_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 6;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 12;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -10,7 +10,7 @@ module spi_host_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[12] = '{12{0}}
+    parameter int unsigned RaclPolicySelVec[spi_host_reg_pkg::NumRegs] = '{spi_host_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/spi_host/spi_host.core
+++ b/hw/ip/spi_host/spi_host.core
@@ -52,6 +52,9 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
+    files:
+      - lint/spi_host.vbl
+    file_type: veribleLintWaiver
 
 parameters:
   SYNTHESIS:

--- a/hw/ip/sram_ctrl/lint/sram_ctrl.vbl
+++ b/hw/ip/sram_ctrl/lint/sram_ctrl.vbl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for sram_ctrl
+
+# waive long line violations in generated code
+waive --rule=line-length --location="sram_ctrl_regs_reg_top.sv"

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -12,26 +12,26 @@ module sram_ctrl
   import sram_ctrl_reg_pkg::*;
 #(
   // Number of words stored in the SRAM.
-  parameter int MemSizeRam                               = 32'h1000,
-  parameter int InstSize                                 = MemSizeRam,
-  parameter int NumRamInst                               = 1,
+  parameter int MemSizeRam                                 = 32'h1000,
+  parameter int InstSize                                   = MemSizeRam,
+  parameter int NumRamInst                                 = 1,
   // Enable asynchronous transitions on alerts.
-  parameter logic [NumAlerts-1:0] AlertAsyncOn           = {NumAlerts{1'b1}},
+  parameter logic [NumAlerts-1:0] AlertAsyncOn             = {NumAlerts{1'b1}},
   // Enables the execute from SRAM feature.
-  parameter bit InstrExec                                = 1,
+  parameter bit InstrExec                                  = 1,
   // Number of PRINCE half rounds for the SRAM scrambling feature, can be [1..5].
   // Note that this needs to be low-latency, hence we have to keep the amount of cipher rounds low.
   // PRINCE has 5 half rounds in its original form, which corresponds to 2*5 + 1 effective rounds.
   // Setting this to 3 lowers this to approximately 7 effective rounds.
-  parameter int NumPrinceRoundsHalf                      = 3,
+  parameter int NumPrinceRoundsHalf                        = 3,
   // Random netlist constants
-  parameter  otp_ctrl_pkg::sram_key_t   RndCnstSramKey   = RndCnstSramKeyDefault,
-  parameter  otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce = RndCnstSramNonceDefault,
-  parameter  lfsr_seed_t                RndCnstLfsrSeed  = RndCnstLfsrSeedDefault,
-  parameter  lfsr_perm_t                RndCnstLfsrPerm  = RndCnstLfsrPermDefault,
-  parameter bit          EnableRacl                      = 1'b0,
-  parameter bit          RaclErrorRsp                    = EnableRacl,
-  parameter int unsigned RaclPolicySelVecRegs[9]         = '{9{0}}
+  parameter  otp_ctrl_pkg::sram_key_t   RndCnstSramKey     = RndCnstSramKeyDefault,
+  parameter  otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce   = RndCnstSramNonceDefault,
+  parameter  lfsr_seed_t                RndCnstLfsrSeed    = RndCnstLfsrSeedDefault,
+  parameter  lfsr_perm_t                RndCnstLfsrPerm    = RndCnstLfsrPermDefault,
+  parameter bit          EnableRacl                        = 1'b0,
+  parameter bit          RaclErrorRsp                      = EnableRacl,
+  parameter int unsigned RaclPolicySelVecRegs[NumRegsRegs] = '{NumRegsRegs{0}}
 ) (
   // SRAM Clock
   input  logic                                               clk_i,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -13,6 +13,10 @@ package sram_ctrl_reg_pkg;
   parameter int RegsAw = 6;
   parameter int RamAw = 1;
 
+  // Number of registers for every interface
+  parameter int NumRegsRegs = 9;
+  parameter int NumRegsRam = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
   ///////////////////////////////////////////////

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -10,7 +10,7 @@ module sram_ctrl_regs_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[9] = '{9{0}}
+    parameter int unsigned RaclPolicySelVec[sram_ctrl_reg_pkg::NumRegsRegs] = '{sram_ctrl_reg_pkg::NumRegsRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/sram_ctrl/sram_ctrl.core
+++ b/hw/ip/sram_ctrl/sram_ctrl.core
@@ -42,6 +42,15 @@ filesets:
       - lint/sram_ctrl.waiver
     file_type: waiver
 
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/sram_ctrl.vbl
+    file_type: veribleLintWaiver
+
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -53,6 +62,7 @@ targets:
     filesets:
       - tool_verilator  ? (files_verilator_waiver)
       - tool_ascentlint ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
     toplevel: sram_ctrl
 

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
@@ -16,6 +16,9 @@ package sysrst_ctrl_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 8;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 43;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/trial1/rtl/trial1_reg_pkg.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_pkg.sv
@@ -9,6 +9,9 @@ package trial1_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 10;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 20;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -9,10 +9,10 @@
 module uart
     import uart_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[13] = '{13{0}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                   EnableRacl                = 1'b0,
+  parameter bit                   RaclErrorRsp              = EnableRacl,
+  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input           clk_i,
   input           rst_ni,

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -14,6 +14,9 @@ package uart_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 6;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 13;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -10,7 +10,7 @@ module uart_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[13] = '{13{0}}
+    parameter int unsigned RaclPolicySelVec[uart_reg_pkg::NumRegs] = '{uart_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -13,6 +13,9 @@ package usbdev_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 12;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 43;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -12,12 +12,9 @@ module ${module_instance_name}
   import prim_esc_pkg::*;
 #(
 % if racl_support:
-  parameter bit                   EnableRacl           = 1'b0,
-  parameter bit                   RaclErrorRsp         = EnableRacl,
-<% 
-num_regs = 6 + 4 * n_alerts + 4 * 7 + n_classes * 14
-%>\
-  parameter int unsigned          RaclPolicySelVec[${num_regs}] = '{${num_regs}{0}},
+  parameter bit          EnableRacl                = 1'b0,
+  parameter bit          RaclErrorRsp              = EnableRacl,
+  parameter int unsigned RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
 % endif
   // Compile time random constants, to be overriden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -25,13 +25,9 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   // and routing the source clocks / resets to the PLIC).
   parameter logic [NumSrc-1:0]    LevelEdgeTrig = '0, // 0: level, 1: edge
 % if racl_support:
-  parameter bit                   EnableRacl    = 1'b0,
-  parameter bit                   RaclErrorRsp  = EnableRacl,
-<% 
-from math import ceil
-num_regs = src + ceil(src / 32) + target * ceil(src / 32) + 3 * target + 1
-%>\
-  parameter int unsigned          RaclPolicySelVec[${num_regs}] = '{${num_regs}{0}},
+  parameter bit                   EnableRacl                = 1'b0,
+  parameter bit                   RaclErrorRsp              = EnableRacl,
+  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
 % endif
   // derived parameter
   localparam int SRCW    = $clog2(NumSrc)

--- a/hw/top_darjeeling/ip/ast/rtl/ast_reg_pkg.sv
+++ b/hw/top_darjeeling/ip/ast/rtl/ast_reg_pkg.sv
@@ -13,6 +13,9 @@ package ast_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 10;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 36;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_reg_pkg.sv
@@ -14,6 +14,10 @@ package soc_proxy_reg_pkg;
   parameter int CoreAw = 4;
   parameter int CtnAw = 1;
 
+  // Number of registers for every interface
+  parameter int NumRegsCore = 4;
+  parameter int NumRegsCtn = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -237,6 +237,9 @@ package alert_handler_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 11;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 494;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -15,6 +15,9 @@ package clkmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 18;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -294,6 +294,10 @@ package otp_ctrl_reg_pkg;
   parameter int CoreAw = 15;
   parameter int PrimAw = 5;
 
+  // Number of registers for every interface
+  parameter int NumRegsCore = 95;
+  parameter int NumRegsPrim = 8;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -18,6 +18,9 @@ package pinmux_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 11;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 503;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -24,6 +24,9 @@ package pwrmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 17;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -13,6 +13,9 @@ package racl_ctrl_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 5;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 5;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -17,6 +17,9 @@ package rstmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 18;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -15,6 +15,9 @@ package rv_plic_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 27;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 172;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
@@ -13,6 +13,9 @@ package ast_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 10;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 44;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -16,6 +16,9 @@ package sensor_ctrl_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 29;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -165,6 +165,9 @@ package alert_handler_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 11;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 350;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -15,6 +15,9 @@ package clkmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 22;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -31,6 +31,11 @@ package flash_ctrl_reg_pkg;
   parameter int PrimAw = 7;
   parameter int MemAw = 1;
 
+  // Number of registers for every interface
+  parameter int NumRegsCore = 108;
+  parameter int NumRegsPrim = 21;
+  parameter int NumRegsMem = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -274,6 +274,10 @@ package otp_ctrl_reg_pkg;
   parameter int CoreAw = 12;
   parameter int PrimAw = 5;
 
+  // Number of registers for every interface
+  parameter int NumRegsCore = 56;
+  parameter int NumRegsPrim = 8;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -18,6 +18,9 @@ package pinmux_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 12;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 568;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -26,6 +26,9 @@ package pwrmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 17;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -17,6 +17,9 @@ package rstmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 28;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -15,6 +15,9 @@ package rv_plic_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 27;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 202;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_pkg.sv
@@ -13,6 +13,9 @@ package ast_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 10;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 44;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -15,6 +15,9 @@ package clkmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 20;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -31,6 +31,11 @@ package flash_ctrl_reg_pkg;
   parameter int PrimAw = 7;
   parameter int MemAw = 1;
 
+  // Number of registers for every interface
+  parameter int NumRegsCore = 108;
+  parameter int NumRegsPrim = 21;
+  parameter int NumRegsMem = 0;
+
   ///////////////////////////////////////////////
   // Typedefs for registers for core interface //
   ///////////////////////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -18,6 +18,9 @@ package pinmux_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 12;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 520;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -23,6 +23,9 @@ package pwrmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 17;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -17,6 +17,9 @@ package rstmgr_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 7;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 18;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -15,6 +15,9 @@ package rv_plic_reg_pkg;
   // Address widths within the block
   parameter int BlockAw = 27;
 
+  // Number of registers for every interface
+  parameter int NumRegs = 98;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -380,6 +380,11 @@ package ${lblock}${"_" + block.alias_impl if block.alias_impl else ""}_reg_pkg;
 % for param_name, width in addr_widths.values():
   parameter int ${param_name} = ${width};
 % endfor
+
+  // Number of registers for every interface
+% for iface_name, rb in block.reg_blocks.items():
+  parameter int NumRegs${iface_name.title() if iface_name else ""} = ${len(rb.flat_regs)};
+% endfor
 <%
   just_default = len(block.reg_blocks) == 1 and None in block.reg_blocks
 %>\

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -28,6 +28,9 @@
   lblock = block.name.lower()
   ublock = lblock.upper()
 
+  reg_pkg = f'{lblock}{alias_impl}_reg_pkg'
+  num_regs = f'NumRegs{if_name.title() if if_name else ""}'
+
   u_mod_base = mod_base.upper()
 
   reg2hw_t = gen_rtl.get_iface_tx_type(block, if_name, False)
@@ -125,7 +128,7 @@ module ${mod_name}${' (' if not racl_support else ''}
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1${"," if dynamic_racl_support else ""}
   % if dynamic_racl_support:
-    parameter int unsigned RaclPolicySelVec[${len(rb.flat_regs)}] = '{${len(rb.flat_regs)}{0}}
+    parameter int unsigned RaclPolicySelVec[${reg_pkg}::${num_regs}] = '{${reg_pkg}::${num_regs}{0}}
   % endif
   ) (
 % endif
@@ -149,10 +152,10 @@ module ${mod_name}${' (' if not racl_support else ''}
 % endif
   // To HW
 % if rb.get_n_bits(["q","qe","re"]):
-  output ${lblock}${alias_impl}_reg_pkg::${reg2hw_t} reg2hw, // Write
+  output ${reg_pkg}::${reg2hw_t} reg2hw, // Write
 % endif
 % if rb.get_n_bits(["d","de"]):
-  input  ${lblock}${alias_impl}_reg_pkg::${hw2reg_t} hw2reg, // Read
+  input  ${reg_pkg}::${hw2reg_t} hw2reg, // Read
 % endif
 
 % if rb.has_internal_shadowed_reg():
@@ -173,7 +176,7 @@ module ${mod_name}${' (' if not racl_support else ''}
   output logic intg_err_o
 );
 
-  import ${lblock}${alias_impl}_reg_pkg::* ;
+  import ${reg_pkg}::* ;
 
 % if needs_aw:
   localparam int AW = ${addr_width};


### PR DESCRIPTION
This PR renders a constant for the number of registers per interface. It's not yet used though in the individual IPs that use them. I want to wait until the naming is approved.