### PR TITLE
[gpio][tb] scoreboard/testbench improvement

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_agent.sv
+++ b/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_agent.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class gpio_strap_agent extends dv_base_agent  #(.CFG_T(gpio_strap_agent_cfg),
+                                                .DRIVER_T(gpio_strap_driver),
+                                                .SEQUENCER_T(strap_sequencer),
+                                                .MONITOR_T(gpio_strap_monitor));
+
+  `uvm_component_utils(gpio_strap_agent)
+
+  gpio_strap_monitor     strap_monitor;
+  gpio_strap_driver      strap_driver;
+  strap_sequencer        strap_sqr;
+  gpio_strap_agent_cfg   cfg;
+
+  // Constructor
+  function new(string name, uvm_component parent);
+      super.new(name, parent);
+  endfunction : new
+
+  // Build phase
+  function void build_phase(uvm_phase phase);
+
+    // Instantiate the monitor
+    strap_monitor = gpio_strap_monitor::type_id::create("strap_monitor", this);
+    // Instantiate the driver
+    strap_driver = gpio_strap_driver::type_id::create("strap_driver", this);
+    // Instantiate the sequencer
+    strap_sqr = strap_sequencer::type_id::create("strap_sqr", this);
+    // Set the sequencer in the config DB for the driver
+    uvm_config_db#(strap_sequencer)::set(this, "*", "strap_sqr", strap_sqr);
+
+    // Instantiate the strap agent config object
+    cfg = gpio_strap_agent_cfg::type_id::create("cfg", this);
+
+    // Set the agent cfg in the config DB
+    uvm_config_db#(gpio_strap_agent_cfg)::set(this, "", "cfg", cfg);
+    // Set the agent cfg in the config DB that is used in the strap monitor
+    uvm_config_db#(gpio_strap_agent_cfg)::set(this, "*", "monitor_cfg", cfg);
+
+    super.build_phase(phase);
+  endfunction : build_phase
+
+  // Connect phase
+  function void connect_phase(uvm_phase phase);
+    strap_driver.seq_item_port.connect(strap_sqr.seq_item_export);
+    super.connect_phase(phase);
+  endfunction : connect_phase
+
+endclass : gpio_strap_agent

--- a/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_agent.sv
+++ b/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_agent.sv
@@ -9,17 +9,13 @@ class gpio_strap_agent extends dv_base_agent  #(.CFG_T(gpio_strap_agent_cfg),
 
   `uvm_component_utils(gpio_strap_agent)
 
+  extern function new(string name, uvm_component parent);
+
   gpio_strap_monitor     strap_monitor;
   gpio_strap_driver      strap_driver;
   strap_sequencer        strap_sqr;
   gpio_strap_agent_cfg   cfg;
 
-  // Constructor
-  function new(string name, uvm_component parent);
-      super.new(name, parent);
-  endfunction : new
-
-  // Build phase
   function void build_phase(uvm_phase phase);
 
     // Instantiate the monitor
@@ -36,16 +32,19 @@ class gpio_strap_agent extends dv_base_agent  #(.CFG_T(gpio_strap_agent_cfg),
 
     // Set the agent cfg in the config DB
     uvm_config_db#(gpio_strap_agent_cfg)::set(this, "", "cfg", cfg);
-    // Set the agent cfg in the config DB that is used in the strap monitor
-    uvm_config_db#(gpio_strap_agent_cfg)::set(this, "*", "monitor_cfg", cfg);
+    // Set the agent cfg in the config DB that is used in the strap monitor and driver.
+    uvm_config_db#(gpio_strap_agent_cfg)::set(this, "*", "sub_cfg", cfg);
 
     super.build_phase(phase);
   endfunction : build_phase
 
-  // Connect phase
   function void connect_phase(uvm_phase phase);
     strap_driver.seq_item_port.connect(strap_sqr.seq_item_export);
     super.connect_phase(phase);
   endfunction : connect_phase
 
 endclass : gpio_strap_agent
+
+function gpio_strap_agent::new(string name, uvm_component parent);
+  super.new(name, parent);
+endfunction

--- a/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_agent_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_agent_cfg.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class gpio_strap_agent_cfg extends dv_base_agent_cfg;
+  `uvm_object_utils(gpio_strap_agent_cfg)
+
+  function new (string name = "gpio_strap_agent_cfg");
+    super.new(name);
+  endfunction : new
+
+endclass

--- a/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_driver.sv
+++ b/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_driver.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class gpio_strap_driver extends dv_base_driver #(.ITEM_T(uvm_sequence_item),
+                                                 .CFG_T(gpio_strap_agent_cfg));
+
+  `uvm_component_utils(gpio_strap_driver)
+
+  straps_vif         m_straps_vif;
+  virtual clk_rst_if clk_rst_vif;
+  strap_sequencer    m_seqr;
+
+  // Constructor: Creates a new instance of the gpio_driver class
+  // @param name - The name of the component
+  // @param parent - The parent component
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
+        `uvm_fatal(`gfn, "Virtual interface m_straps_vif is not set in the uvm_config_db")
+    end
+    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "*.env", "clk_rst_vif", clk_rst_vif)) begin
+        `uvm_fatal(`gfn, "Could not get clk_rst_vif")
+    end
+    if (!uvm_config_db#(strap_sequencer)::get(this, "", "strap_sqr", m_seqr)) begin
+        `uvm_fatal(`gfn, "Failed to get sequencer handle from config DB!")
+    end
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    forever begin
+      gpio_seq_item m_item;
+      seq_item_port.get_next_item(req);
+
+      if(!$cast(m_item , req)) begin
+          `uvm_error("gpio_strap_driver", "Failed to cast item to gpio_seq_item")
+      end
+      drive_item(m_item);
+      seq_item_port.item_done();
+    end
+  endtask
+
+  // Drive the stran_en_i pin
+  virtual task drive_item(gpio_seq_item req);
+    @(posedge clk_rst_vif.clk);
+    m_straps_vif.tb_if.strap_en <= req.strap_en_i;
+  endtask
+
+endclass

--- a/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_monitor.sv
+++ b/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_monitor.sv
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class gpio_strap_monitor extends dv_base_monitor #(.ITEM_T(uvm_sequence_item),
+                                                   .CFG_T(gpio_strap_agent_cfg));
+
+  `uvm_component_utils(gpio_strap_monitor)
+
+  // Used to send the strap outputs to the scoreboard
+  uvm_analysis_port  #(gpio_seq_item) mon_ap;
+  // straps virtual interface
+  straps_vif m_straps_vif;
+  // gpio virtual interface
+  gpio_vif m_gpio_vif;
+  // clk and rst virtual interface
+  virtual clk_rst_if clk_rst_vif;
+  // GPIO sequence item
+  gpio_seq_item item;
+  // strap agent configuration object
+  gpio_strap_agent_cfg cfg;
+
+  // Constructor
+  function new(string name = "gpio_strap_monitor", uvm_component parent = null);
+    super.new(name, parent);
+    mon_ap = new ("mon_ap", this);
+    item = new();
+  endfunction
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
+        `uvm_fatal(`gfn, "Virtual interface m_straps_vif is not set")
+    end
+    if (!uvm_config_db#(gpio_vif)::get(this, "*.env", "gpio_vif", m_gpio_vif)) begin
+        `uvm_fatal(`gfn, "Could not get m_gpio_vif")
+            end
+    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "*.env", "clk_rst_vif", clk_rst_vif)) begin
+        `uvm_fatal(`gfn, "Could not get clk_rst_vif")
+    end
+    if (!uvm_config_db#(gpio_strap_agent_cfg)::get(this, "", "monitor_cfg", cfg)) begin
+        `uvm_fatal(`gfn, "Could not get strap agent config")
+    end
+    // Required because the parent class use the agent configuration object.
+    super.cfg = cfg;
+  endfunction
+
+  // Task to monitor GPIO strap signals
+  virtual task run_phase(uvm_phase phase);
+    fork
+      monitor_gpio_straps();
+    join_none
+  endtask
+
+  // Task: monitor_gpio_straps
+  // The task monitor the gpio straps enable signal
+  // and send the strap ouput information to the scoreboard to be checked.
+  virtual task monitor_gpio_straps();
+    forever begin : monitor_gpio_straps
+      @(posedge clk_rst_vif.clk)
+      clk_rst_vif.wait_clks_or_rst(1);
+      if(m_straps_vif.tb_if.strap_en &&
+        !m_straps_vif.strap_en_q   &&
+        !m_straps_vif.strap_en_qq) begin
+        // Wait for at least 1 clock cycle after strap_en is asserted.
+        clk_rst_vif.wait_clks_or_rst(1);
+        if(clk_rst_vif.rst_n) begin
+          // Sample the straps
+          item.sampled_straps_o.data  = m_straps_vif.tb_if.sampled_straps.data;
+          item.sampled_straps_o.valid = m_straps_vif.tb_if.sampled_straps.valid;
+          // Send the sampled straps to the gpio scoreboard.
+          mon_ap.write(item);
+        end
+      end
+    end
+  endtask : monitor_gpio_straps
+endclass : gpio_strap_monitor

--- a/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_monitor.sv
+++ b/hw/ip/gpio/dv/env/gpio_agent/gpio_strap_monitor.sv
@@ -8,70 +8,67 @@ class gpio_strap_monitor extends dv_base_monitor #(.ITEM_T(uvm_sequence_item),
   `uvm_component_utils(gpio_strap_monitor)
 
   // Used to send the strap outputs to the scoreboard
-  uvm_analysis_port  #(gpio_seq_item) mon_ap;
+  uvm_analysis_port #(gpio_seq_item) mon_ap;
   // straps virtual interface
-  straps_vif m_straps_vif;
-  // gpio virtual interface
-  gpio_vif m_gpio_vif;
+  local straps_vif m_straps_vif;
   // clk and rst virtual interface
-  virtual clk_rst_if clk_rst_vif;
+  virtual clk_rst_if m_clk_rst_vif;
   // GPIO sequence item
-  gpio_seq_item item;
+  local gpio_seq_item item;
   // strap agent configuration object
-  gpio_strap_agent_cfg cfg;
+  local gpio_strap_agent_cfg m_cfg;
+  // gpio config env object;
+  local gpio_env_cfg m_gpio_env_cfg;
 
   // Constructor
   function new(string name = "gpio_strap_monitor", uvm_component parent = null);
     super.new(name, parent);
     mon_ap = new ("mon_ap", this);
-    item = new();
   endfunction
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
-        `uvm_fatal(`gfn, "Virtual interface m_straps_vif is not set")
+
+    // Agent config object
+    if (!uvm_config_db#(gpio_strap_agent_cfg)::get(this, "", "sub_cfg", m_cfg)) begin
+      `uvm_fatal(`gfn, "Could not get strap agent config")
     end
-    if (!uvm_config_db#(gpio_vif)::get(this, "*.env", "gpio_vif", m_gpio_vif)) begin
-        `uvm_fatal(`gfn, "Could not get m_gpio_vif")
-            end
-    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "*.env", "clk_rst_vif", clk_rst_vif)) begin
-        `uvm_fatal(`gfn, "Could not get clk_rst_vif")
+
+    // Environment config object.
+    if (!uvm_config_db#(gpio_env_cfg)::get(null, "uvm_test_top.env", "cfg", m_gpio_env_cfg)) begin
+      `uvm_fatal(`gfn, "Could not get environment config object")
     end
-    if (!uvm_config_db#(gpio_strap_agent_cfg)::get(this, "", "monitor_cfg", cfg)) begin
-        `uvm_fatal(`gfn, "Could not get strap agent config")
-    end
+
+    // Get the vif handles from the environment config object.
+    m_straps_vif  = m_gpio_env_cfg.straps_vif_inst;
+    m_clk_rst_vif = m_gpio_env_cfg.clk_rst_vif;
+
     // Required because the parent class use the agent configuration object.
-    super.cfg = cfg;
+    super.cfg = m_cfg;
   endfunction
 
-  // Task to monitor GPIO strap signals
+  // Monitor the gpio straps enable signal
+  // and send the strap ouput information
+  // to the scoreboard to be checked.
   virtual task run_phase(uvm_phase phase);
-    fork
-      monitor_gpio_straps();
-    join_none
-  endtask
-
-  // Task: monitor_gpio_straps
-  // The task monitor the gpio straps enable signal
-  // and send the strap ouput information to the scoreboard to be checked.
-  virtual task monitor_gpio_straps();
     forever begin : monitor_gpio_straps
-      @(posedge clk_rst_vif.clk)
-      clk_rst_vif.wait_clks_or_rst(1);
-      if(m_straps_vif.tb_if.strap_en &&
-        !m_straps_vif.strap_en_q   &&
-        !m_straps_vif.strap_en_qq) begin
-        // Wait for at least 1 clock cycle after strap_en is asserted.
-        clk_rst_vif.wait_clks_or_rst(1);
-        if(clk_rst_vif.rst_n) begin
-          // Sample the straps
-          item.sampled_straps_o.data  = m_straps_vif.tb_if.sampled_straps.data;
-          item.sampled_straps_o.valid = m_straps_vif.tb_if.sampled_straps.valid;
+      @(posedge m_clk_rst_vif.clk)
+      // Only sends the item if the stran_en is posedged
+      // to avoid sending items every clock cycle after the stran_en is high.
+      @(posedge m_straps_vif.tb_port.strap_en) begin
+        // Wait for at least 2 clock cycles after strap_en is asserted.
+        // to get the registers ready.
+        m_clk_rst_vif.wait_clks(2);
+        // Check if the reset operation is completed.
+        if (m_clk_rst_vif.rst_n) begin
+          // Sample the strap data and valid
+          item = new();
+          item.sampled_straps_o.data  = m_straps_vif.tb_port.sampled_straps.data;
+          item.sampled_straps_o.valid = m_straps_vif.tb_port.sampled_straps.valid;
           // Send the sampled straps to the gpio scoreboard.
           mon_ap.write(item);
         end
       end
     end
-  endtask : monitor_gpio_straps
+  endtask
 endclass : gpio_strap_monitor

--- a/hw/ip/gpio/dv/env/gpio_env.core
+++ b/hw/ip/gpio/dv/env/gpio_env.core
@@ -9,10 +9,16 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:ip:gpio:0.1
     files:
       - gpio_env_pkg.sv
       - gpio_env_cfg.sv: {is_include_file: true}
       - gpio_env_cov.sv: {is_include_file: true}
+      - gpio_virtual_sequencer.sv: {is_include_file: true}
+      - gpio_agent/gpio_strap_agent_cfg.sv: {is_include_file: true}
+      - gpio_agent/gpio_strap_driver.sv: {is_include_file: true}
+      - gpio_agent/gpio_strap_monitor.sv: {is_include_file: true}
+      - gpio_agent/gpio_strap_agent.sv: {is_include_file: true}
       - gpio_scoreboard.sv: {is_include_file: true}
       - gpio_env.sv: {is_include_file: true}
       - seq_lib/gpio_vseq_list.sv: {is_include_file: true}
@@ -29,6 +35,8 @@ filesets:
       - seq_lib/gpio_intr_rand_pgm_vseq.sv: {is_include_file: true}
       - seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv: {is_include_file: true}
       - seq_lib/gpio_rand_straps_vseq.sv : {is_include_file: true}
+      - seq_lib/gpio_seq_item.sv: {is_include_file: true}
+      - seq_lib/gpio_strap_en_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/gpio/dv/env/gpio_env.sv
+++ b/hw/ip/gpio/dv/env/gpio_env.sv
@@ -7,19 +7,46 @@ class gpio_env extends cip_base_env #(
   .COV_T              (gpio_env_cov),
   .VIRTUAL_SEQUENCER_T(gpio_virtual_sequencer),
   .SCOREBOARD_T       (gpio_scoreboard)
-);
+  );
   `uvm_component_utils(gpio_env)
 
-  `uvm_component_new
+  gpio_strap_agent   strap_agent;
+  straps_vif         m_straps_vif;
+  virtual clk_rst_if m_clk_rst_vif;
+  gpio_vif           m_gpio_vif;
+
+  function new (string name, uvm_component parent = null);
+    super.new (name, parent);
+  endfunction
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (!uvm_config_db#(gpio_vif)::get(this, "", "gpio_vif", cfg.gpio_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get gpio_vif from uvm_config_db")
+
+    // Create and configure the gpio_strap_agent
+    strap_agent = gpio_strap_agent::type_id::create("strap_agent", this);
+
+    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
+      `uvm_fatal("gpio_strap_driver", "Could not get m_straps_vif from uvm_config_db ")
     end
-    if (!uvm_config_db#(straps_vif)::get(this, "", "straps_vif", cfg.straps_vif_inst)) begin
-      `uvm_fatal(get_full_name(), "Virtual interface straps_vif_inst is not set")
+    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", m_clk_rst_vif)) begin
+      `uvm_fatal("gpio_strap_driver", "Could not get m_clk_rst_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(gpio_vif)::get(this, "", "gpio_vif", m_gpio_vif)) begin
+      `uvm_fatal("gpio_strap_driver", "Could not get m_gpio_vif from uvm_config_db")
+    end
+    // Set these interfaces instances to the environment configuration object.
+    cfg.gpio_vif        = m_gpio_vif;
+    cfg.straps_vif_inst = m_straps_vif;
+    cfg.clk_rst_vif     = m_clk_rst_vif;
+
   endfunction
 
+  virtual function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    // Connect the strap monitor to the gpio scoreboard
+    strap_agent.strap_monitor.mon_ap.connect(scoreboard.sb_exp);
+    // Register a strap agent sub-sequencer into the virtual sequencer.
+    // to be able to access it through the main sequence test.
+    virtual_sequencer.register_sequencer("strap_sequencer", strap_agent.strap_sqr);
+  endfunction
 endclass

--- a/hw/ip/gpio/dv/env/gpio_env.sv
+++ b/hw/ip/gpio/dv/env/gpio_env.sv
@@ -7,10 +7,10 @@ class gpio_env extends cip_base_env #(
   .COV_T              (gpio_env_cov),
   .VIRTUAL_SEQUENCER_T(gpio_virtual_sequencer),
   .SCOREBOARD_T       (gpio_scoreboard)
-  );
+);
   `uvm_component_utils(gpio_env)
 
-  gpio_strap_agent   strap_agent;
+  gpio_strap_agent   m_strap_agent;
   straps_vif         m_straps_vif;
   virtual clk_rst_if m_clk_rst_vif;
   gpio_vif           m_gpio_vif;
@@ -23,7 +23,7 @@ class gpio_env extends cip_base_env #(
     super.build_phase(phase);
 
     // Create and configure the gpio_strap_agent
-    strap_agent = gpio_strap_agent::type_id::create("strap_agent", this);
+    m_strap_agent = gpio_strap_agent::type_id::create("m_strap_agent", this);
 
     if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
       `uvm_fatal("gpio_strap_driver", "Could not get m_straps_vif from uvm_config_db ")
@@ -38,15 +38,14 @@ class gpio_env extends cip_base_env #(
     cfg.gpio_vif        = m_gpio_vif;
     cfg.straps_vif_inst = m_straps_vif;
     cfg.clk_rst_vif     = m_clk_rst_vif;
-
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    // Connect the strap monitor to the gpio scoreboard
-    strap_agent.strap_monitor.mon_ap.connect(scoreboard.sb_exp);
-    // Register a strap agent sub-sequencer into the virtual sequencer.
+    // Connect the strap monitor to the scoreboard
+    m_strap_agent.strap_monitor.mon_ap.connect(scoreboard.analysis_port);
+    // Register a strap agent sub-sequencer into the virtual sequencer
     // to be able to access it through the main sequence test.
-    virtual_sequencer.register_sequencer("strap_sequencer", strap_agent.strap_sqr);
+    virtual_sequencer.register_sequencer("strap_sequencer", m_strap_agent.strap_sqr);
   endfunction
 endclass

--- a/hw/ip/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cfg.sv
@@ -13,7 +13,7 @@ class gpio_env_cfg extends cip_base_env_cfg #(
   rand bit pulldown_en;
   // gpio virtual interface
   gpio_vif gpio_vif;
-  // gpio straps interface
+  // gpio straps virtual interface
   straps_vif straps_vif_inst;
 
   constraint pullup_pulldown_en_c {pullup_en ^ pulldown_en;}
@@ -35,6 +35,6 @@ class gpio_env_cfg extends cip_base_env_cfg #(
 
     // Used to allow reset operation during a stress all tests and check the CSR after that.
     can_reset_with_csr_accesses = 1'b1;
-  endfunction : initialize
 
+  endfunction : initialize
 endclass

--- a/hw/ip/gpio/dv/env/gpio_env_pkg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_pkg.sv
@@ -30,7 +30,8 @@ package gpio_env_pkg;
   typedef virtual gpio_straps_if straps_vif;
   typedef class gpio_env_cfg;
   typedef class gpio_env_cov;
-  typedef cip_base_virtual_sequencer #(gpio_env_cfg, gpio_env_cov) gpio_virtual_sequencer;
+  typedef class gpio_seq_item;
+  typedef class gpio_strap_agent_cfg;
 
   // structure to indicate gpio pin transition and type of transition
   // transition_occurred: 1-yes, 0-no
@@ -51,9 +52,21 @@ package gpio_env_pkg;
   } gpio_reg_update_due_t;
 
   // package sources
+  `include "gpio_agent/gpio_strap_agent_cfg.sv"
   `include "gpio_env_cfg.sv"
+  `include "seq_lib/gpio_seq_item.sv"
+  `include "gpio_virtual_sequencer.sv"
+
+  typedef gpio_virtual_sequencer #(.CFG_T(gpio_strap_agent_cfg),
+    .COV_T(gpio_env_cov),
+    .ITEM_T(uvm_sequence_item),
+    .RSP_ITEM_T(uvm_sequence_item)) strap_sequencer;
+
+  `include "gpio_agent/gpio_strap_monitor.sv"
+  `include "gpio_agent/gpio_strap_driver.sv"
+  `include "gpio_agent/gpio_strap_agent.sv"
   `include "gpio_env_cov.sv"
+  `include "gpio_vseq_list.sv"
   `include "gpio_scoreboard.sv"
   `include "gpio_env.sv"
-  `include "gpio_vseq_list.sv"
 endpackage

--- a/hw/ip/gpio/dv/env/gpio_env_pkg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_pkg.sv
@@ -58,9 +58,9 @@ package gpio_env_pkg;
   `include "gpio_virtual_sequencer.sv"
 
   typedef gpio_virtual_sequencer #(.CFG_T(gpio_strap_agent_cfg),
-    .COV_T(gpio_env_cov),
-    .ITEM_T(uvm_sequence_item),
-    .RSP_ITEM_T(uvm_sequence_item)) strap_sequencer;
+                                   .COV_T(gpio_env_cov),
+                                   .ITEM_T(uvm_sequence_item),
+                                   .RSP_ITEM_T(uvm_sequence_item)) strap_sequencer;
 
   `include "gpio_agent/gpio_strap_monitor.sv"
   `include "gpio_agent/gpio_strap_driver.sv"

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -40,6 +40,9 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
 
   string common_seq_type;
 
+  // Used to get the gpio data inputs/outputs from the monitor.
+  uvm_analysis_imp #(gpio_seq_item, gpio_scoreboard) analysis_port;
+
   `uvm_component_utils(gpio_scoreboard)
 
   function new (string name = "gpio_scoreboard", uvm_component parent = null);
@@ -49,6 +52,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   // Function: build_phase
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    analysis_port = new("analysis_port", this);
   endfunction
 
   // Task: run_phase
@@ -58,9 +62,42 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     fork
       monitor_gpio_i();
       monitor_gpio_interrupt_pins();
-      monitor_gpio_straps();
     join_none
   endtask
+
+  // Task: write function to get the gpio_seq_item from the straps monitor
+  // and call the checker function.
+  virtual function void write(gpio_seq_item item);
+    // Update the predicted value for strap registers.
+    update_gpio_straps_regs();
+    // Check if the gpio_i input data is matching with the strap output data.
+    check_straps_data(item);
+  endfunction : write
+
+  virtual function void update_gpio_straps_regs();
+    // Update data_in ral register value based on result of input
+    `DV_CHECK_FATAL(ral.hw_straps_data_in.predict(.value(gpio_i_driven),
+                                                  .kind(UVM_PREDICT_DIRECT)));
+    // Update data_in valid register value based on result of input
+    `DV_CHECK_FATAL(ral.hw_straps_data_in_valid.predict(.value('b1),
+                                                        .kind(UVM_PREDICT_DIRECT)));
+  endfunction : update_gpio_straps_regs
+
+  // Task: check_straps_data
+  // Check the sampled straps data
+  virtual function void check_straps_data(gpio_seq_item item);
+    // Check the sampled straps data
+    `uvm_info(`gfn, "Checking the sampled straps data", UVM_HIGH)
+    if (!first_strap_triggered) begin
+      // Checker: Compare actual values of gpio pins with straps register.
+      // Check the register hw_straps_data_in against gpio_i pins
+      `DV_CHECK_CASE_EQ(gpio_i_driven, item.sampled_straps_o.data)
+      // Check the register hw_straps_data_in_valid
+      `DV_CHECK_CASE_EQ(1, item.sampled_straps_o.valid)
+      // Turn-off the checker after the first strap trigger.
+      first_strap_triggered = 1;
+    end
+  endfunction : check_straps_data
 
   // Task : process_tl_access
   // process monitored tl transaction
@@ -93,7 +130,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end else if(data_in_update_queue[$ - 1].needs_update == 1'b1) begin
           // Use previous updated value for "data_in" prediction
           void'(ral.data_in.predict(.value(data_in_update_queue[$ - 1].reg_value),
-                                    .kind(UVM_PREDICT_READ)));
+              .kind(UVM_PREDICT_READ)));
         end
       end
 
@@ -105,11 +142,11 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         if (intr_state_update_queue[$].needs_update == 1'b1 &&
             (int'((crnt_time - intr_state_update_queue[$].eval_time) / clk_period)) > 1) begin
           void'(ral.intr_state.predict(.value(intr_state_update_queue[$].reg_value),
-                                       .kind(UVM_PREDICT_READ)));
+              .kind(UVM_PREDICT_READ)));
         end else if(intr_state_update_queue[$ - 1].needs_update == 1'b1) begin
           // Use previous updated value for "intr_state" prediction
           void'(ral.intr_state.predict(.value(intr_state_update_queue[$ - 1].reg_value),
-                                       .kind(UVM_PREDICT_READ)));
+              .kind(UVM_PREDICT_READ)));
         end
       end
 
@@ -132,7 +169,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           if (intr_state_update_queue.size() > 0) begin
             gpio_reg_update_due_t intr_state_write_to_clear_update = intr_state_update_queue[$];
             `uvm_info(`gfn, $sformatf("Entry taken out for clearing is %0p",
-                                      intr_state_write_to_clear_update), UVM_HIGH)
+                intr_state_write_to_clear_update), UVM_HIGH)
             // Update time
             intr_state_write_to_clear_update.eval_time = $time;
             for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
@@ -151,7 +188,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
             // that caused last interrupt update (As per definition of w1c in comportability
             // specification)
             if (intr_state_write_to_clear_update.eval_time == intr_state_update_queue[$].eval_time)
-                begin
+            begin
               // Re-apply interrupt update
               intr_state_write_to_clear_update.reg_value |= last_intr_update_except_clearing;
               // Delete last entry with same time stamp
@@ -165,10 +202,10 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
                   if (cleared_intr_bits[each_bit]) begin
                     if (last_intr_update_except_clearing[each_bit]) begin
                       cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b1);
+                          $sformatf("%0d", each_bit)}].sample(1'b1);
                     end else begin
                       cov.sticky_intr_cov[{"gpio_sticky_intr_pin",
-                                          $sformatf("%0d", each_bit)}].sample(1'b0);
+                          $sformatf("%0d", each_bit)}].sample(1'b0);
                     end
                   end
                 end
@@ -188,7 +225,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           end else begin
             // Coverage Sampling: coverage on *out* and *oe* register values
             if (cfg.en_cov && (!uvm_re_match("*out*", csr.get_name()) ||
-                               !uvm_re_match("*oe*", csr.get_name()))) begin
+                  !uvm_re_match("*oe*", csr.get_name()))) begin
               for (uint each_pin = 0; each_pin < NUM_GPIOS; each_pin++) begin
                 cov.out_oe_cov_objs[each_pin][csr.get_name()].sample(item.a_data[each_pin]);
               end
@@ -198,7 +235,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
                 {mask, data} = item.a_data;
                 for (uint each_pin = 0; each_pin < NUM_GPIOS/2; each_pin++) begin
                   cov.out_oe_mask_data_cov_objs[each_pin][csr.get_name()].var1_var2_cg.sample(
-                      mask[each_pin], data[each_pin]);
+                    mask[each_pin], data[each_pin]);
                 end
               end
             end
@@ -216,6 +253,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       end // if (write)
     end else begin // if (channel == DataChannel)
       if (write == 0) begin
+        `uvm_info(`gfn, $sformatf("csr read on %0s", csr.get_name()), UVM_HIGH)
         // If do_read_check, is set, then check mirrored_value against item.d_data
         if (do_read_check) begin
           // Checker-2: Check if reg read data matches expected value or not
@@ -223,10 +261,10 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           // Checker-3: Check value of interrupt pins against predicted value
           if (csr.get_name() == "intr_state") begin
             bit [TL_DW-1:0] intr_state = (intr_state_update_queue.size() > 0) ?
-                                         intr_state_update_queue[$].reg_value :
-                                         csr.get_mirrored_value();
+                                          intr_state_update_queue[$].reg_value :
+                                          csr.get_mirrored_value();
             bit [TL_DW-1:0] pred_val_intr_pins = intr_state &
-                                                 ral.intr_enable.get_mirrored_value();
+                                                ral.intr_enable.get_mirrored_value();
             // according to issue #841, interrupt is a flop and the value will be updated after one
             // clock cycle. Because the `pred_val_intr_pins` might be updated during the one clk
             // cycle, we store the predicted intr val into a temp automatic variable.
@@ -246,7 +284,9 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   // Task : monitor_gpio_i
   // monitor gpio input pins interface
   virtual task monitor_gpio_i();
-    logic [NUM_GPIOS-1:0] prev_gpio_i = cfg.gpio_vif.pins;
+
+    logic [NUM_GPIOS-1:0] prev_gpio_i;
+    prev_gpio_i = cfg.gpio_vif.pins;
 
     forever begin : monitor_pins_if
       @(cfg.gpio_vif.pins or cfg.under_reset);
@@ -267,14 +307,14 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
             gpio_i_driven[pin_num] = 1'bz;
           end
           `uvm_info(`gfn, $sformatf("pins_oe[%0d] = %0b pins_o[%0d] = %0b gpio_i_driven[%0d] = %0b",
-                                    pin_num, cfg.gpio_vif.pins_oe[pin_num], pin_num,
-                                    cfg.gpio_vif.pins_o[pin_num], pin_num, gpio_i_driven[pin_num]),
-                                    UVM_HIGH)
+              pin_num, cfg.gpio_vif.pins_oe[pin_num], pin_num,
+              cfg.gpio_vif.pins_o[pin_num], pin_num, gpio_i_driven[pin_num]),
+            UVM_HIGH)
         end
 
         `uvm_info(`gfn, $sformatf("pins = 0x%0h [%0b]) gpio_i_driven = 0x%0h [%0b]",
-                                  cfg.gpio_vif.pins, cfg.gpio_vif.pins, gpio_i_driven,
-                                  gpio_i_driven), UVM_HIGH)
+            cfg.gpio_vif.pins, cfg.gpio_vif.pins, gpio_i_driven,
+            gpio_i_driven), UVM_HIGH)
         // Predict effect on gpio pins
         gpio_predict_and_compare();
 
@@ -285,7 +325,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           gpio_transition_t [NUM_GPIOS-1:0] gpio_i_transition;
           foreach (prev_gpio_i[pin]) begin
             gpio_i_transition[pin].transition_occurred =
-                (cfg.gpio_vif.pins[pin] !== prev_gpio_i[pin]);
+              (cfg.gpio_vif.pins[pin] !== prev_gpio_i[pin]);
             if (gpio_i_transition[pin].transition_occurred) begin
               case (cfg.gpio_vif.pins[pin])
                 1'b0: begin
@@ -320,12 +360,15 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
                     gpio_i_transition[pin].transition_occurred = 1'b0;
                   end
                 end
+                default: begin
+                  `uvm_info(`gfn, "gpio pin undefined!", UVM_HIGH)
+                end
               endcase
             end
           end
           foreach (gpio_i_transition[ii]) begin
             `uvm_info(`gfn, $sformatf("gpio_i_transition[%0d] = %0p", ii, gpio_i_transition[ii]),
-                      UVM_HIGH)
+              UVM_HIGH)
           end
           `uvm_info(`gfn, "Calling gpio_interrupt_predict from monitor_pins_if", UVM_HIGH)
           // Look for interrupt event and update interrupt status
@@ -333,19 +376,17 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           // Update value
           prev_gpio_i = cfg.gpio_vif.pins;
           `uvm_info(`gfn, $sformatf("updated prev_gpio_i = 0x%0h [%0b]", prev_gpio_i, prev_gpio_i),
-                    UVM_HIGH)
+            UVM_HIGH)
         end
         // Update "previous pins if out and out enable" values
         prv_gpio_i_pins_o = cfg.gpio_vif.pins_o;
         prv_gpio_i_pins_oe = cfg.gpio_vif.pins_oe;
         `uvm_info(`gfn, $sformatf("prv_gpio_i_pins_o = 0x%0h [%0b]",
-                                  prv_gpio_i_pins_o, prv_gpio_i_pins_o), UVM_HIGH)
+            prv_gpio_i_pins_o, prv_gpio_i_pins_o), UVM_HIGH)
         `uvm_info(`gfn, $sformatf("prv_gpio_i_pins_oe = 0x%0h [%0b]",
-                                  prv_gpio_i_pins_oe, prv_gpio_i_pins_oe), UVM_HIGH)
+            prv_gpio_i_pins_oe, prv_gpio_i_pins_oe), UVM_HIGH)
       end
-
     end // monitor_pins_if
-
   endtask : monitor_gpio_i
 
   // Task: monitor_gpio_interrupt_pins
@@ -364,54 +405,10 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
   endtask : monitor_gpio_interrupt_pins
 
-  virtual task update_gpio_straps_regs(logic [NUM_GPIOS-1:0] gpio_i_sampled);
-    // Update data_in and data_in_valid ral register value based on result of input
-    `DV_CHECK_FATAL(ral.hw_straps_data_in.predict(.value(gpio_i_sampled),
-                                                  .kind(UVM_PREDICT_READ)));
-    `DV_CHECK_FATAL(ral.hw_straps_data_in_valid.predict(.value('b1),
-                                                        .kind(UVM_PREDICT_READ)));
-  endtask : update_gpio_straps_regs
-
-  // Task: monitor_gpio_straps
-  // The task monitors the gpio straps enable signal
-  // and checks the straps output signal after the first strap trigger
-  virtual task monitor_gpio_straps();
-    logic [NUM_GPIOS-1:0] gpio_i_sampled;
-    forever begin : monitor_gpio_straps
-      // Wait for going out of reset operation.
-      wait(!cfg.under_reset);
-      // Wait until the strap_en input be triggered
-      // if a reset comes in the middle, step-out of the loop.
-      while (!cfg.straps_vif_inst.tb_port.strap_en) begin
-        cfg.clk_rst_vif.wait_clks_or_rst(1);
-        if (cfg.under_reset) break;
-      end
-      // Step out to the next iteration if a reset happens.
-      if (cfg.under_reset) continue;
-      // Get the gpio_i input data from the pins interface.
-      gpio_i_sampled = cfg.gpio_vif.pins;
-      // Wait for one clock cycle to update the register model.
-      cfg.clk_rst_vif.wait_clks_or_rst(1);
-      // Step out from the loop if a reset comes.
-      if (cfg.under_reset) continue;
-      // Update the register model.
-      update_gpio_straps_regs(gpio_i_sampled);
-
-      // Checker: Compare actual values of gpio pins with straps register.
-      // Check the register hw_straps_data_in against gpio_i pins
-      `DV_CHECK_CASE_EQ(gpio_i_sampled, cfg.straps_vif_inst.tb_port.sampled_straps.data)
-      // Check the register hw_straps_data_in_valid
-      `DV_CHECK_CASE_EQ('b1, cfg.straps_vif_inst.tb_port.sampled_straps.valid)
-
-      // Wait for the next reset, if it happens.
-      wait(cfg.under_reset);
-    end
-  endtask : monitor_gpio_straps
-
   // Function: actual_gpio_i_activity
   function bit actual_gpio_i_activity();
     return ~((prv_gpio_i_pins_o === cfg.gpio_vif.pins_o) &&
-             (prv_gpio_i_pins_oe === cfg.gpio_vif.pins_oe));
+      (prv_gpio_i_pins_oe === cfg.gpio_vif.pins_oe));
   endfunction : actual_gpio_i_activity
 
   // Function : gpio_predict_and_compare
@@ -431,7 +428,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         "direct_out": begin
           data_out = csr.get_mirrored_value();
           `uvm_info(`gfn, $sformatf("data_out updated to 0x%0h [%0b]", data_out, data_out),
-                    UVM_HIGH)
+            UVM_HIGH)
           // Update mirror values of *out* registers
           update_gpio_out_regs();
         end
@@ -439,13 +436,13 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           uvm_reg_data_t data = ral.masked_out_lower.data.get_mirrored_value();
 
           for (uint pin_idx = 0;
-               pin_idx < ral.masked_out_lower.mask.get_n_bits(); pin_idx++) begin
+              pin_idx < ral.masked_out_lower.mask.get_n_bits(); pin_idx++) begin
             if (masked_out_lower_mask[pin_idx] == 1'b1) begin
               data_out[pin_idx] = data[pin_idx];
             end
           end
           `uvm_info(`gfn, $sformatf("data_out updated to 0x%0h [%0b]", data_out, data_out),
-                    UVM_HIGH)
+            UVM_HIGH)
           // Update mirror values of *out* registers
           update_gpio_out_regs();
         end
@@ -458,14 +455,14 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
             end
           end
           `uvm_info(`gfn, $sformatf("data_out updated to 0x%0h [%0b]", data_out, data_out),
-                    UVM_HIGH)
+            UVM_HIGH)
           // Update mirror values of *out* registers
           update_gpio_out_regs();
         end
         "direct_oe": begin
           data_oe = csr.get_mirrored_value();
           `uvm_info(`gfn, $sformatf("data_out updated to 0x%0h [%0b]", data_out, data_out),
-                    UVM_HIGH)
+            UVM_HIGH)
           // Update mirror values of *oe* registers
           update_gpio_oe_regs();
         end
@@ -479,7 +476,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
             end
           end
           `uvm_info(`gfn, $sformatf("data_oe reg updated to 0x%0h [%0b]", data_oe, data_oe),
-                    UVM_HIGH)
+            UVM_HIGH)
           // Update mirror values of *oe* registers
           update_gpio_oe_regs();
         end
@@ -546,9 +543,9 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end
       end
       `uvm_info(msg_id, $sformatf("data_out_effect_on_gpio_i = 0x%0h [%0b]",
-                                  data_out_effect_on_gpio_i, data_out_effect_on_gpio_i), UVM_HIGH)
+          data_out_effect_on_gpio_i, data_out_effect_on_gpio_i), UVM_HIGH)
       `uvm_info(msg_id, $sformatf("gpio_i_driven = 0x%0h [%0b]", gpio_i_driven, gpio_i_driven),
-                UVM_HIGH)
+        UVM_HIGH)
 
       // Predict effective value of common wire that-
       // (i) drives gpio_i, and
@@ -572,7 +569,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end
       end
       `uvm_info(msg_id, $sformatf("pred_val_gpio_pins = %0h(%0b)", pred_val_gpio_pins,
-                                  pred_val_gpio_pins), UVM_HIGH)
+          pred_val_gpio_pins), UVM_HIGH)
 
       // Store latest update to be applied to data_in
       begin
@@ -591,9 +588,9 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           for (uint each_bit = 0; each_bit < NUM_GPIOS; each_bit++) begin
             cov.data_in_cov_obj[each_bit].sample(pred_val_gpio_pins[each_bit]);
             cov.data_out_data_oe_data_in_cross_cg.sample(each_bit, data_out[each_bit],
-                data_oe[each_bit], pred_val_gpio_pins[each_bit]);
+              data_oe[each_bit], pred_val_gpio_pins[each_bit]);
             cov.gpio_pins_data_in_cross_cg.sample(each_bit, cfg.gpio_vif.pins[each_bit],
-                pred_val_gpio_pins[each_bit]);
+              pred_val_gpio_pins[each_bit]);
           end
         end
       end
@@ -644,13 +641,13 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     if (cfg.en_cov) begin
       foreach (intr_ctrl_en_rising[each_bit]) begin
         cov.intr_ctrl_en_cov_objs[each_bit]["intr_ctrl_en_rising"].sample(
-            intr_ctrl_en_rising[each_bit]);
+          intr_ctrl_en_rising[each_bit]);
         cov.intr_ctrl_en_cov_objs[each_bit]["intr_ctrl_en_falling"].sample(
-            intr_ctrl_en_falling[each_bit]);
+          intr_ctrl_en_falling[each_bit]);
         cov.intr_ctrl_en_cov_objs[each_bit]["intr_ctrl_en_lvlhigh"].sample(
-            intr_ctrl_en_lvlhigh[each_bit]);
+          intr_ctrl_en_lvlhigh[each_bit]);
         cov.intr_ctrl_en_cov_objs[each_bit]["intr_ctrl_en_lvllow"].sample(
-            intr_ctrl_en_lvllow[each_bit]);
+          intr_ctrl_en_lvllow[each_bit]);
       end
     end
     // 1. Look for edge triggerred interrupts
@@ -660,9 +657,9 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         foreach (rising_edge_intr_events[each_bit]) begin
           if (gpio_i_transition[each_bit].transition_occurred) begin
             rising_edge_intr_events[each_bit]  = gpio_i_transition[each_bit].is_rising_edge &
-                                                 intr_ctrl_en_rising[each_bit];
+              intr_ctrl_en_rising[each_bit];
             falling_edge_intr_events[each_bit] = !gpio_i_transition[each_bit].is_rising_edge &
-                                                 intr_ctrl_en_falling[each_bit];
+              intr_ctrl_en_falling[each_bit];
           end
         end
         foreach (gpio_i_transition[each_bit]) begin
@@ -682,13 +679,13 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       if (cfg.en_cov) begin
         foreach (rising_edge_intr_events[each_bit]) begin
           cov.intr_event_type_cov_objs[each_bit]["intr_event_rising"].intr_type_cg.sample(
-              intr_ctrl_en_rising[each_bit],
-              intr_enable[each_bit],
-              rising_edge_intr_events[each_bit]);
+            intr_ctrl_en_rising[each_bit],
+            intr_enable[each_bit],
+            rising_edge_intr_events[each_bit]);
           cov.intr_event_type_cov_objs[each_bit]["intr_event_falling"].intr_type_cg.sample(
-              intr_ctrl_en_falling[each_bit],
-              intr_enable[each_bit],
-              falling_edge_intr_events[each_bit]);
+            intr_ctrl_en_falling[each_bit],
+            intr_enable[each_bit],
+            falling_edge_intr_events[each_bit]);
         end
       end
     end
@@ -697,9 +694,9 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       bit [TL_DW-1:0] lvlhigh_intr_events, lvllow_intr_events;
       for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
         lvlhigh_intr_events[each_bit] = (cfg.gpio_vif.pins[each_bit] == 1'b1) &&
-                                        (intr_ctrl_en_lvlhigh[each_bit] == 1'b1);
+          (intr_ctrl_en_lvlhigh[each_bit] == 1'b1);
         lvllow_intr_events[each_bit]  = (cfg.gpio_vif.pins[each_bit] == 1'b0) &&
-                                        (intr_ctrl_en_lvllow[each_bit] == 1'b1);
+          (intr_ctrl_en_lvllow[each_bit] == 1'b1);
         if (exp_intr_status[each_bit] == 1'b0) begin
           if (lvlhigh_intr_events[each_bit] || lvllow_intr_events[each_bit]) begin
             exp_intr_status[each_bit] = 1'b1;
@@ -715,13 +712,13 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       if (cfg.en_cov) begin
         foreach (lvlhigh_intr_events[each_bit]) begin
           cov.intr_event_type_cov_objs[each_bit]["intr_event_lvlhigh"].intr_type_cg.sample(
-              intr_ctrl_en_lvlhigh[each_bit],
-              intr_enable[each_bit],
-              lvlhigh_intr_events[each_bit]);
+            intr_ctrl_en_lvlhigh[each_bit],
+            intr_enable[each_bit],
+            lvlhigh_intr_events[each_bit]);
           cov.intr_event_type_cov_objs[each_bit]["intr_event_lvllow"].intr_type_cg.sample(
-              intr_ctrl_en_lvllow[each_bit],
-              intr_enable[each_bit],
-              lvllow_intr_events[each_bit]);
+            intr_ctrl_en_lvllow[each_bit],
+            intr_enable[each_bit],
+            lvllow_intr_events[each_bit]);
         end
       end
     end
@@ -747,15 +744,15 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         end
         // Interrupt Test coverage
         cov.intr_test_cg.sample(each_bit,
-                                last_intr_test_event[each_bit],
-                                intr_enable[each_bit],
-                                exp_intr_status[each_bit]);
+          last_intr_test_event[each_bit],
+          intr_enable[each_bit],
+          exp_intr_status[each_bit]);
       end
     end
     // Clear last_intr_test_event
     last_intr_test_event = '0;
     `uvm_info(msg_id, $sformatf("Predicted interrupt status = 0x%0h [%0b]",
-                                exp_intr_status, exp_intr_status), UVM_HIGH)
+        exp_intr_status, exp_intr_status), UVM_HIGH)
     begin
       gpio_reg_update_due_t crnt_intr_state_update;
       // Keep update pending until register access is done
@@ -785,16 +782,16 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     // 2. Update masked_out_lower
     data = data_out;
     for (uint idx = ral.masked_out_lower.data.get_n_bits();
-         idx < `UVM_REG_DATA_WIDTH;
-         idx++) begin
+        idx < `UVM_REG_DATA_WIDTH;
+        idx++) begin
       data[idx] = 1'b0;
     end
     void'(ral.masked_out_lower.data.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
     // 3. Update masked_out_upper
     data = 0;
     for (uint idx = ral.masked_out_upper.data.get_n_bits();
-         idx < `UVM_REG_DATA_WIDTH;
-         idx++) begin
+        idx < `UVM_REG_DATA_WIDTH;
+        idx++) begin
       data[idx - ral.masked_out_upper.data.get_n_bits()] = data_out[idx];
     end
     void'(ral.masked_out_upper.data.predict(.value(data), .kind(UVM_PREDICT_WRITE)));
@@ -836,7 +833,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     if (cfg.en_cov) begin
       for (uint each_bit = 0; each_bit < NUM_GPIOS; each_bit++) begin
         cov.data_out_data_oe_cov_obj[each_bit].var1_var2_cg.sample(data_out[each_bit],
-                                                                   data_oe[each_bit]);
+          data_oe[each_bit]);
       end
     end
   endfunction : sample_data_out_data_oe_coverage

--- a/hw/ip/gpio/dv/env/gpio_virtual_sequencer.sv
+++ b/hw/ip/gpio/dv/env/gpio_virtual_sequencer.sv
@@ -8,7 +8,8 @@
 class gpio_virtual_sequencer #(type CFG_T      = gpio_env_cfg,
                                type COV_T      = gpio_env_cov,
                                type ITEM_T     = uvm_sequence_item,
-                               type RSP_ITEM_T = uvm_sequence_item) extends cip_base_virtual_sequencer #(CFG_T, COV_T);
+                               type RSP_ITEM_T = uvm_sequence_item)
+                               extends cip_base_virtual_sequencer #(CFG_T, COV_T);
 
   `uvm_component_param_utils(gpio_virtual_sequencer #(CFG_T,
                                                       COV_T,

--- a/hw/ip/gpio/dv/env/gpio_virtual_sequencer.sv
+++ b/hw/ip/gpio/dv/env/gpio_virtual_sequencer.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef GPIO_VIRTUAL_SEQUENCER_SV
+`define GPIO_VIRTUAL_SEQUENCER_SV
+
+class gpio_virtual_sequencer #(type CFG_T      = gpio_env_cfg,
+                               type COV_T      = gpio_env_cov,
+                               type ITEM_T     = uvm_sequence_item,
+                               type RSP_ITEM_T = uvm_sequence_item) extends cip_base_virtual_sequencer #(CFG_T, COV_T);
+
+  `uvm_component_param_utils(gpio_virtual_sequencer #(CFG_T,
+                                                      COV_T,
+                                                      ITEM_T,
+                                                      RSP_ITEM_T))
+
+  // These fifos collects items when req/rsp is received, which are used to communicate between
+  // monitor and sequences. These fifos are optional
+  // When device is re-active, it gets items from req_analysis_fifo and send rsp to driver
+  // When this is a high-level agent, monitors put items to these 2 fifos for high-level seq
+  // This is required to be declared here as similar with dv_base_sequencer.sv to avoid compilation issues
+  // when tries to reuse the dv_base_agent. TODO: Find a better solution if is possible.
+  uvm_tlm_analysis_fifo #(ITEM_T)     req_analysis_fifo;
+  uvm_tlm_analysis_fifo #(RSP_ITEM_T) rsp_analysis_fifo;
+
+  function new(string name = "gpio_virtual_sequencer", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction : new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction : build_phase
+
+endclass
+`endif // GPIO_VIRTUAL_SEQUENCER_SV

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
@@ -13,6 +13,9 @@ class gpio_base_vseq extends cip_base_vseq #(
   rand uint delay;
   bit  do_init_reset = 1;
 
+  // Sequencer used to run sub-sequences inside of a main sequence
+  uvm_sequencer#(.REQ(gpio_seq_item), .RSP(gpio_seq_item)) sqr_h;
+
   constraint delay_c {
     delay dist {0 :/ 20, [1:5] :/ 40, [6:15] :/ 30, [20:25] :/ 10};
   }

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
@@ -106,10 +106,10 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_out)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_oe)
 
-    // User case to test the straps output, with gpio_in data randomised
+    // User case to test the strap outputs, with gpio_in data randomised
     test_straps_gpio_in();
 
-    // User case to test the straps output/registers, with gpio_out data randomised
+    // User case to test the strap outputs, with gpio_out data randomised
     // The gpio_out should not affect the straps output/registers.
     test_straps_gpio_out();
 

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_rand_straps_vseq.sv
@@ -47,21 +47,48 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
     join
   endtask : csr_strap_read
 
+  // Drive the strap_en_i input signal using the strap_en_seq sequence
+  task set_strap_en(bit strap_en);
+
+    string strap_seqr = "strap_sequencer";
+    strap_sequencer seqr;
+    gpio_strap_en_vseq strap_en_seq;
+
+    // Instantiate the strap_en sequence
+    strap_en_seq = gpio_strap_en_vseq::type_id::create("strap_en_seq");
+
+    if(!$cast(seqr, p_sequencer.get_sequencer(strap_seqr))) begin
+      `uvm_fatal(`gfn, "cast error getting the strap sequencer")
+    end
+
+    // Start the strap_en_seq sequence with the desired value.
+    if (seqr != null) begin
+      `uvm_info(`gfn, $sformatf("Driving strap_en = %0d", strap_en), UVM_HIGH)
+      strap_en_seq.strap_en = strap_en;
+      strap_en_seq.start(seqr);
+    end
+  endtask : set_strap_en
+
   task test_straps_gpio_in();
     // Drive the gpio_in
     drive_gpio_in(gpio_in);
 
-    // Random wait to drive the strap_en
-    // The strap feature should work from zero clock cycles
-    // after driving the gpio_i inputs into the interface.
-    short_wait(0);
+    // Wait at least one clock cycle to drive the strap_en
+    // Required because is required one clock cycle to update the gpio_in regsisters.
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 0;)
+    cfg.clk_rst_vif.wait_clks(delay);
 
     // Trigger the snapshot of gpio_in to be stored in the straps registers
     cfg.straps_vif_inst.tb_port.strap_en = 1;
     // Wait at least one clock cycle to update the strap register values.
     short_wait(1);
 
-    // Read the hw_straps_data_in registers and check the expected value in the scoreboard
+    // Wait some clock cycles to avoid race condition between the prediction value updated
+    // in the scoreboard happening together with the csr read transaction.
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 4;)
+    cfg.clk_rst_vif.wait_clks(delay);
+
+    // Read the hw_straps_data_in and check the expected value in the scoreboard
     csr_strap_read();
 
     // Random wait
@@ -74,9 +101,8 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
     // Random wait
     short_wait(0);
 
-    // Read to make sure that if does not affect the straps registers after undrive the gpio_in
+    // Read again to make sure that if does not affect the straps registers after undrive the gpio_in
     csr_strap_read();
-
   endtask : test_straps_gpio_in
 
   task test_straps_gpio_out();
@@ -96,10 +122,6 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
 
   endtask : test_straps_gpio_out
 
-  // This task start the strap en test. First it will test the strap enable
-  // with the driven gpio_i. On a second step drive the gpio_out and check the strap
-  // registers based on that. And finally applies a second reset and check if the strap registers
-  // are reseted.
   task start_test();
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_in)
@@ -116,27 +138,28 @@ class gpio_rand_straps_vseq extends gpio_base_vseq;
     // Random wait
     short_wait(0);
 
+    // Disable the strap_en
+    set_strap_en('b0);
+
     // Set zero to the strap_en input.
     cfg.straps_vif_inst.tb_port.strap_en = 0;
     // Apply reset and make sure the strap registers are clean
     apply_reset();
 
-    // Random wait
-    // At least one clock cycle required to take the updated register values.
+    // Random wait, at least one clock cycle to avoid race condition
+    // between the reset and read transactions.
     short_wait(1);
-
     // Read the straps registers after reset
     csr_strap_read();
 
   endtask : start_test
 
   task body();
-    `uvm_info(`gfn, "Starting the test", UVM_HIGH)
-    // Just a minimum one clock cycle wait between more than one iteration if this
-    // test is executed into the stress_all virtual sequence.
-    short_wait(1);
-    start_test();
-    `uvm_info(`gfn, "End of the test", UVM_HIGH)
+      // Random wait
+      short_wait(0);
+      `uvm_info(`gfn, "Start of Test", UVM_HIGH)
+      start_test();
+      `uvm_info(`gfn, "End of Test", UVM_HIGH)
   endtask : body
 
 endclass : gpio_rand_straps_vseq

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_seq_item.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_seq_item.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef GPIO_SEQ_ITEM_SV
+`define GPIO_SEQ_ITEM_SV
+
+import gpio_pkg::*;
+import tlul_pkg::*;
+class gpio_seq_item extends uvm_sequence_item;
+
+    `uvm_object_utils(gpio_seq_item)
+
+    // Input and output variables
+    rand bit                 strap_en_i;
+    rand bit                 alert_rx_i;
+    rand tl_h2d_t            tl_i;
+    rand bit [NUM_GPIOS-1:0] cio_gpio_i;
+
+    tl_d2h_t            tl_o;
+    gpio_straps_t       sampled_straps_o;
+    bit                 intr_gpio_o;
+    bit                 alert_tx_o;
+    bit [NUM_GPIOS-1:0] cio_gpio_o;
+    bit [NUM_GPIOS-1:0] cio_gpio_en_o;
+
+    // Constructor
+    function new(string name = "gpio_seq_item");
+        super.new(name);
+    endfunction
+endclass
+`endif // GPIO_SEQ_ITEM_SV

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_strap_en_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_strap_en_vseq.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class gpio_strap_en_vseq extends  uvm_sequence #(gpio_seq_item);
+    `uvm_object_utils(gpio_strap_en_vseq)
+
+    gpio_seq_item item;
+    bit strap_en;
+
+    function new(string name = "gpio_strap_en_vseq");
+        super.new(name);
+        item = gpio_seq_item::type_id::create("item");
+    endfunction
+
+    task body();
+        start_item(item);
+        assert(item.randomize() with {strap_en_i == strap_en;});
+        finish_item(item);
+    endtask : body
+
+  endclass : gpio_strap_en_vseq

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_vseq_list.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_vseq_list.sv
@@ -14,4 +14,5 @@
 `include "gpio_random_long_reg_writes_reg_reads_vseq.sv"
 `include "gpio_full_random_vseq.sv"
 `include "gpio_stress_all_vseq.sv"
+`include "gpio_strap_en_vseq.sv"
 `include "gpio_rand_straps_vseq.sv"

--- a/hw/ip/gpio/dv/interfaces/gpio_straps_if.sv
+++ b/hw/ip/gpio/dv/interfaces/gpio_straps_if.sv
@@ -2,20 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // interface : gpio_straps_if
-`ifndef GPIO_STRAPS_IF_SV
-`define GPIO_STRAPS_IF_SV
 
 import gpio_pkg::*;
-
 // Interface definition
 interface gpio_straps_if(input logic clk, input logic rst_n);
 
-  logic          strap_en;       // Signal to enable straps
-  gpio_straps_t  sampled_straps; // Sampled gpio_i snapshot data from GPIO (DUT)
+logic strap_en; // Signal to enable straps
+logic strap_en_qq;
+logic strap_en_q;
+gpio_straps_t sampled_straps; // Sampled gpio_i snapshot data from GPIO (DUT)
 
   modport dut_port(input strap_en, output sampled_straps);
   modport tb_port(output strap_en, input sampled_straps);
 
 endinterface
-
-`endif // GPIO_STRAPS_IF_SV

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -92,5 +92,4 @@ module tb;
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
-
 endmodule

--- a/hw/ip/gpio/dv/tests/gpio_base_test.sv
+++ b/hw/ip/gpio/dv/tests/gpio_base_test.sv
@@ -22,8 +22,12 @@ class gpio_base_test extends cip_base_test #(
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", straps_vif_inst)) begin
-      `uvm_fatal("SEQ", "Virtual interface straps_vif_inst is not set")
+    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
+      `uvm_fatal(`gfn, "Virtual interface straps_vif_inst is not set in the uvm_config_db")
     end
   endfunction : build_phase
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+  endtask
 endclass : gpio_base_test

--- a/hw/ip/gpio/dv/tests/gpio_base_test.sv
+++ b/hw/ip/gpio/dv/tests/gpio_base_test.sv
@@ -22,7 +22,7 @@ class gpio_base_test extends cip_base_test #(
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", m_straps_vif)) begin
+    if (!uvm_config_db#(straps_vif)::get(this, "*.*", "straps_vif", straps_vif_inst)) begin
       `uvm_fatal(`gfn, "Virtual interface straps_vif_inst is not set in the uvm_config_db")
     end
   endfunction : build_phase


### PR DESCRIPTION
Scoreboard/testbench gpio strap improvements.
Basically the goal is remove the tasks monitor_* that are in the scoreboard and create proper monitor/drive/agent components for the strap feature, and keep only the checkers inside the scoreboard.