### PR TITLE
[manuf] update individualization to exclude AST data from OTP digest

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -280,6 +280,7 @@ manifest(d = {
         deps = [
             ":perso_tlv_data",
             ":personalize_ext",
+            "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
             "//sw/device/lib/crypto/drivers:entropy",
             "//sw/device/lib/dif:flash_ctrl",
             "//sw/device/lib/dif:lc_ctrl",

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -47,6 +47,7 @@
 
 #include "flash_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                         .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
@@ -247,7 +248,7 @@ static status_t measure_otp_partition(otp_partition_t partition,
                                       hmac_digest_t *measurement,
                                       bool use_expected_values) {
   // Compute the digest.
-  otp_dai_read(partition, /*address=*/0, otp_state,
+  otp_dai_read(partition, /*relative_address=*/0, otp_state,
                kOtpPartitions[partition].size / sizeof(uint32_t));
 
   if (use_expected_values) {
@@ -262,7 +263,17 @@ static status_t measure_otp_partition(otp_partition_t partition,
     }
   }
 
-  hmac_sha256(otp_state, kOtpPartitions[partition].size, measurement);
+  uint32_t *otp_state_ptr = otp_state;
+  size_t otp_state_size = kOtpPartitions[partition].size;
+  if (partition == kOtpPartitionCreatorSwCfg) {
+    // Note: we purposely exclude the AST configuration data field of this
+    // partition from the digest calculation. See
+    // sw/device/silicon_creator/manuf/lib/util.c for why.
+    otp_state_ptr = &otp_state[OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE /
+                               sizeof(uint32_t)];
+    otp_state_size -= OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE;
+  }
+  hmac_sha256(otp_state_ptr, otp_state_size, measurement);
 
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -236,6 +236,7 @@ opentitan_test(
         "//sw/device/lib/testing:otp_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
 
@@ -102,6 +103,69 @@ static status_t check_otp_ast_cfg(void) {
 }
 
 /**
+ * Check the *SW_CFG partition digests.
+ */
+static status_t check_otp_sw_cfg_digest(dif_otp_ctrl_partition_t partition) {
+  uint64_t expected_digest, actual_digest = 0;
+
+  // Get actual_digest.
+  CHECK_DIF_OK(dif_otp_ctrl_get_digest(&otp_ctrl, partition, &actual_digest));
+
+  // Compute expected_digest.
+  hmac_sha256_init();
+  switch (partition) {
+    case kDifOtpCtrlPartitionCreatorSwCfg: {
+      hmac_sha256_update(
+          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                            OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET),
+          OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
+              OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE);
+    } break;
+    case kDifOtpCtrlPartitionOwnerSwCfg: {
+      hmac_sha256_update(
+          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                            OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET),
+          OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
+              OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE);
+    } break;
+    case kDifOtpCtrlPartitionRotCreatorAuthCodesign: {
+      hmac_sha256_update(
+          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET),
+          OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
+              OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE);
+    } break;
+    case kDifOtpCtrlPartitionRotCreatorAuthState: {
+      hmac_sha256_update(
+          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET),
+          OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
+              OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE);
+    } break;
+    default:
+      return INVALID_ARGUMENT();
+  }
+  hmac_sha256_process();
+  hmac_digest_t otp_measurement;
+  hmac_sha256_final(&otp_measurement);
+  expected_digest = otp_measurement.digest[1];
+  expected_digest = (expected_digest << 32) | otp_measurement.digest[0];
+
+  // Check actual digest matches the expect digest.
+  LOG_INFO("Actual Digest:   0x%08x%08x", (uint32_t)(actual_digest >> 32),
+           (uint32_t)actual_digest);
+  LOG_INFO("Expected Digest: 0x%08x%08x", (uint32_t)(expected_digest >> 32),
+           (uint32_t)expected_digest);
+  TRY_CHECK(actual_digest == expected_digest);
+
+  return OK_STATUS();
+}
+
+/**
  * Perform software reset.
  */
 static void sw_reset(void) {
@@ -126,14 +190,12 @@ bool test_main(void) {
     CHECK_STATUS_OK(manuf_individualize_device_field_cfg(
         &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET));
     CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));
-    CHECK_STATUS_OK(check_otp_ast_cfg());
     LOG_INFO("Provisioned and locked CREATOR_SW_CFG OTP partition.");
     // Halt the CPU here to enable host to perform POR and bootstrap again since
     // flash scrambling enablement has changed. Bootstrap resets the chip as
     // well, which completes the locking of this partition.
     abort();
   }
-
   bool perform_reset = false;
 
   // Provision OWNER_SW_CFG partition.
@@ -176,6 +238,18 @@ bool test_main(void) {
           &otp_ctrl)) &&
       status_ok(
           manuf_individualize_device_rot_creator_auth_state_check(&otp_ctrl))) {
+    // Check OTP AST and digest contents.
+    CHECK_STATUS_OK(check_otp_ast_cfg());
+    LOG_INFO("Checking CreatorSwCfg digest ...");
+    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kDifOtpCtrlPartitionCreatorSwCfg));
+    LOG_INFO("Checking OwnerSwCfg digest ...");
+    CHECK_STATUS_OK(check_otp_sw_cfg_digest(kDifOtpCtrlPartitionOwnerSwCfg));
+    LOG_INFO("Checking RotCreatorAuthCodesign digest ...");
+    CHECK_STATUS_OK(
+        check_otp_sw_cfg_digest(kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+    LOG_INFO("Checking RotCreatorAuthState digest ...");
+    CHECK_STATUS_OK(
+        check_otp_sw_cfg_digest(kDifOtpCtrlPartitionRotCreatorAuthState));
     return true;
   }
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
@@ -113,36 +113,32 @@ static status_t check_otp_sw_cfg_digest(dif_otp_ctrl_partition_t partition) {
 
   // Compute expected_digest.
   hmac_sha256_init();
+  const unsigned char *const kOtpSwCfgWindowBase =
+      (unsigned char *)TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+      OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET;
   switch (partition) {
     case kDifOtpCtrlPartitionCreatorSwCfg: {
-      hmac_sha256_update(
-          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                            OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET),
-          OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
-              OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE);
+      hmac_sha256_update(kOtpSwCfgWindowBase +
+                             OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET,
+                         OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
+                             OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE -
+                             OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE);
     } break;
     case kDifOtpCtrlPartitionOwnerSwCfg: {
       hmac_sha256_update(
-          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                            OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET),
+          kOtpSwCfgWindowBase + OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET,
           OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
               OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE);
     } break;
     case kDifOtpCtrlPartitionRotCreatorAuthCodesign: {
       hmac_sha256_update(
-          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET),
+          kOtpSwCfgWindowBase + OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
           OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
               OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE);
     } break;
     case kDifOtpCtrlPartitionRotCreatorAuthState: {
       hmac_sha256_update(
-          (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET),
+          kOtpSwCfgWindowBase + OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET,
           OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
               OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE);
     } break;

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -90,12 +90,24 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       TRY(otcrypto_hash(input, digest));
     } break;
     case kDifOtpCtrlPartitionCreatorSwCfg: {
+      // Note: we purposely exclude the AST configuration data field of this
+      // partition from the digest calculation because this could be different
+      // per chip and we do not want to it to be part of the foundation for the
+      // UDS keys if the OWNER_SW_CFG_ROM_KEYMGR_OTP_MEAS_EN switch is set to
+      // enabled. If this field is intended to be set for a given SKU, during
+      // personalization we need to be able to inject the expected OTP SW
+      // partition measurement into the manifest of the perso image so that the
+      // same CreatorRootKey keymgr attestation binding value computed in the
+      // field by the ROM is the same as the one used during perso when all the
+      // CreatorSwCfg fields have not yet been set.
       otcrypto_const_byte_buf_t input = {
-          .data = (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                                    OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                                    OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET),
+          .data = (unsigned char
+                       *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
+                          OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                          OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET),
           .len = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
-                 OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE,
+                 OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE -
+                 OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_CFG_SIZE,
       };
       TRY(otcrypto_hash(input, digest));
     } break;


### PR DESCRIPTION
We update the individualization firmware to purposely exclude the AST configuration data field of the CreatorSwCfg partition from the same partition's digest calculation because this could be different per chip and we do not want to it to be part of the foundation for the UDS keys if the `OWNER_SW_CFG_ROM_KEYMGR_OTP_MEAS_EN` switch is set to enabled.

If the `OWNER_SW_CFG_ROM_KEYMGR_OTP_MEAS_EN` field is intended to be set for a given SKU, during personalization we need to be able to inject the expected OTP SW partition measurement (which is computed as `sha256(CreatorSwCfg digest || OwnerSwCfg digest || root key hash)` into the manifest of the perso image so that the same CreatorRootKey keymgr attestation binding value computed in the field by the ROM is the same as the one used during perso when all the CreatorSwCfg fields have not yet been set.