### PR TITLE
[manuf,ast] do not copy all AST values to CSRs during SRAM load

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -239,7 +239,7 @@ static status_t patch_ast_config_value(void) {
   // Check the address is within range before programming.
   // Check the value is non-zero and not all ones before programming.
   if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) {
-    TRY_CHECK(ast_patch_addr_offset > AST_REGAL_REG_OFFSET);
+    TRY_CHECK(ast_patch_addr_offset <= AST_REGAL_REG_OFFSET);
     TRY_CHECK(ast_patch_value != 0 && ast_patch_value != UINT32_MAX);
   }
 

--- a/sw/device/silicon_creator/manuf/lib/ast_program.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program.c
@@ -101,7 +101,10 @@ status_t ast_program_config(bool verbose) {
   // Program AST CSRs.
   LOG_INFO("Programming %u AST words",
            kFlashInfoAstCalibrationDataSizeIn32BitWords);
-  for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
+  // Don't write the last 3 words of AST config to CSRs on SRAM program boot;
+  // they will get copied to OTP later and written by the ROM on boot.
+  for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords - 3;
+       ++i) {
     uint32_t addr = TOP_EARLGREY_AST_BASE_ADDR + i * sizeof(uint32_t);
     uint32_t data = ast_data[i];
     LOG_INFO("\tAddress = 0x%08x, Data = 0x%08x", addr, data);

--- a/sw/device/silicon_creator/manuf/lib/ast_program_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program_functest.c
@@ -82,9 +82,9 @@ static status_t execute_test(void) {
   TRY(program_page());
   TRY(ast_program_config(true));
   uint32_t crc =
-      crc32(ast_cfg_data,
-            kFlashInfoAstCalibrationDataSizeIn32BitWords * sizeof(uint32_t));
-  TRY_CHECK(ast_nr_writes == 39);
+      crc32(ast_cfg_data, (kFlashInfoAstCalibrationDataSizeIn32BitWords - 3) *
+                              sizeof(uint32_t));
+  TRY_CHECK(ast_nr_writes == 36);
   TRY_CHECK(crc32_finish(&ast_crc) == crc);
   return OK_STATUS();
 }


### PR DESCRIPTION
All value will be copied to OTP and subsequently loaded into the CSRs by the ROM.