### PR TITLE
Cherry-pick to master: [rom_ext,ownership] Diversify `keymgr` on owner measurements

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -220,6 +220,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
         "//sw/device/silicon_creator/lib/cert:dice",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:kmac",
         "//sw/device/silicon_creator/manuf/base:perso_tlv_data",

--- a/sw/device/silicon_creator/lib/cert/dice_chain.h
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_CHAIN_H_
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
@@ -45,14 +46,17 @@ rom_error_t dice_chain_attestation_creator(
 /**
  * Check the CDI_1 certificate and regenerate if invalid.
  *
- * @param owner_measurement Pointer to the measurements to attest.
  * @param owner_manifest Pointer to the owner SW manifest to be boot.
+ * @param bl0_measurement Pointer to the measurement of the owner firmware.
+ * @param owner_measurement Pointer to the measurement of the owner config.
+ * @param sealing_binding Pointer to the owner's sealing diversification
+ *        constant.
  * @return errors encountered during the operation.
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_chain_attestation_owner(
-    keymgr_binding_value_t *owner_measurement,
-    const manifest_t *owner_manifest);
+    const manifest_t *owner_manifest, keymgr_binding_value_t *bl0_measurement,
+    hmac_digest_t *owner_measurement, keymgr_binding_value_t *sealing_binding);
 
 /**
  * Write back the certificate chain to flash if changed.

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -120,6 +120,7 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -166,14 +166,19 @@ typedef struct owner_application_key {
   tlv_header_t header;
   /** Key algorithm.  One of ECDSA, SPX+ or SPXq20. */
   uint32_t key_alg;
-  /** Key domain.  Recognized values: PROD, DEV, TEST */
-  uint32_t key_domain;
-  /** Key diversifier.
-   *
-   * This value is concatenated to key_domain to create an 8 word
-   * diversification constant to be programmed into the keymgr.
-   */
-  uint32_t key_diversifier[7];
+  union {
+    struct {
+      /** Key domain.  Recognized values: PROD, DEV, TEST */
+      uint32_t key_domain;
+      /** Key diversifier.
+       *
+       * This value is concatenated to key_domain to create an 8 word
+       * diversification constant to be programmed into the keymgr.
+       */
+      uint32_t key_diversifier[7];
+    };
+    uint32_t raw_diversifier[8];
+  };
   /** Usage constraint must match manifest header's constraint */
   uint32_t usage_constraint;
   /** Key material.  Varies by algorithm type. */

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -115,6 +115,13 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
                                    size_t *index);
 
 /**
+ * Determine whether the given key is on owner page 0 or page 1.
+ *
+ * @return page number.
+ */
+size_t owner_block_key_page(const owner_application_key_t *key);
+
+/**
  * Determine whether a particular rescue command is allowed.
  *
  * @param rescue A pointer to the rescue configuration.
@@ -123,6 +130,14 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
  */
 hardened_bool_t owner_rescue_command_allowed(
     const owner_rescue_config_t *rescue, uint32_t command);
+
+/**
+ * Measure the content of the owner page.
+ *
+ * @param page The owner page to measure.
+ * @param measurement The measurement value.
+ */
+void owner_block_measurement(size_t page, hmac_digest_t *mesaurment);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
Note: this is manual cherry-pick from #25007 

1. Measure the owner configuration and combine that measurement with the BL0 measurement to diversify the attestation ladder.
2. Apply the diversifier from the app verification key to the sealing ladder iff the ownership state is LockedOwner.

Addresses: #21583 (adds owner firmware measurement to CDI_1 cert)
Addresses: #19596 (add owner configuration block measurement to CDI_1 cert)

Signed-off-by: Chris Frantz <cfrantz@google.com>
(cherry picked from commit 6c4a600e7d272787c8ff0cf65f3c403ec91f9e77) 
(cherry picked from commit ff6e7d4c176203099f0e214b59c992a9cf44f74e)