### PR TITLE
[rtl,racl] Fixes to RACL signaling to ensure non-X

### DIFF
--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -764,14 +764,18 @@ module gpio_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -3472,14 +3472,18 @@ module i2c_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -519,14 +519,18 @@ module mbx_soc_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -3165,14 +3165,18 @@ module pwm_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -19588,14 +19588,18 @@ module spi_device_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -1782,14 +1782,18 @@ module spi_host_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -704,14 +704,18 @@ module sram_ctrl_regs_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg_racl.sv
@@ -92,9 +92,13 @@ module tlul_adapter_reg_racl
     );
 
     // Collect RACL error information
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
-    assign racl_error_log_o.racl_role   = racl_role;
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
+    //
+    // Drive these signals only when receiving a request to avoid triggering the assertion which
+    // checks all bits of racl_error_log_o are non-X.
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
+    assign racl_error_log_o.racl_role   = tl_i.a_valid ? racl_role : '0;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
   end else begin : gen_no_racl_role_logic
     // Pass through and default assignments
     assign tl_h2d_filtered  = tl_i;

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1629,14 +1629,18 @@ module uart_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
@@ -355,6 +355,8 @@ import math
         regwen: "RANGE_REGWEN"
         regwen_multi: true
         shadowed: "true",
+        update_err_alert: "recov_ctrl_update_err",
+        storage_err_alert: "fatal_fault",
         fields: [
           { name: "write_perm"
             desc: "Write permission policy bitmap."

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -128,8 +128,8 @@ module ${module_instance_name}
                        (ctn_tl_h2d_i.a_address < limit_ext);
 
     // Request hits an enabled range and comparison logic
-    assign addr_hit[i] = prim_mubi_pkg::mubi4_test_true_loose(reg2hw.range_perm[i].enable.q) &
-                         tor_hit;
+    assign addr_hit[i] = prim_mubi_pkg::mubi4_test_true_loose(
+                           prim_mubi_pkg::mubi4_t'(reg2hw.range_perm[i].enable.q)) & tor_hit;
 
     // Perform RACL checks - check if the incoming role matches with the configured policy
     assign racl_read_hit [i] = |(racl_role_vec & reg2hw.range_racl_policy_shadowed[i].read_perm.q);
@@ -137,15 +137,15 @@ module ${module_instance_name}
 
     // Decode the multi-bit access fields for convinient access
     logic perm_read_access, perm_write_access, perm_execute_access;
-    assign perm_read_access =
-      prim_mubi_pkg::mubi4_test_true_strict(reg2hw.range_perm[i].read_access.q) &
-      racl_read_hit[i];
-    assign perm_write_access =
-      prim_mubi_pkg::mubi4_test_true_strict(reg2hw.range_perm[i].write_access.q) &
-      racl_write_hit[i];
-    assign perm_execute_access =
-      prim_mubi_pkg::mubi4_test_true_strict(reg2hw.range_perm[i].execute_access.q) &
-      racl_read_hit[i];
+    assign perm_read_access = prim_mubi_pkg::mubi4_test_true_strict(
+                                prim_mubi_pkg::mubi4_t'(reg2hw.range_perm[i].read_access.q)) &
+                                racl_read_hit[i];
+    assign perm_write_access = prim_mubi_pkg::mubi4_test_true_strict(
+                                 prim_mubi_pkg::mubi4_t'(reg2hw.range_perm[i].write_access.q)) &
+                                 racl_write_hit[i];
+    assign perm_execute_access = prim_mubi_pkg::mubi4_test_true_strict(
+                                   prim_mubi_pkg::mubi4_t'(reg2hw.range_perm[i].execute_access.q)) &
+                                   racl_read_hit[i];
 
     // Access is denied if no read_, write_, or execute access is set in the permission mask
     // The permission masks need to be reversed to allow for the right priority order.
@@ -154,8 +154,8 @@ module ${module_instance_name}
       addr_hit[i] & ~(perm_read_access | perm_write_access | perm_execute_access);
 
     // TODO(#25456) Use log_enable_mask to mask logging
-    assign log_enable_mask[NumRanges - 1 - i] =
-      prim_mubi_pkg::mubi4_test_true_strict(reg2hw.range_perm[i].log_denied_access.q);
+    assign log_enable_mask[NumRanges - 1 - i] = prim_mubi_pkg::mubi4_test_true_strict(
+      prim_mubi_pkg::mubi4_t'(reg2hw.range_perm[i].log_denied_access.q));
 
     // Determine the read, write, and execute mask. Store a hit in their index
     assign read_mask   [NumRanges - 1 - i] = addr_hit[i] & perm_read_access;
@@ -163,10 +163,12 @@ module ${module_instance_name}
     assign execute_mask[NumRanges - 1 - i] = addr_hit[i] & perm_execute_access;
   end
 
-  // Fiddle out bits to determine if its an execute request or not
+  // Fiddle out bits to determine if it's an execute request or not
   logic no_exec_access, exec_access;
-  assign no_exec_access = prim_mubi_pkg::mubi4_test_false_strict(ctn_tl_h2d_i.a_user.instr_type);
-  assign exec_access    = prim_mubi_pkg::mubi4_test_true_strict(ctn_tl_h2d_i.a_user.instr_type);
+  assign no_exec_access = prim_mubi_pkg::mubi4_test_false_strict(
+                            prim_mubi_pkg::mubi4_t'(ctn_tl_h2d_i.a_user.instr_type));
+  assign exec_access    = prim_mubi_pkg::mubi4_test_true_strict(
+                            prim_mubi_pkg::mubi4_t'(ctn_tl_h2d_i.a_user.instr_type));
 
   // Fiddle out what access we are performing
   logic read_access, write_access, execute_access;
@@ -343,5 +345,8 @@ module ${module_instance_name}
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_ac_range_check_reg,
                                                  alert_tx_o[0])
+  // Deny Counter error
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(DenyCountCheck_A, u_deny_count,
+                                         alert_tx_o[1])
 
 endmodule

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
@@ -347,6 +347,8 @@
         regwen: "RANGE_REGWEN"
         regwen_multi: true
         shadowed: "true",
+        update_err_alert: "recov_ctrl_update_err",
+        storage_err_alert: "fatal_fault",
         fields: [
           { name: "write_perm"
             desc: "Write permission policy bitmap."

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -637,14 +637,18 @@ module racl_ctrl_reg_top
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -740,14 +740,18 @@ ${finst_gen(sr, field, finst_name, fsig_name, fidx)}
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
 % if racl_support:
-  // A valid address hit, access, but failed the RACL check
+  // A valid address hit, access, but failed the RACL check.
+  //
+  // Drive these signals only when receiving a request to avoid triggering the assertion which
+  // checks all bits of racl_error_log_o are non-X.
   assign racl_error_o = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
                                      (reg_we & ~|racl_addr_hit_write));
-  assign racl_error_log_o.racl_role  = racl_role;
+  assign racl_error_log_o.racl_role  = tl_i.a_valid ? racl_role : '0;
 
   if (EnableRacl) begin : gen_racl_log
-    assign racl_error_log_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
-    assign racl_error_log_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+    assign racl_error_log_o.ctn_uid     = tl_i.a_valid ?
+      top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd) : '0;
+    assign racl_error_log_o.read_access = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
   end else begin : gen_no_racl_log
     assign racl_error_log_o.ctn_uid     = '0;
     assign racl_error_log_o.read_access = 1'b0;


### PR DESCRIPTION
Presently all RACL log-generating IP include an assertion that all of 'racl_error_log_o' is known. This is not true in simulation unless the 'a_valid' input signal is asserted. In simulation the other signals are deliberately driven to 'X' when a_valid is deasserted.

Therefore this change suppresses the RACL log information when it is invalid.

**Attention please:** This is a draft PR to raise awareness of the issue, and it allows simulations to proceed. However:

1. I presume that the `racl_error_log_o` data is used only when qualified `racl_error_o` is asserted, since there is no obvious validity indicator in the log information itself. racl_error_o and racl_error_log_o presently _may_ not have the same timing if the tlul_adapter_reg timing is changed, since reg_re/reg_we may have different timing to tl_i. I have raised this concern before, but note that the racl_error_log_o signaling is already driven directly from tl_i so this change introduces _no new_ fragility.
2. This is to resolve an assertion issue, since ASSERT_KNOWN is used in the top module of the block-level IP, rather than a design issue and yet it does introduce additional logic into the design that is unnecessary if its use is qualified with 'racl_error_o' assertion.
3. Is it worth considering merging 'racl_error_o' and 'racl_error_log_o' into a single structure, so that they can be treated as a consistent whole, or would that change be too far-reaching at this stage?
My preference would be to modify the assertions and annotate their behavior.

Aside: it's presently built upon the ac_range_check fixes just because both affect the auto-generated RTL.