### PR TITLE
[bazel,python] re-enable building of airgapped python wheels repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ python_deps()
 load("//third_party/python:pip.bzl", "pip_deps")
 pip_deps()
 load("//third_party/python:requirements.bzl", install_ot_python_deps="install_deps")
-install_ot_python_deps()
+install_ot_python_deps(local_wheels_repo_target = "@ot_python_wheels//:sanitized_requirements.txt")
 
 # Google/Bazel dependencies.  This needs to be after Python initialization
 # so that our preferred python configuration takes precedence.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,7 +68,7 @@ fuzzing_repos()
 load("//third_party/google:fuzzing_deps.bzl", "fuzzing_deps")
 fuzzing_deps()
 load("@fuzzing_py_deps//:requirements.bzl", install_fuzzing_python_deps="install_deps")
-install_fuzzing_python_deps()
+install_fuzzing_python_deps(local_wheels_repo_target = "@ot_python_wheels//:sanitized_requirements.txt")
 
 # Rust Toolchain + crates.io Dependencies
 load("//third_party/rust:repos.bzl", "rust_repos")

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -23,7 +23,7 @@ sudo ip netns exec airgapped ip link set dev lo up
 sudo ip netns exec airgapped sudo -u "$USER" \
   env \
     BAZEL_BITSTREAMS_CACHE="${PWD}/bazel-airgapped/bitstreams-cache" \
-    OT_AIRGAPPED="true"                                              \
+    BAZEL_PYTHON_WHEELS_REPO="${PWD}/bazel-airgapped/ot_python_wheels" \
     BITSTREAM="--offline latest"                                     \
   "${PWD}/bazel-airgapped/bazel" build                               \
     --distdir="${PWD}/bazel-airgapped/bazel-distdir"                 \

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -8,6 +8,9 @@ set -ex
 # Prefetch bazel airgapped dependencies.
 util/prep-bazel-airgapped-build.sh -f
 
+# Clean out bazel cache so no remnants exist for test.
+"${PWD}/bazel-airgapped/bazel" clean --expunge
+
 # Remove the airgapped network namespace.
 remove_airgapped_netns() {
   sudo ip netns delete airgapped

--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -109,7 +109,7 @@ ifneq (${sw_images},)
 			if [[ -n $${BAZEL_OTP_DATA_PERM_FLAG} ]]; then \
 				bazel_opts+=" --//hw/ip/otp_ctrl/data:data_perm=$${BAZEL_OTP_DATA_PERM_FLAG}"; \
 			fi; \
-			if [[ $${OT_AIRGAPPED} != true ]]; then \
+			if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \
 				echo "Building \"$${bazel_label}\" on network connected machine."; \
 				bazel_cmd="./bazelisk.sh"; \
 			else \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ dependencies = [
   "types-pyyaml==6.0.11",
   "types-tabulate==0.8.11",
 
+  # Dependencies of rules_fuzzing.
+  "absl-py==2.0.0",
+  "six==1.16.0",
+
   # Dependency of sw/host/vendor/google_verible_verilog_syntax_py
   "anytree==2.8.0",
 

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -5,6 +5,9 @@
 # THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
 # ./util/sh/scripts/gen-python-requirements.sh
 
+absl-py==2.0.0 \
+    --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3 \
+    --hash=sha256:d9690211c5fcfefcdd1a45470ac2b5c5acd45241c3af71eed96bc5441746c0d5
 anytree==2.8.0 \
     --hash=sha256:14c55ac77492b11532395049a03b773d14c7e30b22aa012e337b1e983de31521 \
     --hash=sha256:3f0f93f355a91bc3e6245319bf4c1d50e3416cc7a35cc1133c1ff38306bbccab
@@ -711,9 +714,9 @@ semantic-version==2.10.0 \
 simplesat==0.9.1 \
     --hash=sha256:4f7d7a121ba13db987ea635205db8897d7d01220962e8a9c8cfd41b9886e6b8a \
     --hash=sha256:990115b1bb32a76c30b2416f645e99e61360382c795203e25ab59b26cd173749
-six==1.17.0 \
-    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
-    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+six==1.16.0 \
+    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
+    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
 smmap==5.0.2 \
     --hash=sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5 \
     --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e

--- a/third_party/google/no-hash-python-packages.patch
+++ b/third_party/google/no-hash-python-packages.patch
@@ -1,0 +1,12 @@
+diff --git a/fuzzing/init.bzl b/fuzzing/init.bzl
+index f8149d8..1823be7 100644
+--- a/fuzzing/init.bzl
++++ b/fuzzing/init.bzl
+@@ -20,7 +20,6 @@ load("@rules_python//python:pip.bzl", "pip_parse")
+ def rules_fuzzing_init():
+     pip_parse(
+         name = "fuzzing_py_deps",
+-        extra_pip_args = ["--require-hashes"],
+         requirements_lock = "@rules_fuzzing//fuzzing:requirements.txt",
+     )
+     bazel_skylib_workspace()

--- a/third_party/google/repos.bzl
+++ b/third_party/google/repos.bzl
@@ -64,4 +64,6 @@ def fuzzing_repos():
         sha256 = "e6bc219bfac9e1f83b327dd090f728a9f973ee99b9b5d8e5a184a2732ef08623",
         strip_prefix = "rules_fuzzing-0.5.2",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
+        patches = [Label("//third_party/google:no-hash-python-packages.patch")],
+        patch_args = ["-p1"],
     )

--- a/third_party/python/airgapped-wheels-cache.patch
+++ b/third_party/python/airgapped-wheels-cache.patch
@@ -1,0 +1,48 @@
+diff --git a/python/private/pypi/requirements.bzl.tmpl.workspace b/python/private/pypi/requirements.bzl.tmpl.workspace
+index 2f4bcd69..3e935465 100644
+--- a/python/private/pypi/requirements.bzl.tmpl.workspace
++++ b/python/private/pypi/requirements.bzl.tmpl.workspace
+@@ -64,7 +64,8 @@ def install_deps(**whl_library_kwargs):
+ 
+         whl_library(
+             name = name,
+-            requirement = requirement,
++            # Ignore hashes due to mismatches when caching wheels for airgapped builds.
++            requirement = requirement.split(" ")[0],
+             group_name = group_name,
+             group_deps = group_deps,
+             annotation = _get_annotation(requirement),
+diff --git a/python/private/pypi/whl_library.bzl b/python/private/pypi/whl_library.bzl
+index 612ca2cf..44d6aba8 100644
+--- a/python/private/pypi/whl_library.bzl
++++ b/python/private/pypi/whl_library.bzl
+@@ -112,10 +112,18 @@ def _parse_optional_attrs(rctx, args, extra_pip_args = None):
+     # support rctx.getenv(name, default): When building incrementally, any change to the value of
+     # the variable named by name will cause this repository to be re-fetched.
+     if "getenv" in dir(rctx):
+-        getenv = rctx.getenv
++        getenv = rctx.getenvot_python_wheels
+     else:
+         getenv = rctx.os.environ.get
+ 
++    # Check if a pre-cached wheels repo is available.
++    if rctx.attr.local_wheels_repo_target:
++        local_wheels_repo_path = rctx.path(rctx.attr.local_wheels_repo_target).dirname
++        extra_pip_args += [
++            "--no-index",
++            "--find-links={}".format(local_wheels_repo_path),
++        ]
++
+     # Check for None so we use empty default types from our attrs.
+     # Some args want to be list, and some want to be dict.
+     if extra_pip_args != None:
+@@ -404,6 +412,9 @@ and the target that we need respectively.
+     "group_name": attr.string(
+         doc = "Name of the group, if any.",
+     ),
++    "local_wheels_repo_target": attr.label(
++        doc = "Pointer to a target in the external repo where pre-cached wheels may be found. Used for airgapped builds.",
++    ),
+     "repo": attr.string(
+         mandatory = True,
+         doc = "Pointer to parent repo name. Used to make these rules rerun if the parent repo changes.",

--- a/third_party/python/pip.bzl
+++ b/third_party/python/pip.bzl
@@ -2,10 +2,148 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_python//python:pip.bzl", "pip_parse")
 load("@python3//:defs.bzl", "interpreter")
+load("@rules_python//python:pip.bzl", "pip_parse")
+
+_WHEEL_BUILD_FILE_CONTENTS = """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "sanitized_requirements.txt",
+])
+
+filegroup(
+    name = "all_wheels",
+    srcs = glob(["**/*.whl"])
+)
+"""
+
+def _pip_wheel_impl(rctx):
+    # First, check if an existing pre-built Python wheels repo exists, and if
+    # so, use it instead of building one.
+    python_wheel_repo_path = rctx.os.environ.get(
+        "BAZEL_PYTHON_WHEELS_REPO",
+        None,
+    )
+    if python_wheel_repo_path:
+        rctx.report_progress("Mounting existing Python wheels repo")
+        rctx.symlink(python_wheel_repo_path, ".")
+        return
+
+    # If a pre-built Python wheels repo does not exist, we need to build it.
+    rctx.report_progress("No Python wheels repo detected, building it instead")
+
+    # First, we install the Python wheel package so we can build other wheels.
+    args = [
+        rctx.path(rctx.attr.python_interpreter),
+        "-m",
+        "pip",
+        "install",
+        "-U",
+        "--ignore-installed",
+        "--user",
+        "wheel",
+    ]
+    rctx.report_progress("Installing the Python wheel package")
+    result = rctx.execute(
+        args,
+        environment = {
+            "SOURCE_DATE_EPOCH": "315532800",
+            "PYTHONHASHSEED": "0",
+        },
+        timeout = rctx.attr.timeout,
+        quiet = rctx.attr.quiet,
+    )
+    if result.return_code:
+        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
+
+    # Next, we download/build all the Python wheels for each requirement.
+    args = [
+        rctx.path(rctx.attr.python_interpreter),
+        "-m",
+        "pip",
+        "wheel",
+        "--use-pep517",
+        "-r",
+        rctx.path(rctx.attr.requirements),
+        "-w",
+        "./",
+    ]
+    rctx.report_progress("Pre-building Python wheels")
+    result = rctx.execute(
+        args,
+        environment = {
+            "SOURCE_DATE_EPOCH": "315532800",
+            "PYTHONHASHSEED": "0",
+        },
+        timeout = rctx.attr.timeout,
+        quiet = rctx.attr.quiet,
+    )
+    if result.return_code:
+        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
+
+    # Last, we generate a new Python requirements file that does not contain any
+    # VCS links. We avoid just patching the existing python_requirements.txt
+    # file, and instead generate a requirements file based on the wheels that
+    # were built above. This enables us to make changes to the main
+    # python_requirements.txt file without impacting this step.
+    args = [rctx.path(rctx.attr._gen_requirements_script)]
+    rctx.report_progress("Generating sanitzed requirements file")
+    result = rctx.execute(
+        args,
+        environment = {
+            "SOURCE_DATE_EPOCH": "315532800",
+            "PYTHONHASHSEED": "0",
+        },
+        timeout = rctx.attr.timeout,
+        quiet = rctx.attr.quiet,
+        working_directory = "./",
+    )
+    if result.return_code:
+        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
+
+    # We need a BUILD file to load the downloaded Python packages.
+    rctx.file(
+        "BUILD.bazel",
+        _WHEEL_BUILD_FILE_CONTENTS,
+    )
+
+pip_wheel = repository_rule(
+    implementation = _pip_wheel_impl,
+    attrs = {
+        "python_interpreter": attr.label(
+            default = interpreter,
+            allow_single_file = True,
+            doc = "Python interpreter to use.",
+        ),
+        "requirements": attr.label(
+            default = "@lowrisc_opentitan//:python-requirements.txt",
+            allow_single_file = True,
+            doc = "Python requirements file describing package dependencies.",
+        ),
+        "quiet": attr.bool(
+            default = True,
+            doc = "If True, suppress printing stdout/stderr to the terminal.",
+        ),
+        "timeout": attr.int(
+            default = 300,
+            doc = "Timeout (in seconds) on the rule's execution duration.",
+        ),
+        "_gen_requirements_script": attr.label(
+            default = "//third_party/python:gen_requirements.sh",
+            allow_single_file = True,
+            doc = "Shell script that generates a requirements file without VCS links.",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    environ = ["BAZEL_PYTHON_WHEELS_REPO"],
+)
 
 def pip_deps():
+    pip_wheel(
+        name = "ot_python_wheels",
+    )
     pip_parse(
         name = "ot_python_deps",
         python_interpreter_target = interpreter,

--- a/third_party/python/repos.bzl
+++ b/third_party/python/repos.bzl
@@ -15,4 +15,6 @@ def python_repos():
             _RULES_PYTHON_VERSION,
             _RULES_PYTHON_VERSION,
         ),
+        patches = [Label("//third_party/python:airgapped-wheels-cache.patch")],
+        patch_args = ["-p1"],
     )

--- a/third_party/python/requirements.bzl
+++ b/third_party/python/requirements.bzl
@@ -416,7 +416,8 @@ def install_deps(**whl_library_kwargs):
 
         whl_library(
             name = name,
-            requirement = requirement,
+            # Ignore hashes due to mismatches when caching wheels for airgapped builds.
+            requirement = requirement.split(" ")[0],
             group_name = group_name,
             group_deps = group_deps,
             annotation = _get_annotation(requirement),

--- a/third_party/python/requirements.bzl
+++ b/third_party/python/requirements.bzl
@@ -7,6 +7,7 @@ load("@rules_python//python:pip.bzl", "pip_utils")
 load("@rules_python//python/pip_install:pip_repository.bzl", "group_library", "whl_library")
 
 all_requirements = [
+    "@ot_python_deps_vendored_absl_py//:pkg",
     "@ot_python_deps_vendored_anytree//:pkg",
     "@ot_python_deps_vendored_attrs//:pkg",
     "@ot_python_deps_vendored_beautifulsoup4//:pkg",
@@ -92,6 +93,7 @@ all_requirements = [
 ]
 
 all_whl_requirements_by_package = {
+    "absl_py": "@ot_python_deps_vendored_absl_py//:whl",
     "anytree": "@ot_python_deps_vendored_anytree//:whl",
     "attrs": "@ot_python_deps_vendored_attrs//:whl",
     "beautifulsoup4": "@ot_python_deps_vendored_beautifulsoup4//:whl",
@@ -179,6 +181,7 @@ all_whl_requirements_by_package = {
 all_whl_requirements = all_whl_requirements_by_package.values()
 
 all_data_requirements = [
+    "@ot_python_deps_vendored_absl_py//:data",
     "@ot_python_deps_vendored_anytree//:data",
     "@ot_python_deps_vendored_attrs//:data",
     "@ot_python_deps_vendored_beautifulsoup4//:data",
@@ -264,6 +267,7 @@ all_data_requirements = [
 ]
 
 _packages = [
+    ("ot_python_deps_vendored_absl_py", "absl-py==2.0.0     --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3     --hash=sha256:d9690211c5fcfefcdd1a45470ac2b5c5acd45241c3af71eed96bc5441746c0d5"),
     ("ot_python_deps_vendored_anytree", "anytree==2.8.0     --hash=sha256:14c55ac77492b11532395049a03b773d14c7e30b22aa012e337b1e983de31521     --hash=sha256:3f0f93f355a91bc3e6245319bf4c1d50e3416cc7a35cc1133c1ff38306bbccab"),
     ("ot_python_deps_vendored_attrs", "attrs==25.1.0     --hash=sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e     --hash=sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"),
     ("ot_python_deps_vendored_beautifulsoup4", "beautifulsoup4==4.12.2     --hash=sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da     --hash=sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"),
@@ -329,7 +333,7 @@ _packages = [
     ("ot_python_deps_vendored_rich", "rich==12.6.0     --hash=sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e     --hash=sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"),
     ("ot_python_deps_vendored_semantic_version", "semantic-version==2.10.0     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c     --hash=sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"),
     ("ot_python_deps_vendored_simplesat", "simplesat==0.9.1     --hash=sha256:4f7d7a121ba13db987ea635205db8897d7d01220962e8a9c8cfd41b9886e6b8a     --hash=sha256:990115b1bb32a76c30b2416f645e99e61360382c795203e25ab59b26cd173749"),
-    ("ot_python_deps_vendored_six", "six==1.17.0     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"),
+    ("ot_python_deps_vendored_six", "six==1.16.0     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"),
     ("ot_python_deps_vendored_smmap", "smmap==5.0.2     --hash=sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5     --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e"),
     ("ot_python_deps_vendored_soupsieve", "soupsieve==2.6     --hash=sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb     --hash=sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"),
     ("ot_python_deps_vendored_tabulate", "tabulate==0.8.10     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc     --hash=sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"),

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 : "${BAZEL_CACHEDIR:=bazel-cache}"
 : "${BAZEL_BITSTREAMS_CACHE:=bitstreams-cache}"
 : "${BAZEL_BITSTREAMS_CACHEDIR:=${BAZEL_BITSTREAMS_CACHE}/cache}"
+: "${BAZEL_PYTHON_WHEEL_REPO:=ot_python_wheels}"
 : "${BAZEL_BITSTREAMS_REPO:=bitstreams}"
 
 LINE_SEP="====================================================================="
@@ -149,6 +150,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @local_config_cc_toolchains//... \
     @local_config_platform//... \
     @local_config_sh//... \
+    @ot_python_wheels//... \
     @python3_toolchains//... \
     @remotejdk11_linux//... \
     @riscv-compliance//... \
@@ -159,6 +161,8 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @rust_analyzer_1.71.1_tools//... \
     @rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//... \
     @rust_linux_x86_64__riscv32imc-unknown-none-elf__nightly_tools//...
+  cp -R "$(${BAZELISK} info output_base)"/external/${BAZEL_PYTHON_WHEEL_REPO} \
+    ${BAZEL_AIRGAPPED_DIR}/
   # We don't need all bitstreams in the cache, we just need the latest one so
   # that the cache is "initialized" and "offline" mode will work correctly.
   mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHEDIR}


### PR DESCRIPTION
This re-adds the ability to generate an external Bazel repository that contains all Python wheels for used as dependencies for this project. This capability was originally added to workaround a rules_python shortcoming that prevented Python wheels from being downloaded and cached through the bazel third party dependency caching mechanism (specifically, the repository cache). This issue caused airgapped builds to fail. This issue was believed to solved in newer versions of rules_python, so this wheel caching mechanism we removed in #24361.

However, after further testing, we found that newer rules_python version suffer the same issue, i.e., the default to downloading Python wheels through Python, rather than the bazel download/caching mechanism, as shown here: https://github.com/bazelbuild/rules_python/blob/466da1d9710289bfb01061b9be7bb124132996e0/python/private/pypi/whl_installer/wheel_installer.py#L169 As a result, airgapped builds were broken. Moreover, re-enabling them required patching rules_python to use the pre-cached python wheels repo.

Throughout this process, it was also discovered the airgapped build test failed to clean out the bazel cache before attempting a build with the pre-populated repository cache. This caused the test to pass even when it should not have.