### PR TITLE
[topgen] Don't gate ac_range_check generation by topcfg

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1239,10 +1239,8 @@ def generate_full_ipgens(args: argparse.Namespace, topcfg: Dict[str, object],
     generate_modules("rstmgr", generate_rstmgr, single_instance=True)
 
     # Generate ac_range_check
-    if "ac_range_check" in topcfg:
-        generate_modules("ac_range_check",
-                         generate_ac_range_check,
-                         single_instance=True)
+    generate_modules("ac_range_check", generate_ac_range_check,
+                     single_instance=True)
 
     # Generate RACL collateral
     if "racl_config" in topcfg:


### PR DESCRIPTION
AC ranges do not use the top-level cfg anymore.
Instead the number of ranges is defined on a per instance basis.