### PR TITLE
[gpio,rtl] Remove overly strong assumption

### DIFF
--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -85,7 +85,6 @@ module gpio
     assign hw2reg.hw_straps_data_in.d        = data_in_d;
     assign sampled_straps_o.data             = reg2hw.hw_straps_data_in.q;
     assign sampled_straps_o.valid            = reg2hw.hw_straps_data_in_valid.q;
-    `ASSUME(StrapSampleOnce_A, ##1 $fell(sample_trigger) |-> always !sample_trigger)
   end else begin : gen_no_strap_sample
     assign hw2reg.hw_straps_data_in_valid.de = 1'b0;
     assign hw2reg.hw_straps_data_in_valid.d  = 1'b0;


### PR DESCRIPTION
[gpio,rtl] Remove overly strong assumption

The "always" part of this assumption (and assertion) is false if there is a reset. It also doesn't really give an assumption that constrains the input behaviour, so we should just drop it.