### PR TITLE
[manuf] enable patching a single AST config CSR

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -58,6 +58,7 @@ UJSON_SERDE_STRUCT(ManufCpTestData, \
 #define STRUCT_MANUF_FT_INDIVIDUALIZE_DATA(field, string) \
     field(enable_alerts, bool) \
     field(use_ext_clk, bool) \
+    field(patch_ast, bool) \
     field(ft_device_id, uint32_t, 4)
 UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
                    manuf_ft_individualize_data_t, \

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -160,6 +160,7 @@ opentitan_test(
         deps = [
             ":flash_info_permissions",
             "//hw/top_earlgrey:alert_handler_c_regs",
+            "//hw/top_earlgrey/ip/ast/data:ast_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/arch:device",
             "//sw/device/lib/base:abs_mmio",

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -16,6 +16,7 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -25,11 +26,13 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/manuf/base/flash_info_permissions.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
 #include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
 
 #include "alert_handler_regs.h"  // Generated.
+#include "ast_regs.h"            // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
@@ -210,6 +213,53 @@ status_t otp_ctrl_testutils_dai_write_post_error_check_hook(
 }
 
 /**
+ * Patch AST config if patch exists in flash info page 0.
+ */
+static status_t patch_ast_config_value(void) {
+  uint32_t byte_address = 0;
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
+      &flash_ctrl_state, kFlashInfoFieldAstIndividPatchAddr.page,
+      kFlashInfoFieldAstIndividPatchAddr.bank,
+      kFlashInfoFieldAstIndividPatchAddr.partition, kFlashInfoPage0Permissions,
+      &byte_address));
+
+  // Read patch address and value from flash info 0.
+  uint32_t ast_patch_addr_offset;
+  uint32_t ast_patch_value;
+  TRY(manuf_flash_info_field_read(
+      &flash_ctrl_state, kFlashInfoFieldAstIndividPatchAddr,
+      &ast_patch_addr_offset,
+      kFlashInfoFieldAstIndividPatchAddrSizeIn32BitWords));
+  TRY(manuf_flash_info_field_read(
+      &flash_ctrl_state, kFlashInfoFieldAstIndividPatchVal, &ast_patch_value,
+      kFlashInfoFieldAstIndividPatchValSizeIn32BitWords));
+  LOG_INFO("AST patch address offset = 0x%08x", ast_patch_addr_offset);
+  LOG_INFO("AST patch address value  = 0x%08x", ast_patch_value);
+
+  // Check the address is within range before programming.
+  // Check the value is non-zero and not all ones before programming.
+  if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) {
+    TRY_CHECK(ast_patch_addr_offset > AST_REGAL_REG_OFFSET);
+    TRY_CHECK(ast_patch_value != 0 && ast_patch_value != UINT32_MAX);
+  }
+
+  // Write patch value.
+  abs_mmio_write32(
+      TOP_EARLGREY_AST_BASE_ADDR + ast_patch_addr_offset * sizeof(uint32_t),
+      ast_patch_value);
+
+  // Read back AST calibration values loaded into CSRs.
+  LOG_INFO("AST Calibration Values (in CSRs):");
+  for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
+    LOG_INFO(
+        "Word %d = 0x%08x", i,
+        abs_mmio_read32(TOP_EARLGREY_AST_BASE_ADDR + i * sizeof(uint32_t)));
+  }
+
+  return OK_STATUS();
+}
+
+/**
  * Provision OTP {CreatorSw,OwnerSw,Hw}Cfg and RotCreatorAuth{Codesign,State}
  * partitions.
  *
@@ -236,17 +286,13 @@ static status_t provision(ujson_t *uj) {
     LOG_INFO("External clock enabled.");
   }
 
+  // Patch AST config if requested.
+  if (in_data.patch_ast) {
+    TRY(patch_ast_config_value());
+  }
+
   // Enable GPIO indicators during OTP writes.
   TRY(configure_gpio_indicators());
-
-  // Turn off OTP runtime checks.
-  TRY(dif_otp_ctrl_configure(
-      &otp_ctrl,
-      (dif_otp_ctrl_config_t){
-          .check_timeout = 0,            // Disable the check timeout mechanism.
-          .integrity_period_mask = 0,    // Disable integrity checks.
-          .consistency_period_mask = 0,  // Disable consistency checks.
-      }));
 
   // Perform OTP writes.
   LOG_INFO("Writing HW_CFG* OTP partitions ...");

--- a/sw/device/silicon_creator/manuf/lib/ast_program.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program.c
@@ -92,17 +92,11 @@ status_t ast_program_config(bool verbose) {
 
   // Read AST calibration values from flash.
   LOG_INFO("Reading AST data");
-  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
-  uint32_t byte_address =
-      (kFlashInfoFieldAstCalibrationData.page * device_info.bytes_per_page) +
-      kFlashInfoFieldAstCalibrationData.byte_offset;
-  uint32_t ast_data[kFlashInfoAstCalibrationDataSizeIn32BitWords];
   TRY(flash_ctrl_testutils_wait_for_init(&flash_state));
-  TRY(flash_ctrl_testutils_read(&flash_state, byte_address,
-                                kFlashInfoFieldAstCalibrationData.partition,
-                                ast_data, kDifFlashCtrlPartitionTypeInfo,
-                                kFlashInfoAstCalibrationDataSizeIn32BitWords,
-                                /*delay=*/0));
+  uint32_t ast_data[kFlashInfoAstCalibrationDataSizeIn32BitWords];
+  TRY(manuf_flash_info_field_read(
+      &flash_state, kFlashInfoFieldAstCalibrationData, ast_data,
+      kFlashInfoAstCalibrationDataSizeIn32BitWords));
 
   // Program AST CSRs.
   LOG_INFO("Programming %u AST words",

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -66,6 +66,20 @@ const flash_info_field_t kFlashInfoFieldCpDeviceId = {
     .byte_offset = kFlashInfoFieldCpDeviceIdStartOffset,
 };
 
+const flash_info_field_t kFlashInfoFieldAstIndividPatchAddr = {
+    .partition = 0,
+    .bank = 0,
+    .page = 0,
+    .byte_offset = kFlashInfoFieldAstIndividPatchAddrStartOffset,
+};
+
+const flash_info_field_t kFlashInfoFieldAstIndividPatchVal = {
+    .partition = 0,
+    .bank = 0,
+    .page = 0,
+    .byte_offset = kFlashInfoFieldAstIndividPatchValStartOffset,
+};
+
 /**
  * Partition 0, page 1 fields.
  */

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -69,6 +69,18 @@ enum {
   kFlashInfoFieldCpDeviceIdSizeInBytes =
       kFlashInfoFieldCpDeviceIdSizeIn32BitWords * sizeof(uint32_t),
 
+  /**
+   * AST Individualize Patch Address Start / Size - Bank 0, Page 0
+   */
+  kFlashInfoFieldAstIndividPatchAddrStartOffset = 400,
+  kFlashInfoFieldAstIndividPatchAddrSizeIn32BitWords = 1,
+
+  /**
+   * AST Individualize Patch Value Start / Size - Bank 0, Page 0
+   */
+  kFlashInfoFieldAstIndividPatchValStartOffset = 404,
+  kFlashInfoFieldAstIndividPatchValSizeIn32BitWords = 1,
+
   // Creator/Owner Seeds - Bank 0, Pages 1 and 2
   kFlashInfoFieldKeySeedSizeIn32BitWords = 32 / sizeof(uint32_t),
 
@@ -90,6 +102,8 @@ extern const flash_info_field_t kFlashInfoFieldWaferYCoord;
 extern const flash_info_field_t kFlashInfoFieldProcessData;
 extern const flash_info_field_t kFlashInfoFieldAstCalibrationData;
 extern const flash_info_field_t kFlashInfoFieldCpDeviceId;
+extern const flash_info_field_t kFlashInfoFieldAstIndividPatchAddr;
+extern const flash_info_field_t kFlashInfoFieldAstIndividPatchVal;
 
 // Info Page 1 fields.
 extern const flash_info_field_t kFlashInfoFieldCreatorSeed;

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -46,6 +46,9 @@ pub struct ManufFtProvisioningDataInput {
     #[arg(long)]
     pub use_ext_clk_during_individualize: bool,
 
+    #[arg(long)]
+    pub use_ast_patch_during_individualize: bool,
+
     /// TestUnlock token; a 128-bit hex string.
     #[arg(long)]
     pub test_unlock_token: String,
@@ -161,6 +164,7 @@ fn main() -> Result<()> {
     let ft_individualize_data_in = ManufFtIndividualizeData {
         enable_alerts: opts.provisioning_data.enable_alerts_during_individualize,
         use_ext_clk: opts.provisioning_data.use_ext_clk_during_individualize,
+        patch_ast: opts.provisioning_data.use_ast_patch_during_individualize,
         ft_device_id,
     };
 

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -129,6 +129,12 @@ def main(args_in):
         help="Use external clock during FT individualize step.",
     )
     parser.add_argument(
+        "--patch-ast",
+        action="store_true",
+        default=False,
+        help="Use AST patch in flash info page 0 during FT individualize step.",
+    )
+    parser.add_argument(
         "--non-interactive",
         action="store_true",
         default=False,
@@ -193,6 +199,7 @@ def main(args_in):
                 fpga_dont_clear_bitstream=args.fpga_dont_clear_bitstream,
                 enable_alerts=args.enable_alerts,
                 use_ext_clk=args.use_ext_clk,
+                patch_ast=args.patch_ast,
                 require_confirmation=not args.non_interactive)
     dut.run_cp()
     if args.cp_only:

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -53,6 +53,7 @@ class OtDut():
     fpga_dont_clear_bitstream: bool
     enable_alerts: bool
     use_ext_clk: bool
+    patch_ast: bool
     require_confirmation: bool = True
 
     def _make_log_dir(self) -> None:
@@ -285,6 +286,11 @@ class OtDut():
             # Enable external clock during individualization if requested.
             if self.use_ext_clk:
                 cmd += " --use-ext-clk-during-individualize"
+
+            # Patch AST config (with patch value in flash info page 0) during
+            # individualization if requested.
+            if self.patch_ast:
+                cmd += " --use-ast-patch-during-individualize"
 
             # Get user confirmation before running command.
             logging.info(f"Running command: {cmd}")

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//third_party/python:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
@@ -13,6 +12,7 @@ load(
     "orchestrator_cw340_test_settings_transition",
     "orchestrator_hyper310_test_settings_transition",
 )
+load("//third_party/python:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
@@ -32,6 +32,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --ast-cfg-version=0 \
   --enable-alerts \
   --use-ext-clk \
+  --patch-ast \
   --non-interactive \
-  --cp-only \
   --db-path=$TEST_TMPDIR/registry.sqlite


### PR DESCRIPTION
This updates the individualization firmware to enable patching a single AST config CSR based on an address and value stored in flash info page 0. This is activated by a CLI arg `--patch-ast` passed to the orchestrator script.