### PR TITLE
[bazel] Add QEMU execution environment to `earlgrey_1.0.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,3 +713,19 @@ jobs:
       - name: Check for unrunnable tests
         run: ./ci/scripts/check-unrunnable-tests.sh
         continue-on-error: true
+
+  qemu_smoketest:
+    name: QEMU smoketest
+    runs-on: ubuntu-22.04-vivado
+    needs: quick_lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Execute QEMU smoketest
+        run: |
+          ./bazelisk.sh test //sw/device/tests:rom_exit_immediately_sim_qemu_base

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,6 +153,9 @@ bitstreams_repo(name = "bitstreams")
 load("//third_party/open-dice:repos.bzl", "open_dice_repos")
 open_dice_repos()
 
+load("//third_party/qemu:repos.bzl", "qemu_opentitan_repos")
+qemu_opentitan_repos()
+
 # Setup for linking in externally managed test and provisioning customizations
 # for both secure/non-secure manufacturer domains.
 load("//rules:hooks_setup.bzl", "hooks_setup", "provisioning_exts_setup", "secure_hooks_setup")

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -16,8 +16,10 @@ load(
     "fpga_cw340",
     "silicon",
     "sim_dv",
+    "sim_qemu",
     "sim_verilator",
 )
+load("//rules/opentitan:qemu.bzl", "qemu_cfg", "qemu_flash", "qemu_otp")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -114,6 +116,29 @@ fpga_cw310(
     base = ":fpga_cw310_test_rom",
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "test_key_0"},
     exec_env = "fpga_cw310_rom_with_fake_keys",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
+    rom = "//sw/device/silicon_creator/rom:mask_rom",
+)
+
+sim_qemu(
+    name = "sim_qemu_base",
+    design = "earlgrey",
+    exec_env = "sim_qemu_base",
+    libs = [
+        "//sw/device/lib/arch:boot_stage_rom_ext",
+        "//sw/device/lib/arch:sim_qemu",
+    ],
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    otp = "//hw/ip/otp_ctrl/data:img_rma",
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
+)
+
+sim_qemu(
+    name = "sim_qemu_rom_with_fake_keys",
+    testonly = True,
+    base = ":sim_qemu_base",
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "test_key_0"},
+    exec_env = "sim_qemu_rom_with_fake_keys",
     manifest = "//sw/device/silicon_creator/rom_ext:manifest",
     rom = "//sw/device/silicon_creator/rom:mask_rom",
 )

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -388,9 +388,13 @@ def _opentitan_test(ctx):
         p = None
 
     executable, runfiles = exec_env.test_dispatch(ctx, exec_env, p)
+    if ctx.attr.test_harness != None:
+        harness_runfiles = ctx.attr.test_harness[DefaultInfo].default_runfiles
+    else:
+        harness_runfiles = ctx.runfiles()
     return DefaultInfo(
         executable = executable,
-        runfiles = ctx.runfiles(files = runfiles),
+        runfiles = ctx.runfiles(files = runfiles).merge_all([harness_runfiles]),
     )
 
 opentitan_test = rv_rule(
@@ -403,6 +407,7 @@ opentitan_test = rv_rule(
         "test_harness": attr.label(
             executable = True,
             cfg = "exec",
+            allow_files = True,
         ),
         "binaries": attr.label_keyed_string_dict(
             allow_files = True,

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -108,6 +108,7 @@ EARLGREY_TEST_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     "//hw/top_earlgrey:sim_dv": None,
     "//hw/top_earlgrey:sim_verilator": None,
+    "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,
 }
 
 # The default set of test environments for Earlgrey.

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -28,12 +28,17 @@ SimVerilatorBinaryInfo = provider(
     doc = "Verilator Binary Info",
 )
 
+SimQemuBinaryInfo = provider(
+    doc = "QEMU Binary Info",
+)
+
 ALL_BINARY_PROVIDERS = [
     Cw310BinaryInfo,
     Cw340BinaryInfo,
     SiliconBinaryInfo,
     SimDvBinaryInfo,
     SimVerilatorBinaryInfo,
+    SimQemuBinaryInfo,
 ]
 
 PROVIDER_FIELDS = [

--- a/rules/opentitan/qemu.bzl
+++ b/rules/opentitan/qemu.bzl
@@ -1,0 +1,403 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "@lowrisc_opentitan//rules/opentitan:providers.bzl",
+    "SimQemuBinaryInfo",
+)
+load(
+    "@lowrisc_opentitan//rules/opentitan:util.bzl",
+    "get_fallback",
+    "get_override",
+)
+load(
+    "//rules/opentitan:exec_env.bzl",
+    "ExecEnvInfo",
+    "common_test_setup",
+    "exec_env_as_dict",
+    "exec_env_common_attrs",
+)
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+
+_TEST_SCRIPT = """#!/bin/bash
+set -e
+
+# QEMU requires mutable flash and OTP files but Bazel only provides RO
+# files so we have to create copies unique to this test run.
+cp {otp} {mutable_otp} && chmod +w {mutable_otp}
+if [ ! -z {flash} ]; then
+    cp {flash} {mutable_flash} && chmod +w {mutable_flash}
+fi
+
+echo Invoking test: {test_harness} {args} "$@"
+{test_harness} {args} "$@"
+"""
+
+def qemu_params(
+        tags = [],
+        timeout = "short",
+        local = True,
+        test_harness = "//rules/scripts:qemu_pass",
+        binaries = {},
+        rom = None,
+        rom_ext = None,
+        otp = None,
+        bitstream = None,
+        test_cmd = "",
+        data = [],
+        defines = [],
+        icount = 6,
+        globals = {},
+        **kwargs):
+    extra_params = {
+        "icount": str(icount),
+        # We have to stringify this dictionary here because `_opentitan_test` only accepts
+        # a dict with string values, not more dicts.
+        "globals": json.encode(globals),
+    }
+
+    return struct(
+        tags = tags,
+        timeout = timeout,
+        local = local,
+        test_harness = test_harness,
+        binaries = binaries,
+        rom = rom,
+        rom_ext = rom_ext,
+        otp = otp,
+        bitstream = bitstream,
+        test_cmd = test_cmd,
+        data = data,
+        param = kwargs | extra_params,
+        defines = defines,
+    )
+
+def gen_cfg(ctx, **kwargs):
+    """Generate a QEMU `readconfig` INI file containing OpenTitan RTL secrets"""
+    name = get_override(ctx, "label.name", kwargs)
+    cfggen = get_override(ctx, "executable.cfggen", kwargs)
+
+    otp_sv = get_override(ctx, "file.otp_sv", kwargs)
+    lc_sv = get_override(ctx, "file.lc_sv", kwargs)
+    top_hjson = get_override(ctx, "file.top_hjson", kwargs)
+
+    top_name = get_override(ctx, "attr.top_name", kwargs)
+
+    out = ctx.actions.declare_file(name + ".ini")
+
+    ctx.actions.run(
+        inputs = [otp_sv, lc_sv, top_hjson],
+        outputs = [out],
+        executable = cfggen[DefaultInfo].files_to_run,
+        arguments = [
+            "--out",
+            out.path,
+            "--top",
+            top_name,
+            "--topcfg",
+            top_hjson.path,
+            "--otpconst",
+            otp_sv.path,
+            "--lifecycle",
+            lc_sv.path,
+            ".",
+        ],
+        mnemonic = "CfgGen",
+    )
+    return out
+
+qemu_cfg = rule(
+    implementation = lambda ctx: [DefaultInfo(files = depset([gen_cfg(ctx)]))],
+    attrs = {
+        "top_name": attr.string(),
+        "top_hjson": attr.label(allow_single_file = True),
+        "otp_sv": attr.label(allow_single_file = True),
+        "lc_sv": attr.label(allow_single_file = True),
+        "cfggen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:cfggen"),
+        ),
+    },
+)
+
+def gen_otp(ctx, **kwargs):
+    """Generate a QEMU-compatible OTP image"""
+    name = get_override(ctx, "label.name", kwargs)
+    out = ctx.actions.declare_file(name + ".raw")
+
+    vmem = get_override(ctx, "file.vmem", kwargs)
+    otptool = get_override(ctx, "executable.otptool", kwargs)
+
+    ctx.actions.run(
+        inputs = [vmem],
+        outputs = [out],
+        executable = otptool[DefaultInfo].files_to_run,
+        arguments = [
+            "-m",
+            vmem.path,
+            "-r",
+            out.path,
+            "-k",
+            "otp",
+        ],
+        mnemonic = "OtpGen",
+    )
+    return out
+
+qemu_otp = rule(
+    implementation = lambda ctx: [DefaultInfo(files = depset([gen_otp(ctx)]))],
+    attrs = {
+        "vmem": attr.label(allow_single_file = True),
+        "otptool": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:otptool"),
+        ),
+    },
+)
+
+# NOTE: currently only single-bank flash programs are supported.
+def gen_flash(ctx, **kwargs):
+    """\
+    Generate a QEMU-compatible flash image.
+
+    NOTE: currently only single-bank flash images are supported.
+    """
+    name = get_override(ctx, "label.name", kwargs)
+    out = ctx.actions.declare_file(name + ".qemu_bin")
+
+    firmware_bin = get_override(ctx, "file.firmware_bin", kwargs)
+    firmware_elf = get_override(ctx, "file.firmware_elf", kwargs)
+
+    flashgen = get_override(ctx, "executable.flashgen", kwargs)
+
+    ctx.actions.run(
+        inputs = [firmware_bin, firmware_elf],
+        outputs = [out],
+        executable = flashgen[DefaultInfo].files_to_run,
+        arguments = [
+            "-x",
+            firmware_bin.path,
+            "-X",
+            firmware_elf.path,
+            out.path,
+        ],
+        mnemonic = "FlashGen",
+    )
+    return out
+
+qemu_flash = rule(
+    implementation = lambda ctx: [DefaultInfo(files = depset([gen_flash(ctx)]))],
+    attrs = {
+        "firmware_bin": attr.label(
+            allow_single_file = True,
+            doc = "Binary firmware to be run after the ROM, usually signed",
+        ),
+        "firmware_elf": attr.label(
+            allow_single_file = True,
+            doc = "ELF version of the `firmware_bin` attribute for symbol tracking",
+        ),
+        "flashgen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:flashgen"),
+        ),
+    },
+)
+
+def _sim_qemu(ctx):
+    fields = exec_env_as_dict(ctx)
+    return ExecEnvInfo(
+        provider = SimQemuBinaryInfo,
+        test_dispatch = _test_dispatch,
+        transform = _transform,
+        cfggen = ctx.attr.cfggen,
+        otptool = ctx.attr.otptool,
+        flashgen = ctx.attr.flashgen,
+        otp_sv = ctx.file.otp_sv,
+        lc_sv = ctx.file.lc_sv,
+        top_hjson = ctx.file.top_hjson,
+        **fields
+    )
+
+sim_qemu = rule(
+    implementation = _sim_qemu,
+    attrs = exec_env_common_attrs() | {
+        "cfggen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:cfggen"),
+        ),
+        "otptool": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:otptool"),
+        ),
+        "flashgen": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+            default = Label("//third_party/qemu:flashgen"),
+        ),
+        "otp_sv": attr.label(
+            allow_single_file = True,
+            # TODO: should we really use Earl Grey as the default?
+            default = Label("//hw/ip/otp_ctrl:rtl/otp_ctrl_part_pkg.sv"),
+        ),
+        "lc_sv": attr.label(
+            allow_single_file = True,
+            default = Label("//hw/ip/lc_ctrl:rtl/lc_ctrl_state_pkg.sv"),
+        ),
+        "top_hjson": attr.label(
+            allow_single_file = True,
+            default = Label("//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson"),
+        ),
+    },
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
+)
+
+def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfile):
+    if ctx.attr.kind == "rom":
+        default = elf
+        rom = elf
+    elif ctx.attr.kind == "ram":
+        default = elf
+        rom = None
+    elif ctx.attr.kind == "flash":
+        default = gen_flash(
+            ctx,
+            flashgen = exec_env.flashgen,
+            firmware_bin = signed_bin or binary,
+            firmware_elf = elf,
+        )
+        rom = exec_env.rom[SimQemuBinaryInfo].rom
+    else:
+        fail("Not implemented: kind == ", ctx.attr.kind)
+
+    otp = gen_otp(
+        ctx,
+        otptool = exec_env.otptool,
+        vmem = exec_env.otp,
+    )
+
+    qemu_cfg = gen_cfg(
+        ctx,
+        cfggen = exec_env.cfggen,
+        otp_sv = exec_env.otp_sv,
+        lc_sv = exec_env.lc_sv,
+        top_hjson = exec_env.top_hjson,
+        top_name = exec_env.design,
+    )
+
+    return {
+        "elf": elf,
+        "binary": binary,
+        "default": default,
+        "rom": rom,
+        "rom32": None,
+        "signed_bin": signed_bin,
+        "disassembly": disassembly,
+        "mapfile": mapfile,
+        "hashfile": None,
+        "qemu_cfg": qemu_cfg,
+        "otp": otp,
+    }
+
+def _test_dispatch(ctx, exec_env, firmware):
+    """Dispatch a test for the sim_qemu environment.
+
+    Args:
+      ctx: The rule context.
+      exec_env: The ExecEnvInfo for this environment.
+      firmware: A label with a SimQemuBinaryInfo provider attached.
+    Returns:
+      (File, List[File]) The test script and needed runfiles.
+    """
+
+    test_harness, data_labels, data_files, param, action_param = common_test_setup(ctx, exec_env, firmware)
+
+    data_files += [firmware.qemu_cfg, firmware.otp]
+    test_script_fmt = {}
+
+    # Get the pre-test_cmd args.
+    args = get_fallback(ctx, "attr.args", exec_env)
+    args = " ".join(args).format(**param)
+    args = ctx.expand_location(args, data_labels)
+
+    # Add arguments to pass directly to QEMU.
+    qemu_args = []
+
+    qemu_args += ["-display", "none"]
+    qemu_args += ["-M", "ot-{}".format(exec_env.design)]
+
+    # Provide top-specific files.
+    qemu_args += ["-readconfig", "{}".format(firmware.qemu_cfg.short_path)]
+    qemu_args += ["-object", "ot-rom_img,id=rom,file={}".format(firmware.rom.short_path)]
+
+    qemu_args += ["-drive", "if=pflash,file=otp_img.raw,format=raw"]
+    test_script_fmt |= {
+        "mutable_otp": "otp_img.raw",
+        "otp": firmware.otp.short_path,
+    }
+
+    if firmware.signed_bin != None and firmware.binary != None:
+        qemu_args += ["-drive", "if=mtd,bus=1,file=flash_img.bin,format=raw"]
+        test_script_fmt |= {
+            "flash": firmware.default.short_path,
+            "mutable_flash": "flash_img.bin",
+        }
+    else:
+        test_script_fmt |= {
+            "flash": "",
+            "mutable_flash": "",
+        }
+
+    # Forward UART0 to stdout.
+    qemu_args += ["-chardev", "stdio,id=serial0"]
+    qemu_args += ["-serial", "chardev:serial0"]
+
+    # Scale the Ibex clock by an `icount` factor.
+    qemu_args += ["-icount", "shift={}".format(param["icount"])]
+
+    # Quit QEMU immediately on rstmgr fatal resets by default.
+    qemu_args += ["-global", "ot-rstmgr.fatal_reset=1"]
+
+    # Add parameter-specified globals.
+    if param["globals"]:
+        globals = json.decode(param["globals"])
+        for key, val in globals.items():
+            qemu_args += ["-global", "{}={}".format(key, val)]
+
+    args += " " + " ".join(qemu_args)
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+
+    post_test_harness_path = ctx.executable.post_test_harness
+    post_test_cmd = ctx.attr.post_test_cmd.format(**param)
+
+    if post_test_harness_path != None:
+        data_files.append(post_test_harness_path)
+        post_test_harness_path = post_test_harness_path.short_path
+    else:
+        post_test_harness_path = ""
+
+    ctx.actions.write(
+        script,
+        _TEST_SCRIPT.format(
+            test_harness = test_harness.executable.short_path,
+            args = args,
+            post_test_harness = post_test_harness_path,
+            post_test_cmd = post_test_cmd,
+            **test_script_fmt
+        ),
+    )
+
+    return script, data_files

--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//third_party/python:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
@@ -37,4 +37,11 @@ py_test(
 sh_binary(
     name = "modid_check",
     srcs = ["modid_check.sh"],
+)
+
+py_binary(
+    name = "qemu_pass",
+    srcs = ["qemu_pass.py"],
+    data = ["//third_party/qemu:qemu-system-riscv32"],
+    deps = ["@rules_python//python/runfiles"],
 )

--- a/rules/scripts/qemu_pass.py
+++ b/rules/scripts/qemu_pass.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""\
+This script executes QEMU (as provided by Bazel runfiles) and checks for
+`PASS!` to be printed from the UART. If QEMU also exited successfully, this
+script will exit with `0`.
+"""
+
+from python.runfiles import Runfiles
+import subprocess
+import sys
+
+
+def main() -> int:
+    r = Runfiles.Create()
+    qemu_bin = r.Rlocation("_main~qemu~qemu_opentitan/build/qemu-system-riscv32")
+
+    # Run the process capturing (then echoing) `stdout` and `stderr`.
+    proc = subprocess.run(
+        [qemu_bin] + sys.argv[1:],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    sys.stdout.write(proc.stdout or "")
+    sys.stderr.write(proc.stderr or "")
+
+    if proc.stdout.find("PASS!") != -1:
+        return proc.returncode
+    elif proc.returncode == 0:
+        # QEMU exited successfully but we didn't see `PASS!`, fail instead.
+        return 1
+    else:
+        return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -103,3 +103,16 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )
+
+cc_library(
+    name = "sim_qemu",
+    srcs = ["device_sim_qemu.c"],
+    deps = [
+        ":device",
+        "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//hw/ip/uart/data:uart_c_regs",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+)

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -66,6 +66,11 @@ typedef enum device_type {
    * Silicon.
    */
   kDeviceSilicon = 5,
+  /**
+   * Represents the "QEMU" device, i.e. an emulation of OpenTitan written
+   * independently of the RTL.
+   */
+  kDeviceSimQemu = 6,
 } device_type_t;
 
 /**

--- a/sw/device/lib/arch/device_sim_qemu.c
+++ b/sw/device/lib/arch/device_sim_qemu.c
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated
+#include "rv_core_ibex_regs.h"                        // Generated
+#include "uart_regs.h"                                // Generated
+
+/**
+ * @file
+ * @brief Device-specific symbol definitions for the QEMU emulation.
+ */
+
+const device_type_t kDeviceType = kDeviceSimQemu;
+
+const uint64_t kClockFreqCpuMhz = 24;
+
+const uint64_t kClockFreqCpuHz = kClockFreqCpuMhz * 1000 * 1000;
+
+uint64_t to_cpu_cycles(uint64_t usec) { return usec * kClockFreqCpuMhz; }
+
+const uint64_t kClockFreqHiSpeedPeripheralHz = 24 * 1000 * 1000;  // 24MHz
+
+const uint64_t kClockFreqPeripheralHz = 6 * 1000 * 1000;  // 6MHz
+
+const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
+
+const uint64_t kClockFreqAonHz = 250 * 1000;  // 250kHz
+
+const uint64_t kUartBaudrate = 115200;
+
+const uint32_t kUartNCOValue =
+    CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
+
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
+
+const uint32_t kAstCheckPollCpuCycles =
+    CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
+
+// QEMU supports the DV_SIM register for terminating when a test status has been
+// written.
+const uintptr_t kDeviceTestStatusAddress =
+    TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
+    RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+// Although QEMU isn't an FPGA, there's no harm in us printing the version here.
+void device_fpga_version_print(void) {
+  uint32_t version = ibex_fpga_version();
+  //                       : M O R
+  const uint32_t kRom = 0x3a4d4f52;
+  uart_write_imm(kRom);
+  // The cast to unsigned int stops GCC from complaining about uint32_t
+  // being a `long unsigned int` while the %x specifier takes `unsigned int`.
+  const uint32_t kNewline = 0x0a0d;
+  uart_write_hex(version, sizeof(version), kNewline);
+}

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -17,6 +17,7 @@ load(
     "EARLGREY_TEST_ENVS",
     "fpga_params",
     "opentitan_test",
+    "qemu_params",
     "verilator_params",
 )
 
@@ -688,6 +689,12 @@ opentitan_test(
     name = "rstmgr_functest",
     srcs = ["rstmgr_functest.c"],
     exec_env = EARLGREY_TEST_ENVS,
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -13,6 +13,7 @@ load(
     "EARLGREY_TEST_ENVS",
     "fpga_params",
     "opentitan_test",
+    "qemu_params",
     "verilator_params",
 )
 load(
@@ -309,6 +310,9 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
+        timeout = "long",
+    ),
+    qemu = qemu_params(
         timeout = "long",
     ),
     # This test can take > 40 minutes, so mark it manual as it shouldn't run

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -195,6 +195,7 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+        "//hw/top_earlgrey:sim_qemu_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
     kind = "rom",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -33,6 +33,7 @@ load(
     "fpga_params",
     "opentitan_binary",
     "opentitan_test",
+    "qemu_params",
     "silicon_params",
     "verilator_params",
 )
@@ -102,6 +103,11 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    qemu = qemu_params(
+        globals = {
+            "ot-aes.fast-mode": "false",
         },
     ),
     deps = [
@@ -3606,6 +3612,12 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
+        },
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -3654,6 +3666,12 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
         },
     ),
     deps = [
@@ -5230,6 +5248,12 @@ opentitan_test(
     ),
     fpga = fpga_params(
         timeout = "moderate",
+    ),
+    qemu = qemu_params(
+        globals = {
+            # Test uses rstmgr, keep running on fatal resets:
+            "ot-rstmgr.fatal_reset": 0,
+        },
     ),
     silicon = silicon_params(
         tags = ["broken"],

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4176,9 +4176,13 @@ opentitan_test(
 opentitan_test(
     name = "sram_ctrl_execution_test",
     srcs = ["sram_ctrl_execution_test.c"],
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    exec_env = dicts.omit(
+        dicts.add(
+            EARLGREY_TEST_ENVS,
+            EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        ),
+        # TODO (#26100): QEMU's `flashgen.py` script does not like this test.
+        ["//hw/top_earlgrey:sim_qemu_rom_with_fake_keys"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7439,3 +7439,28 @@ opentitan_test(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+cc_library(
+    name = "rom_exit_immediately_lib",
+    srcs = ["rom_exit_immediately.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/silicon_creator/lib/base:static_critical",
+    ],
+)
+
+opentitan_test(
+    name = "rom_exit_immediately",
+    exec_env = {
+        "//hw/top_earlgrey:sim_qemu_base": None,
+    },
+    kind = "rom",
+    linker_script = "//sw/device/lib/testing/test_rom:linker_script",
+    qemu = qemu_params(
+        # This test doesn't print `PASS!`, just check the exit code.
+        test_harness = "//third_party/qemu:qemu-system-riscv32",
+    ),
+    deps = [":rom_exit_immediately_lib"],
+)

--- a/sw/device/tests/rom_exit_immediately.S
+++ b/sw/device/tests/rom_exit_immediately.S
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "rv_core_ibex_regs.h"
+
+// This code can be used as the ROM in test environments to exit immediately.
+
+  .balign 4
+  .global _reset_start
+  .type _reset_start, @function
+_reset_start:
+
+// Write exit code 0 to `rv_core_ibex.sw_fatal_err`.
+li a0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR
+lui a1, 0xc0de0
+sw a1, RV_CORE_IBEX_SW_FATAL_ERR_REG_OFFSET(a0)
+
+// Wait for shutdown.
+wfi

--- a/third_party/qemu/BUILD
+++ b/third_party/qemu/BUILD
@@ -1,0 +1,47 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//third_party/python:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+py_binary(
+    name = "cfggen",
+    srcs = ["@qemu_opentitan//:scripts/opentitan/cfggen.py"],
+    deps = [
+        ":ot",
+        requirement("hjson"),
+    ],
+)
+
+py_binary(
+    name = "flashgen",
+    srcs = ["@qemu_opentitan//:scripts/opentitan/flashgen.py"],
+    deps = [
+        ":ot",
+        requirement("pyelftools"),
+    ],
+)
+
+py_binary(
+    name = "otptool",
+    srcs = ["@qemu_opentitan//:scripts/opentitan/otptool.py"],
+    deps = [":ot"],
+)
+
+py_library(
+    name = "ot",
+    srcs = ["@qemu_opentitan//:ot"],
+)
+
+alias(
+    name = "qemu-system-riscv32",
+    actual = "@qemu_opentitan//:build/qemu-system-riscv32",
+)
+
+alias(
+    name = "qemu-img",
+    actual = "@qemu_opentitan//:build/qemu-img",
+)

--- a/third_party/qemu/BUILD.qemu_opentitan.bazel
+++ b/third_party/qemu/BUILD.qemu_opentitan.bazel
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))
+
+filegroup(
+    name = "ot",
+    srcs = glob([
+        "python/qemu/ot/**",
+    ]),
+)

--- a/third_party/qemu/repos.bzl
+++ b/third_party/qemu/repos.bzl
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def qemu_opentitan_repos():
+    QEMU_VERSION = "v9.1.0-2025-01-28"
+
+    url = "/".join([
+        "https://github.com/lowRISC/qemu/releases/download",
+        QEMU_VERSION,
+        "qemu-ot-earlgrey-{}-x86_64-unknown-linux-gnu.tar.gz".format(QEMU_VERSION),
+    ])
+
+    http_archive(
+        name = "qemu_opentitan",
+        url = url,
+        build_file = Label(":BUILD.qemu_opentitan.bazel"),
+        sha256 = "530bb7568f17ba3f9ba1245388c2625259d180188c8c5c9e15634b942ebeb108",
+    )


### PR DESCRIPTION
Backport of #25909

Mostly the same but with `WORKSPACE` instead of `MODULE.bazel` and with some paths (e.g. to `otp_ctrl`) fixed. No material differences.