### PR TITLE
[hw,racl_ctrl,doc] Uniquify hjson path when calling regtool

### DIFF
--- a/hw/ip_templates/racl_ctrl/doc/interfaces.md.tpl
+++ b/hw/ip_templates/racl_ctrl/doc/interfaces.md.tpl
@@ -1,4 +1,4 @@
 ${"#"} Hardware Interfaces
 
-<!-- BEGIN CMDGEN util/regtool.py --interfaces ./hw/top_${topname}/ip_autogen/racl_ctrl/data/racl_ctrl.hjson -->
+<!-- BEGIN CMDGEN util/regtool.py --interfaces ./hw/top_${topname}/ip_autogen/${module_instance_name}/data/${module_instance_name}.hjson -->
 <!-- END CMDGEN -->

--- a/hw/ip_templates/racl_ctrl/doc/registers.md.tpl
+++ b/hw/ip_templates/racl_ctrl/doc/registers.md.tpl
@@ -1,4 +1,4 @@
 ${"#"} Registers
 
-<!-- BEGIN CMDGEN util/regtool.py -d ./hw/top_${topname}/ip_autogen/racl_ctrl/data/racl_ctrl.hjson -->
+<!-- BEGIN CMDGEN util/regtool.py -d ./hw/top_${topname}/ip_autogen/${module_instance_name}/data/${module_instance_name}.hjson -->
 <!-- END CMDGEN -->


### PR DESCRIPTION
Use the uniquified path when generating the register and interface description.