### PR TITLE
Cherry-pick to earlgrey_1.0.0: [rom_ext] Introduce ISFB data structures.

### DIFF
--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MANIFEST_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MANIFEST_H_
 
+#include <limits.h>
 #include <stddef.h>
 
 #include "sw/device/lib/base/macros.h"
@@ -399,6 +400,20 @@ enum {
    */
   kManifestExtIdSpxKey = 0x94ac01ec,
   kManifestExtIdSpxSignature = 0xad77f84a,
+  kManifestExtIdSecVerWrite = 0x3f086a41,
+
+  /**
+   * ASCII "ISFB".
+   *
+   * Integration Specific Firmware Binding (ISFB) extension.
+   */
+  kManifestExtIdIsfb = 0x42465349,
+  /**
+   * ASCII "ISFE".
+   *
+   * Integration Specific Firmware Binding (ISFB) erase policy extension.
+   */
+  kManifestExtIdIsfbErase = 0x45465349,
   /**
    * ASCII "EXT0.
    */
@@ -438,6 +453,92 @@ typedef struct manifest_ext_spx_signature {
 } manifest_ext_spx_signature_t;
 
 /**
+ * Manifest extension: Write the securty version.
+ */
+typedef struct manifest_ext_secver_write {
+  /**
+   * Required manifest header.
+   */
+  manifest_ext_header_t header;
+  /**
+   * Hardened bool indicating whether or not to write the security version to
+   * boot data.
+   */
+  uint32_t write;
+} manifest_ext_secver_write_t;
+
+/**
+ * Manifest extension: Integration Specific Firmware Binding (ISFB).
+ *
+ * The Integration Specific Firmware Binding (ISFB) extension is used to bind
+ * firmware to certain integrator-device phases (e.g. restrict firmware to
+ * unreleased integrator devices only). The `ROM_EXT` needs to perform these
+ * constraint checks instead of the firmware because the rescure protocol
+ * bypasses any owner firmware level enforcement.
+ *
+ * This extension also provides a mechanism to enable firmware owners to perform
+ * their own rollback and upgrade automated testing. The rollback policy is
+ * implemented on top of the `strike_bits` provided in the ISFB info flash
+ * region.
+ */
+typedef struct manifest_ext_isfb {
+  /**
+   * Required manifest header.
+   */
+  manifest_ext_header_t header;
+  /**
+   * Strikeout mask.
+   *
+   * The size of this array is equal to 128 strike bits packed into uint32_t
+   * words. Each strike bit corresponds to a flash word in the ISFB info flash
+   * page.
+   *
+   * For each 1-bit in the strike mask, the corresponding flash word in the ISFB
+   * info flash page must have a non-zero value.
+   */
+  uint32_t strike_mask[128 / (CHAR_BIT * sizeof(uint32_t))];
+  /**
+   * Number of product expressions that follow. Must be less than or equal to
+   * the number of `product_words` in the `owner_isfb_config_t` configuration.
+   */
+  uint32_t product_expr_count;
+  /**
+   * Product expressions. The size of this array is equal to
+   * `product_expr_count`.
+   */
+  struct {
+    uint32_t mask;
+    uint32_t value;
+  } product_expr[];
+} manifest_ext_isfb_t;
+OT_ASSERT_MEMBER_OFFSET(manifest_ext_isfb_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(manifest_ext_isfb_t, strike_mask, 8);
+OT_ASSERT_MEMBER_OFFSET(manifest_ext_isfb_t, product_expr_count, 24);
+OT_ASSERT_MEMBER_OFFSET(manifest_ext_isfb_t, product_expr, 28);
+
+/**
+ * Manifest extension: ISFB erase policy.
+ *
+ * The ISFB erase policy extension is used to allow or disallow erasing the ISFB
+ * info flash region.
+ *
+ * This extension should be attached to the firmware's signed manifest to
+ * indicate that a firmware image may erase the ISFB info page.  This extension
+ * is required when the configuration indicates that the isfb_erase extension
+ * must be present to authorize erase operations.
+ */
+typedef struct manifest_ext_isfb_erase {
+  /**
+   * Required manifest header.
+   */
+  manifest_ext_header_t header;
+  /**
+   * Hardened bool indicating whether or not to allow erasing the ISFB region.
+   */
+  uint32_t erase_allowed;
+} manifest_ext_isfb_erase_t;
+
+/**
  * Table of manifest extensions.
  *
  * Columns: Table index, type name, extenstion name, identifier, signed or not.
@@ -445,7 +546,10 @@ typedef struct manifest_ext_spx_signature {
 // clang-format off
 #define MANIFEST_EXTENSIONS(X) \
   X(0, manifest_ext_spx_key_t,       spx_key,       kManifestExtIdSpxKey,       true ) \
-  X(1, manifest_ext_spx_signature_t, spx_signature, kManifestExtIdSpxSignature, false)
+  X(1, manifest_ext_spx_signature_t, spx_signature, kManifestExtIdSpxSignature, false) \
+  X(2, manifest_ext_secver_write_t,  secver_write,  kManifestExtIdSecVerWrite,  true)  \
+  X(3, manifest_ext_isfb_t,          isfb,          kManifestExtIdIsfb,         true)  \
+  X(4, manifest_ext_isfb_erase_t,    isfb_erase,    kManifestExtIdIsfbErase,    true)
 // clang-format on
 
 #if defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -126,6 +126,8 @@ typedef enum tlv_tag {
   kTlvTagInfoConfig = 0x4f464e49,
   /** Rescue Configuration: `RESQ`. */
   kTlvTagRescueConfig = 0x51534552,
+  /** Integration Specific Firmware Binding: `ISFB`. */
+  kTlvTagIntegrationSpecificFirmwareBinding = 0x42465349,
   /** Not Present: `ZZZZ`. */
   kTlvTagNotPresent = 0x5a5a5a5a,
 } tlv_tag_t;
@@ -396,6 +398,68 @@ OT_ASSERT_MEMBER_OFFSET(owner_rescue_config_t, start, 12);
 OT_ASSERT_MEMBER_OFFSET(owner_rescue_config_t, size, 14);
 OT_ASSERT_MEMBER_OFFSET(owner_rescue_config_t, command_allow, 16);
 OT_ASSERT_SIZE(owner_rescue_config_t, 16);
+
+/**
+ * The owner Integration Specific Firmware Binding (ISFB) configuration
+ * describes the configuration parameters for the ISFB region.
+ *
+ * Integrators have their own constraints that require owner firmware to be
+ * locked to certain integrator-device phases. The `ROM_EXT` needs to perform
+ * these constraint checks instead of the owner firmware because the rescue
+ * protocol bypasses any owner firmware level enforcement.
+ *
+ * Integrators can also perform their own rollback and upgrade automated testing
+ * using the strike words in the ISFB region. The erase policy implemented by
+ * this configuration entry allows the integrator to authorize erase operations
+ * of the ISFB region to configure devices for testing purposes.
+ */
+typedef struct owner_isfb_config {
+  /**
+   * Header identifiying this struct.
+   * tag: `ISFB`.
+   * length: 44 words.
+   */
+  tlv_header_t header;
+  /** The flash bank where the ISFB region is located. */
+  uint8_t bank;
+  /** The info flash page where the ISFB region is located. */
+  uint8_t page;
+  /** Padding for alignment */
+  uint16_t _pad;
+
+  /**
+   * The erase conditions for the ISFB region.
+   *
+   * This is a packed array of MUBI4 bools indicating which conditions authorize
+   * an erase. The conditions are aligned in little endian order: [B7, B6, B5,
+   * B4, B3, B2, B1, B0]
+   *
+   * The conditions are:
+   * - B0: Firmware must be signed with key specified by `key_domain` field.
+   * - B1: Firmware must be node locked (e.g. manifest usage constraints must be
+   * enabled).
+   * - B2: `manifest_ext_isfb_erase_t` must be present and set to harden true in
+   * the firmware manifest.
+   * - B3-B7: Reserved.
+   */
+  uint32_t erase_conditions;
+  /** If `B0`, part of erase authorization criteria. */
+  uint32_t key_domain;
+  /** Reserved space for future use. */
+  uint32_t reserved[5];
+  /** Number of `uint32_t` reserved for product expressions. It has to be a
+   * value less than or equal to 256. */
+  uint32_t product_words;
+} owner_isfb_config_t;
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, bank, 8);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, page, 9);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, _pad, 10);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, erase_conditions, 12);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, key_domain, 16);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, reserved, 20);
+OT_ASSERT_MEMBER_OFFSET(owner_isfb_config_t, product_words, 40);
+OT_ASSERT_SIZE(owner_isfb_config_t, 44);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Introduce Integrator Specific Firmware Binding (ISFB) data structures used to implement integrator-device specific binding as well as anti-rollback based on ownership configuration.

Data structures:

1. `manifest_ext_isfb_t`: Integration specific firmware binding manifest extension. Contains anti-rollback strike mask as well as device expecific product expression.
2. `manifest_ext_isfb_erase_t`: ISFB erase policy manifest extension. This extension is used to authorize erasing of the ISFB region. Intended for testing purposes. The implementation will require node-locking for this policy to be effective.
3. `owner_isfb_config`: ISFB owner configuration. Defines the ISFB info flash page configuration as well as its erase policy.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>
(cherry picked from commit 3c72c0ed03608a03d1d0350c8e759a81ad55dfd7)