### PR TITLE
[rom_ext] Perform ECDSA ans SPX verification in parallel 

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -26,6 +26,7 @@ enum {
    * Highest index of OTBN error bits.
    */
   kOtbnErrBitsLast = OTBN_ERR_BITS_FATAL_SOFTWARE_BIT,
+  kIntrStateDone = (1 << OTBN_INTR_COMMON_DONE_BIT),
 };
 
 /**
@@ -134,19 +135,19 @@ rom_error_t sc_otbn_dmem_read(size_t num_words, sc_otbn_addr_t src,
  * @param error Error to return if operation fails.
  * @return Result of the operation.
  */
+static void sc_otbn_cmd_start(sc_otbn_cmd_t cmd) {
+  abs_mmio_write32(kBase + OTBN_INTR_STATE_REG_OFFSET, kIntrStateDone);
+  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, cmd);
+}
+
 OT_WARN_UNUSED_RESULT
-static rom_error_t sc_otbn_cmd_run(sc_otbn_cmd_t cmd, rom_error_t error) {
+static rom_error_t sc_otbn_cmd_finish(rom_error_t error) {
   enum {
-    kIntrStateDone = (1 << OTBN_INTR_COMMON_DONE_BIT),
     // Use a bit index that doesn't overlap with error bits.
     kResDoneBit = 31,
   };
   static_assert((UINT32_C(1) << kResDoneBit) > kOtbnErrBitsLast,
                 "kResDoneBit must not overlap with OTBN error bits");
-
-  abs_mmio_write32(kBase + OTBN_INTR_STATE_REG_OFFSET, kIntrStateDone);
-  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, cmd);
-
   rom_error_t res = kErrorOk ^ (UINT32_C(1) << kResDoneBit);
   uint32_t reg = 0;
   do {
@@ -177,7 +178,12 @@ static rom_error_t sc_otbn_cmd_run(sc_otbn_cmd_t cmd, rom_error_t error) {
   return error;
 }
 
-rom_error_t sc_otbn_execute(void) {
+static rom_error_t sc_otbn_cmd_run(sc_otbn_cmd_t cmd, rom_error_t error) {
+  sc_otbn_cmd_start(cmd);
+  return sc_otbn_cmd_finish(error);
+}
+
+rom_error_t sc_otbn_execute_start(void) {
   // If OTBN is busy, wait for it to be done.
   HARDENED_RETURN_IF_ERROR(sc_otbn_busy_wait_for_done());
 
@@ -187,7 +193,17 @@ rom_error_t sc_otbn_execute(void) {
   sec_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET,
                    1 << OTBN_CTRL_SOFTWARE_ERRS_FATAL_BIT);
 
-  return sc_otbn_cmd_run(kScOtbnCmdExecute, kErrorOtbnExecutionFailed);
+  sc_otbn_cmd_start(kScOtbnCmdExecute);
+  return kErrorOk;
+}
+
+rom_error_t sc_otbn_execute_finish(void) {
+  return sc_otbn_cmd_finish(kErrorOtbnExecutionFailed);
+}
+
+rom_error_t sc_otbn_execute(void) {
+  HARDENED_RETURN_IF_ERROR(sc_otbn_execute_start());
+  return sc_otbn_execute_finish();
 }
 
 uint32_t sc_otbn_instruction_count_get(void) {

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -247,14 +247,33 @@ rom_error_t sc_otbn_dmem_read(size_t num_words, const sc_otbn_addr_t src,
                               uint32_t *dest);
 
 /**
- * Start the execution of the application loaded into OTBN.
+ * Execute the application loaded into OTBN.
  *
- * This function blocks until OTBN is idle.
+ * This function blocks until OTBN is idle and waits for the OTBN application to
+ * finish.
  *
  * @return Result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t sc_otbn_execute(void);
+
+/**
+ * Start execution of the application loaded into OTBN.
+ *
+ * This function blocks until OTBN is idle and then starts the OTBN application.
+ *
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_otbn_execute_start(void);
+
+/**
+ * Wait for the OTBN application to finish execution.
+ *
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_otbn_execute_finish(void);
 
 /**
  * Blocks until OTBN is idle.

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -273,10 +273,9 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
   return kErrorOk;
 }
 
-rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,
-                                const ecdsa_p256_signature_t *sig,
-                                const hmac_digest_t *digest,
-                                uint32_t *recovered_r) {
+rom_error_t otbn_boot_sigverify_start(const ecdsa_p256_public_key_t *key,
+                                      const ecdsa_p256_signature_t *sig,
+                                      const hmac_digest_t *digest) {
   // Write the mode.
   uint32_t mode = kOtbnBootModeSigverify;
   HARDENED_RETURN_IF_ERROR(
@@ -299,9 +298,12 @@ rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,
                                               sig->s, kOtbnVarBootS));
 
   // Start the OTBN routine.
-  HARDENED_RETURN_IF_ERROR(sc_otbn_execute());
   SEC_MMIO_WRITE_INCREMENT(kScOtbnSecMmioExecute);
+  return sc_otbn_execute_start();
+}
 
+rom_error_t otbn_boot_sigverify_finish(uint32_t *recovered_r) {
+  HARDENED_RETURN_IF_ERROR(sc_otbn_execute_finish());
   // Check if the signature passed basic checks.
   uint32_t ok;
   HARDENED_RETURN_IF_ERROR(sc_otbn_dmem_read(1, kOtbnVarBootOk, &ok));
@@ -318,4 +320,12 @@ rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,
   // Read the recovered `r` value from DMEM.
   return sc_otbn_dmem_read(kEcdsaP256SignatureComponentWords, kOtbnVarBootXr,
                            recovered_r);
+}
+
+rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,
+                                const ecdsa_p256_signature_t *sig,
+                                const hmac_digest_t *digest,
+                                uint32_t *recovered_r) {
+  HARDENED_RETURN_IF_ERROR(otbn_boot_sigverify_start(key, sig, digest));
+  return otbn_boot_sigverify_finish(recovered_r);
 }

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -169,6 +169,34 @@ rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,
                                 const hmac_digest_t *digest,
                                 uint32_t *recovered_r);
 
+/**
+ * Start an ECDSA-P256 signature verify on OTBN.
+ *
+ * Expects the OTBN boot-services program to already be loaded; see
+ * `otbn_boot_app_load`.
+ *
+ * @param key An ECDSA-P256 public key.
+ * @param sig An ECDSA-P256 signature.
+ * @param digest Message digest to check against.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t otbn_boot_sigverify_start(const ecdsa_p256_public_key_t *key,
+                                      const ecdsa_p256_signature_t *sig,
+                                      const hmac_digest_t *digest);
+
+/**
+ * Finish an ECDSA-P256 signature verify on OTBN.
+ *
+ * Call after the `start` operation to wait for completion and collect the
+ * result.
+ *
+ * @param[out] recovered_r Buffer for the recovered `r` value.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t otbn_boot_sigverify_finish(uint32_t *recovered_r);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
@@ -40,6 +40,30 @@ rom_error_t sigverify_ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
                                         uint32_t *flash_exec);
 
 /**
+ * Starts an ECDSA-P256 signature verification.
+ *
+ * @param signature The signature to verify, little endian.
+ * @param key The public key to use for verification, little endian.
+ * @param act_digest The actual digest of the signed message.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sigverify_ecdsa_p256_start(const ecdsa_p256_signature_t *signature,
+                                       const ecdsa_p256_public_key_t *key,
+                                       const hmac_digest_t *act_digest);
+
+/**
+ * Finishes an ECDSA-P256 signature verification.
+ *
+ * @param signature The signature to verify, little endian.
+ * @param[out] flash_exec The partial value to write to the flash_ctrl EXEC
+ * register.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sigverify_ecdsa_p256_finish(const ecdsa_p256_signature_t *signature,
+                                        uint32_t *flash_exec);
+/**
  * Transforms `kSigverifyEcdsaSuccess` into `kErrorOk`.
  *
  * Callers should transform the result to a suitable error value if it is not

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -351,16 +351,23 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   } else if ((key_alg & kOwnershipKeyAlgCategoryMask) ==
              kOwnershipKeyAlgCategoryHybrid) {
     // Hybrid signatures check both ECDSA and SPX+ signatures.
-    // TODO: as a future optimization, start the ECDSA verify operation on
-    // OTBN and compute the SPX+ verify in parallel on Ibex.
-    HARDENED_RETURN_IF_ERROR(sigverify_ecdsa_p256_verify(
+    // Start the ECDSA verify.
+    HARDENED_RETURN_IF_ERROR(sigverify_ecdsa_p256_start(
         &manifest->ecdsa_signature, &keyring.key[verify_key]->data.hybrid.ecdsa,
-        &act_digest, &flash_exec));
-    return rom_ext_spx_verify(
+        &act_digest));
+    // While ECDSA verify is running in OTBN, compute the SPX verify on Ibex.
+    rom_error_t spx = rom_ext_spx_verify(
         &ext_spx_signature->signature,
         &keyring.key[verify_key]->data.hybrid.spx, key_alg,
         &usage_constraints_from_hw, sizeof(usage_constraints_from_hw), NULL, 0,
         digest_region.start, digest_region.length, act_digest);
+    // ECDSA should be finished.  Poll for completeion and get the result.
+    rom_error_t ecdsa =
+        sigverify_ecdsa_p256_finish(&manifest->ecdsa_signature, &flash_exec);
+    HARDENED_RETURN_IF_ERROR(spx);
+    HARDENED_RETURN_IF_ERROR(ecdsa);
+    // Both values should be kErrorOk.  Mix them and return the result.
+    return (rom_error_t)((spx + ecdsa) >> 1);
   } else {
     // TODO: consider whether an SPX+-only verify is sufficent.
     return kErrorOwnershipInvalidAlgorithm;


### PR DESCRIPTION
1. Split ECDSA sigverify into start and finish operations so Ibex can perform SPX verification while OTBN is verifying the P256 signature.
2. Update the ROM_EXT to use the split P256 operations.

By running the ECDSA and SPX operations in parallel, the 4.2ms ECDSA verification time is subsumed into the ~9ms SPX verification time.