### PR TITLE
Cherry-pick to earlgrey_1.0.0: Immutable rom ext related changes

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "main_lib",
+    srcs = ["imm_rom_ext.c"],
+    hdrs = ["imm_rom_ext.h"],
+)

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h"
+
+void imm_rom_ext_main(void) {
+  // TODO(opentitan#24368): Implement this.
+  return;
+}

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void imm_rom_ext_main(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_H_

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -886,3 +886,16 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "epmp",
+    srcs = ["epmp.c"],
+    hdrs = ["epmp.h"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:epmp_state",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/epmp.h
+++ b/sw/device/silicon_creator/lib/drivers/epmp.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_EPMP_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_EPMP_H_
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_EPMP_H_
 
 #include <stdint.h>
 
@@ -14,7 +14,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * ROM_EXT ROM enhanced Physical Memory Protection (ePMP) library.
+ * Enhanced Physical Memory Protection (ePMP) library.
  *
  * The ePMP configuration is managed in two parts:
  *
@@ -33,8 +33,6 @@ extern "C" {
  * initialized) with the in-memory copy of the state used to double check the
  * configuration as required.
  */
-// TODO(lowrisc/opentitan#8800): Implement ePMP initialization for ROM_EXT
-// stage.
 
 /**
  * Clear an ePMP entry.
@@ -43,7 +41,7 @@ extern "C" {
  *
  * @param entry The ePMP entry to clear.
  */
-void rom_ext_epmp_clear(uint8_t entry);
+void epmp_clear(uint8_t entry);
 
 /**
  * Configures an ePMP entry for a NAPOT or NA4 region.
@@ -59,8 +57,7 @@ void rom_ext_epmp_clear(uint8_t entry);
  * @param region The address region to configure.
  * @param perm The ePMP permissions for the region.
  */
-void rom_ext_epmp_set_napot(uint8_t entry, epmp_region_t region,
-                            epmp_perm_t perm);
+void epmp_set_napot(uint8_t entry, epmp_region_t region, epmp_perm_t perm);
 
 /**
  * Configures an ePMP entry for a TOR region.
@@ -73,18 +70,17 @@ void rom_ext_epmp_set_napot(uint8_t entry, epmp_region_t region,
  * @param region The address region to configure.
  * @param perm The ePMP permissions for the region.
  */
-void rom_ext_epmp_set_tor(uint8_t entry, epmp_region_t region,
-                          epmp_perm_t perm);
+void epmp_set_tor(uint8_t entry, epmp_region_t region, epmp_perm_t perm);
 
 /**
  * Clear the rule-locking-bypass (RLB) bit.
  *
  * Clearing RLB causes the Lock bit in the ePMP to be enforced.
  */
-void rom_ext_epmp_clear_rlb(void);
+void epmp_clear_rlb(void);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_EPMP_H_
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_EPMP_H_

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -17,19 +17,6 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "rom_ext_epmp",
-    srcs = ["rom_ext_epmp.c"],
-    hdrs = ["rom_ext_epmp.h"],
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:csr",
-        "//sw/device/lib/base:hardened",
-        "//sw/device/silicon_creator/lib:epmp_state",
-    ],
-)
-
-cc_library(
     name = "rescue",
     srcs = ["rescue.c"],
     hdrs = ["rescue.h"],
@@ -170,7 +157,6 @@ cc_test(
             ":rescue",
             ":rom_ext_boot_policy",
             ":rom_ext_boot_policy_ptrs",
-            ":rom_ext_epmp",
             ":sigverify_keys",
             "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
             "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
@@ -198,6 +184,7 @@ cc_test(
             "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
             "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
             "//sw/device/silicon_creator/lib/drivers:ast",
+            "//sw/device/silicon_creator/lib/drivers:epmp",
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
             "//sw/device/silicon_creator/lib/drivers:hmac",
             "//sw/device/silicon_creator/lib/drivers:ibex",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -166,6 +166,7 @@ cc_test(
             "//sw/device/lib/base:stdasm",
             "//sw/device/lib/crypto/drivers:entropy",
             "//sw/device/lib/runtime:hart",
+            "//sw/device/silicon_creator/imm_rom_ext:main_lib",
             "//sw/device/silicon_creator/lib:attestation",
             "//sw/device/silicon_creator/lib:boot_data",
             "//sw/device/silicon_creator/lib:boot_log",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -26,6 +26,7 @@
 #include "sw/device/silicon_creator/lib/cert/dice.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/ast.h"
+#include "sw/device/silicon_creator/lib/drivers/epmp.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
@@ -56,7 +57,6 @@
 #include "sw/device/silicon_creator/rom_ext/rescue.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
-#include "sw/device/silicon_creator/rom_ext/rom_ext_epmp.h"
 #include "sw/device/silicon_creator/rom_ext/sigverify_keys.h"
 
 #include "flash_ctrl_regs.h"                          // Generated.
@@ -947,25 +947,25 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
                            kOtpSecMmioCreatorSwCfgLockDown);
 
   // ePMP region 15 gives read/write access to RAM.
-  rom_ext_epmp_set_napot(15, kRamRegion, kEpmpPermReadWrite);
+  epmp_set_napot(15, kRamRegion, kEpmpPermReadWrite);
 
   // Reconfigure the ePMP MMIO region to be NAPOT region 14, thus freeing
   // up an ePMP entry for use elsewhere.
-  rom_ext_epmp_set_napot(14, kMmioRegion, kEpmpPermReadWrite);
+  epmp_set_napot(14, kMmioRegion, kEpmpPermReadWrite);
 
   // ePMP region 13 allows RvDM access.
   if (lc_state == kLcStateProd || lc_state == kLcStateProdEnd) {
     // No RvDM access in Prod states, so we can clear the entry.
-    rom_ext_epmp_clear(13);
+    epmp_clear(13);
   } else {
-    rom_ext_epmp_set_napot(13, kRvDmRegion, kEpmpPermReadWriteExecute);
+    epmp_set_napot(13, kRvDmRegion, kEpmpPermReadWriteExecute);
   }
 
   // ePMP region 12 gives read access to all of flash for both M and U modes.
   // The flash access was in ePMP region 5.  Clear it so it doesn't take
   // priority over 12.
-  rom_ext_epmp_set_napot(12, kFlashRegion, kEpmpPermReadOnly);
-  rom_ext_epmp_clear(5);
+  epmp_set_napot(12, kFlashRegion, kEpmpPermReadOnly);
+  epmp_clear(5);
 
   // Move the ROM_EXT TOR region from entries 3/4/6 to 9/10/11.
   // If the ROM_EXT is located in the virtual window, the ROM will have
@@ -987,15 +987,13 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
     vwindow = (vwindow & ~(size - 1)) << 2;
     size <<= 3;
 
-    rom_ext_epmp_set_napot(
-        11, (epmp_region_t){.start = vwindow, .end = vwindow + size},
-        kEpmpPermReadOnly);
+    epmp_set_napot(11, (epmp_region_t){.start = vwindow, .end = vwindow + size},
+                   kEpmpPermReadOnly);
   }
-  rom_ext_epmp_set_tor(rxindex,
-                       (epmp_region_t){.start = start << 2, .end = end << 2},
-                       kEpmpPermReadExecute);
+  epmp_set_tor(rxindex, (epmp_region_t){.start = start << 2, .end = end << 2},
+               kEpmpPermReadExecute);
   for (int8_t i = (int8_t)rxindex - 1; i >= 0; --i) {
-    rom_ext_epmp_clear((uint8_t)i);
+    epmp_clear((uint8_t)i);
   }
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
 
@@ -1017,7 +1015,7 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
 
       // Unlock read-only for the whole rom_ext virtual memory.
       HARDENED_RETURN_IF_ERROR(epmp_state_check());
-      rom_ext_epmp_set_napot(
+      epmp_set_napot(
           4,
           (epmp_region_t){.start = (uintptr_t)_owner_virtual_start_address,
                           .end = (uintptr_t)_owner_virtual_start_address +
@@ -1038,7 +1036,7 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
       // anymore and since it isn't being used to encode access to the virtual
       // window.  However, for SiVal, we want to keep low entries locked to
       // prevent using low entries to override policy in higher entries.
-      // rom_ext_epmp_clear_rom_region();
+      // epmp_clear_rom_region();
       break;
     default:
       HARDENED_TRAP();
@@ -1048,11 +1046,11 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   // unlock the ROM_EXT code regions so the next stage can re-use those
   // entries and clear RLB to prevent further changes to locked ePMP regions.
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
-  rom_ext_epmp_set_tor(2, text_region, kEpmpPermReadExecute);
+  epmp_set_tor(2, text_region, kEpmpPermReadExecute);
 
   // Now that we're done reconfiguring the ePMP, we'll clear the RLB bit to
   // prevent any modification to locked entries.
-  rom_ext_epmp_clear_rlb();
+  epmp_clear_rlb();
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
 
   // Lock the address translation windows.

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/runtime/hart.h"
+#include "sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/chip.h"
@@ -1383,6 +1384,11 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 }
 
 void rom_ext_main(void) {
+  // TODO(opentitan#24368): Call immutable main in .rom_ext_immutable.
+  // The immutable rom_ext startup code is not ready yet, so we call it here
+  // to avoid breaking tests.
+  imm_rom_ext_main();
+
   rom_ext_check_rom_expectations();
   boot_data_t boot_data;
   boot_log_t *boot_log = &retention_sram_get()->creator.boot_log;
@@ -1405,3 +1411,9 @@ void rom_ext_exception_handler(void);
 
 OT_ALIAS("rom_ext_interrupt_handler")
 void rom_ext_nmi_handler(void);
+
+// A no-op immutable rom_ext fallback to avoid breaking tests before the
+// proper bazel target is ready.
+// TODO(opentitan#24368): Remove this nop fallback.
+OT_SECTION(".rom_ext_immutable.fallback")
+void imm_rom_ext_placeholder(void) {}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -77,6 +77,10 @@ SECTIONS {
     _text_start = .;
     _rom_ext_immutable_start = .;
     KEEP(*(.rom_ext_immutable))
+
+    /* TODO: Remove this fallback when rom_ext_immutable section is ready. */
+    KEEP(*(.rom_ext_immutable.fallback))
+
     /* Ensure section end is word-aligned. */
     . = ALIGN(256);
     _rom_ext_immutable_end = .;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "sw/device/lib/base/hardened_asm.h"
+#include "otp_ctrl_regs.h"
 
 /**
  * ROM_EXT Interrupt Vector
@@ -78,15 +80,32 @@ _rom_ext_interrupt_vector:
   .type _rom_ext_start_boot, @function
 _rom_ext_start_boot:
   /**
-   * Set up the global pointer `gp`.
-   *
    * Linker relaxations are disabled until the global pointer is setup below,
    * because otherwise some sequences may be turned into `gp`-relative
    * sequences, which is incorrect when `gp` is not initialized.
    */
   .option push
   .option norelax
+
+  /**
+   * Call the .rom_ext_immutable first if it's not called by ROM.
+   */
+  li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
+            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET(a0)
+  li   t1, HARDENED_BOOL_TRUE
+  beq  t0, t1, .L_mutable_start_boot
+  call _rom_ext_immutable_start
+
+  /**
+   * Continue booting the mutable rom_ext.
+   */
+.L_mutable_start_boot:
+  /**
+   * Set up the global pointer `gp`.
+   */
   la gp, __global_pointer$
+
   .option pop
 
   /**


### PR DESCRIPTION
This PR manually cherrypick the preparatory refactoring commits about immutable rom ext to earlgrey_1.0.0 branch.

Includes
* #24980
* #25049

There is only extra syntactical fixup (i.e. wrong indent) compared to the original commit in master.