### PR TITLE
[hw,racl_ctrl,corefiles] Fix path to lint file

### DIFF
--- a/hw/ip_templates/racl_ctrl/racl_ctrl.core.tpl
+++ b/hw/ip_templates/racl_ctrl/racl_ctrl.core.tpl
@@ -30,7 +30,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/racl_ctrl.waiver
+      - lint/${module_instance_name}.waiver
     file_type: waiver
 
   files_veriblelint_waiver:


### PR DESCRIPTION
Lint file gets renamed to the module_instance_name, need to update the path in the core file.