### PR TITLE
[RACL] Deduplicate RACL templates

### DIFF
--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -486,44 +486,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
 %>\
   % if m["param_list"] or block.alerts:
   ${m["type"]} #(
-<%doc>
-  Note: The RACL parameters must be generated identically across multiple files.
-        Thus, this template needs to be manually synced between the following files:
-        util/raclgen.py
-        util/topgen/templates/toplevel_racl_pkg.sv.tpl
-        hw/top_darjeeling/templates/toplevel.sv.tpl
-        hw/top_earlgrey/templates/toplevel.sv.tpl
-        hw/top_englishbreakfast/templates/toplevel.sv.tpl
-</%doc>\
-  % if m.get('racl_mappings'):
-    .EnableRacl(1'b1),
-    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
-    % for if_name in m['racl_mappings'].keys():
-<%
-        register_mapping = m['racl_mappings'][if_name]['register_mapping']
-        window_mapping = m['racl_mappings'][if_name]['window_mapping']
-        range_mapping = m['racl_mappings'][if_name]['range_mapping']
-        racl_group = m['racl_mappings'][if_name]['racl_group']
-        group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
-        if_suffix = f"_{if_name.upper()}" if if_name else ""
-        if_suffix2 = f"{if_name.title()}" if if_name else ""
-        policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}"
-%>\
-      % if len(register_mapping) > 0:
-    .RaclPolicySelVec${if_suffix2}(${policy_sel_name}),
-      % endif
-      % for window_name, policy_idx in window_mapping.items():
-    .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(${policy_sel_name}_WIN_${window_name.upper()}),
-      % endfor
-      % if len(range_mapping) > 0:
-    .RaclPolicySelRanges${if_suffix2}Num(top_racl_pkg::${policy_sel_name}_NUM_RANGES),
-    .RaclPolicySelRanges${if_suffix2}(top_racl_pkg::${policy_sel_name}_RANGES),
-      % endif
-    % endfor
-  % endif
-  % if m.get('template_type') == 'racl_ctrl':
-    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
-  % endif
+<%include file="/toplevel_racl.tpl" args="m=m,top=top"/>\
   % if block.alerts:
 <%
 w = len(block.alerts)

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -502,44 +502,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
 %>\
   % if m["param_list"] or block.alerts:
   ${m["type"]} #(
-<%doc>
-  Note: The RACL parameters must be generated identically across multiple files.
-        Thus, this template needs to be manually synced between the following files:
-        util/raclgen.py
-        util/topgen/templates/toplevel_racl_pkg.sv.tpl
-        hw/top_darjeeling/templates/toplevel.sv.tpl
-        hw/top_earlgrey/templates/toplevel.sv.tpl
-        hw/top_englishbreakfast/templates/toplevel.sv.tpl
-</%doc>\
-  % if 'racl_mappings' in m:
-    .EnableRacl(1'b1),
-    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
-    % for if_name in m['racl_mappings'].keys():
-<%
-        register_mapping = m['racl_mappings'][if_name]['register_mapping']
-        window_mapping = m['racl_mappings'][if_name]['window_mapping']
-        range_mapping = m['racl_mappings'][if_name]['range_mapping']
-        racl_group = m['racl_mappings'][if_name]['racl_group']
-        group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
-        if_suffix = f"_{if_name.upper()}" if if_name else ""
-        if_suffix2 = f"{if_name.title()}" if if_name else ""
-        policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}"
-%>\
-      % if len(register_mapping) > 0:
-    .RaclPolicySelVec${if_suffix2}(${policy_sel_name}),
-      % endif
-      % for window_name, policy_idx in window_mapping.items():
-    .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(${policy_sel_name}_WIN_${window_name.upper()}),
-      % endfor
-      % if len(range_mapping) > 0:
-    .RaclPolicySelRanges${if_suffix2}Num(top_racl_pkg::${policy_sel_name}_NUM_RANGES),
-    .RaclPolicySelRanges${if_suffix2}(top_racl_pkg::${policy_sel_name}_RANGES),
-      % endif
-    % endfor
-  % endif
-  % if m.get('template_type') == 'racl_ctrl':
-    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
-  % endif
+<%include file="/toplevel_racl.tpl" args="m=m,top=top"/>\
   % if block.alerts:
 <%
 w = len(block.alerts)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -22,6 +22,7 @@ from ipgen import (IpBlockRenderer, IpConfig, IpDescriptionOnlyRenderer,
 from design.lib.OtpMemMap import OtpMemMap
 from mako import exceptions
 from mako.template import Template
+from mako.lookup import TemplateLookup
 from raclgen.lib import DEFAULT_RACL_CONFIG
 from reggen import access, gen_rtl, gen_sec_cm_testplan, window
 from reggen.countermeasure import CounterMeasure
@@ -137,7 +138,7 @@ def ipgen_render(template_name: str, topname: str, params: Dict[str, object],
 
 def generate_top(top: Dict[str, object], name_to_block: Dict[str, IpBlock],
                  tpl_filename: str, **kwargs: Dict[str, object]) -> None:
-    top_tpl = Template(filename=tpl_filename)
+    top_tpl = Template(filename=tpl_filename, lookup=TemplateLookup([TOPGEN_TEMPLATE_PATH, "/"]))
 
     try:
         return top_tpl.render(top=top, name_to_block=name_to_block, **kwargs)

--- a/util/topgen/templates/toplevel_racl.tpl
+++ b/util/topgen/templates/toplevel_racl.tpl
@@ -1,0 +1,33 @@
+## Copyright lowRISC contributors (OpenTitan project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+<%page args="m, top"/>\
+% if m.get('racl_mappings'):
+    .EnableRacl(1'b1),
+    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
+  % for if_name, mappings in m['racl_mappings'].items():
+<%
+      register_mapping = mappings.get('register_mapping', {})
+      window_mapping   = mappings.get('window_mapping', {})
+      range_mapping    = mappings.get('range_mapping', [])
+      racl_group       = mappings.get('racl_group')
+      group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
+      if_suffix = f"_{if_name.upper()}" if if_name else ""
+      if_suffix2 = f"{if_name.title()}" if if_name else ""
+      policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}"
+%>\
+    % if len(register_mapping) > 0:
+    .RaclPolicySelVec${if_suffix2}(${policy_sel_name}),
+    % endif
+    % for window_name, policy_idx in window_mapping.items():
+    .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(${policy_sel_name}_WIN_${window_name.upper()}),
+    % endfor
+    % if len(range_mapping) > 0:
+    .RaclPolicySelRanges${if_suffix2}Num(${policy_sel_name}_NUM_RANGES),
+    .RaclPolicySelRanges${if_suffix2}(${policy_sel_name}_RANGES),
+    % endif
+  % endfor
+% endif
+% if m.get('template_type') == 'racl_ctrl':
+    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
+% endif

--- a/util/topgen/templates/toplevel_racl_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg.sv.tpl
@@ -7,25 +7,18 @@ ${gencmd}
 package top_${topcfg["name"]}_racl_pkg;
   import top_racl_pkg::*;
 
-<%doc>
-  Note: The RACL parameters must be generated identically across multiple files.
-        Thus, this template needs to be manually synced between the following files:
-        util/raclgen.py
-        util/topgen/templates/toplevel_racl_pkg.sv.tpl
-        hw/top_darjeeling/templates/toplevel.sv.tpl
-        hw/top_earlgrey/templates/toplevel.sv.tpl
-        hw/top_englishbreakfast/templates/toplevel.sv.tpl
-</%doc>\
 <% import raclgen.lib as raclgen %>\
 <% import math %>\
 % if 'racl' in topcfg:
   /**
    * RACL groups:
-% for racl_group in topcfg['racl']['policies']:
-<% policy_names = [policy['name'] for policy in topcfg['racl']['policies'][racl_group]] %>\
-<% policy_name_len = max( (len(name) for name in policy_names) ) %>\
-<% policy_idx_len = math.ceil(math.log10(max(1,len(policy_names)+1))) %>\
+% for racl_group in racl_config['policies']:
    *   ${racl_group}
+<%
+    policy_names = [policy['name'] for policy in racl_config['policies'][racl_group]]
+    policy_name_len = max( (len(name) for name in policy_names) )
+    policy_idx_len = math.ceil(math.log10(max(1,len(policy_names)+1)))
+%>\
   % for policy_idx, policy_name in enumerate(policy_names):
    *     ${f"{policy_name}".ljust(policy_name_len)} (Idx ${f"{policy_idx}".rjust(policy_idx_len)})
   % endfor
@@ -34,60 +27,22 @@ package top_${topcfg["name"]}_racl_pkg;
 
 % endif
 % for m in topcfg['module']:
-  % if 'racl_mappings' in m:
-    % for if_name in m['racl_mappings'].keys():
-<% register_mapping = m['racl_mappings'][if_name]['register_mapping'] %>\
-<% window_mapping = m['racl_mappings'][if_name]['window_mapping'] %>\
-<% range_mapping = m['racl_mappings'][if_name]['range_mapping'] %>\
-<% racl_group = m['racl_mappings'][if_name]['racl_group'] %>\
-<% group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else "" %>\
-<% if_suffix = f"_{if_name.upper()}" if if_name else "" %>\
-<% reg_name_len = max( (len(name) for name in register_mapping.keys()), default=0 ) %>\
-<% window_name_len = max( (len(name) for name in window_mapping.keys()), default=0 ) %>\
-<% policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}" %>\
-  /**
-   * Policy selection vector for ${m["name"]}
-   *   TLUL interface name: ${if_name}
-   *   RACL group: ${racl_group}
-      % if len(register_mapping) > 0:
-   *   Register to policy mapping:
-        % for reg_name, policy_idx in register_mapping.items():
-   *     ${f"{reg_name}:".ljust(reg_name_len+1)} ${policy_names[policy_idx]} (Idx ${f"{policy_idx}".rjust(policy_idx_len)})
-        % endfor
-      % endif
-      % if len(window_mapping) > 0:
-   *   Window to policy mapping:
-        % for window_name, policy_idx in window_mapping.items():
-   *     ${f"{window_name}:".ljust(window_name_len+1)} ${policy_names[policy_idx]} (Idx ${f"{policy_idx}".rjust(policy_idx_len)})
-        % endfor
-      % endif
-      % if len(range_mapping) > 0:
-   *   Range to policy mapping:
-        % for range in range_mapping:
-   *     ${f"0x{range['base']:08x}"} -- ${f"0x{(range['base']+range['size']):08x}"} \
-policy: ${policy_names[range['policy']]} (Idx ${f"{range['policy']}".rjust(policy_idx_len)})
-        % endfor
-      % endif
-   */
-      % if len(register_mapping) > 0:
-<% policy_sel_value = ", ".join(map(str, reversed(register_mapping.values())))%>\
-<% policy_sel_value = "\n    ".join(textwrap.wrap(policy_sel_value, 94))%>\
-  parameter racl_policy_sel_t ${policy_sel_name} [${len(register_mapping)}] = '{
-    ${policy_sel_value}
-  };
-      % endif
-      % for window_name, policy_idx in window_mapping.items():
-  parameter racl_policy_sel_t ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
-      % endfor
-      % if len(range_mapping) > 0:
-  parameter racl_policy_sel_t ${policy_sel_name}_NUM_RANGES = ${len(range_mapping)};
-<% value =  ",\\n".join(map(raclgen.format_parameter_range_value, range_mapping)) %>\
-  parameter racl_range_t ${policy_sel_name}_RANGES [${len(range_mapping)}] = '{
-    ${value}
-  };
-      % endif
+  % for if_name, mapping in m.get('racl_mappings', {}).items():
+<%
+      racl_group = mapping['racl_group']
+      policy_names = [policy['name'] for policy in racl_config['policies'][racl_group]]
+      racl_tpl_args = {
+        "register_mapping" : mapping.get('register_mapping', {}),
+        "window_mapping"   : mapping.get('window_mapping', {}),
+        "range_mapping"    : mapping.get('range_mapping', []),
+        "policy_names"     : policy_names,
+        "racl_group"       : racl_group,
+        "module_name"      : m['name'],
+        "if_name"          : if_name
+      }
+%>\
+<%include file="toplevel_racl_pkg_parameters.tpl" args="**racl_tpl_args"/>\
 
-    % endfor
-  % endif
+  % endfor
 % endfor
 endpackage

--- a/util/topgen/templates/toplevel_racl_pkg_parameters.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg_parameters.tpl
@@ -1,0 +1,56 @@
+## Copyright lowRISC contributors (OpenTitan project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+<%page args="register_mapping, window_mapping, range_mapping, policy_names, racl_group, module_name, if_name"/>\
+<% import textwrap %>\
+<% import math %>\
+<% policy_idx_len = math.ceil(math.log10(max(1,len(policy_names)+1))) %>\
+<% group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else "" %>\
+<% if_suffix = f"_{if_name.upper()}" if if_name else "" %>\
+<% reg_name_len = max( (len(name) for name in register_mapping.keys()), default=0 ) %>\
+<% window_name_len = max( (len(name) for name in window_mapping.keys()), default=0 ) %>\
+<% policy_sel_name = f"RACL_POLICY_SEL_{module_name.upper()}{group_suffix}{if_suffix}" %>\
+  /**
+   * Policy selection vector for ${module_name}
+   *   TLUL interface name: ${if_name}
+   *   RACL group: ${racl_group}
+% if len(register_mapping) > 0:
+   *   Register to policy mapping:
+  % for reg_name, policy_idx in register_mapping.items():
+   *     ${f"{reg_name}:".ljust(reg_name_len+1)} ${policy_names[policy_idx]} \
+(Idx ${f"{policy_idx}".rjust(policy_idx_len)})
+  % endfor
+% endif
+% if len(window_mapping) > 0:
+   *   Window to policy mapping:
+  % for window_name, policy_idx in window_mapping.items():
+   *     ${f"{window_name}:".ljust(window_name_len+1)} ${policy_names[policy_idx]} \
+(Idx ${f"{policy_idx}".rjust(policy_idx_len)})
+  % endfor
+% endif
+% if len(range_mapping) > 0:
+   *   Range to policy mapping:
+  % for range in range_mapping:
+   *     ${f"0x{range['base']:08x}"} -- ${f"0x{(range['base']+range['size']):08x}"} \
+policy: ${policy_names[range['policy']]} (Idx ${f"{range['policy']}".rjust(policy_idx_len)})
+  % endfor
+% endif
+   */
+% if len(register_mapping) > 0:
+<% policy_sel_value = ", ".join(map(str, reversed(register_mapping.values())))%>\
+<% policy_sel_value = "\n    ".join(textwrap.wrap(policy_sel_value, 94))%>\
+  parameter racl_policy_sel_t ${policy_sel_name} [${len(register_mapping)}] = '{
+    ${policy_sel_value}
+  };
+% endif
+% for window_name, policy_idx in window_mapping.items():
+  parameter racl_policy_sel_t ${policy_sel_name}_WIN_${window_name.upper()} = ${policy_idx};
+% endfor
+% if len(range_mapping) > 0:
+  parameter racl_policy_sel_t ${policy_sel_name}_NUM_RANGES = ${len(range_mapping)};
+<% fmt_range = "'{{base:'h{base:x},mask:'h{mask:x},policy:{policy}}}" %>\
+<% value =  ",\n".join(map(fmt_range.format_map, range_mapping)) %>\
+  parameter racl_range_t ${policy_sel_name}_RANGES [${len(range_mapping)}] = '{
+    ${value}
+  };
+% endif


### PR DESCRIPTION
This PR:
* deduplicates all of the RACL templates and consolidates them into two separate files
* allows including template files within other templates
* updates lowrisc_misc_linters to the latest version to allow for comments within .tpl files (which are needed for the license checker)