### PR TITLE
[regtool] multireg: Fix bad reserved field in json

### DIFF
--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -165,7 +165,7 @@ class MultiRegister(RegBase):
             self.dv_compact = False
 
     def next_offset(self, addrsep: int) -> int:
-        return self.offset + len(self.regs) * addrsep
+        return self.offset + self.count * addrsep
 
     def get_n_bits(self, bittype: List[str] = ["q"]) -> int:
         return sum(reg.get_n_bits(bittype) for reg in self.regs)


### PR DESCRIPTION
In some cases, len(self.regs) seems to be set to the incorrect length of the register array. Changing this logic to use self.count instead fixes the issue. See bug #26102 for reproduction details.