### PR TITLE
[bazel] Bump OT QEMU to v9.2.0-2025-02-05

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -696,7 +696,7 @@
     },
     "//third_party/qemu:extensions.bzl%qemu": {
       "general": {
-        "bzlTransitiveDigest": "4R38A1PY0Fs1IU7UtI0WqOuKbZ4lDeM34jpVT1P8LQY=",
+        "bzlTransitiveDigest": "VUYPN/uT8OQN/4Jzecrdt8UuzJI/8MgX6ivjL8Ke+lA=",
         "usagesDigest": "le4nFQIsMEytUZA5Dz/GdRTwr0Ri5kyC+VIeW4HnJLI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -705,9 +705,9 @@
           "qemu_opentitan": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "url": "https://github.com/lowRISC/qemu/releases/download/v9.1.0-2025-01-28/qemu-ot-earlgrey-v9.1.0-2025-01-28-x86_64-unknown-linux-gnu.tar.gz",
+              "url": "https://github.com/lowRISC/qemu/releases/download/v9.2.0-2025-02-11/qemu-ot-earlgrey-v9.2.0-2025-02-11-x86_64-unknown-linux-gnu.tar.gz",
               "build_file": "@@//third_party/qemu:BUILD.qemu_opentitan.bazel",
-              "sha256": "530bb7568f17ba3f9ba1245388c2625259d180188c8c5c9e15634b942ebeb108"
+              "sha256": "85091287ee67dee337968071b7d10d39d44bb582c90991eae3d61f11a13ccf29"
             }
           }
         },

--- a/rules/opentitan/qemu.bzl
+++ b/rules/opentitan/qemu.bzl
@@ -184,6 +184,11 @@ def gen_flash(ctx, **kwargs):
             firmware_bin.path,
             "-X",
             firmware_elf.path,
+            # Skip `flashgen`'s ELF/binary mtime checks - it will fail if the
+            # binary is older than the ELF which usually suggests that the
+            # binary has not been regenerated, however Bazel often messes with
+            # mtimes causing false negatives.
+            "--ignore-time",
             out.path,
         ],
         mnemonic = "FlashGen",

--- a/rules/opentitan/qemu.bzl
+++ b/rules/opentitan/qemu.bzl
@@ -348,7 +348,7 @@ def _test_dispatch(ctx, exec_env, firmware):
     }
 
     if firmware.signed_bin != None and firmware.binary != None:
-        qemu_args += ["-drive", "if=mtd,bus=1,file=flash_img.bin,format=raw"]
+        qemu_args += ["-drive", "if=mtd,id=eflash,bus=2,file=flash_img.bin,format=raw"]
         test_script_fmt |= {
             "flash": firmware.default.short_path,
             "mutable_flash": "flash_img.bin",

--- a/third_party/qemu/extensions.bzl
+++ b/third_party/qemu/extensions.bzl
@@ -5,7 +5,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def qemu_opentitan_repos():
-    QEMU_VERSION = "v9.1.0-2025-01-28"
+    QEMU_VERSION = "v9.2.0-2025-02-11"
 
     url = "/".join([
         "https://github.com/lowRISC/qemu/releases/download",
@@ -17,7 +17,7 @@ def qemu_opentitan_repos():
         name = "qemu_opentitan",
         url = url,
         build_file = Label(":BUILD.qemu_opentitan.bazel"),
-        sha256 = "530bb7568f17ba3f9ba1245388c2625259d180188c8c5c9e15634b942ebeb108",
+        sha256 = "85091287ee67dee337968071b7d10d39d44bb582c90991eae3d61f11a13ccf29",
     )
 
 qemu = module_extension(


### PR DESCRIPTION
The bus for the Earl Grey `eflash` has changed from 1 to 2. Updating QEMU here in OpenTitan will make upstream development slightly easier.