### PR TITLE
[RACL] Add racl_policy_sel_t

### DIFF
--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -10,13 +10,13 @@ module gpio
   import gpio_pkg::*;
   import gpio_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
-  parameter bit                   GpioAsHwStrapsEn          = 1,
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             GpioAsHwStrapsEn          = 1,
   // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
-  parameter bit                   GpioAsyncOn               = 1,
-  parameter bit                   EnableRacl                = 1'b0,
-  parameter bit                   RaclErrorRsp              = 1'b1,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
+  parameter bit                             GpioAsyncOn               = 1,
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = 1'b1,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -10,7 +10,8 @@ module gpio_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[gpio_reg_pkg::NumRegs] = '{gpio_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[gpio_reg_pkg::NumRegs] =
+      '{gpio_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -9,11 +9,11 @@
 module i2c
   import i2c_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
-  parameter int unsigned          InputDelayCycles          = 0,
-  parameter bit                   EnableRacl                = 1'b0,
-  parameter bit                   RaclErrorRsp              = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter int unsigned                    InputDelayCycles          = 0,
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input                                    clk_i,
   input                                    rst_ni,

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -10,7 +10,8 @@ module i2c_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[i2c_reg_pkg::NumRegs] = '{i2c_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[i2c_reg_pkg::NumRegs] =
+      '{i2c_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/mbx/rtl/mbx.sv
+++ b/hw/ip/mbx/rtl/mbx.sv
@@ -8,17 +8,17 @@ module mbx
   import tlul_pkg::*;
   import mbx_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn           = {NumAlerts{1'b1}},
-  parameter int unsigned CfgSramAddrWidth                = 32,
-  parameter int unsigned CfgSramDataWidth                = 32,
-  parameter int unsigned CfgObjectSizeWidth              = 11,
-  parameter bit          DoeIrqSupport                   = 1'b1,
-  parameter bit          DoeAsyncMsgSupport              = 1'b1,
-  parameter bit          EnableRacl                      = 1'b0,
-  parameter bit          RaclErrorRsp                    = EnableRacl,
-  parameter int unsigned RaclPolicySelVecSoc[NumRegsSoc] = '{NumRegsSoc{0}},
-  parameter int unsigned RaclPolicySelWinSocWdata        = 0,
-  parameter int unsigned RaclPolicySelWinSocRdata        = 0
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn                    = {NumAlerts{1'b1}},
+  parameter int unsigned                    CfgSramAddrWidth                = 32,
+  parameter int unsigned                    CfgSramDataWidth                = 32,
+  parameter int unsigned                    CfgObjectSizeWidth              = 11,
+  parameter bit                             DoeIrqSupport                   = 1'b1,
+  parameter bit                             DoeAsyncMsgSupport              = 1'b1,
+  parameter bit                             EnableRacl                      = 1'b0,
+  parameter bit                             RaclErrorRsp                    = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecSoc[NumRegsSoc] = '{NumRegsSoc{0}},
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinSocWdata        = 0,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinSocRdata        = 0
 ) (
   input  logic                                      clk_i,
   input  logic                                      rst_ni,

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -10,7 +10,8 @@ module mbx_soc_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[mbx_reg_pkg::NumRegsSoc] = '{mbx_reg_pkg::NumRegsSoc{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[mbx_reg_pkg::NumRegsSoc] =
+      '{mbx_reg_pkg::NumRegsSoc{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/mbx/rtl/mbx_sysif.sv
+++ b/hw/ip/mbx/rtl/mbx_sysif.sv
@@ -6,16 +6,16 @@ module mbx_sysif
   import tlul_pkg::*;
   import mbx_reg_pkg::*;
 #(
-  parameter int unsigned CfgSramAddrWidth                = 32,
-  parameter int unsigned CfgSramDataWidth                = 32,
+  parameter int unsigned                    CfgSramAddrWidth         = 32,
+  parameter int unsigned                    CfgSramDataWidth         = 32,
   // PCIe capabilities
-  parameter bit          DoeIrqSupport                   = 1'b1,
-  parameter bit          DoeAsyncMsgSupport              = 1'b1,
-  parameter bit          EnableRacl                      = 1'b0,
-  parameter bit          RaclErrorRsp                    = 1'b1,
-  parameter int unsigned RaclPolicySelVecSoc[NumRegsSoc] = '{NumRegsSoc{0}},
-  parameter int unsigned RaclPolicySelWinSocWdata        = 0,
-  parameter int unsigned RaclPolicySelWinSocRdata        = 0
+  parameter bit                             DoeIrqSupport            = 1'b1,
+  parameter bit                             DoeAsyncMsgSupport       = 1'b1,
+  parameter bit                             EnableRacl               = 1'b0,
+  parameter bit                             RaclErrorRsp             = 1'b1,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecSoc[NumRegsSoc]   = '{NumRegsSoc{0}},
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinSocWdata = 0,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinSocRdata = 0
 ) (
   input  logic                           clk_i,
   input  logic                           rst_ni,

--- a/hw/ip/pwm/rtl/pwm.sv
+++ b/hw/ip/pwm/rtl/pwm.sv
@@ -7,12 +7,12 @@
 module pwm
   import pwm_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
-  parameter bit                   EnableRacl                = 1'b0,
-  parameter bit                   RaclErrorRsp              = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
-  parameter int                   PhaseCntDw                = 16,
-  parameter int                   BeatCntDw                 = 27
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
+  parameter int                             PhaseCntDw                = 16,
+  parameter int                             BeatCntDw                 = 27
 ) (
   input                       clk_i,
   input                       rst_ni,

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -10,7 +10,8 @@ module pwm_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[pwm_reg_pkg::NumRegs] = '{pwm_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[pwm_reg_pkg::NumRegs] =
+      '{pwm_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -12,11 +12,11 @@ module spi_device
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
   parameter spi_device_pkg::sram_type_e SramType       = spi_device_pkg::DefaultSramType,
-  parameter bit          EnableRacl                    = 1'b0,
-  parameter bit          RaclErrorRsp                  = EnableRacl,
-  parameter int unsigned RaclPolicySelVec[73]          = '{73{0}},
-  parameter int unsigned RaclPolicySelWinEgressbuffer  = 0,
-  parameter int unsigned RaclPolicySelWinIngressbuffer = 0
+  parameter bit                             EnableRacl                    = 1'b0,
+  parameter bit                             RaclErrorRsp                  = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[73]          = '{73{0}},
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinEgressbuffer  = 0,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinIngressbuffer = 0
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -10,7 +10,8 @@ module spi_device_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[spi_device_reg_pkg::NumRegs] = '{spi_device_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[spi_device_reg_pkg::NumRegs] =
+      '{spi_device_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -11,13 +11,13 @@
 module spi_host
   import spi_host_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn     = {NumAlerts{1'b1}},
-  parameter int unsigned          NumCS            = 1,
-  parameter bit          EnableRacl                = 1'b0,
-  parameter bit          RaclErrorRsp              = EnableRacl,
-  parameter int unsigned RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
-  parameter int unsigned RaclPolicySelWinRXDATA    = 0,
-  parameter int unsigned RaclPolicySelWinTXDATA    = 0
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter int unsigned                    NumCS                     = 1,
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinRXDATA    = 0,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinTXDATA    = 0
 ) (
   input              clk_i,
   input              rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -10,7 +10,8 @@ module spi_host_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[spi_host_reg_pkg::NumRegs] = '{spi_host_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[spi_host_reg_pkg::NumRegs] =
+      '{spi_host_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_window.sv
+++ b/hw/ip/spi_host/rtl/spi_host_window.sv
@@ -7,10 +7,10 @@
 
 module spi_host_window
 #(
-  parameter bit          EnableRacl             = 1'b0,
-  parameter bit          RaclErrorRsp           = 1'b1,
-  parameter int unsigned RaclPolicySelWinRXDATA = 0,
-  parameter int unsigned RaclPolicySelWinTXDATA = 0
+  parameter bit                             EnableRacl             = 1'b0,
+  parameter bit                             RaclErrorRsp           = 1'b1,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinRXDATA = 0,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelWinTXDATA = 0
 ) (
   input  clk_i,
   input  rst_ni,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -25,13 +25,13 @@ module sram_ctrl
   // Setting this to 3 lowers this to approximately 7 effective rounds.
   parameter int NumPrinceRoundsHalf                        = 3,
   // Random netlist constants
-  parameter  otp_ctrl_pkg::sram_key_t   RndCnstSramKey     = RndCnstSramKeyDefault,
-  parameter  otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce   = RndCnstSramNonceDefault,
-  parameter  lfsr_seed_t                RndCnstLfsrSeed    = RndCnstLfsrSeedDefault,
-  parameter  lfsr_perm_t                RndCnstLfsrPerm    = RndCnstLfsrPermDefault,
-  parameter bit          EnableRacl                        = 1'b0,
-  parameter bit          RaclErrorRsp                      = EnableRacl,
-  parameter int unsigned RaclPolicySelVecRegs[NumRegsRegs] = '{NumRegsRegs{0}}
+  parameter  otp_ctrl_pkg::sram_key_t   RndCnstSramKey   = RndCnstSramKeyDefault,
+  parameter  otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce = RndCnstSramNonceDefault,
+  parameter  lfsr_seed_t                RndCnstLfsrSeed  = RndCnstLfsrSeedDefault,
+  parameter  lfsr_perm_t                RndCnstLfsrPerm  = RndCnstLfsrPermDefault,
+  parameter bit                         EnableRacl       = 1'b0,
+  parameter bit                         RaclErrorRsp     = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecRegs[NumRegsRegs] = '{NumRegsRegs{0}}
 ) (
   // SRAM Clock
   input  logic                                               clk_i,

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -10,7 +10,8 @@ module sram_ctrl_regs_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[sram_ctrl_reg_pkg::NumRegsRegs] = '{sram_ctrl_reg_pkg::NumRegsRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[sram_ctrl_reg_pkg::NumRegsRegs] =
+      '{sram_ctrl_reg_pkg::NumRegsRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
@@ -20,7 +20,8 @@ module tlul_adapter_reg_racl
   parameter  int AccessLatency     = 0,           // 0: same cycle, 1: next cycle
   parameter  bit EnableRacl        = 0,           // 1: Enable RACL checks on access
   parameter  bit RaclErrorRsp      = EnableRacl,  // 1: Return TLUL error on RACL errors
-  parameter  int RaclPolicySelVec  = 0,           // RACL policy for this reg adapter
+  parameter  top_racl_pkg::racl_policy_sel_t RaclPolicySelVec  = 0, // RACL policy for this reg
+                                                                    // adapter
   localparam int RegBw             = RegDw/8
 ) (
   input clk_i,

--- a/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
@@ -41,7 +41,8 @@ module tlul_adapter_sram_racl
   parameter bit DataXorAddr       = 0,          // 1: XOR data and address for address protection
   parameter bit EnableRacl        = 0,          // 1: Enable RACL checks on access
   parameter bit RaclErrorRsp      = EnableRacl, // 1: Return TLUL error on RACL errors
-  parameter int RaclPolicySelVec  = 0,          // RACL policy for this SRAM adapter
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec = 0, // RACL policy for this SRAM
+                                                                  // adapter
   localparam int WidthMult        = SramDw / top_pkg::TL_DW,
   localparam int IntgWidth        = tlul_pkg::DataIntgWidth * WidthMult,
   localparam int DataOutW         = EnableDataIntgPt ? SramDw + IntgWidth : SramDw

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -9,10 +9,10 @@
 module uart
     import uart_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn              = {NumAlerts{1'b1}},
-  parameter bit                   EnableRacl                = 1'b0,
-  parameter bit                   RaclErrorRsp              = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input           clk_i,
   input           rst_ni,

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -10,7 +10,8 @@ module uart_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[uart_reg_pkg::NumRegs] = '{uart_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[uart_reg_pkg::NumRegs] =
+      '{uart_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -6,10 +6,10 @@ module ${module_instance_name}
   import tlul_pkg::*;
   import ${module_instance_name}_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter bit                   EnableRacl   = 1'b0,
-  parameter bit                   RaclErrorRsp = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input  logic                                      clk_i,
   input  logic                                      rst_ni,

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -12,9 +12,9 @@ module ${module_instance_name}
   import prim_esc_pkg::*;
 #(
 % if racl_support:
-  parameter bit          EnableRacl                = 1'b0,
-  parameter bit          RaclErrorRsp              = EnableRacl,
-  parameter int unsigned RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
+  parameter bit          EnableRacl                                   = 1'b0,
+  parameter bit          RaclErrorRsp                                 = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
 % endif
   // Compile time random constants, to be overriden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_reg_wrap.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_reg_wrap.sv.tpl
@@ -13,7 +13,7 @@ module ${module_instance_name}_reg_wrap
 <% 
 num_regs = 6 + 4 * n_alerts + 4 * 7 + n_classes * 14
 %>\
-  parameter int unsigned RaclPolicySelVec[${num_regs}] = '{${num_regs}{0}}
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${num_regs}] = '{${num_regs}{0}}
 ) (
 % else:
 module ${module_instance_name}_reg_wrap import ${module_instance_name}_pkg::*; (

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -25,9 +25,9 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   // and routing the source clocks / resets to the PLIC).
   parameter logic [NumSrc-1:0]    LevelEdgeTrig = '0, // 0: level, 1: edge
 % if racl_support:
-  parameter bit                   EnableRacl                = 1'b0,
-  parameter bit                   RaclErrorRsp              = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}},
 % endif
   // derived parameter
   localparam int SRCW    = $clog2(NumSrc)

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -6,10 +6,10 @@ module ac_range_check
   import tlul_pkg::*;
   import ac_range_check_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter bit                   EnableRacl   = 1'b0,
-  parameter bit                   RaclErrorRsp = EnableRacl,
-  parameter int unsigned          RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
+  parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             EnableRacl                = 1'b0,
+  parameter bit                             RaclErrorRsp              = EnableRacl,
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
 ) (
   input  logic                                      clk_i,
   input  logic                                      rst_ni,

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -10,7 +10,8 @@ module ac_range_check_reg_top
   # (
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1,
-    parameter int unsigned RaclPolicySelVec[ac_range_check_reg_pkg::NumRegs] = '{ac_range_check_reg_pkg::NumRegs{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[ac_range_check_reg_pkg::NumRegs] =
+      '{ac_range_check_reg_pkg::NumRegs{0}}
   ) (
   input clk_i,
   input rst_ni,

--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -15,6 +15,12 @@ package top_racl_pkg;
   // Number of RACL policies used
   parameter int unsigned NrRaclPolicies = 3;
 
+  // RACL Policy selector bits
+  parameter int unsigned RaclPolicySelLen = prim_util_pkg::vbits(NrRaclPolicies);
+
+  // RACL Policy selector type
+  typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = 4;
 
@@ -153,11 +159,11 @@ package top_racl_pkg;
    *     WDATA: ALL_RD_WR (Idx 0)
    *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX0_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX0_SOC [4] = '{
     0, 0, 0, 0
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX0_SOC_WIN_WDATA = 0;
-  parameter int unsigned RACL_POLICY_SEL_MBX0_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX0_SOC_WIN_WDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX0_SOC_WIN_RDATA = 0;
 
   /**
    * Policy selection vector for mbx1
@@ -172,11 +178,11 @@ package top_racl_pkg;
    *     WDATA: ALL_RD_WR (Idx 0)
    *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX1_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX1_SOC [4] = '{
     0, 0, 0, 0
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX1_SOC_WIN_WDATA = 0;
-  parameter int unsigned RACL_POLICY_SEL_MBX1_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX1_SOC_WIN_WDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX1_SOC_WIN_RDATA = 0;
 
   /**
    * Policy selection vector for mbx2
@@ -191,11 +197,11 @@ package top_racl_pkg;
    *     WDATA: ALL_RD_WR (Idx 0)
    *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX2_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX2_SOC [4] = '{
     0, 0, 0, 0
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX2_SOC_WIN_WDATA = 0;
-  parameter int unsigned RACL_POLICY_SEL_MBX2_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX2_SOC_WIN_WDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX2_SOC_WIN_RDATA = 0;
 
   /**
    * Policy selection vector for mbx4
@@ -210,11 +216,11 @@ package top_racl_pkg;
    *     WDATA: ALL_RD_WR (Idx 0)
    *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX4_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX4_SOC [4] = '{
     0, 0, 0, 0
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX4_SOC_WIN_WDATA = 0;
-  parameter int unsigned RACL_POLICY_SEL_MBX4_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX4_SOC_WIN_WDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX4_SOC_WIN_RDATA = 0;
 
   /**
    * Policy selection vector for mbx5
@@ -229,11 +235,11 @@ package top_racl_pkg;
    *     WDATA: ALL_RD_WR (Idx 0)
    *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX5_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX5_SOC [4] = '{
     0, 0, 0, 0
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX5_SOC_WIN_WDATA = 0;
-  parameter int unsigned RACL_POLICY_SEL_MBX5_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX5_SOC_WIN_WDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX5_SOC_WIN_RDATA = 0;
 
   /**
    * Policy selection vector for mbx_jtag
@@ -248,11 +254,11 @@ package top_racl_pkg;
    *     WDATA: ALL_RD_WR (Idx 0)
    *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX_JTAG_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_JTAG_SOC [4] = '{
     0, 0, 0, 0
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_WDATA = 0;
-  parameter int unsigned RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_WDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_RDATA = 0;
 
   /**
    * Policy selection vector for mbx_pcie0
@@ -267,11 +273,11 @@ package top_racl_pkg;
    *     WDATA: SOC_ROT (Idx 2)
    *     RDATA: SOC_ROT (Idx 2)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX_PCIE0_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE0_SOC [4] = '{
     2, 2, 2, 2
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_WDATA = 2;
-  parameter int unsigned RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_RDATA = 2;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_WDATA = 2;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_RDATA = 2;
 
   /**
    * Policy selection vector for mbx_pcie1
@@ -286,11 +292,11 @@ package top_racl_pkg;
    *     WDATA: SOC_ROT (Idx 2)
    *     RDATA: SOC_ROT (Idx 2)
    */
-  parameter int unsigned RACL_POLICY_SEL_MBX_PCIE1_SOC [4] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE1_SOC [4] = '{
     2, 2, 2, 2
   };
-  parameter int unsigned RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_WDATA = 2;
-  parameter int unsigned RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_RDATA = 2;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_WDATA = 2;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_RDATA = 2;
 
   /**
    * Policy selection vector for ac_range_check
@@ -465,7 +471,7 @@ package top_racl_pkg;
    *     RANGE_RACL_POLICY_SHADOWED_30: SOC_ROT (Idx 2)
    *     RANGE_RACL_POLICY_SHADOWED_31: SOC_ROT (Idx 2)
    */
-  parameter int unsigned RACL_POLICY_SEL_AC_RANGE_CHECK [167] = '{
+  parameter racl_policy_sel_t RACL_POLICY_SEL_AC_RANGE_CHECK [167] = '{
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,

--- a/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
@@ -15,6 +15,12 @@ package top_racl_pkg;
   // Number of RACL policies used
   parameter int unsigned NrRaclPolicies = 1;
 
+  // RACL Policy selector bits
+  parameter int unsigned RaclPolicySelLen = prim_util_pkg::vbits(NrRaclPolicies);
+
+  // RACL Policy selector type
+  typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = 1;
 

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -15,6 +15,12 @@ package top_racl_pkg;
   // Number of RACL policies used
   parameter int unsigned NrRaclPolicies = 1;
 
+  // RACL Policy selector bits
+  parameter int unsigned RaclPolicySelLen = prim_util_pkg::vbits(NrRaclPolicies);
+
+  // RACL Policy selector type
+  typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = 1;
 

--- a/util/raclgen.py
+++ b/util/raclgen.py
@@ -90,9 +90,9 @@ def main():
    */
 <% policy_sel_name = f"RACL_POLICY_SEL_{module_name.upper()}{group_suffix}{if_suffix}" %>\
 <% policy_sel_value = "'{" + ", ".join(map(str, reversed(register_mapping.values()))) + "};" %>\
-  parameter int unsigned ${policy_sel_name} [${len(register_mapping)}] = ${policy_sel_value}
+  parameter racl_policy_sel_t ${policy_sel_name} [${len(register_mapping)}] = ${policy_sel_value}
       % for window_name, policy_idx in window_mapping.items():
-  parameter int unsigned ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
+  parameter racl_policy_sel_t ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
       % endfor
     """
 

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -128,7 +128,8 @@ module ${mod_name}${' (' if not racl_support else ''}
     parameter bit          EnableRacl           = 1'b0,
     parameter bit          RaclErrorRsp         = 1'b1${"," if dynamic_racl_support else ""}
   % if dynamic_racl_support:
-    parameter int unsigned RaclPolicySelVec[${reg_pkg}::${num_regs}] = '{${reg_pkg}::${num_regs}{0}}
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${reg_pkg}::${num_regs}] =
+      '{${reg_pkg}::${num_regs}{0}}
   % endif
   ) (
 % endif

--- a/util/topgen/templates/toplevel_racl_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg.sv.tpl
@@ -9,6 +9,12 @@ package top_racl_pkg;
   // Number of RACL policies used
   parameter int unsigned NrRaclPolicies = ${racl_config['nr_policies']};
 
+  // RACL Policy selector bits
+  parameter int unsigned RaclPolicySelLen = prim_util_pkg::vbits(NrRaclPolicies);
+
+  // RACL Policy selector type
+  typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = ${racl_config['nr_role_bits']};
 
@@ -167,11 +173,11 @@ package top_racl_pkg;
 <% policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}" %>\
 <% policy_sel_value = ", ".join(map(str, reversed(register_mapping.values())))%>\
 <% policy_sel_value = "\n    ".join(textwrap.wrap(policy_sel_value, 94))%>\
-  parameter int unsigned ${policy_sel_name} [${len(register_mapping)}] = '{
+  parameter racl_policy_sel_t ${policy_sel_name} [${len(register_mapping)}] = '{
     ${policy_sel_value}
   };
       % for window_name, policy_idx in window_mapping.items():
-  parameter int unsigned ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
+  parameter racl_policy_sel_t ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
       % endfor
 
     % endfor


### PR DESCRIPTION
This commit adds a new type `racl_policy_sel_t` for storing the index of a policy to prevent errors such as `length 32 is larger than the 2 bits required to address 'racl_policies_i' range '[NrRaclPolicies - 1:0]' ([2:0])`