### PR TITLE
[opentitantool] Several small fixes

### DIFF
--- a/sw/host/opentitanlib/src/app/i2c.rs
+++ b/sw/host/opentitanlib/src/app/i2c.rs
@@ -131,7 +131,6 @@ impl Bus for LogicalI2cWrapper {
         serial_data: Option<&Rc<dyn GpioPin>>,
         gsc_ready: Option<&Rc<dyn GpioPin>>,
     ) -> Result<()> {
-        log::error!("LogicalI2cWrapper::set_pins()");
         let mut inner = self.inner.borrow_mut();
         if serial_clock.is_some() {
             inner.serial_clock = serial_clock.map(Rc::clone);

--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -273,7 +273,7 @@ const SPI_TPM_WRITE: u32 = 0x40000000;
 const SPI_TPM_DATA_LEN_POS: u8 = 24;
 const SPI_TPM_ADDRESS_OFFSET: u32 = 0x00D40000;
 
-const MAX_TRANSACTION_SIZE: usize = 32;
+const MAX_TRANSACTION_SIZE: usize = 64;
 const RESPONSE_HEADER_SIZE: usize = 6;
 const MAX_RESPONSE_SIZE: usize = 4096;
 const TIMEOUT: Duration = Duration::from_millis(500);
@@ -288,9 +288,9 @@ impl Driver for SpiDriver {
         if self.use_gsc_ready {
             self.spi.run_transaction(&mut [
                 spi::Transfer::Write(&req),
-                spi::Transfer::GscReady,
                 spi::Transfer::TpmPoll,
                 spi::Transfer::Read(data),
+                spi::Transfer::GscReady,
             ])
         } else {
             self.spi.run_transaction(&mut [

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -809,7 +809,7 @@ impl Target for HyperdebugSpiTarget {
                 self.receive(rbuf)?;
                 return Ok(());
             }
-            [Transfer::Write(wbuf), Transfer::GscReady, Transfer::TpmPoll, Transfer::Read(rbuf)] => {
+            [Transfer::Write(wbuf), Transfer::TpmPoll, Transfer::Read(rbuf), Transfer::GscReady] => {
                 // Hyperdebug can do SPI TPM transaction as a single USB
                 // request/reply.
                 ensure!(

--- a/sw/host/opentitanlib/src/util/bitbang.rs
+++ b/sw/host/opentitanlib/src/util/bitbang.rs
@@ -171,7 +171,7 @@ pub fn parse_delay(num: &str, time_unit: &str, clock: Duration) -> Result<u32> {
     let actual_duration = clock.mul(closest_ticks);
     let ratio = actual_duration.as_secs_f64() / duration;
     ensure!(
-        (0.99..=1.00).contains(&ratio),
+        (0.99..=1.01).contains(&ratio),
         "Requested delay cannot be approximated to within 1%, try increasing clock frequency",
     );
     Ok(closest_ticks)


### PR DESCRIPTION
- Removed leftover debug logging from opentitanlib/src/app/i2c.rs .
- Reordered the proprietary `GscReady` for I2C transactions, to more accurately reflect what HyperDebug does.
- Increased maximum TPM FIFO transfer burst size from 32 to 64 bytes.
- Fixed bitbang pauses to allow 1% tolerance either way.