### PR TITLE
[lc_ctrl] Buffer hardware revision to allow differentiating metal spins

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -335,11 +335,20 @@ module lc_ctrl
 
   logic lc_idle_d, lc_done_d;
 
-  // Assign hardware revision output
-  assign hw_rev_o = '{silicon_creator_id: SiliconCreatorId,
-                      product_id:         ProductId,
-                      revision_id:        RevisionId,
-                      reserved:           '0};
+  // Assign the hardware revision constant and feed it through an anchor buffer. This ensures the
+  // individual bits remain visible in the netlist, thereby enabling metal fixes to be reflected
+  // in the hardware revision.
+  lc_hw_rev_t hw_rev;
+  assign hw_rev = '{silicon_creator_id: SiliconCreatorId,
+                    product_id:         ProductId,
+                    revision_id:        RevisionId,
+                    reserved:           '0};
+  prim_sec_anchor_buf #(
+    .Width($bits(lc_hw_rev_t))
+  ) u_hw_rev_anchor_buf (
+    .in_i(hw_rev),
+    .out_o(hw_rev_o)
+  );
 
   // OTP Vendor control bits
   logic ext_clock_switched;


### PR DESCRIPTION
This commit places a prim_sec_anchor_buf on the constant hardware revision signal inside lc_ctrl. This prevents synthesis from performing logic optimizations on the hardware revision CSRs and output signals and ensures the individual bits of the constant remain visible in the netlist. This enables differentiating metal spins of the same design via the hardware revision in the future.