### PR TITLE
[rom_ext] Perform the length check before computing boot service header's digest

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_header_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_header_unittest.cc
@@ -19,6 +19,7 @@ bool operator==(boot_svc_header_t lhs, boot_svc_header_t rhs) {
 namespace boot_svc_header_unittest {
 namespace {
 using ::testing::_;
+using ::testing::AtMost;
 using ::testing::ElementsAreArray;
 using ::testing::SetArgPointee;
 
@@ -153,6 +154,7 @@ TEST_P(BootSvcHeaderCheckTest, Check) {
   EXPECT_CALL(hmac_,
               sha256(&GetParam().msg.header.identifier,
                      GetParam().msg.header.length - sizeof(hmac_digest_t), _))
+      .Times(AtMost(1))
       .WillOnce(SetArgPointee<2>(hmac_digest_t{}));
 
   EXPECT_EQ(boot_svc_header_check(&GetParam().msg.header),


### PR DESCRIPTION
The current implementation of boot service will calculate the [digest](https://github.com/lowRISC/opentitan/blob/a1742284cda1f9fee37c1269bd6189096349653f/sw/device/silicon_creator/lib/boot_svc/boot_svc_header.c#L20-L30) first before checking the header's length, which might lead to out of bound access when `header->length` is less than `kDigestRegionOffset`.

This commit updates the order of `boot_svc_header_check` by performing the length check before digest calculation.