### PR TITLE
[lint] Waive LINE_LENGTH AscentLint warnings in top_darjeeling.sv

### DIFF
--- a/hw/top_darjeeling/lint/top_darjeeling.waiver
+++ b/hw/top_darjeeling/lint/top_darjeeling.waiver
@@ -72,5 +72,5 @@ waive -rules SAME_NAME_TYPE -location {spi_device.sv mbx.sv} -regexp {'mbx' is u
 waive -rules {NOT_READ HIER_NET_NOT_READ} -location {top_darjeeling.sv} -regexp {.*cio_otp_ctrl_test_(en_)?d2p\[7:1\].* is not read} \
       -comment "otp test bus made deliberately larger on purpose"
 
-waive -rules {LINE_LENGTH} -location {top_racl_pkg.sv} -regexp {Line length of \[[0-9]+\] exceeds 100 character limit} \
-      -comment "top_racl_pkg is auto-generated and expected to exceed line length limit"
+waive -rules {LINE_LENGTH} -location {top_darjeeling.sv} -regexp {Line length of [0-9]+ exceeds 100 character limit} \
+      -comment "top_darjeeling is auto-generated and adhering to the line length limit is not always feasible for auto-generated code"


### PR DESCRIPTION
top_darjeeling.sv is auto-generated and adhering to the line length limit is not always feasible for auto-generated files. In particular when dealing with uniquified and parameterized input/ouput ports and signal names.

Automatically wrapping those lines would hinder readability and so would coming up with shorter signal/parameter names (which is especially challenging given the auto-generation / unification aspects here).