### PR TITLE
[bazel] Fix runfile path to QEMU binary

### DIFF
--- a/rules/scripts/qemu_pass.py
+++ b/rules/scripts/qemu_pass.py
@@ -15,7 +15,7 @@ import sys
 
 def main() -> int:
     r = Runfiles.Create()
-    qemu_bin = r.Rlocation("_main~qemu~qemu_opentitan/build/qemu-system-riscv32")
+    qemu_bin = r.Rlocation("qemu_opentitan/build/qemu-system-riscv32")
 
     # Run the process capturing (then echoing) `stdout` and `stderr`.
     proc = subprocess.run(


### PR DESCRIPTION
These canonical paths are different between Bazel 6, 7, and 8. The `rules_python` runfiles library will perform repository mappings before using this path, so we can use `qemu_opentitan` instead of the canonical name.