### PR TITLE
[manuf] add post perso dev seed validation

### DIFF
--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -586,7 +586,35 @@ pub fn check_slot_b_boot_up(
     response.stats.log_elapsed_time("rom_ext-done", t0);
     let rom_ext_failure_msg = r"Invalid UDS certificate detected!";
     let anchor_text = if let Some(owner_anchor) = &owner_fw_success_string {
-        format!(r"({}|{})", rom_ext_failure_msg, owner_anchor)
+        let full_owner_anchor = if response.seeds.number != 0 {
+            let seed0 = response.seeds.seed[0].as_slice();
+            let mut values: [u32; 2] = [0u32; 2];
+
+            // Generate the expected string containing same two items the DUT
+            // code prints after starting the owners' image in the end of the
+            // perso, and mix it with the constant owner's anchor text.
+            //
+            // TODO(vbendeb): this needs to be moved to SKU specific space.
+            for (i, value) in values.iter_mut().enumerate() {
+                let index = 32 + i * 16;
+                let bytes: [u8; 4] = [
+                    seed0[index],
+                    seed0[index + 1],
+                    seed0[index + 2],
+                    seed0[index + 3],
+                ];
+                *value = u32::from_le_bytes(bytes);
+            }
+
+            format!(
+                r"Got dev seed of {:08x}\.\.{:08x}.*{}",
+                values[0], values[1], owner_anchor
+            )
+        } else {
+            (*owner_anchor).clone()
+        };
+
+        format!(r"(?s)({}|{})", rom_ext_failure_msg, full_owner_anchor)
     } else {
         rom_ext_failure_msg.to_string()
     };


### PR DESCRIPTION
In case the perso code generats dev seeds verify that the Owner's image started in the end of the process can reproduce the seeds.

Tested on CW310 FPGA by running perso with an updated Cros image. Also verified that all the rest of the SKUs pass the provisioning test.