### PR TITLE
[hw,ac_ranges,rtl] Compute denied range index using PPC

### DIFF
--- a/hw/ip/prim/prim_leading_one_ppc.core
+++ b/hw/ip/prim/prim_leading_one_ppc.core
@@ -3,34 +3,26 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:arbiter"
-description: "Generic arbiter"
+name: "lowrisc:prim:leading_one_ppc"
+description: "Leading one computation using parallel prefix computation"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:assert
-      - lowrisc:prim:leading_one_ppc
+      - lowrisc:prim:util
     files:
-      - rtl/prim_arbiter_fixed.sv
-      - rtl/prim_arbiter_ppc.sv
-      - rtl/prim_arbiter_tree.sv
-      - rtl/prim_arbiter_tree_dup.sv
+      - rtl/prim_leading_one_ppc.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      - lint/prim_arbiter.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      - lint/prim_arbiter.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim/rtl/prim_leading_one_ppc.sv
+++ b/hw/ip/prim/rtl/prim_leading_one_ppc.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Leading one detector based on parallel prefix computation
+// See also: prim_arbiter_ppc
+
+module prim_leading_one_ppc #(
+  parameter int unsigned N = 8,
+  localparam int IdxW      = prim_util_pkg::vbits(N)
+) (
+  input        [ N-1:0]    in_i,
+  output logic [ N-1:0]    leading_one_o,
+  output logic [ N-1:0]    ppc_out_o,
+  output logic [IdxW-1:0]  idx_o
+);
+  logic [N-1:0] ppc_out;
+
+  // PPC
+  //   Even below code looks O(n) but DC optimizes it to O(log(N))
+  //   Using Parallel Prefix Computation
+  always_comb begin
+    ppc_out[0] = in_i[0];
+    for (int i = 1 ; i < N ; i++) begin
+      ppc_out[i] = ppc_out[i-1] | in_i[i];
+    end
+  end
+
+  // Leading-One detector
+  assign leading_one_o = ppc_out ^ {ppc_out[N-2:0], 1'b0};
+  assign ppc_out_o     = ppc_out;
+
+  always_comb begin
+    idx_o = '0;
+    for (int unsigned i = 0 ; i < N ; i++) begin
+      if (leading_one_o[i]) begin
+        idx_o = i[IdxW-1:0];
+      end
+    end
+  end
+
+endmodule

--- a/hw/ip_templates/ac_range_check/ac_range_check.core.tpl
+++ b/hw/ip_templates/ac_range_check/ac_range_check.core.tpl
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:mubi
       - lowrisc:prim:all
+      - lowrisc:prim:leading_one_ppc
       - lowrisc:systems:top_racl_pkg
     files:
       - rtl/${module_instance_name}_reg_pkg.sv

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -184,6 +184,20 @@ module ${module_instance_name}
   assign write_allowed   = write_access   & (write_mask   > deny_mask);
   assign execute_allowed = execute_access & (execute_mask > deny_mask);
 
+  // Based on the deny mask, we compute the leading bit in the mask. The index of the leading
+  // bit determines the index of the range that denied the request.
+
+  localparam int unsigned NumRangesWidth = prim_util_pkg::vbits(NumRanges);
+  logic [NumRangesWidth-1:0] deny_index;
+  prim_leading_one_ppc #(
+    .N ( NumRanges )
+  ) u_leading_one (
+    .in_i          ( deny_mask  ),
+    .leading_one_o (            ),
+    .ppc_out_o     (            ),
+    .idx_o         ( deny_index )
+  );
+
   // The access fails if nothing is allowed and no overwrite is present
   logic range_check_fail;
   assign range_check_fail =
@@ -275,9 +289,8 @@ module ${module_instance_name}
   assign hw2reg.log_status.denied_ctn_uid.d  =
     top_racl_pkg::tlul_extract_ctn_uid_bits(ctn_tl_h2d_i.a_user.rsvd);
 
-  // TODO(#25456): Need to determine the index that caused the denial
   assign hw2reg.log_status.deny_range_index.de = log_first_deny | clear_log;
-  assign hw2reg.log_status.deny_range_index.d  = log_first_deny ? 0 : 0;
+  assign hw2reg.log_status.deny_range_index.d  = log_first_deny ? deny_index : 0;
 
   assign hw2reg.log_address.de = log_first_deny | clear_log;
   assign hw2reg.log_address.d  = log_first_deny ? ctn_tl_h2d_i.a_address : '0;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/ac_range_check.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/ac_range_check.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:mubi
       - lowrisc:prim:all
+      - lowrisc:prim:leading_one_ppc
       - lowrisc:systems:top_racl_pkg
     files:
       - rtl/ac_range_check_reg_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -184,6 +184,20 @@ module ac_range_check
   assign write_allowed   = write_access   & (write_mask   > deny_mask);
   assign execute_allowed = execute_access & (execute_mask > deny_mask);
 
+  // Based on the deny mask, we compute the leading bit in the mask. The index of the leading
+  // bit determines the index of the range that denied the request.
+
+  localparam int unsigned NumRangesWidth = prim_util_pkg::vbits(NumRanges);
+  logic [NumRangesWidth-1:0] deny_index;
+  prim_leading_one_ppc #(
+    .N ( NumRanges )
+  ) u_leading_one (
+    .in_i          ( deny_mask  ),
+    .leading_one_o (            ),
+    .ppc_out_o     (            ),
+    .idx_o         ( deny_index )
+  );
+
   // The access fails if nothing is allowed and no overwrite is present
   logic range_check_fail;
   assign range_check_fail =
@@ -275,9 +289,8 @@ module ac_range_check
   assign hw2reg.log_status.denied_ctn_uid.d  =
     top_racl_pkg::tlul_extract_ctn_uid_bits(ctn_tl_h2d_i.a_user.rsvd);
 
-  // TODO(#25456): Need to determine the index that caused the denial
   assign hw2reg.log_status.deny_range_index.de = log_first_deny | clear_log;
-  assign hw2reg.log_status.deny_range_index.d  = log_first_deny ? 0 : 0;
+  assign hw2reg.log_status.deny_range_index.d  = log_first_deny ? deny_index : 0;
 
   assign hw2reg.log_address.de = log_first_deny | clear_log;
   assign hw2reg.log_address.d  = log_first_deny ? ctn_tl_h2d_i.a_address : '0;


### PR DESCRIPTION
This computes the denied index (the leading 1 in the deny mask) to identify the range that corresponds to the denied request. The index is logged to the status log register.

Resolves https://github.com/lowRISC/opentitan/issues/25456