### PR TITLE
[alert_handler, dv] Alert happened after ping

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -33,6 +33,9 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   // Monitor will set this value to 1 when the agent is under ping handshake.
   bit under_ping_handshake = 0;
 
+  // Monitor will set this value to 1 when the agent is under ping handshake phase 2.
+  bit under_ping_handshake_ph_2 = 0;
+
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -108,6 +108,7 @@ class alert_monitor extends alert_esc_base_monitor;
                   wait_ack();
                   req.alert_handshake_sta = AlertAckReceived;
                   cfg.under_ping_handshake = 0;
+                  cfg.under_ping_handshake_ph_2 = 1;
                 end
                 begin
                   wait (under_reset || cfg.en_alert_lpg);
@@ -139,6 +140,11 @@ class alert_monitor extends alert_esc_base_monitor;
       end
       ping_p = cfg.vif.monitor_cb.alert_rx_final.ping_p;
       alert_p = cfg.vif.monitor_cb.alert_tx_final.alert_p;
+
+      // Wait for alert_rx_final.ack_p to get deasserted to make sure we are no longer in ping
+      // handshake phase 2.
+      wait_ack_complete();
+      cfg.under_ping_handshake_ph_2 = 0;
     end
   endtask : ping_thread
 

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -312,6 +312,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endtask
 
   virtual task check_alert_triggered(string alert_name);
+    // If the alert happens when we are in the middle of ping handshake phases then wait until we
+    // are out of ping.
+    wait(!cfg.m_alert_agent_cfgs[alert_name].under_ping_handshake &&
+         !cfg.m_alert_agent_cfgs[alert_name].under_ping_handshake_ph_2)
     // Add 1 extra negedge edge clock to make sure no race condition.
     repeat(alert_esc_agent_pkg::ALERT_B2B_DELAY + 1 + expected_alert[alert_name].max_delay) begin
       cfg.clk_rst_vif.wait_n_clks(1);


### PR DESCRIPTION
When ping happens we go to ping handshake phases and
meanwhile if alert happens we can't proceed with
alert handshake phases until ping finishes. But in
cip_base_scb, if a fatal alert happens then the task
check_alert_triggered() waits for 6 cycles to get the
alert in the middle of alert handshake.
This PR tweaks check_alert_triggered() to watch ping
handshakes in both of the phases and once the handshakes
finishes then wait for 6 cycles to get the alert in the
middle of alert handshake.