### PR TITLE
[topgen,dtgen] Fix handling of external interrupts

### DIFF
--- a/util/dtgen/helper.py
+++ b/util/dtgen/helper.py
@@ -424,7 +424,10 @@ registers to connect a peripheral to this pad.""",  # noqa:E501
                 name = Name.from_snake_case(intr["name"])
                 if width > 1:
                     name += Name([str(i)])
-                module_name = Name.from_snake_case(intr["module_name"])
+                if intr["incoming"]:
+                    module_name = Name(["unknown"])
+                else:
+                    module_name = Name.from_snake_case(intr["module_name"])
                 self.inst_from_irq_values[name] = module_name
 
     def _init_dev_type_map(self):

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -1118,7 +1118,8 @@ class TopGen:
             else:
                 name = Name.from_snake_case(intr["name"])
                 irq_id = interrupts.add_constant(name, docstring=intr["name"])
-                source_name = source_name_map[intr["module_name"]]
+                source_name_key = 'unknown' if intr['incoming'] else intr['module_name']
+                source_name = source_name_map[source_name_key]
                 plic_mapping.add_entry(irq_id, source_name)
                 self.device_irqs[intr["module_name"]].append(intr["name"])
 


### PR DESCRIPTION
The code is trying to find the module of external interrupts which of course does not exists. Instead, map those to the 'unknown' peripheral.