### PR TITLE
[topgen] All RACL configs are relative to the project root

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -13,7 +13,7 @@
   type: top
   rnd_cnst_seed: 1017106219537032642877583828875051302543807092889754935647094601236425074047
   datawidth: "32"
-  racl_config: top_darjeeling/data/racl/racl.hjson
+  racl_config: racl/racl.hjson
   power:
   {
     domains:

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -16,7 +16,7 @@
   datawidth: "32",
 
   // Enable RACL on Darjeeling based on the following configuration
-  racl_config: 'top_darjeeling/data/racl/racl.hjson'
+  racl_config: 'racl/racl.hjson'
 
   // Power information for the design
   power: {
@@ -901,7 +901,7 @@
         soc:  {soc_mbx: "0x01465000"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/all_rd_wr_mapping.hjson'
+        soc: 'racl/all_rd_wr_mapping.hjson'
       }
     },
     { name: "mbx1",
@@ -914,7 +914,7 @@
         soc:  {soc_mbx: "0x01465100"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/all_rd_wr_mapping.hjson'
+        soc: 'racl/all_rd_wr_mapping.hjson'
       }
     },
     { name: "mbx2",
@@ -927,7 +927,7 @@
         soc:  {soc_mbx: "0x01465200"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/all_rd_wr_mapping.hjson'
+        soc: 'racl/all_rd_wr_mapping.hjson'
       }
     },
     { name: "mbx3",
@@ -950,7 +950,7 @@
         soc:  {soc_mbx: "0x01465400"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/all_rd_wr_mapping.hjson'
+        soc: 'racl/all_rd_wr_mapping.hjson'
       }
     },
     { name: "mbx5",
@@ -963,7 +963,7 @@
         soc:  {soc_mbx: "0x01465500"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/all_rd_wr_mapping.hjson'
+        soc: 'racl/all_rd_wr_mapping.hjson'
       }
     },
     { name: "mbx6",
@@ -986,7 +986,7 @@
         soc:  {soc_dbg: "0x1000"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/all_rd_wr_mapping.hjson'
+        soc: 'racl/all_rd_wr_mapping.hjson'
       }
     },
     { name: "mbx_pcie0",
@@ -999,7 +999,7 @@
         soc:  {soc_mbx: "0x01460100"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/soc_rot_mapping.hjson'
+        soc: 'racl/soc_rot_mapping.hjson'
       }
     },
     { name: "mbx_pcie1",
@@ -1012,7 +1012,7 @@
         soc:  {soc_mbx: "0x01460200"},
       },
       racl_mappings: {
-        soc: 'top_darjeeling/data/racl/soc_rot_mapping.hjson'
+        soc: 'racl/soc_rot_mapping.hjson'
       }
     },
     { name: "soc_dbg_ctrl",
@@ -1049,7 +1049,7 @@
         num_ranges: 32
       }
       attr: "ipgen",
-      racl_mapping: 'top_darjeeling/data/racl/soc_rot_mapping.hjson'
+      racl_mapping: 'racl/soc_rot_mapping.hjson'
     },
     { name: "rv_core_ibex",
       type: "rv_core_ibex",

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1530,8 +1530,13 @@ def main():
         log.info("Generation pass {}".format(pass_idx + 1))
         # Use the same seed for each pass to have stable random constants.
         secure_prng.reseed(topcfg["rnd_cnst_seed"])
+        # Insert the config file path of the HJSON to allow parsing files relative
+        # the config directory
+        cfg_copy["cfg_path"] = Path(args.topcfg).parent
         completecfg, name_to_block, name_to_hjson = _process_top(
             cfg_copy, args, cfg_path, out_path_gen, alias_cfgs)
+        # Delete config path before dumping, not needed
+        del completecfg["cfg_path"]
         dump_path = Path(f"/tmp/top{topname}cfg_{pass_idx}.hjson")
         _dump_cfg(dump_path, completecfg)
         if pass_idx > 0 and filecmp.cmp(

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -1450,7 +1450,7 @@ def amend_racl(top_cfg: OrderedDict,
         return
 
     # Read the top-level RACL information
-    top_cfg['racl'] = parse_racl_config(top_cfg['racl_config'])
+    top_cfg["racl"] = parse_racl_config(top_cfg["cfg_path"] / top_cfg["racl_config"])
 
     # Generate the RACL mappings for all subscribing IPs
     for m in top_cfg['module']:
@@ -1467,8 +1467,8 @@ def amend_racl(top_cfg: OrderedDict,
                 # once and need no further updates.
                 continue
             parsed_register_mapping, parsed_window_mapping, racl_group, _ = (
-                parse_racl_mapping(top_cfg['racl'], mapping_path, if_name,
-                                   block))
+                parse_racl_mapping(top_cfg["racl"], top_cfg["cfg_path"] / mapping_path,
+                                   if_name, block))
             m['racl_mappings'][if_name] = {
                 'racl_group': racl_group,
                 'register_mapping': parsed_register_mapping,

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -85,6 +85,7 @@ top_added = {
         'l',
         'list of wakeup requests each holding name, width, and module'
     ],
+    'cfg_path': ['s', 'Path to the folder of the toplevel HJSON file']
 }
 
 pinmux_required = {


### PR DESCRIPTION
To allow topgen to be called from different paths.