### PR TITLE
Add Darjeeling CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,31 @@ jobs:
         run: ./ci/scripts/check-unrunnable-tests.sh
         continue-on-error: true
 
+  dj_sw_build_test:
+    name: Build and test Darjeeling software
+    runs-on: ubuntu-22.04-vivado
+    timeout-minutes: 120
+    needs: quick_lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for bitstream cache to work.
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+      - name: Check Bazel build graph
+        run: |
+          # Test the graph with both an empty and filled bitstream cache.
+          ./ci/scripts/test-empty-bitstream-cache.sh
+          ./bazelisk.sh build --nobuild --//hw/top=darjeeling //...
+      - name: Build software targets
+        run: |
+          # Compile some selected targets
+          ./bazelisk.sh build                                \
+            --build_tests_only=false                         \
+            //sw/device/tests:uart_smoketest_sim_dv
+
   qemu_smoketest:
     name: QEMU smoketest
     runs-on: ubuntu-22.04-vivado

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -247,6 +247,16 @@ def opentitan_binary(name, exec_env, **kwargs):
         topname = ev_map[ev]
         select_map[topname] = select_map.get(topname, []) + [ev]
 
+    kwargs["target_compatible_with"] = \
+        kwargs.get("target_compatible_with", []) + \
+        opentitan_select_top(
+            {
+                top: []
+                for top in select_map.keys()
+            },
+            ["@platforms//:incompatible"],
+        )
+
     _opentitan_binary(
         name = name,
         exec_env = opentitan_select_top(select_map, []),

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//hw/top:defs.bzl", "opentitan_if_ip", "opentitan_select_top")
+load("//hw/top:defs.bzl", "opentitan_if_ip", "opentitan_require_top", "opentitan_select_top")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
@@ -300,6 +300,7 @@ output_groups(
         "sim_verilator_rom",
         "sim_verilator_mapfile",
     ],
+    target_compatible_with = opentitan_require_top("earlgrey"),
 )
 
 pkg_files(

--- a/util/dtgen/helper.py
+++ b/util/dtgen/helper.py
@@ -485,6 +485,7 @@ class IpHelper:
 
     def _init_reg_blocks(self):
         reg_blocks = []
+        self._reg_block_map = {}
         for rb in self.ip.reg_blocks.keys():
             if rb is None:
                 reg_blocks.append(self.UNNAMED_REG_BLOCK_NAME)
@@ -660,12 +661,13 @@ This can be `kDtPlicIrqIdNone` if the block is not connected to the PLIC."""
         # Base address map.
         base_addr_map = OrderedDict()
         for (rb, addr) in m["base_addrs"].items():
-            if self._addr_space not in addr:
-                continue
             if rb == "null":
                 rb = self.UNNAMED_REG_BLOCK_NAME
             rb = Name.from_snake_case(rb)
-            base_addr_map[rb] = addr[self._addr_space]
+            # It is possible that this module is not accessible in this
+            # address space. In this case, return a dummy value.
+            # FIXME Maybe find a better way of doing this.
+            base_addr_map[rb] = addr.get(self._addr_space, "0xffffffff")
         inst_desc[self.BASE_ADDR_FIELD_NAME] = base_addr_map
         # Clock map.
         if self.has_clocks():


### PR DESCRIPTION
This check verifies that the build graph sense when the top is set  to Darjeeling. Furthermore, it tries to build a restricted set of tests for Darjeeling DV (currently only the uart_smoketest). The purpose of this check is to prevent regression while the codebase is being converted to multitop.

Requires #26150, otherwise the uart_smoketest won't compile because of dt_racl_ctrl.