### PR TITLE
[RACL] Add documentation and example config

### DIFF
--- a/hw/ip_templates/racl_ctrl/README.md
+++ b/hw/ip_templates/racl_ctrl/README.md
@@ -1,1 +1,118 @@
 # RACL Control Permission IP
+
+`racl_ctrl` is currently being used in [top_darjeeling.hjson](../../../../hw/top_darjeeling/data/top_darjeeling.hjson).
+There `racl_config` points to the main configuration file of the RACL Controller.
+E.g., `racl_config: 'racl/racl.hjson'`.
+Furthermore, each module instance that supports RACL must specify a valid `racl_mapping` for each of its `bus_interfaces`.
+If there is only one such interface, the racl mapping may be specified as follows:
+```
+racl_mapping: 'racl/soc_rot_mapping.hjson'
+```
+whereas multiple `bus_interfaces` require a mapping for each interface:
+```hjson
+racl_mappings: {
+    soc:  'racl/soc_rot_mapping.hjson'
+    sram: 'racl/all_rd_wr_mapping.hjson'
+}
+```
+
+## Example RACL configuration
+
+```hjson
+{
+  // error_response controls whether to return TLUL error on RACL errors
+  error_response: true
+  // The CTN UID is transfered via the TLUL reserved user bits: rsvd[ctn_uid_bit_msb:ctn_uid_bit_lsb]
+  ctn_uid_bit_lsb: 0
+  ctn_uid_bit_msb: 4
+  // The RACL role is transfered via the TLUL reserved user bits: rsvd[role_bit_msb:role_bit_lsb]
+  role_bit_lsb: 5
+  role_bit_msb: 8
+  roles: {
+    "ROT" :  { role_id: 0 }
+    "ROLE1": { role_id: 1 }
+    "SOC":   { role_id: 2 }
+  }
+  policies: {
+    Null: [
+      // Standard policies allowing all roles to access a register
+      { name: "ALL_RD_WR"
+        allowed_rd: [ "ROT", "ROLE1", "SOC" ]
+        allowed_wr: [ "ROT", "ROLE1", "SOC" ]
+      }
+      // Standard policies allowing only the ROT role to access a register
+      { name: "ROT_PRIVATE"
+        rot_private: true
+        allowed_rd: [ "ROT" ]
+        allowed_wr: [ "ROT" ]
+      }
+      // Custom policy
+      { name: "SOC_ROT"
+        allowed_rd: [ "ROT", "SOC" ]
+        allowed_wr: [ "ROT", "SOC" ]
+      }
+    ]
+  }
+}
+```
+
+## Example RACL mappings
+
+A minimal example for a module that only uses registers (and no windows or ranges) can look as follows.
+There the `*` maps to all registers.
+
+```hjson
+{
+  Null: {
+    registers: {
+      "*": "SOC_ROT"
+    }
+  }
+}
+```
+
+The `*` option does not exist for ranges. These must be explicitly defined as follows.
+
+```hjson
+{
+  Null: {
+    registers: {
+      "*": "SOC_ROT"
+    }
+    windows: {
+      "*": "SOC_ROT"
+    }
+    ranges: [
+        {
+            'base': "0x0000"
+            'size': "0x1000"
+            'policy': "ROT_PRIVATE"
+        }
+        {
+            'base': "0x1000"
+            'size': "0x0004"
+            'policy': "ALL_RD_WR"
+        }
+    ]
+  }
+}
+```
+
+Mapping individual registers/windows is done like so (using the `mbx` as an example):
+
+```hjson
+{
+  Null: {
+    registers: {
+      "SOC_CONTROL":           "SOC_ROT"
+      "SOC_STATUS":            "SOC_ROT"
+      "SOC_DOE_INTR_MSG_ADDR": "SOC_ROT"
+      "SOC_DOE_INTR_MSG_DATA": "SOC_ROT"
+    }
+    windows: {
+      "WDATA": "SOC_ROT"
+      "RDATA": "SOC_ROT"
+    }
+  }
+}
+```

--- a/hw/ip_templates/racl_ctrl/README.md
+++ b/hw/ip_templates/racl_ctrl/README.md
@@ -35,19 +35,19 @@ racl_mappings: {
   }
   policies: {
     Null: [
-      // Standard policies allowing all roles to access a register
       { name: "ALL_RD_WR"
+        desc: "Standard policies allowing all roles to access a register"
         allowed_rd: [ "ROT", "ROLE1", "SOC" ]
         allowed_wr: [ "ROT", "ROLE1", "SOC" ]
       }
-      // Standard policies allowing only the ROT role to access a register
       { name: "ROT_PRIVATE"
+        desc: "Standard policies allowing only the ROT role to access a register"
         rot_private: true
         allowed_rd: [ "ROT" ]
         allowed_wr: [ "ROT" ]
       }
-      // Custom policy
       { name: "SOC_ROT"
+        desc: "Custom policy"
         allowed_rd: [ "ROT", "SOC" ]
         allowed_wr: [ "ROT", "SOC" ]
       }

--- a/hw/ip_templates/racl_ctrl/doc/racl_configuration.md.tpl
+++ b/hw/ip_templates/racl_ctrl/doc/racl_configuration.md.tpl
@@ -1,0 +1,4 @@
+${"#"} RACL Configuration
+
+<!-- BEGIN CMDGEN util/raclgen.py --doc ./hw/top_${topname}/data/autogen/top_${topname}.gen.hjson -->
+<!-- END CMDGEN -->

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -17728,6 +17728,7 @@
       [
         {
           name: ALL_RD_WR
+          desc: Standard policies allowing all roles to access a register
           allowed_rd:
           [
             ROT
@@ -17746,6 +17747,7 @@
         {
           name: ROT_PRIVATE
           rot_private: true
+          desc: Standard policies allowing only the ROT role to access a register
           allowed_rd:
           [
             ROT
@@ -17759,6 +17761,7 @@
         }
         {
           name: SOC_ROT
+          desc: Custom policy
           allowed_rd:
           [
             ROT

--- a/hw/top_darjeeling/data/racl/racl.hjson
+++ b/hw/top_darjeeling/data/racl/racl.hjson
@@ -18,19 +18,19 @@
   }
   policies: {
     Null: [
-      // Standard policies allowing all roles to access a register
       { name: "ALL_RD_WR"
+        desc: "Standard policies allowing all roles to access a register"
         allowed_rd: [ "ROT", "ROLE1", "SOC" ]
         allowed_wr: [ "ROT", "ROLE1", "SOC" ]
       }
-      // Standard policies allowing only the ROT role to access a register
       { name: "ROT_PRIVATE"
         rot_private: true
+        desc: "Standard policies allowing only the ROT role to access a register"
         allowed_rd: [ "ROT" ]
         allowed_wr: [ "ROT" ]
       }
-      // Custom policy
       { name: "SOC_ROT"
+        desc: "Custom policy"
         allowed_rd: [ "ROT", "SOC" ]
         allowed_wr: [ "ROT", "SOC" ]
       }

--- a/hw/top_darjeeling/data/racl/racl.hjson
+++ b/hw/top_darjeeling/data/racl/racl.hjson
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {
+  // error_response controls whether to return TLUL error on RACL errors
   error_response: true
+  // The CTN UID is transfered via the TLUL reserved user bits: rsvd[ctn_uid_bit_msb:ctn_uid_bit_lsb]
   ctn_uid_bit_lsb: 0
   ctn_uid_bit_msb: 4
+  // The RACL role is transfered via the TLUL reserved user bits: rsvd[role_bit_msb:role_bit_lsb]
   role_bit_lsb: 5
   role_bit_msb: 8
   roles: {

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/README.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/README.md
@@ -1,1 +1,118 @@
 # RACL Control Permission IP
+
+`racl_ctrl` is currently being used in [top_darjeeling.hjson](../../../../hw/top_darjeeling/data/top_darjeeling.hjson).
+There `racl_config` points to the main configuration file of the RACL Controller.
+E.g., `racl_config: 'racl/racl.hjson'`.
+Furthermore, each module instance that supports RACL must specify a valid `racl_mapping` for each of its `bus_interfaces`.
+If there is only one such interface, the racl mapping may be specified as follows:
+```
+racl_mapping: 'racl/soc_rot_mapping.hjson'
+```
+whereas multiple `bus_interfaces` require a mapping for each interface:
+```hjson
+racl_mappings: {
+    soc:  'racl/soc_rot_mapping.hjson'
+    sram: 'racl/all_rd_wr_mapping.hjson'
+}
+```
+
+## Example RACL configuration
+
+```hjson
+{
+  // error_response controls whether to return TLUL error on RACL errors
+  error_response: true
+  // The CTN UID is transfered via the TLUL reserved user bits: rsvd[ctn_uid_bit_msb:ctn_uid_bit_lsb]
+  ctn_uid_bit_lsb: 0
+  ctn_uid_bit_msb: 4
+  // The RACL role is transfered via the TLUL reserved user bits: rsvd[role_bit_msb:role_bit_lsb]
+  role_bit_lsb: 5
+  role_bit_msb: 8
+  roles: {
+    "ROT" :  { role_id: 0 }
+    "ROLE1": { role_id: 1 }
+    "SOC":   { role_id: 2 }
+  }
+  policies: {
+    Null: [
+      // Standard policies allowing all roles to access a register
+      { name: "ALL_RD_WR"
+        allowed_rd: [ "ROT", "ROLE1", "SOC" ]
+        allowed_wr: [ "ROT", "ROLE1", "SOC" ]
+      }
+      // Standard policies allowing only the ROT role to access a register
+      { name: "ROT_PRIVATE"
+        rot_private: true
+        allowed_rd: [ "ROT" ]
+        allowed_wr: [ "ROT" ]
+      }
+      // Custom policy
+      { name: "SOC_ROT"
+        allowed_rd: [ "ROT", "SOC" ]
+        allowed_wr: [ "ROT", "SOC" ]
+      }
+    ]
+  }
+}
+```
+
+## Example RACL mappings
+
+A minimal example for a module that only uses registers (and no windows or ranges) can look as follows.
+There the `*` maps to all registers.
+
+```hjson
+{
+  Null: {
+    registers: {
+      "*": "SOC_ROT"
+    }
+  }
+}
+```
+
+The `*` option does not exist for ranges. These must be explicitly defined as follows.
+
+```hjson
+{
+  Null: {
+    registers: {
+      "*": "SOC_ROT"
+    }
+    windows: {
+      "*": "SOC_ROT"
+    }
+    ranges: [
+        {
+            'base': "0x0000"
+            'size': "0x1000"
+            'policy': "ROT_PRIVATE"
+        }
+        {
+            'base': "0x1000"
+            'size': "0x0004"
+            'policy': "ALL_RD_WR"
+        }
+    ]
+  }
+}
+```
+
+Mapping individual registers/windows is done like so (using the `mbx` as an example):
+
+```hjson
+{
+  Null: {
+    registers: {
+      "SOC_CONTROL":           "SOC_ROT"
+      "SOC_STATUS":            "SOC_ROT"
+      "SOC_DOE_INTR_MSG_ADDR": "SOC_ROT"
+      "SOC_DOE_INTR_MSG_DATA": "SOC_ROT"
+    }
+    windows: {
+      "WDATA": "SOC_ROT"
+      "RDATA": "SOC_ROT"
+    }
+  }
+}
+```

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/README.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/README.md
@@ -35,19 +35,19 @@ racl_mappings: {
   }
   policies: {
     Null: [
-      // Standard policies allowing all roles to access a register
       { name: "ALL_RD_WR"
+        desc: "Standard policies allowing all roles to access a register"
         allowed_rd: [ "ROT", "ROLE1", "SOC" ]
         allowed_wr: [ "ROT", "ROLE1", "SOC" ]
       }
-      // Standard policies allowing only the ROT role to access a register
       { name: "ROT_PRIVATE"
+        desc: "Standard policies allowing only the ROT role to access a register"
         rot_private: true
         allowed_rd: [ "ROT" ]
         allowed_wr: [ "ROT" ]
       }
-      // Custom policy
       { name: "SOC_ROT"
+        desc: "Custom policy"
         allowed_rd: [ "ROT", "SOC" ]
         allowed_wr: [ "ROT", "SOC" ]
       }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -14,6 +14,7 @@
     [
       {
         name: ALL_RD_WR
+        desc: Standard policies allowing all roles to access a register
         allowed_rd:
         [
           ROT
@@ -32,6 +33,7 @@
       {
         name: ROT_PRIVATE
         rot_private: true
+        desc: Standard policies allowing only the ROT role to access a register
         allowed_rd:
         [
           ROT
@@ -45,6 +47,7 @@
       }
       {
         name: SOC_ROT
+        desc: Custom policy
         allowed_rd:
         [
           ROT

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/racl_configuration.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/racl_configuration.md
@@ -1,0 +1,323 @@
+# RACL Configuration
+
+<!-- BEGIN CMDGEN util/raclgen.py --doc ./hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson -->
+## RACL groups
+
+### RACL group: Null
+
+| Policy Name   |   Index |
+|:--------------|--------:|
+| ALL_RD_WR     |       0 |
+| ROT_PRIVATE   |       1 |
+| SOC_ROT       |       2 |
+
+
+## RACL configuration
+
+### RACL configuration for `mbx0` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1465000
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx0.soc.`SOC_CONTROL`           | 0x8      | 0x1465008 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx0.soc.`SOC_STATUS`            | 0xc      | 0x146500c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx0.soc.`WDATA`                 | 0x10     | 0x1465010 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx0.soc.`RDATA`                 | 0x14     | 0x1465014 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx0.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465018 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx0.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146501c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx1` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1465100
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx1.soc.`SOC_CONTROL`           | 0x8      | 0x1465108 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx1.soc.`SOC_STATUS`            | 0xc      | 0x146510c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx1.soc.`WDATA`                 | 0x10     | 0x1465110 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx1.soc.`RDATA`                 | 0x14     | 0x1465114 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx1.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465118 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx1.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146511c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx2` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1465200
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx2.soc.`SOC_CONTROL`           | 0x8      | 0x1465208 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx2.soc.`SOC_STATUS`            | 0xc      | 0x146520c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx2.soc.`WDATA`                 | 0x10     | 0x1465210 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx2.soc.`RDATA`                 | 0x14     | 0x1465214 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx2.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465218 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx2.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146521c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx4` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1465400
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx4.soc.`SOC_CONTROL`           | 0x8      | 0x1465408 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx4.soc.`SOC_STATUS`            | 0xc      | 0x146540c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx4.soc.`WDATA`                 | 0x10     | 0x1465410 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx4.soc.`RDATA`                 | 0x14     | 0x1465414 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx4.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465418 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx4.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146541c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx5` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1465500
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx5.soc.`SOC_CONTROL`           | 0x8      | 0x1465508 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx5.soc.`SOC_STATUS`            | 0xc      | 0x146550c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx5.soc.`WDATA`                 | 0x10     | 0x1465510 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx5.soc.`RDATA`                 | 0x14     | 0x1465514 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx5.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465518 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx5.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146551c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx_jtag` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1000
+- RACL group: Null
+
+
+| Name                                 | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:-------------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx_jtag.soc.`SOC_CONTROL`           | 0x8      | 0x1008    | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx_jtag.soc.`SOC_STATUS`            | 0xc      | 0x100c    | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx_jtag.soc.`WDATA`                 | 0x10     | 0x1010    | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx_jtag.soc.`RDATA`                 | 0x14     | 0x1014    | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx_jtag.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1018    | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx_jtag.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x101c    | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx_pcie0` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1460100
+- RACL group: Null
+
+
+| Name                                  | Offset   | Address   | Width   | Policy      | ROT   | ROLE1   | SOC   |
+|:--------------------------------------|:---------|:----------|:--------|:------------|:------|:--------|:------|
+| mbx_pcie0.soc.`SOC_CONTROL`           | 0x8      | 0x1460108 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie0.soc.`SOC_STATUS`            | 0xc      | 0x146010c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie0.soc.`WDATA`                 | 0x10     | 0x1460110 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie0.soc.`RDATA`                 | 0x14     | 0x1460114 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie0.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1460118 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie0.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146011c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+
+### RACL configuration for `mbx_pcie1` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1460200
+- RACL group: Null
+
+
+| Name                                  | Offset   | Address   | Width   | Policy      | ROT   | ROLE1   | SOC   |
+|:--------------------------------------|:---------|:----------|:--------|:------------|:------|:--------|:------|
+| mbx_pcie1.soc.`SOC_CONTROL`           | 0x8      | 0x1460208 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie1.soc.`SOC_STATUS`            | 0xc      | 0x146020c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie1.soc.`WDATA`                 | 0x10     | 0x1460210 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie1.soc.`RDATA`                 | 0x14     | 0x1460214 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie1.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1460218 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| mbx_pcie1.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146021c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+
+### RACL configuration for `ac_range_check` and interface `null`
+
+- IP: ac_range_check
+- Instance base address: 0x1464000
+- RACL group: Null
+
+
+| Name                                           | Offset   | Address   | Width   | Policy      | ROT   | ROLE1   | SOC   |
+|:-----------------------------------------------|:---------|:----------|:--------|:------------|:------|:--------|:------|
+| ac_range_check.`INTR_STATE`                    | 0x0      | 0x1464000 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`INTR_ENABLE`                   | 0x4      | 0x1464004 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`INTR_TEST`                     | 0x8      | 0x1464008 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`ALERT_TEST`                    | 0xc      | 0x146400c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`LOG_CONFIG`                    | 0x10     | 0x1464010 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`LOG_STATUS`                    | 0x14     | 0x1464014 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`LOG_ADDRESS`                   | 0x18     | 0x1464018 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_0`                | 0x1c     | 0x146401c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_1`                | 0x20     | 0x1464020 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_2`                | 0x24     | 0x1464024 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_3`                | 0x28     | 0x1464028 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_4`                | 0x2c     | 0x146402c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_5`                | 0x30     | 0x1464030 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_6`                | 0x34     | 0x1464034 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_7`                | 0x38     | 0x1464038 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_8`                | 0x3c     | 0x146403c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_9`                | 0x40     | 0x1464040 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_10`               | 0x44     | 0x1464044 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_11`               | 0x48     | 0x1464048 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_12`               | 0x4c     | 0x146404c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_13`               | 0x50     | 0x1464050 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_14`               | 0x54     | 0x1464054 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_15`               | 0x58     | 0x1464058 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_16`               | 0x5c     | 0x146405c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_17`               | 0x60     | 0x1464060 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_18`               | 0x64     | 0x1464064 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_19`               | 0x68     | 0x1464068 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_20`               | 0x6c     | 0x146406c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_21`               | 0x70     | 0x1464070 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_22`               | 0x74     | 0x1464074 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_23`               | 0x78     | 0x1464078 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_24`               | 0x7c     | 0x146407c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_25`               | 0x80     | 0x1464080 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_26`               | 0x84     | 0x1464084 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_27`               | 0x88     | 0x1464088 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_28`               | 0x8c     | 0x146408c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_29`               | 0x90     | 0x1464090 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_30`               | 0x94     | 0x1464094 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_REGWEN_31`               | 0x98     | 0x1464098 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_0`                  | 0x9c     | 0x146409c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_1`                  | 0xa0     | 0x14640a0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_2`                  | 0xa4     | 0x14640a4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_3`                  | 0xa8     | 0x14640a8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_4`                  | 0xac     | 0x14640ac | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_5`                  | 0xb0     | 0x14640b0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_6`                  | 0xb4     | 0x14640b4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_7`                  | 0xb8     | 0x14640b8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_8`                  | 0xbc     | 0x14640bc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_9`                  | 0xc0     | 0x14640c0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_10`                 | 0xc4     | 0x14640c4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_11`                 | 0xc8     | 0x14640c8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_12`                 | 0xcc     | 0x14640cc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_13`                 | 0xd0     | 0x14640d0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_14`                 | 0xd4     | 0x14640d4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_15`                 | 0xd8     | 0x14640d8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_16`                 | 0xdc     | 0x14640dc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_17`                 | 0xe0     | 0x14640e0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_18`                 | 0xe4     | 0x14640e4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_19`                 | 0xe8     | 0x14640e8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_20`                 | 0xec     | 0x14640ec | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_21`                 | 0xf0     | 0x14640f0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_22`                 | 0xf4     | 0x14640f4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_23`                 | 0xf8     | 0x14640f8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_24`                 | 0xfc     | 0x14640fc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_25`                 | 0x100    | 0x1464100 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_26`                 | 0x104    | 0x1464104 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_27`                 | 0x108    | 0x1464108 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_28`                 | 0x10c    | 0x146410c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_29`                 | 0x110    | 0x1464110 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_30`                 | 0x114    | 0x1464114 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_BASE_31`                 | 0x118    | 0x1464118 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_0`                 | 0x11c    | 0x146411c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_1`                 | 0x120    | 0x1464120 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_2`                 | 0x124    | 0x1464124 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_3`                 | 0x128    | 0x1464128 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_4`                 | 0x12c    | 0x146412c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_5`                 | 0x130    | 0x1464130 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_6`                 | 0x134    | 0x1464134 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_7`                 | 0x138    | 0x1464138 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_8`                 | 0x13c    | 0x146413c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_9`                 | 0x140    | 0x1464140 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_10`                | 0x144    | 0x1464144 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_11`                | 0x148    | 0x1464148 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_12`                | 0x14c    | 0x146414c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_13`                | 0x150    | 0x1464150 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_14`                | 0x154    | 0x1464154 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_15`                | 0x158    | 0x1464158 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_16`                | 0x15c    | 0x146415c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_17`                | 0x160    | 0x1464160 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_18`                | 0x164    | 0x1464164 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_19`                | 0x168    | 0x1464168 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_20`                | 0x16c    | 0x146416c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_21`                | 0x170    | 0x1464170 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_22`                | 0x174    | 0x1464174 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_23`                | 0x178    | 0x1464178 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_24`                | 0x17c    | 0x146417c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_25`                | 0x180    | 0x1464180 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_26`                | 0x184    | 0x1464184 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_27`                | 0x188    | 0x1464188 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_28`                | 0x18c    | 0x146418c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_29`                | 0x190    | 0x1464190 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_30`                | 0x194    | 0x1464194 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_LIMIT_31`                | 0x198    | 0x1464198 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_0`                  | 0x19c    | 0x146419c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_1`                  | 0x1a0    | 0x14641a0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_2`                  | 0x1a4    | 0x14641a4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_3`                  | 0x1a8    | 0x14641a8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_4`                  | 0x1ac    | 0x14641ac | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_5`                  | 0x1b0    | 0x14641b0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_6`                  | 0x1b4    | 0x14641b4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_7`                  | 0x1b8    | 0x14641b8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_8`                  | 0x1bc    | 0x14641bc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_9`                  | 0x1c0    | 0x14641c0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_10`                 | 0x1c4    | 0x14641c4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_11`                 | 0x1c8    | 0x14641c8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_12`                 | 0x1cc    | 0x14641cc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_13`                 | 0x1d0    | 0x14641d0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_14`                 | 0x1d4    | 0x14641d4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_15`                 | 0x1d8    | 0x14641d8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_16`                 | 0x1dc    | 0x14641dc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_17`                 | 0x1e0    | 0x14641e0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_18`                 | 0x1e4    | 0x14641e4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_19`                 | 0x1e8    | 0x14641e8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_20`                 | 0x1ec    | 0x14641ec | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_21`                 | 0x1f0    | 0x14641f0 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_22`                 | 0x1f4    | 0x14641f4 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_23`                 | 0x1f8    | 0x14641f8 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_24`                 | 0x1fc    | 0x14641fc | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_25`                 | 0x200    | 0x1464200 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_26`                 | 0x204    | 0x1464204 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_27`                 | 0x208    | 0x1464208 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_28`                 | 0x20c    | 0x146420c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_29`                 | 0x210    | 0x1464210 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_30`                 | 0x214    | 0x1464214 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_PERM_31`                 | 0x218    | 0x1464218 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_0`  | 0x21c    | 0x146421c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_1`  | 0x220    | 0x1464220 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_2`  | 0x224    | 0x1464224 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_3`  | 0x228    | 0x1464228 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_4`  | 0x22c    | 0x146422c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_5`  | 0x230    | 0x1464230 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_6`  | 0x234    | 0x1464234 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_7`  | 0x238    | 0x1464238 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_8`  | 0x23c    | 0x146423c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_9`  | 0x240    | 0x1464240 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_10` | 0x244    | 0x1464244 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_11` | 0x248    | 0x1464248 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_12` | 0x24c    | 0x146424c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_13` | 0x250    | 0x1464250 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_14` | 0x254    | 0x1464254 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_15` | 0x258    | 0x1464258 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_16` | 0x25c    | 0x146425c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_17` | 0x260    | 0x1464260 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_18` | 0x264    | 0x1464264 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_19` | 0x268    | 0x1464268 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_20` | 0x26c    | 0x146426c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_21` | 0x270    | 0x1464270 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_22` | 0x274    | 0x1464274 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_23` | 0x278    | 0x1464278 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_24` | 0x27c    | 0x146427c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_25` | 0x280    | 0x1464280 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_26` | 0x284    | 0x1464284 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_27` | 0x288    | 0x1464288 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_28` | 0x28c    | 0x146428c | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_29` | 0x290    | 0x1464290 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_30` | 0x294    | 0x1464294 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+| ac_range_check.`RANGE_RACL_POLICY_SHADOWED_31` | 0x298    | 0x1464298 | 0x4     | 2 (SOC_ROT) | R / W | - / -   | R / W |
+
+
+<!-- END CMDGEN -->

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/racl_configuration.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/racl_configuration.md
@@ -5,11 +5,11 @@
 
 ### RACL group: Null
 
-| Policy Name   |   Index |
-|:--------------|--------:|
-| ALL_RD_WR     |       0 |
-| ROT_PRIVATE   |       1 |
-| SOC_ROT       |       2 |
+| Policy Name   |   Index | Description                                                       |
+|:--------------|--------:|:------------------------------------------------------------------|
+| ALL_RD_WR     |       0 | Standard policies allowing all roles to access a register         |
+| ROT_PRIVATE   |       1 | Standard policies allowing only the ROT role to access a register |
+| SOC_ROT       |       2 | Custom policy                                                     |
 
 
 ## RACL configuration

--- a/util/raclgen.py
+++ b/util/raclgen.py
@@ -7,28 +7,44 @@ This utility computes the policy selection vector for a given ip, RACL config, a
 """
 
 import argparse
-
+import sys
+from pathlib import Path
 from mako.template import Template
-from raclgen.lib import parse_racl_config, parse_racl_mapping
+from raclgen.lib import parse_racl_config, parse_racl_mapping, gen_md, gen_md_header, _read_hjson
 from reggen.ip_block import IpBlock
+import topgen.lib as topgen_lib
+
+# This file is $REPO_TOP/util/, so it takes two parent() calls to get back to the top.
+REPO_TOP = Path(__file__).resolve().parent.parent
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    is_doc = "--doc" in sys.argv
+    parser = argparse.ArgumentParser(usage='''
+%(prog)s --doc DOC
+    Generates markdown documentation of the RACL configuration for a given top.
+
+%(prog)s --racl-config RACL_CONFIG --ip IP --mapping MAPPING [--if-name IF_NAME]
+    Generates the RACL policy selection vector for the given IP, RACL mapping, and interface name.
+              ''')
+
+    parser.add_argument('--doc',
+                        '-d',
+                        help='Path to top_topname.gen.hjson.')
 
     parser.add_argument('--racl-config',
                         '-r',
-                        required=True,
+                        required=not is_doc,
                         help='Path to RACL config hjson file.')
 
     parser.add_argument('--ip',
                         '-i',
-                        required=True,
+                        required=not is_doc,
                         help='Path to IP block hjson file.')
 
     parser.add_argument('--mapping',
                         '-m',
-                        required=True,
+                        required=not is_doc,
                         help='Path to RACL mapping hjson file.')
 
     parser.add_argument(
@@ -38,6 +54,46 @@ def main():
         'TLUL path interface name. Required if multiple bus_interfaces exist.')
 
     args = parser.parse_args()
+
+    if args.doc:
+        top = _read_hjson(args.doc)
+        if 'racl_ctrl' not in (module['name'] for module in top['module']):
+            raise SystemExit(f'No racl_ctrl module found in {args.doc}')
+        if 'racl' not in top:
+            raise SystemExit(f'Missing key "racl" in {args.doc}')
+
+        racl_config = top['racl']
+        ips_with_racl = {}
+
+        gen_md_header(racl_config)
+
+        for module in top['module']:
+            if 'racl_mappings' not in module:
+                continue
+            ip_name = module['type']
+            if ip_name not in ips_with_racl:
+                try:
+                    ip_path = topgen_lib.get_ip_hjson_path(ip_name, top, REPO_TOP)
+                    ips_with_racl[ip_name] = IpBlock.from_path(path=ip_path, param_defaults=[])
+                except ValueError as err:
+                    raise SystemExit(f'Failed to parse IP block "{ip_name}". Error: {err}')
+
+            for if_name, racl_mappings in module['racl_mappings'].items():
+                if 'racl_group' not in racl_mappings:
+                    raise SystemExit(f'racl_mappings of {module["name"]} is missing "racl_group".')
+                racl_mapping = {
+                    'if_name': if_name,
+                    'racl_group': racl_mappings['racl_group'],
+                    'register_mapping': racl_mappings.get('register_mapping', {}),
+                    'window_mapping': racl_mappings.get('window_mapping', {}),
+                    'range_mapping': racl_mappings.get('range_mapping', []),
+                }
+                gen_md(block=ips_with_racl[ip_name],
+                       racl_config=racl_config,
+                       racl_mapping=racl_mapping,
+                       module=module)
+
+        sys.exit(0)
 
     try:
         ip_block = IpBlock.from_path(path=args.ip, param_defaults=[])

--- a/util/raclgen/lib.py
+++ b/util/raclgen/lib.py
@@ -270,14 +270,13 @@ def gen_md_header(racl_config: Dict[str, object], output: TextIO = sys.stdout):
     output.write(title('RACL groups', 2))
     output.write('\n')
 
-    header = ['Policy Name', 'Index']
+    header = ['Policy Name', 'Index', 'Description']
 
     for racl_group in racl_config['policies']:
         policies_for_racl_group = racl_config['policies'][racl_group]
-        policy_names = [policy['name'] for policy in policies_for_racl_group]
         rows: List[List[str]] = []
-        for policy_idx, policy_name in enumerate(policy_names):
-            rows.append([policy_name, str(policy_idx)])
+        for policy_idx, policy in enumerate(policies_for_racl_group):
+            rows.append([policy['name'], str(policy_idx), policy.get('desc', '')])
 
         output.write(title(f'RACL group: {racl_group}', 3))
         output.write(table(header, rows))

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -321,6 +321,14 @@ py_library(
 )
 
 py_library(
+    name = "md_helpers",
+    srcs = ["md_helpers.py"],
+    deps = [
+        ":signal",
+    ],
+)
+
+py_library(
     name = "validate",
     srcs = ["validate.py"],
 )

--- a/util/topgen/BUILD
+++ b/util/topgen/BUILD
@@ -59,6 +59,7 @@ py_library(
         "//util:version_file",
         "//util/reggen:inter_signal",
         "//util/reggen:ip_block",
+        "//util/reggen:md_helpers",
         "//util/reggen:validate",
         requirement("hjson"),
         requirement("mako"),


### PR DESCRIPTION
This commit adds initial documentation for RACL and describes the racl configuration files in the form of inline examples.
Furthermore, it generates a `racl_configuration.md` file which documents the current RACL configuration for each module instance and interface.

I don't have a strong opinion on how to format the RACL config information in the generated tables. We can still discuss and changes this!

