### PR TITLE
[rules] Fix linker rule to correct set the includes path

### DIFF
--- a/rules/linker.bzl
+++ b/rules/linker.bzl
@@ -106,7 +106,7 @@ def _ld_library_impl(ctx):
                 compilation_context = cc_common.create_compilation_context(
                     defines = depset(ctx.attr.defines),
                     headers = depset(ctx.files.includes),
-                    includes = depset([f.path for f in ctx.files.includes]),
+                    includes = depset([f.dirname for f in ctx.files.includes]),
                 ),
             )],
         ),


### PR DESCRIPTION
The compilation context created by `ld_library` was incorrectly using the full file name (e.g. sw/device/file.ld) as the include path instead of the directory name (e.g. sw/device).