### PR TITLE
[opentitanlib] expose backend configs to enable downstream use

### DIFF
--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -18,13 +18,13 @@ use crate::transport::hyperdebug::{
 use crate::transport::{EmptyTransport, Transport};
 use crate::util::parse_int::ParseInt;
 
-mod chip_whisperer;
+pub mod chip_whisperer;
 mod ftdi;
 mod hyperdebug;
-mod proxy;
-mod ti50emulator;
+pub mod proxy;
+pub mod ti50emulator;
 mod ultradebug;
-mod verilator;
+pub mod verilator;
 
 #[derive(Debug, Args)]
 pub struct BackendOpts {

--- a/sw/host/opentitanlib/src/backend/proxy.rs
+++ b/sw/host/opentitanlib/src/backend/proxy.rs
@@ -11,9 +11,9 @@ use crate::transport::Transport;
 #[derive(Debug, Args)]
 pub struct ProxyOpts {
     #[arg(long)]
-    proxy: Option<String>,
+    pub proxy: Option<String>,
     #[arg(long, default_value = "9900")]
-    port: u16,
+    pub port: u16,
 }
 
 pub fn create(args: &ProxyOpts) -> Result<Box<dyn Transport>> {

--- a/sw/host/opentitanlib/src/backend/ti50emulator.rs
+++ b/sw/host/opentitanlib/src/backend/ti50emulator.rs
@@ -12,13 +12,13 @@ use std::str::FromStr;
 #[derive(Debug, Args)]
 pub struct Ti50EmulatorOpts {
     #[arg(long, default_value = "ti50")]
-    instance_prefix: String,
+    pub instance_prefix: String,
 
     #[arg(long, value_parser = PathBuf::from_str, default_value = "")]
-    executable_directory: PathBuf,
+    pub executable_directory: PathBuf,
 
     #[arg(long, default_value = "")]
-    executable: String,
+    pub executable: String,
 }
 
 pub fn create(args: &Ti50EmulatorOpts) -> Result<Box<dyn Transport>> {

--- a/sw/host/opentitanlib/src/backend/verilator.rs
+++ b/sw/host/opentitanlib/src/backend/verilator.rs
@@ -13,21 +13,21 @@ use crate::transport::Transport;
 #[derive(Debug, Args)]
 pub struct VerilatorOpts {
     #[arg(long, default_value_t)]
-    verilator_bin: String,
+    pub verilator_bin: String,
 
     #[arg(long, default_value_t)]
-    verilator_rom: String,
+    pub verilator_rom: String,
     #[arg(long, required = false)]
-    verilator_flash: Vec<String>,
+    pub verilator_flash: Vec<String>,
     #[arg(long, default_value_t)]
-    verilator_otp: String,
+    pub verilator_otp: String,
 
     #[arg(long, required = false)]
-    verilator_args: Vec<String>,
+    pub verilator_args: Vec<String>,
 
     /// Verilator startup timeout.
     #[arg(long, value_parser = parse_duration, default_value = "60s")]
-    verilator_timeout: Duration,
+    pub verilator_timeout: Duration,
 }
 
 pub fn create(args: &VerilatorOpts) -> Result<Box<dyn Transport>> {


### PR DESCRIPTION
We are developing a downstream provisioning test flow harness in the `lowRISC/opentitan-provisioning` repo that makes use of opentitanlib. We need to expose backend function structs to enable programs to configuring these settings outside of a CLI-like environment.