### PR TITLE
Aon timer fcov fixes

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer_testplan.hjson
+++ b/hw/ip/aon_timer/data/aon_timer_testplan.hjson
@@ -82,6 +82,43 @@
       stage: V2
       tests: ["aon_timer_stress_all"]
     }
+    {
+      name: max_threshold
+      desc: '''
+            Run the basic smoke sequence, but constrained to set max thresholds. This helps
+            close coverage.
+            '''
+      stage: V3
+      tests: ["aon_timer_smoke_max_thold"]
+    }
+    {
+      name: min_threshold
+      desc: '''
+            Run the basic smoke sequence, but constrained to set min thresholds. This helps
+            close coverage.
+            '''
+      stage: V3
+      tests: ["aon_timer_smoke_min_thold"]
+    }
+    {
+      name: wkup_count_hi_cdc
+      desc: '''
+            Run aon_timer_wkup_count_cdc_hi_vseq which maximises the chances to hit
+            conditional and branch coverage in wkup_count_hi_cdc (prim_reg_cdc and
+            prim_reg_cdc_arb).
+            '''
+      stage: V3
+      tests: ["aon_timer_wkup_count_cdc_hi"]
+    }
+    {
+      name: custom_intr
+      desc: '''
+            Run aon_timer_custom_intr_vseq, which drives random wdog/wkup control enables
+            as well as intr_test writes in order to help close intr_test_cg covergroup.
+            '''
+      stage: V3
+      tests: ["aon_timer_custom_intr"]
+    }
   ]
 
   covergroups: [

--- a/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
+++ b/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
@@ -39,7 +39,7 @@
   sim_tops: ["aon_timer_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 15
 
   // Add specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/aon_timer/dv/cov/aon_timer_unr_excl.el",
@@ -58,6 +58,7 @@
     {
       name: aon_timer_smoke
       uvm_test_seq: aon_timer_smoke_vseq
+      reseed: 5
     }
     {
       name: aon_timer_prescaler
@@ -66,6 +67,7 @@
     {
       name: aon_timer_jump
       uvm_test_seq: aon_timer_jump_vseq
+      reseed: 5
     }
     {
       name: aon_timer_custom_intr

--- a/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
+++ b/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson
@@ -67,6 +67,26 @@
       name: aon_timer_jump
       uvm_test_seq: aon_timer_jump_vseq
     }
+    {
+      name: aon_timer_custom_intr
+      uvm_test_seq: aon_timer_custom_intr_vseq
+      reseed: 10
+    }
+    {
+      name: aon_timer_smoke_max_thold
+      uvm_test_seq: aon_timer_smoke_max_thold_vseq
+      reseed: 5
+    }
+    {
+      name: aon_timer_smoke_min_thold
+      uvm_test_seq: aon_timer_smoke_min_thold_vseq
+      reseed: 5
+    }
+    {
+      name: aon_timer_wkup_count_cdc_hi
+      uvm_test_seq: aon_timer_wkup_count_cdc_hi_vseq
+      reseed: 5
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/aon_timer/dv/env/aon_timer_env.core
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.core
@@ -25,6 +25,10 @@ filesets:
       - seq_lib/aon_timer_prescaler_vseq.sv: {is_include_file: true}
       - seq_lib/aon_timer_jump_vseq.sv: {is_include_file: true}
       - seq_lib/aon_timer_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/aon_timer_custom_intr_vseq.sv: {is_include_file: true}
+      - seq_lib/aon_timer_smoke_max_thold_vseq.sv: {is_include_file: true}
+      - seq_lib/aon_timer_smoke_min_thold_vseq.sv: {is_include_file: true}
+      - seq_lib/aon_timer_wkup_count_cdc_hi_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
@@ -47,6 +47,8 @@ function void aon_timer_env_cfg::initialize(bit [31:0] csr_base_addr = '1);
   // set num_interrupts & num_alerts
   num_interrupts = ral.intr_state.get_n_used_bits();
   set_intr_state_has_prediction();
+  // Allow mid-TL-US accesses
+  can_reset_with_csr_accesses = 1;
 endfunction : initialize
 
 function bit aon_timer_env_cfg::hdl_read_bit(string path);

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
@@ -14,6 +14,10 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
   // the base class provides the following handles for use:
   // aon_timer_env_cfg: cfg
 
+  const bit [WKUP_WIDTH-1:0]      max_wkup      = 2**WKUP_WIDTH - 1;
+  const bit [WDOG_WIDTH-1:0]      max_wdog      = 2**WDOG_WIDTH - 1;
+  const bit [PRESCALER_WIDTH-1:0] max_prescaler = 2**PRESCALER_WIDTH - 1;
+
   // covergroups
 
   // Covergroup: timer_cfg_cg
@@ -27,29 +31,27 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
                                                             bit wkup_cause);
     prescale_cp: coverpoint prescale {
       bins prescale_0 = {0};
-      bins prescale[32] = {[1:$]};
+      bins prescale[16] = {[1:max_prescaler-1]};
       bins prescale_max = {'1};
     }
     bark_thold_cp: coverpoint bark_thold {
       bins bark_0 = {0};
-      bins bark[32] = {[1:$]};
+      bins bark[16] = {[1:max_wdog-1]};
       bins bark_max = {'1};
     }
     bite_thold_cp: coverpoint bite_thold {
       bins bite_0 = {0};
-      bins bite[32] = {[1:$]};
+      bins bite[16] = {[1:max_wdog-1]};
       bins bite_max = {'1};
     }
     wkup_thold_cp: coverpoint wkup_thold {
       bins wkup_0 = {0};
-      bins wkup[64] = {[1:$]};
+      bins wkup[32] = {[1:max_wkup-1]};
       bins wkup_max = {'1};
     }
-
     wkup_cause_cp: coverpoint wkup_cause {
       bins wkup_cause_cleared = {0};
     }
-
     wdog_regwen_cp: coverpoint wdog_regwen;
     pause_in_sleep_cp: coverpoint pause_in_sleep;
 
@@ -64,13 +66,13 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
 
     wkup_count_cp: coverpoint wkup_count {
       bins min_val    = {0};
-      bins middle_val = {[1:(2**64-2)]};
-      bins max_val    = {2**64-1};
+      bins middle_val = {[1:(max_wkup-1)]};
+      bins max_val    = {max_wkup};
     }
     wkup_thold_cp: coverpoint wkup_thold {
       bins min_val    = {0};
-      bins middle_val = {[1:(2**64-2)]};
-      bins max_val    = {2**64-1};
+      bins middle_val = {[1:(max_wkup-1)]};
+      bins max_val    = {max_wkup};
     }
     wkup_int_cp  : coverpoint wkup_int   {bins unset          = {0};
                                           bins set            = {1};
@@ -87,13 +89,13 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
 
     wdog_count_cp:    coverpoint wdog_count {
       bins min_val    = {0};
-      bins middle_val = {[1:(2**32-2)]};
-      bins max_val    = {2**32-1};
+      bins middle_val = {[1:(max_wdog-1)]};
+      bins max_val    = {max_wdog};
     }
     wdog_thold_cp:    coverpoint wdog_thold {
       bins min_val    = {0};
-      bins middle_val = {[1:(2**32-2)]};
-      bins max_val    = {2**32-1};
+      bins middle_val = {[1:(max_wdog-1)]};
+      bins max_val    = {max_wdog};
     }
     wdog_bite_rst_cp: coverpoint wdog_bite_rst   { bins unset    = {0};
                                                    bins set      = {1};
@@ -110,13 +112,13 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
 
     wdog_count_cp:    coverpoint wdog_count {
       bins min_val    = {0};
-      bins middle_val = {[1:(2**32-2)]};
-      bins max_val    = {2**32-1};
+      bins middle_val = {[1:(max_wdog-1)]};
+      bins max_val    = {max_wdog};
     }
     wdog_thold_cp:    coverpoint wdog_thold {
       bins min_val    = {0};
-      bins middle_val = {[1:(2**32-2)]};
-      bins max_val    = {2**32-1};
+      bins middle_val = {[1:(max_wdog-1)]};
+      bins max_val    = {max_wdog};
     }
     wdog_bark_int_cp: coverpoint wdog_bark_int   { bins unset          = {0};
                                                    bins set            = {1};

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_pkg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_pkg.sv
@@ -23,9 +23,16 @@ package aon_timer_env_pkg;
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
 
-  // types
+  // Dummy objects used to derive the actual size from structs in aon_timer_reg_pkg
+  aon_timer_reg_pkg::aon_timer_reg2hw_wkup_ctrl_reg_t     wkup_ctrl_fields;
+  aon_timer_reg_pkg::aon_timer_reg2hw_wkup_count_hi_reg_t wkup_count_hi;
+  aon_timer_reg_pkg::aon_timer_reg2hw_wkup_count_lo_reg_t wkup_count_lo;
+  aon_timer_reg_pkg::aon_timer_reg2hw_wdog_count_reg_t    wdog_count;
 
-  // functions
+  // Widths of WKUP/WDOG counters/threshold registers, respectively.
+  parameter int unsigned WKUP_WIDTH      = $bits(wkup_count_hi.q) + $bits(wkup_count_lo.q);
+  parameter int unsigned WDOG_WIDTH      = $bits(wdog_count.q);
+  parameter int unsigned PRESCALER_WIDTH = $bits(wkup_ctrl_fields.prescaler.q);
 
   // package sources
   `include "aon_timer_env_cfg.sv"

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -72,21 +72,35 @@ endclass : aon_timer_base_vseq
 constraint aon_timer_base_vseq::thold_count_c {
   solve wkup_count_gap, wkup_thold before wkup_count;
   solve aim_bite, wdog_count_gap, wdog_bark_thold, wdog_bite_thold before wdog_count;
-  wkup_count_gap inside {[1:500]};
-  wdog_count_gap inside {[1:500]};
+  wkup_count_gap inside {[1:10]};
+  wdog_count_gap inside {[1:10]};
+  wkup_thold      <= (2**WKUP_WIDTH-1);
+  wdog_bark_thold <= (2**WDOG_WIDTH-1);
+  wdog_bite_thold <= (2**WDOG_WIDTH-1);
 
-  wkup_thold      inside {[1:10]};
-  wdog_bark_thold inside {[1:10]};
-  wdog_bite_thold inside {[1:10]};
+  wkup_thold dist {0                     :/ 20,
+                   [1:(2**WKUP_WIDTH-2)] :/ 60,
+                   (2**WKUP_WIDTH-1)     :/ 20};
 
-  wkup_thold      <= (2**64-1);
-  wdog_bark_thold <= (2**32-1);
-  wdog_bite_thold <= (2**32-1);
+  wdog_bark_thold dist {0                     :/ 20,
+                        [1:(2**WDOG_WIDTH-2)] :/ 60,
+                        (2**WDOG_WIDTH-1)     :/ 20};
 
-  wkup_count inside {[wkup_thold-wkup_count_gap:wkup_thold]};
-  !aim_bite -> wdog_count inside {[wdog_bark_thold-wdog_count_gap:wdog_bark_thold]};
-  aim_bite  -> wdog_count inside {[wdog_bite_thold-wdog_count_gap:wdog_bite_thold]};
+  wdog_bite_thold dist {0                     :/ 20,
+                        [1:(2**WDOG_WIDTH-2)] :/ 60,
+                        (2**WDOG_WIDTH-1)     :/ 20};
 
+
+  wkup_thold != 0 -> wkup_count inside {[wkup_thold-wkup_count_gap:wkup_thold]};
+  wkup_thold == 0 -> wkup_count == 0;
+  if (!aim_bite) {
+    wdog_bark_thold != 0 -> wdog_count inside {[wdog_bark_thold-wdog_count_gap:wdog_bark_thold]};
+    wdog_bark_thold == 0 -> wdog_count == 0;
+  }
+  else {
+    wdog_bite_thold != 0 -> wdog_count inside {[wdog_bite_thold-wdog_count_gap:wdog_bite_thold]};
+    wdog_bite_thold == 0 -> wdog_count == 0;
+  }
 }
 
 function aon_timer_base_vseq::new (string name="");
@@ -103,31 +117,38 @@ endtask : dut_init
 
 task aon_timer_base_vseq::aon_timer_shutdown();
   `uvm_info(`gfn, "Shutting down AON Timer...", UVM_LOW)
-
+  if (cfg.under_reset) return;
   `uvm_info(`gfn, "Writing 0 to WKUP_CTRL and WDOG_CTRL to disable AON timer", UVM_HIGH)
   write_wkup_reg(ral.wkup_ctrl.enable, 1'b0);
+  if (cfg.under_reset) return;
   `uvm_info(`gfn, "write_reg wdog_ctr.enable", UVM_DEBUG);
   csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b0);
   `uvm_info(`gfn, "Clearing interrupts, count registers and wakeup request.", UVM_HIGH)
   // Clear wake-up request if we have any
   csr_utils_pkg::csr_wr(ral.wkup_cause, 1'b0);
+  if (cfg.under_reset) return;
 
   // We need to ensure the prediction has kicked in before we read the intr_state
   wait (ral.intr_state.is_busy() == 0);
+
   // Clear the interrupts
   csr_utils_pkg::csr_wr(ral.intr_state, 2'b11);
+  if (cfg.under_reset) return;
 
-  `uvm_info(`gfn, $sformatf({"Initializating AON Timer. Writing ",
+  `uvm_info(`gfn, $sformatf({"Shutting down: AON Timer. Writing ",
                              "0x%0x to WKUP_COUNT and 0x%0x ",
                              "to WDOG_COUNT."},
                             wkup_count, wdog_count), UVM_LOW)
   // Register Write
   write_wkup_reg(ral.wkup_count_lo, wkup_count[31:0]);
+  if (cfg.under_reset) return;
   write_wkup_reg(ral.wkup_count_hi, wkup_count[63:32]);
+  if (cfg.under_reset) return;
   write_wkup_reg(ral.wdog_count, wdog_count);
+  if (cfg.under_reset) return;
 
   // Wait to settle registers on AON timer domain
-  cfg.aon_clk_rst_vif.wait_clks(5);
+  cfg.aon_clk_rst_vif.wait_clks_or_rst(5);
 endtask : aon_timer_shutdown
 
 // setup basic aon_timer features
@@ -135,29 +156,38 @@ task aon_timer_base_vseq::aon_timer_init();
   bit wkup_thold_lo_we, wkup_thold_hi_we;
   // Clear the interrupts
   csr_utils_pkg::csr_wr(ral.intr_state, 2'b11);
+  if (cfg.under_reset) return;
 
   `uvm_info(`gfn, "Initializating AON Timer. Writing 0 to WKUP_COUNT and WDOG_COUNT", UVM_LOW)
   // Register Write
-  write_wkup_reg(ral.wkup_count_lo, 32'h0000_0000);
-  write_wkup_reg(ral.wkup_count_hi, 32'h0000_0000);
-  csr_utils_pkg::csr_wr(ral.wdog_count, 32'h0000_0000);
+  write_wkup_reg(ral.wkup_count_lo, wkup_count[31:0]);
+  if (cfg.under_reset) return;
+  write_wkup_reg(ral.wkup_count_hi, wkup_count[63:32]);
+  if (cfg.under_reset) return;
+  csr_utils_pkg::csr_wr(ral.wdog_count, wdog_count);
+  if (cfg.under_reset) return;
 
   `uvm_info(`gfn, "Randomizing AON Timer thresholds", UVM_HIGH)
 
   `uvm_info(`gfn, $sformatf("Writing 0x%0h to wkup_thold", wkup_thold), UVM_HIGH)
   write_wkup_reg(ral.wkup_thold_lo, wkup_thold[31:0]);
+  if (cfg.under_reset) return;
   write_wkup_reg(ral.wkup_thold_hi, wkup_thold[63:32]);
+  if (cfg.under_reset) return;
 
   `uvm_info(`gfn, $sformatf("Writing 0x%0h to wdog_bark_thold", wdog_bark_thold), UVM_HIGH)
   write_wkup_reg(ral.wdog_bark_thold, wdog_bark_thold);
+  if (cfg.under_reset) return;
 
   `uvm_info(`gfn, $sformatf("Writing 0x%0h to wdog_bite_thold", wdog_bite_thold), UVM_HIGH)
   write_wkup_reg(ral.wdog_bite_thold, wdog_bite_thold);
+  if (cfg.under_reset) return;
 
   cfg.lc_escalate_en_vif.drive(0);
 
   `uvm_info(`gfn, $sformatf("Writing 0x%0h to WDOG_REGWEN", wdog_regwen), UVM_HIGH)
   csr_utils_pkg::csr_wr(ral.wdog_regwen, wdog_regwen);
+  if (cfg.under_reset) return;
 
 endtask : aon_timer_init
 
@@ -193,11 +223,14 @@ task aon_timer_base_vseq::wait_for_interrupt(bit intr_state_read = 1);
     uvm_reg_data_t intr_state_value;
 
     @(negedge cfg.aon_clk_rst_vif.rst_n or cfg.aon_intr_vif.pins);
+    if (cfg.under_reset) return;
+    `uvm_info(`gfn, $sformatf("Interrupt detected: 0x%0x ",cfg.aon_intr_vif.pins), UVM_DEBUG)
 
     if (intr_state_read) begin
       // Wait 2 clocks to ensure interrupt is visible on intr_state read
-      cfg.aon_clk_rst_vif.wait_clks(2);
+      cfg.aon_clk_rst_vif.wait_clks_or_rst(2);
 
+      if (cfg.under_reset) return;
       // We need to ensure the prediction has kicked in before we read the intr_state
       wait (ral.intr_state.is_busy() == 0);
       if (cfg.under_reset) return;
@@ -218,6 +251,7 @@ task aon_timer_base_vseq::write_wkup_reg(input uvm_object ptr, input uvm_reg_dat
   string path_to_we;
   csr_field_t csr_or_fld = decode_csr_or_field(ptr);
 
+  if (cfg.under_reset) return;
   if (csr_or_fld.csr == null)
     `uvm_fatal(`gfn, "Couldn't decode argument into CSR reg")
   path_to_we = {".u_reg.aon_", csr_or_fld.csr.get_name(), "_we"};

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -129,7 +129,7 @@ task aon_timer_base_vseq::aon_timer_shutdown();
   if (cfg.under_reset) return;
 
   // We need to ensure the prediction has kicked in before we read the intr_state
-  wait (ral.intr_state.is_busy() == 0);
+  wait (ral.intr_state.m_is_busy == 0);
 
   // Clear the interrupts
   csr_utils_pkg::csr_wr(ral.intr_state, 2'b11);
@@ -232,7 +232,7 @@ task aon_timer_base_vseq::wait_for_interrupt(bit intr_state_read = 1);
 
       if (cfg.under_reset) return;
       // We need to ensure the prediction has kicked in before we read the intr_state
-      wait (ral.intr_state.is_busy() == 0);
+      wait (ral.intr_state.m_is_busy == 0);
       if (cfg.under_reset) return;
       csr_utils_pkg::csr_rd(ral.intr_state, intr_state_value);
     end

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_custom_intr_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_custom_intr_vseq.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Custom intr_test with the intent of hitting cross-coverage for intr_test/intr_state/enables
+class aon_timer_custom_intr_vseq extends aon_timer_base_vseq;
+  `uvm_object_utils(aon_timer_custom_intr_vseq)
+
+  rand bit wdog_enable, wkup_enable;
+  rand bit [1:0] intr_test_value;
+
+  extern constraint intr_test_c;
+
+  extern function new (string name="");
+  extern task intr_stimulus();
+  extern task body();
+endclass : aon_timer_custom_intr_vseq
+
+constraint aon_timer_custom_intr_vseq::intr_test_c {
+  intr_test_value != 0;
+}
+
+function aon_timer_custom_intr_vseq::new (string name="");
+  super.new(name);
+endfunction : new
+
+task aon_timer_custom_intr_vseq::intr_stimulus();
+  bit [1:0] read_intr_state;
+  // Write random value to the wkup_ctrl/wdog_ctrl and intr_test registers
+  cfg.aon_clk_rst_vif.wait_clks_or_rst(1);
+
+  `uvm_info(`gfn, $sformatf("Setting CTRL registers with enables for WKUP=0x%0x/WDOG=0x%0x",
+                            wkup_enable, wdog_enable), UVM_DEBUG)
+  csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, wdog_enable);
+  csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, wkup_enable);
+
+  `uvm_info(`gfn, $sformatf("Write: Test_intr=0x%0x",intr_test_value), UVM_DEBUG)
+  csr_utils_pkg::csr_wr(ral.intr_test, intr_test_value);
+  csr_utils_pkg::csr_rd(ral.intr_state, read_intr_state);
+  cfg.aon_clk_rst_vif.wait_clks_or_rst(5);
+endtask : intr_stimulus
+
+task aon_timer_custom_intr_vseq::body();
+  aon_timer_init();
+  intr_stimulus();
+  aon_timer_shutdown();
+endtask : body

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
@@ -40,17 +40,18 @@ endtask : body
 
 task aon_timer_jump_vseq::jump_configure();
 
-  // Write random value to the COUNT registers
-  write_wkup_reg(ral.wkup_count_lo, wkup_count[31:0]);
-  write_wkup_reg(ral.wkup_count_hi, wkup_count[63:32]);
   `uvm_info(`gfn,
             $sformatf("\n\t Writing random COUNT value of %d to WKUP", wkup_count),
             UVM_HIGH)
+  // Write random value to the COUNT registers
+  write_wkup_reg(ral.wkup_count_lo, wkup_count[31:0]);
+  write_wkup_reg(ral.wkup_count_hi, wkup_count[63:32]);
+  if (cfg.under_reset) return;
 
-  csr_utils_pkg::csr_wr(ral.wdog_count, wdog_count);
   `uvm_info(`gfn,
             $sformatf("\n\t Writing random COUNT value of %d to WDOG", wdog_count),
             UVM_HIGH)
+  csr_utils_pkg::csr_wr(ral.wdog_count, wdog_count);
 
   cfg.aon_clk_rst_vif.wait_clks(1);
 

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
@@ -53,11 +53,14 @@ task aon_timer_jump_vseq::jump_configure();
             UVM_HIGH)
   csr_utils_pkg::csr_wr(ral.wdog_count, wdog_count);
 
-  cfg.aon_clk_rst_vif.wait_clks(1);
+  cfg.aon_clk_rst_vif.wait_clks_or_rst(1);
+  if (cfg.under_reset) return;
 
   `uvm_info(`gfn, "Enabling AON Timer. Writing 1 to WKUP_CTRL and WDOG_CTRL", UVM_HIGH)
   csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b1);
+  if (cfg.under_reset) return;
   csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b1);
+  if (cfg.under_reset) return;
 
   `uvm_info(`gfn, "\n\t Waiting for AON Timer to finish (interrupt)", UVM_HIGH)
 endtask : jump_configure

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_prescaler_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_prescaler_vseq.sv
@@ -40,19 +40,15 @@ endtask : body
 
 task aon_timer_prescaler_vseq::prescaler_configure();
 
-  // Write random value to the prescaler
-  csr_utils_pkg::csr_wr(ral.wkup_ctrl.prescaler, prescaler);
   `uvm_info(`gfn,
             $sformatf("\n\t Writing random prescaler value of %d to WKUP CTRL", prescaler),
             UVM_HIGH)
-
+  // Write random value to the prescaler
+  csr_utils_pkg::csr_wr(ral.wkup_ctrl.prescaler, prescaler);
   csr_utils_pkg::csr_spinwait(.ptr(ral.wkup_ctrl.prescaler), .exp_data(prescaler), .backdoor(1));
   `uvm_info(`gfn, "Written values (wkup_prescaler) has propagated through the CDC", UVM_DEBUG)
-
-
   `uvm_info(`gfn, "Enabling AON Timer (WKUP ONLY). Writing 1 to WKUP_CTRL", UVM_HIGH)
   csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b1);
   csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b0);
-
   `uvm_info(`gfn, "\n\t Waiting for AON Timer to finish (interrupt)", UVM_HIGH)
 endtask : prescaler_configure

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_prescaler_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_prescaler_vseq.sv
@@ -7,10 +7,11 @@ class aon_timer_prescaler_vseq extends aon_timer_base_vseq;
   `uvm_object_utils(aon_timer_prescaler_vseq)
 
   // Randomize prescaler configuration of the wake up timer.
-  randc bit [11:0] prescaler;
+  rand bit [11:0] prescaler;
 
   //Overrides constraint in parent vseq:
   extern constraint thold_count_c;
+  extern constraint prescaler_c;
 
   extern function new (string name="");
   extern task body();
@@ -27,14 +28,23 @@ constraint aon_timer_prescaler_vseq::thold_count_c {
   wdog_count == 0;
 }
 
+constraint aon_timer_prescaler_vseq::prescaler_c {
+  prescaler dist {0                          :/ 15,
+                  [1:(2**PRESCALER_WIDTH-2)] :/ 70,
+                  (2**PRESCALER_WIDTH-1)     :/ 15};
+}
+
 function aon_timer_prescaler_vseq::new (string name="");
   super.new(name);
 endfunction : new
 
 task aon_timer_prescaler_vseq::body();
   aon_timer_init();
+  if (cfg.under_reset) return;
   prescaler_configure();
+  if (cfg.under_reset) return;
   wait_for_interrupt();
+  if (cfg.under_reset) return;
   aon_timer_shutdown();
 endtask : body
 
@@ -49,6 +59,7 @@ task aon_timer_prescaler_vseq::prescaler_configure();
   `uvm_info(`gfn, "Written values (wkup_prescaler) has propagated through the CDC", UVM_DEBUG)
   `uvm_info(`gfn, "Enabling AON Timer (WKUP ONLY). Writing 1 to WKUP_CTRL", UVM_HIGH)
   csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b1);
+  if (cfg.under_reset) return;
   csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b0);
   `uvm_info(`gfn, "\n\t Waiting for AON Timer to finish (interrupt)", UVM_HIGH)
 endtask : prescaler_configure

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_max_thold_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_max_thold_vseq.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// smoke test with maximum threshold - helps close FCOV corner cases
+class aon_timer_smoke_max_thold_vseq extends aon_timer_smoke_vseq;
+  `uvm_object_utils(aon_timer_smoke_max_thold_vseq)
+
+  extern constraint extra_thold_count_c;
+
+  extern function new (string name="");
+
+endclass : aon_timer_smoke_max_thold_vseq
+
+function aon_timer_smoke_max_thold_vseq::new (string name="");
+  super.new(name);
+endfunction : new
+
+constraint aon_timer_smoke_max_thold_vseq::extra_thold_count_c {
+  wdog_bark_thold == (2**WDOG_WIDTH-1);
+  wdog_bite_thold == (2**WDOG_WIDTH-1);
+  wkup_thold      == (2**WKUP_WIDTH-1);
+}

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_min_thold_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_min_thold_vseq.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// smoke test with minimum threshold - helps close FCOV corner cases
+class aon_timer_smoke_min_thold_vseq extends aon_timer_smoke_vseq;
+  `uvm_object_utils(aon_timer_smoke_min_thold_vseq)
+
+  extern constraint extra_thold_count_c;
+
+  extern function new (string name="");
+
+endclass : aon_timer_smoke_min_thold_vseq
+
+function aon_timer_smoke_min_thold_vseq::new (string name="");
+  super.new(name);
+endfunction : new
+
+constraint aon_timer_smoke_min_thold_vseq::extra_thold_count_c {
+  wdog_bark_thold == 0;
+  wdog_bite_thold == 0;
+  wkup_thold      == 0;
+}

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_vseq.sv
@@ -18,8 +18,11 @@ endfunction : new
 
 task aon_timer_smoke_vseq::body();
   aon_timer_init();
+  if (cfg.under_reset) return;
   smoke_configure();
+  if (cfg.under_reset) return;
   wait_for_interrupt();
+  if (cfg.under_reset) return;
   aon_timer_shutdown();
 endtask : body
 
@@ -27,9 +30,11 @@ task aon_timer_smoke_vseq::smoke_configure();
 
   `uvm_info(`gfn, "Enabling AON Timer. Writing 1 to WKUP_CTRL and WDOG_CTRL", UVM_HIGH)
   csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b1);
+  if (cfg.under_reset) return;
   wdog_ctrl_pause_in_sleep = $urandom_range(0, 1);
   ral.wdog_ctrl.enable.set(1);
   ral.wdog_ctrl.pause_in_sleep.set(wdog_ctrl_pause_in_sleep);
   csr_update(ral.wdog_ctrl);
+  if (cfg.under_reset) return;
   `uvm_info(`gfn, "\n\t Waiting for AON Timer to finish (interrupt)", UVM_HIGH)
 endtask : smoke_configure

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_stress_all_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_stress_all_vseq.sv
@@ -13,7 +13,7 @@ class aon_timer_stress_all_vseq extends aon_timer_base_vseq;
 endclass : aon_timer_stress_all_vseq
 
 constraint aon_timer_stress_all_vseq::num_trans_c {
-  num_trans inside {[15:20]};
+  num_trans inside {[5:15]};
 }
 
 function aon_timer_stress_all_vseq::new (string name="");
@@ -48,5 +48,6 @@ task aon_timer_stress_all_vseq::body();
     end
 
     aon_timer_vseq.start(p_sequencer);
+    if (cfg.under_reset) break;
   end
 endtask : body

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_vseq_list.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_vseq_list.sv
@@ -8,3 +8,7 @@
 `include "aon_timer_jump_vseq.sv"
 `include "aon_timer_common_vseq.sv"
 `include "aon_timer_stress_all_vseq.sv"
+`include "aon_timer_custom_intr_vseq.sv"
+`include "aon_timer_smoke_max_thold_vseq.sv"
+`include "aon_timer_smoke_min_thold_vseq.sv"
+`include "aon_timer_wkup_count_cdc_hi_vseq.sv"

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_wkup_count_cdc_hi_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_wkup_count_cdc_hi_vseq.sv
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// aon_timer_wkup_count_cdc_hi_vseq aims to get the wkup_count[31:0] to overflow
+// in order to have wkup_count[63:32].
+// In addition to the lowest 32-bit overflow, the Vseq drives wkup_ctrl.enable via
+// the backdoor in order to have finer control as in when the enable sets in due to CDC
+// crossing to hit conditional coverage more easily
+class aon_timer_wkup_count_cdc_hi_vseq extends aon_timer_smoke_vseq;
+    `uvm_object_utils(aon_timer_wkup_count_cdc_hi_vseq)
+
+  localparam WKUP_HALF_REG_LP = WKUP_WIDTH/2;
+  rand int unsigned delay;
+
+  extern constraint wkup_count_upper_32_bits_c;
+
+  extern function new (string name="");
+  // u_wkup_count_hi_cdc CCOV closure task.
+  // It's very difficult to close some CCOV for the instance above (including the arbiter)
+  // because the counter is 64-bits and is split in two 32-bit half registers which means the
+  // 'hi' part of the register won't be counting frequently unless the bottom 32-bits overflow.
+  // This task aims to:
+  // 1) Disable the wkup_ctrl.enable field at the right time to allow for missing conditional
+  //    and branch coverage to be hit in the arbiter (prim_reg_cdc_arb). In particular, the counter
+  //    must be disabled exactly at the cycle the 'hi' part of the counter update. This causes
+  //    `dst_qs_o != dst_qs_i` which will cause `dst_lat_q=1` and clear all the associated holes.
+  // 2) In addition to the above, prim_reg_cdc requires a front-door wkup_count_hi write right after
+  //    the counter is disabled in order to achieve the condition `src_update==1 && busy==1`
+  //
+  // Note: The enabling/disabling as well as some of the write wkup_countr_hi could also be achieved
+  //       through front-door accesses. However, it would take longer to close coverage since each
+  //       TL access needs to cross the CDC.
+  extern task wkup_count_hi_cdc_ccov_closure();
+  extern task body();
+
+endclass : aon_timer_wkup_count_cdc_hi_vseq
+
+constraint aon_timer_wkup_count_cdc_hi_vseq::wkup_count_upper_32_bits_c {
+  solve delay before wkup_count;
+  wkup_thold > 0;
+  wkup_count[WKUP_HALF_REG_LP-1:0] == ({WKUP_HALF_REG_LP{1'b1}} - delay);
+  delay > 0;
+  delay < 15;
+}
+
+function aon_timer_wkup_count_cdc_hi_vseq::new (string name="");
+  super.new(name);
+endfunction : new
+
+task aon_timer_wkup_count_cdc_hi_vseq::wkup_count_hi_cdc_ccov_closure();
+
+  // Disable escalation, to allow the wkup_counter to count (aon_timer_core.wkup_incr=1)
+  // Otherwise, we probably won't hit the missing coverage holes for wkup_count_hi_cdc and arbiter
+  cfg.lc_escalate_en_vif.drive(0);
+
+  for (int i = 0; i < 30; i++) begin
+    if (!this.randomize())
+      `uvm_fatal(`gfn, "Randomization Failure")
+
+    // Clear interrupts in case any had been raised (via backdoor to avoid any delay)
+    csr_utils_pkg::csr_wr(.ptr(ral.intr_state), .value(2'b11), .backdoor(1));
+    `uvm_info(`gfn, $sformatf("Initializating AON Timer. Writing 0x%0x to WKUP_COUNT",
+                              wkup_count), UVM_DEBUG)
+    csr_utils_pkg::csr_wr(.ptr(ral.wkup_count_lo), .value(wkup_count[31:0]), .backdoor(1));
+    csr_utils_pkg::csr_wr(.ptr(ral.wkup_count_hi), .value(wkup_count[63:32]), .backdoor(1));
+    if (cfg.under_reset) break;
+
+    cfg.aon_clk_rst_vif.wait_clks_or_rst(delay);
+    // Enable wkup_counter via backdoor to ensure no CDC delay
+    csr_utils_pkg::csr_wr(.ptr(ral.wkup_ctrl.enable), .value(1), .backdoor(1));
+    if (cfg.under_reset) break;
+
+    cfg.aon_clk_rst_vif.wait_clks_or_rst(delay+$urandom_range(0,1));
+
+    csr_utils_pkg::csr_wr(.ptr(ral.wkup_ctrl.enable), .value(0), .backdoor(1));
+    if (cfg.under_reset) break;
+
+    write_wkup_reg(ral.wkup_count_hi, $random);
+    if (cfg.under_reset) break;
+    write_wkup_reg(ral.wkup_count_lo, $random);
+    if (cfg.under_reset) break;
+  end
+endtask : wkup_count_hi_cdc_ccov_closure
+
+
+task aon_timer_wkup_count_cdc_hi_vseq::body();
+  wkup_count_hi_cdc_ccov_closure();
+endtask : body


### PR DESCRIPTION
This PR tackles the Functional coverage gap to reach to 100%. 

A few more constrained tests have been added for easier coverage closure (min/max threshold and intr_test).
Some of the covergroups have been fixed since not all bins were populated due to incorrect range values. 

Mid-TL_UL transaction reset have been added as well.

Running a regression with these improvements plus the remaining RTL exclusions from PR #26165 brings CCOV over ~99%.  
FCOV should already be at 100% for a single regression run (`-rx 1`). 

There's a couple of missing items for `tb.dut.u_reg.u_wkup_count_hi_cdc` and its arbiter below which I'm still working on generating stimulus for.
The goal is also to diminish the regression length to allow for faster sign-off and less simulation cycles

