### PR TITLE
[RACL] Add support for ranges and enable racl for sram_ctrl

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -86,6 +86,18 @@ module spi_device
   localparam int unsigned TpmRdFifoWidth  = spi_device_reg_pkg::TpmRdFifoWidth;
 
   // Derived parameters
+  localparam top_racl_pkg::racl_range_t RaclPolicySelRangesEgressbuffer[1] = '{
+    '{base: {top_pkg::TL_AW{1'b0}},
+      mask: {top_pkg::TL_AW{1'b1}},
+      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinEgressbuffer)
+    }
+  };
+  localparam top_racl_pkg::racl_range_t RaclPolicySelRangesIngressbuffer[1] = '{
+    '{base: {top_pkg::TL_AW{1'b0}},
+      mask: {top_pkg::TL_AW{1'b1}},
+      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinIngressbuffer)
+    }
+  };
 
   logic clk_spi_in, clk_spi_in_muxed, clk_spi_in_buf;   // clock for latch SDI
   logic clk_spi_out, clk_spi_out_muxed, clk_spi_out_buf; // clock for driving SDO
@@ -1687,7 +1699,8 @@ module spi_device
     .ByteAccess       (0),
     .EnableRacl       (EnableRacl),
     .RaclErrorRsp     (RaclErrorRsp),
-    .RaclPolicySelVec (RaclPolicySelWinEgressbuffer)
+    .RaclPolicySelNumRanges(1),
+    .RaclPolicySelRanges(RaclPolicySelRangesEgressbuffer)
   ) u_tlul2sram_egress (
     .clk_i,
     .rst_ni,
@@ -1725,7 +1738,8 @@ module spi_device
     .ByteAccess       (0),
     .EnableRacl       (EnableRacl),
     .RaclErrorRsp     (RaclErrorRsp),
-    .RaclPolicySelVec (RaclPolicySelWinIngressbuffer)
+    .RaclPolicySelNumRanges(1),
+    .RaclPolicySelRanges(RaclPolicySelRangesIngressbuffer)
   ) u_tlul2sram_ingress (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_window.sv
+++ b/hw/ip/spi_host/rtl/spi_host_window.sv
@@ -32,6 +32,13 @@ module spi_host_window
   localparam int AW = spi_host_reg_pkg::BlockAw;
   localparam int DW = 32;
   localparam int ByteMaskW = DW / 8;
+  localparam top_racl_pkg::racl_range_t RaclPolicySelRangesTXDATA[1] = '{
+    '{
+      base: {top_pkg::TL_AW{1'b0}},
+      mask: {top_pkg::TL_AW{1'b1}},
+      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinTXDATA)
+    }
+  };
 
   logic         rx_we;
 
@@ -97,7 +104,8 @@ module spi_host_window
     .ErrOnRead(1),
     .EnableRacl(EnableRacl),
     .RaclErrorRsp(RaclErrorRsp),
-    .RaclPolicySelVec(RaclPolicySelWinTXDATA)
+    .RaclPolicySelNumRanges(1),
+    .RaclPolicySelRanges(RaclPolicySelRangesTXDATA)
   ) u_adapter_tx (
     .clk_i,
     .rst_ni,

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -29,7 +29,7 @@
 
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "regs", racl_support: true }
-    { protocol: "tlul", direction: "device", name: "ram" },
+    { protocol: "tlul", direction: "device", name: "ram" , racl_support: true }
   ],
 
   ///////////////////////////

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
@@ -79,8 +79,8 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
     // their counters. This avoids a problem where we generate a spurious request when the FIFO was
     // actually empty and lots of signals in the design become X. This will let the fifos error
     // signal stuck at X. Zeroing the backing memory avoids that problem.
-    splat_fifo_storage("tb.dut.u_tlul_adapter_sram.u_reqfifo", 2);
-    splat_fifo_storage("tb.dut.u_tlul_adapter_sram.u_sramreqfifo", 2);
+    splat_fifo_storage("tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_reqfifo", 2);
+    splat_fifo_storage("tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_sramreqfifo", 2);
 
     super.dut_init(reset_kind);
   endtask
@@ -168,13 +168,13 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
       if (is_ptr_in_adapters_fifo(if_proxy.path, touching_req_fifo)) begin
         if (!enable) begin
           `uvm_info(`gfn, "Doing FI on a prim_fifo_sync. Disabling related assertions", UVM_HIGH)
-          $assertoff(0, "tb.dut.u_tlul_adapter_sram.u_reqfifo");
-          $assertoff(0, "tb.dut.u_tlul_adapter_sram.u_sramreqfifo");
-          $assertoff(0, "tb.dut.u_tlul_adapter_sram.u_rspfifo");
+          $assertoff(0, "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_reqfifo");
+          $assertoff(0, "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_sramreqfifo");
+          $assertoff(0, "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_rspfifo");
         end else begin
-          $asserton(0, "tb.dut.u_tlul_adapter_sram.u_reqfifo");
-          $asserton(0, "tb.dut.u_tlul_adapter_sram.u_sramreqfifo");
-          $asserton(0, "tb.dut.u_tlul_adapter_sram.u_rspfifo");
+          $asserton(0, "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_reqfifo");
+          $asserton(0, "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_sramreqfifo");
+          $asserton(0, "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_rspfifo");
         end
 
         // Disable assertions that we expect to fail if we corrupt a request FIFO. This causes us to

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_readback_err_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_readback_err_vseq.sv
@@ -110,7 +110,8 @@ class sram_ctrl_readback_err_vseq extends sram_ctrl_base_vseq;
     cfg.is_fi_test = 1'b1;
 
     // If we are faulting the sram_we signal, this assertion would trigger. Disable it.
-    $assertoff(0, "tb.dut.u_tlul_adapter_sram.u_sram_byte.gen_integ_handling");
+    $assertoff(0,
+      "tb.dut.u_tlul_adapter_sram_racl.tlul_adapter_sram.u_sram_byte.gen_integ_handling");
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_fi_op)

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_ram_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_ram_reg_top.sv
@@ -6,12 +6,23 @@
 
 `include "prim_assert.sv"
 
-module sram_ctrl_ram_reg_top (
+module sram_ctrl_ram_reg_top
+  # (
+    parameter bit          EnableRacl           = 1'b0,
+    parameter bit          RaclErrorRsp         = 1'b1,
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[sram_ctrl_reg_pkg::NumRegsRam] =
+      '{sram_ctrl_reg_pkg::NumRegsRam{0}}
+  ) (
   input clk_i,
   input rst_ni,
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
   // To HW
+
+  // RACL interface
+  input  top_racl_pkg::racl_policy_vec_t racl_policies_i,
+  output logic                           racl_error_o,
+  output top_racl_pkg::racl_error_log_t  racl_error_log_o,
 
   // Integrity check errors
   output logic intg_err_o
@@ -39,4 +50,6 @@ module sram_ctrl_ram_reg_top (
   assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
+  logic unused_policy_sel;
+  assign unused_policy_sel = ^racl_policies_i;
 endmodule

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -7732,6 +7732,7 @@
             WDATA: 0
             RDATA: 0
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -7934,6 +7935,7 @@
             WDATA: 0
             RDATA: 0
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -8136,6 +8138,7 @@
             WDATA: 0
             RDATA: 0
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -8514,6 +8517,7 @@
             WDATA: 0
             RDATA: 0
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -8716,6 +8720,7 @@
             WDATA: 0
             RDATA: 0
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -9094,6 +9099,7 @@
             WDATA: 0
             RDATA: 0
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -9296,6 +9302,7 @@
             WDATA: 2
             RDATA: 2
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -9498,6 +9505,7 @@
             WDATA: 2
             RDATA: 2
           }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -10383,6 +10391,7 @@
             RANGE_RACL_POLICY_SHADOWED_31: 2
           }
           window_mapping: {}
+          range_mapping: []
         }
       }
       domain:

--- a/hw/top_darjeeling/data/racl/all_rd_wr_mapping.hjson
+++ b/hw/top_darjeeling/data/racl/all_rd_wr_mapping.hjson
@@ -4,6 +4,11 @@
 
 {
   Null: {
-    "*": "ALL_RD_WR"
+    registers: {
+      "*": "ALL_RD_WR"
+    }
+    windows: {
+      "*": "ALL_RD_WR"
+    }
   }
 }

--- a/hw/top_darjeeling/data/racl/soc_rot_mapping.hjson
+++ b/hw/top_darjeeling/data/racl/soc_rot_mapping.hjson
@@ -4,6 +4,11 @@
 
 {
   Null: {
-    "*": "SOC_ROT"
+    registers: {
+      "*": "SOC_ROT"
+    }
+    windows: {
+      "*": "SOC_ROT"
+    }
   }
 }

--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -48,6 +48,12 @@ package top_racl_pkg;
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
 
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;
+    logic [top_pkg::TL_AW-1:0] mask;
+    racl_policy_sel_t          policy_sel;
+  } racl_range_t;
+
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = 16'h1;
 

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -494,7 +494,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
         hw/top_earlgrey/templates/toplevel.sv.tpl
         hw/top_englishbreakfast/templates/toplevel.sv.tpl
 </%doc>\
-  % if 'racl_mappings' in m:
+  % if m.get('racl_mappings'):
     .EnableRacl(1'b1),
     .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
     % for if_name in m['racl_mappings'].keys():

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -501,6 +501,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
 <%
         register_mapping = m['racl_mappings'][if_name]['register_mapping']
         window_mapping = m['racl_mappings'][if_name]['window_mapping']
+        range_mapping = m['racl_mappings'][if_name]['range_mapping']
         racl_group = m['racl_mappings'][if_name]['racl_group']
         group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
         if_suffix = f"_{if_name.upper()}" if if_name else ""
@@ -513,6 +514,10 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
       % for window_name, policy_idx in window_mapping.items():
     .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(top_racl_pkg::${policy_sel_name}_WIN_${window_name.upper()}),
       % endfor
+      % if len(range_mapping) > 0:
+    .RaclPolicySelRanges${if_suffix2}Num(top_racl_pkg::${policy_sel_name}_NUM_RANGES),
+    .RaclPolicySelRanges${if_suffix2}(top_racl_pkg::${policy_sel_name}_RANGES),
+      % endif
     % endfor
   % endif
   % if m.get('template_type') == 'racl_ctrl':

--- a/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
@@ -48,6 +48,12 @@ package top_racl_pkg;
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
 
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;
+    logic [top_pkg::TL_AW-1:0] mask;
+    racl_policy_sel_t          policy_sel;
+  } racl_range_t;
+
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = 2'h0;
 

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -518,6 +518,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
 <%
         register_mapping = m['racl_mappings'][if_name]['register_mapping']
         window_mapping = m['racl_mappings'][if_name]['window_mapping']
+        range_mapping = m['racl_mappings'][if_name]['range_mapping']
         racl_group = m['racl_mappings'][if_name]['racl_group']
         group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
         if_suffix = f"_{if_name.upper()}" if if_name else ""
@@ -530,6 +531,10 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
       % for window_name, policy_idx in window_mapping.items():
     .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(top_racl_pkg::${policy_sel_name}_WIN_${window_name.upper()}),
       % endfor
+      % if len(range_mapping) > 0:
+    .RaclPolicySelRanges${if_suffix2}Num(top_racl_pkg::${policy_sel_name}_NUM_RANGES),
+    .RaclPolicySelRanges${if_suffix2}(top_racl_pkg::${policy_sel_name}_RANGES),
+      % endif
     % endfor
   % endif
   % if m.get('template_type') == 'racl_ctrl':

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -48,6 +48,12 @@ package top_racl_pkg;
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
 
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;
+    logic [top_pkg::TL_AW-1:0] mask;
+    racl_policy_sel_t          policy_sel;
+  } racl_range_t;
+
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = 2'h0;
 

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -1466,13 +1466,14 @@ def amend_racl(top_cfg: OrderedDict,
                 # The racl_mappings values are expanded in place into a dict
                 # once and need no further updates.
                 continue
-            parsed_register_mapping, parsed_window_mapping, racl_group, _ = (
+            parsed_register_mapping, parsed_window_mapping, parsed_range_mapping, racl_group, _ = (
                 parse_racl_mapping(top_cfg["racl"], top_cfg["cfg_path"] / mapping_path,
                                    if_name, block))
             m['racl_mappings'][if_name] = {
                 'racl_group': racl_group,
                 'register_mapping': parsed_register_mapping,
                 'window_mapping': parsed_window_mapping,
+                'range_mapping': parsed_range_mapping,
             }
 
 

--- a/util/topgen/templates/toplevel_racl_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg.sv.tpl
@@ -42,6 +42,12 @@ package top_racl_pkg;
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
 
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;
+    logic [top_pkg::TL_AW-1:0] mask;
+    racl_policy_sel_t          policy_sel;
+  } racl_range_t;
+
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = ${racl_role_vec_len}'h${f"{racl_config['rot_private_policy_rd']:x}"};
 
@@ -127,6 +133,7 @@ package top_racl_pkg;
         hw/top_earlgrey/templates/toplevel.sv.tpl
         hw/top_englishbreakfast/templates/toplevel.sv.tpl
 </%doc>\
+<% import raclgen.lib as raclgen %>\
 <% import math %>\
 % if 'racl' in topcfg:
 <% policy_names = [policy['name'] for policy in topcfg['racl']['policies'][racl_group]] %>\
@@ -148,11 +155,13 @@ package top_racl_pkg;
     % for if_name in m['racl_mappings'].keys():
 <% register_mapping = m['racl_mappings'][if_name]['register_mapping'] %>\
 <% window_mapping = m['racl_mappings'][if_name]['window_mapping'] %>\
+<% range_mapping = m['racl_mappings'][if_name]['range_mapping'] %>\
 <% racl_group = m['racl_mappings'][if_name]['racl_group'] %>\
 <% group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else "" %>\
 <% if_suffix = f"_{if_name.upper()}" if if_name else "" %>\
 <% reg_name_len = max( (len(name) for name in register_mapping.keys()), default=0 ) %>\
 <% window_name_len = max( (len(name) for name in window_mapping.keys()), default=0 ) %>\
+<% policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}" %>\
   /**
    * Policy selection vector for ${m["name"]}
    *   TLUL interface name: ${if_name}
@@ -169,16 +178,31 @@ package top_racl_pkg;
    *     ${f"{window_name}:".ljust(window_name_len+1)} ${policy_names[policy_idx]} (Idx ${f"{policy_idx}".rjust(policy_idx_len)})
         % endfor
       % endif
+      % if len(range_mapping) > 0:
+   *   Range to policy mapping:
+        % for range in range_mapping:
+   *     ${f"0x{range['base']:08x}"} -- ${f"0x{(range['base']+range['size']):08x}"} \
+policy: ${policy_names[range['policy']]} (Idx ${f"{range['policy']}".rjust(policy_idx_len)})
+        % endfor
+      % endif
    */
-<% policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}" %>\
+      % if len(register_mapping) > 0:
 <% policy_sel_value = ", ".join(map(str, reversed(register_mapping.values())))%>\
 <% policy_sel_value = "\n    ".join(textwrap.wrap(policy_sel_value, 94))%>\
   parameter racl_policy_sel_t ${policy_sel_name} [${len(register_mapping)}] = '{
     ${policy_sel_value}
   };
+      % endif
       % for window_name, policy_idx in window_mapping.items():
   parameter racl_policy_sel_t ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
       % endfor
+      % if len(range_mapping) > 0:
+  parameter racl_policy_sel_t ${policy_sel_name}_NUM_RANGES = ${len(range_mapping)};
+<% value =  ",\\n".join(map(raclgen.format_parameter_range_value, range_mapping)) %>\
+  parameter racl_range_t ${policy_sel_name}_RANGES [${len(range_mapping)}] = '{
+    ${value}
+  };
+      % endif
 
     % endfor
   % endif


### PR DESCRIPTION
This PR adds racl support for the `ram` tlul interface of `sram_ctrl`. (RACL for its `regs` interface was addded in #26047)
However, for this it was necessary to add so-called RACL ranges.
Due to this new type, the format of the racl mapping hjson files changes.
Furthermore, this PR also allows non-`*` mappings now (as mentioned in #25986).
I could not reasonably split the changes in `raclgen/lib.py` into separate commits. I hope this is still okay.

~~Note: This PR is based on #26096 and should not be merged before #26096.
I will rebase this PR and drop the first commit when that happens.~~
