### PR TITLE
[mem_bkdr_util,otp_ctrl] Restore the use of EnCsrngSwAppReadSize

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env.core.tpl
@@ -15,8 +15,8 @@ filesets:
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:crypto_dpi_present
       - lowrisc:dv:lc_ctrl_dv_utils
-      - ${instance_vlnv("lowrisc:dv:otp_ctrl_mem_bkdr_util:0.1")}
     files:
+      - otp_scrambler_pkg.sv
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_if.sv
       - otp_ctrl_ast_inputs_cfg.sv: {is_include_file: true}

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -5,6 +5,9 @@
 // This package has functions that perform mem_bkdr_util accesses to different partitions in OTP.
 // These functions end up performing reads and writes to the underlying simulated otp memory, so
 // the functions must get a handle to the mem_bkdr_util instance for otp_ctrl as an argument.
+//
+// NB: this package is only suitable for top-level environments since it depends on SKU-dependent
+// OTP ctrl fields.
 
 package otp_ctrl_mem_bkdr_util_pkg;
 
@@ -167,13 +170,9 @@ package otp_ctrl_mem_bkdr_util_pkg;
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
-
-  // TODO(#25883): The size of these parameters depends on the top-level. This injected a fact about
-  // the top-level into the mem_bkdr_util class. For now, we're replacing "EnCsrngSwAppReadSize" with
-  // 1 as a short-term hack.
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [1*8-1:0] en_csrng_sw_app_read,
+      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
       bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
   );

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -15,8 +15,8 @@ filesets:
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:crypto_dpi_present
       - lowrisc:dv:lc_ctrl_dv_utils
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_mem_bkdr_util:0.1
     files:
+      - otp_scrambler_pkg.sv
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_if.sv
       - otp_ctrl_ast_inputs_cfg.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -5,6 +5,9 @@
 // This package has functions that perform mem_bkdr_util accesses to different partitions in OTP.
 // These functions end up performing reads and writes to the underlying simulated otp memory, so
 // the functions must get a handle to the mem_bkdr_util instance for otp_ctrl as an argument.
+//
+// NB: this package is only suitable for top-level environments since it depends on SKU-dependent
+// OTP ctrl fields.
 
 package otp_ctrl_mem_bkdr_util_pkg;
 
@@ -167,13 +170,9 @@ package otp_ctrl_mem_bkdr_util_pkg;
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
-
-  // TODO(#25883): The size of these parameters depends on the top-level. This injected a fact about
-  // the top-level into the mem_bkdr_util class. For now, we're replacing "EnCsrngSwAppReadSize" with
-  // 1 as a short-term hack.
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [1*8-1:0] en_csrng_sw_app_read,
+      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
       bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
   );

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -15,8 +15,8 @@ filesets:
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:crypto_dpi_present
       - lowrisc:dv:lc_ctrl_dv_utils
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_mem_bkdr_util:0.1
     files:
+      - otp_scrambler_pkg.sv
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_if.sv
       - otp_ctrl_ast_inputs_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -5,6 +5,9 @@
 // This package has functions that perform mem_bkdr_util accesses to different partitions in OTP.
 // These functions end up performing reads and writes to the underlying simulated otp memory, so
 // the functions must get a handle to the mem_bkdr_util instance for otp_ctrl as an argument.
+//
+// NB: this package is only suitable for top-level environments since it depends on SKU-dependent
+// OTP ctrl fields.
 
 package otp_ctrl_mem_bkdr_util_pkg;
 
@@ -167,13 +170,9 @@ package otp_ctrl_mem_bkdr_util_pkg;
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
-
-  // TODO(#25883): The size of these parameters depends on the top-level. This injected a fact about
-  // the top-level into the mem_bkdr_util class. For now, we're replacing "EnCsrngSwAppReadSize" with
-  // 1 as a short-term hack.
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [1*8-1:0] en_csrng_sw_app_read,
+      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
       bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
   );


### PR DESCRIPTION
Use mem_bkdr_util_pkg for top-level only:
- The block level DV code doesn't use this package, so don't add it as a block-level dependency.
- Moreover, the code depends on SKU-specific OTP fields which are only available in the top-level DV environment, so it won't compile at block level.

Fixes #25883