### PR TITLE
[silicon_creator] Remove cbor dependency on log

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -141,7 +141,6 @@ cc_library(
     hdrs = ["cbor.h"],
     deps = [
         "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:log",
         "@open-dice//:cbor_reader_writer",
     ],
 )

--- a/sw/device/silicon_creator/lib/cert/cbor.h
+++ b/sw/device/silicon_creator/lib/cert/cbor.h
@@ -6,15 +6,13 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_
 
 #include "include/dice/cbor_writer.h"
-#include "sw/device/lib/runtime/log.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#define CBOR_RETURN_IF_OVERFLOWED(p)    \
-  do {                                  \
-    if (CborOutOverflowed(p)) {         \
-      LOG_ERROR("CborOutOverflowed!!"); \
-      return kErrorCertInvalidSize;     \
-    }                                   \
+#define CBOR_RETURN_IF_OVERFLOWED(p) \
+  do {                               \
+    if (CborOutOverflowed(p)) {      \
+      return kErrorCertInvalidSize;  \
+    }                                \
   } while (0)
 
 #define CBOR_CHECK_OVERFLOWED_AND_RETURN(p) \


### PR DESCRIPTION
This dependency is only used to log an error message which is already covered by a specific error code anyway. Also since `log` only compiles on OT, it prevents the unittests from being runnable on host.