### PR TITLE
[dtgen] Add pad information for DIOs

### DIFF
--- a/sw/device/lib/dif/dif_pinmux.c
+++ b/sw/device/lib/dif/dif_pinmux.c
@@ -357,11 +357,11 @@ dif_result_t dif_pinmux_pad_from_dt_pad(dt_pad_t pad,
   switch (dt_pad_type(pad)) {
     case kDtPadTypeMio:
       *type_out = kDifPinmuxPadKindMio;
-      *index_out = dt_pad_mio_pad(pad);
+      *index_out = dt_pad_mio_pad_index(pad);
       return kDifOk;
     case kDtPadTypeDio:
       *type_out = kDifPinmuxPadKindDio;
-      *index_out = dt_pad_dio_pad(pad);
+      *index_out = dt_pad_dio_pad_index(pad);
       return kDifOk;
     default:
       return kDifError;

--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -69,9 +69,9 @@ void pinmux_testutils_init(dif_pinmux_t *pinmux) {
         .flags = kDifPinmuxPadAttrPullResistorEnable |
                  kDifPinmuxPadAttrPullResistorUp};
 
-    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(pinmux, dt_pad_mio_pad(kPadUart0Rx),
-                                            kDifPinmuxPadKindMio, in_attr,
-                                            &out_attr));
+    CHECK_DIF_OK(
+        dif_pinmux_pad_write_attrs(pinmux, dt_pad_mio_pad_index(kPadUart0Rx),
+                                   kDifPinmuxPadKindMio, in_attr, &out_attr));
   };
 
 #ifdef HAS_UART1

--- a/util/dtgen/dt_api.c.tpl
+++ b/util/dtgen/dt_api.c.tpl
@@ -69,7 +69,7 @@ dt_pinmux_mio_out_t dt_pad_mio_out(dt_pad_t pad) {
   return (dt_pinmux_mio_out_t)dt_pad[pad].mio_out_or_direct_pad;
 }
 
-dt_pinmux_muxed_pad_t dt_pad_mio_pad(dt_pad_t pad) {
+dt_pinmux_muxed_pad_t dt_pad_mio_pad_index(dt_pad_t pad) {
   if(${invalid_pad_check}) {
     return (dt_pinmux_muxed_pad_t)0;
   }
@@ -84,7 +84,7 @@ dt_pinmux_insel_t dt_pad_mio_insel(dt_pad_t pad) {
   return (dt_pinmux_insel_t)dt_pad[pad].insel;
 }
 
-dt_pinmux_direct_pad_t dt_pad_dio_pad(dt_pad_t pad) {
+dt_pinmux_direct_pad_t dt_pad_dio_pad_index(dt_pad_t pad) {
   if(${invalid_pad_check}) {
     return (dt_pinmux_direct_pad_t)0;
   }
@@ -96,7 +96,7 @@ const dt_periph_io_t kDtPeriphIoConstantHighZ = {
   .__internal = {
     .type = kDtPeriphIoTypeMio,
     .periph_input_or_direct_pad = 0,
-    .outsel = kDtPinmuxOutselConstantHighZ,
+    .outsel_or_dt_pad = kDtPinmuxOutselConstantHighZ,
   }
 };
 
@@ -105,7 +105,7 @@ const dt_periph_io_t kDtPeriphIoConstantZero = {
   .__internal = {
     .type = kDtPeriphIoTypeMio,
     .periph_input_or_direct_pad = 0,
-    .outsel = kDtPinmuxOutselConstantZero,
+    .outsel_or_dt_pad = kDtPinmuxOutselConstantZero,
   }
 };
 
@@ -114,6 +114,6 @@ const dt_periph_io_t kDtPeriphIoConstantOne = {
   .__internal = {
     .type = kDtPeriphIoTypeMio,
     .periph_input_or_direct_pad = 0,
-    .outsel = kDtPinmuxOutselConstantOne,
+    .outsel_or_dt_pad = kDtPinmuxOutselConstantOne,
   }
 };

--- a/util/dtgen/dt_api.h.tpl
+++ b/util/dtgen/dt_api.h.tpl
@@ -84,6 +84,11 @@ ${helper.clock_enum.render()}
 uint32_t dt_clock_frequency(dt_clock_t clk);
 
 /**
+ * List of pads names.
+ */
+${helper.pad_enum.render()}
+
+/**
  * Pinmux types.
  *
  * These types are aliases to top-level types for backward compatibility
@@ -169,7 +174,7 @@ static inline dt_periph_io_dir_t dt_periph_io_dir(dt_periph_io_t periph_io) {
 /**
  * Return the peripheral input for an MIO peripheral I/O.
  *
- * This is the index of the MIO_PERIPH_INSEL register that controls this peripheral I/O.
+ * This is the index of the `MIO_PERIPH_INSEL` pinmux register that controls this peripheral I/O.
  *
  * @param dev A peripheral I/O of type `kDtPeriphIoTypeMio`.
  * @return The peripheral input number of the MIO that this peripheral I/O is connected to.
@@ -184,7 +189,7 @@ static inline dt_pinmux_peripheral_in_t dt_periph_io_mio_periph_input(dt_periph_
 /**
  * Return the outsel for an MIO peripheral I/O.
  *
- * This is the value to put in the `MIO_OUTSEL` registers to connect a pad to this peripheral I/O.
+ * This is the value to put in the `MIO_OUTSEL` pinmux registers to connect a pad to this peripheral I/O.
  *
  * @param dev A peripheral I/O of type `kDtPeriphIoTypeMio`.
  * @return The outsel of the MIO that this peripheral I/O is connected to.
@@ -193,13 +198,13 @@ static inline dt_pinmux_peripheral_in_t dt_periph_io_mio_periph_input(dt_periph_
  * outputs (`kDtPeriphIoDirOut`). For any other peripheral I/O, the return value is unspecified.
  */
 static inline dt_pinmux_outsel_t dt_periph_io_mio_outsel(dt_periph_io_t periph_io) {
-  return (dt_pinmux_outsel_t)periph_io.__internal.outsel;
+  return (dt_pinmux_outsel_t)periph_io.__internal.outsel_or_dt_pad;
 }
 
 /**
  * Return the direct pad number of a DIO peripheral I/O.
  *
- * This is the index of the various `DIO_PAD_*` registers that control this peripheral I/O.
+ * This is the index of the various `DIO_PAD_*` pinmux registers that control this peripheral I/O.
  *
  * @param dev A peripheral I/O of type `kDtPeriphIoTypeDio`.
  * @return The direct pad number of the DIO that this peripheral I/O is connected to.
@@ -207,14 +212,22 @@ static inline dt_pinmux_outsel_t dt_periph_io_mio_outsel(dt_periph_io_t periph_i
  * NOTE This function only makes sense for peripheral I/Os of type `kDtPeriphIoTypeDio` which are
  * either outputs or inouts. For any other peripheral I/O type, the return value is unspecified.
  */
-static inline dt_pinmux_direct_pad_t dt_periph_io_dio_pad(dt_periph_io_t periph_io) {
+static inline dt_pinmux_direct_pad_t dt_periph_io_dio_pad_index(dt_periph_io_t periph_io) {
   return (dt_pinmux_direct_pad_t)periph_io.__internal.periph_input_or_direct_pad;
 }
 
 /**
- * List of pads names.
+ * Return the pad of a DIO peripheral I/O.
+ *
+ * @param dev A peripheral I/O of type `kDtPeriphIoTypeDio`.
+ * @return The pad to which this peripheral I/O is connected to.
+ *
+ * NOTE This function only makes sense for peripheral I/Os of type `kDtPeriphIoTypeDio` which are
+ * either outputs or inouts. For any other peripheral I/O type, the return value is unspecified.
  */
-${helper.pad_enum.render()}
+static inline dt_pad_t dt_periph_io_dio_pad(dt_periph_io_t periph_io) {
+  return (dt_pad_t)periph_io.__internal.outsel_or_dt_pad;
+}
 
 /** Type of a pad. */
 typedef enum dt_pad_type {
@@ -260,7 +273,7 @@ dt_pinmux_mio_out_t dt_pad_mio_out(dt_pad_t pad);
  * NOTE This function only makes sense for pads of type `kDtPadTypeMio`.
  * For any other pad, the return value is unspecified.
  */
-dt_pinmux_muxed_pad_t dt_pad_mio_pad(dt_pad_t pad);
+dt_pinmux_muxed_pad_t dt_pad_mio_pad_index(dt_pad_t pad);
 
 /**
  * Return the insel for an MIO pad.
@@ -286,6 +299,6 @@ dt_pinmux_insel_t dt_pad_mio_insel(dt_pad_t pad);
  * NOTE This function only makes sense for pads of type `kDtPeriphIoTypeDio` which are
  * either outputs or inouts. For any other pad type, the return value is unspecified.
  */
-dt_pinmux_direct_pad_t dt_pad_dio_pad(dt_pad_t pad);
+dt_pinmux_direct_pad_t dt_pad_dio_pad_index(dt_pad_t pad);
 
 #endif  // ${include_guard}

--- a/util/dtgen/helper.py
+++ b/util/dtgen/helper.py
@@ -212,7 +212,7 @@ class TopHelper:
     DT_PERIPH_IO_DIR_FIELD_NAME = Name(["dir"])
     DT_PERIPH_IO_DIR_ENUM_NAME = Name.from_snake_case("dt_periph_io_dir")
     DT_PERIPH_IO_PERIPH_IN_DIO_PAD_FIELD_NAME = Name.from_snake_case("periph_input_or_direct_pad")
-    DT_PERIPH_IO_OUTSEL_FIELD_NAME = Name(["outsel"])
+    DT_PERIPH_IO_OUTSEL_FIELD_NAME = Name.from_snake_case("outsel_or_dt_pad")
 
     DT_PAD_NAME = Name(["dt", "pad"])
     DT_PAD_STRUCT_NAME = Name(["dt", "pad", "desc"])
@@ -337,7 +337,7 @@ that control this peripheral I/O.""",  # noqa:E501
             name = self.DT_PERIPH_IO_OUTSEL_FIELD_NAME,
             field_type = ScalarType("uint16_t"),
             docstring = """For `kDtPeriphIoTypeMio`: peripheral output number. This is the value to put in the MIO_OUTSEL registers
-to connect an output to this peripheral I/O.""",  # noqa:E501
+to connect an output to this peripheral I/O. For `kDtPeriphIoTypeDio`: the pad index (`dt_pad_t`) to which this I/O is connected.""",  # noqa:E501
         )
 
     def _create_pad_struct(self):
@@ -757,7 +757,26 @@ This can be `kDtPlicIrqIdNone` if the block is not connected to the PLIC."""
             pin_type = "Dio"
             direct_pad = f"top_{topname}_direct_pads_{modname}_{pin_name}"
             pin_periph_input_or_direct_pad = Name.from_snake_case(direct_pad).as_c_enum()
-            pin_outsel = "0"
+            # Unfortunately, the top level has two distinct names for pads: the pads listed
+            # in top.pinmux.pads and the ones in top.pinmux.ios. Since the pad list uses
+            # names from top.pinmux.ios for DIOs, but that the connections use the names
+            # from top.pinmux.pads, we need to map between the two.
+            padname = None
+            for io in self.top['pinmux']['ios']:
+                if io["connection"] == "direct" and io["pad"] == conn["pad"]:
+                    if padname is not None:
+                        raise RuntimeError(
+                            "found at least two IOs that maps to pad {}".format(conn["pad"]) +
+                            ": {} and {}".format(padname, io["name"])
+                        )
+                    padname = Name.from_snake_case(io["name"])
+                    # IOs have a width, we need to handle that
+                    if int(io["width"]) > 1:
+                        padname += Name([str(io["idx"])])
+            if padname is None:
+                raise RuntimeError("could not find IO that maps to pad {}".format(conn["pad"]))
+            pad_index = self.top_helper.pad_enum.name + padname
+            pin_outsel = pad_index.as_c_enum()
         else:
             assert conn["connection"] == "manual", \
                 "unexpected connection type '{}'".format(conn["connection"])


### PR DESCRIPTION
At the moment the peripheral I/Os of type DIO include information about the PAD register to use to configure them. However they do not provide any information about the corresponding `dt_pad_t` which can be valuable in some context. Add this information to the DT.