### PR TITLE
[sw] Simplify dbg_printf in immutable rom ext

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
@@ -38,7 +38,7 @@ static rom_error_t imm_rom_ext_start(void) {
   pinmux_init_uart0_tx();
   uart_init(kUartNCOValue);
 
-  dbg_printf("IMM_ROM_EXT:0.1\r\n");
+  dbg_puts("IMM_ROM_EXT:0.1\r\n");
 
   // Establish our identity.
   const manifest_t *rom_ext = rom_ext_manifest();

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -295,7 +295,7 @@ rom_error_t dice_chain_attestation_silicon(void) {
     //
     // In both cases, we do nothing, and boot normally, later attestation
     // attempts will fail in a detectable manner.
-    dbg_printf("Warning: UDS certificate not valid.\r\n");
+    dbg_puts("Warning: UDS certificate not valid.\r\n");
   } else {
     // Cert is valid, move to the next one.
     dice_chain_next_cert_obj();
@@ -334,7 +334,7 @@ rom_error_t dice_chain_attestation_creator(
   // Check if the current CDI_0 cert is valid.
   RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_0", /*name_size=*/6));
   if (dice_chain.cert_valid == kHardenedBoolFalse) {
-    dbg_printf("CDI_0 certificate not valid. Updating it ...\r\n");
+    dbg_puts("CDI_0 certificate not valid. Updating it ...\r\n");
     // Update the cert page buffer.
     size_t updated_cert_size = kScratchCertSizeBytes;
     HARDENED_RETURN_IF_ERROR(
@@ -398,7 +398,7 @@ rom_error_t dice_chain_attestation_owner(
   // Check if the current CDI_0 cert is valid.
   RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_1", /*name_size=*/6));
   if (dice_chain.cert_valid == kHardenedBoolFalse) {
-    dbg_printf("CDI_1 certificate not valid. Updating it ...\r\n");
+    dbg_puts("CDI_1 certificate not valid. Updating it ...\r\n");
     // Update the cert page buffer.
     size_t updated_cert_size = kScratchCertSizeBytes;
     // TODO(#19596): add owner configuration block measurement to CDI_1 cert.
@@ -438,8 +438,7 @@ rom_error_t dice_chain_flush_flash(void) {
         /*offset=*/0,
         /*word_count=*/FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
         dice_chain.data));
-    dbg_printf("Flushed dice cert page %d\r\n",
-               dice_chain.info_page->base_addr);
+    dbg_puts("Flushed dice cert page\r\n");
     dice_chain.data_dirty = kHardenedBoolFalse;
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -33,6 +33,12 @@ static void print_integer(unsigned value, bool is_signed) {
   }
 }
 
+void dbg_puts(const char *str) {
+  while (*str) {
+    uart_putchar(*str++);
+  }
+}
+
 void dbg_printf(const char *format, ...) {
   va_list args;
   va_start(args, format);

--- a/sw/device/silicon_creator/lib/dbg_print.h
+++ b/sw/device/silicon_creator/lib/dbg_print.h
@@ -41,6 +41,14 @@ extern "C" {
 void dbg_printf(const char *format, ...) __attribute__((format(printf, 1, 2)));
 
 /**
+ * Print the string to the console.
+ *
+ * Note: `dbg_puts` will NOT output an additional newline character '\n' after
+ * `str`, unlike the standard C puts.
+ */
+void dbg_puts(const char *str);
+
+/**
  * Print the ePMP configuration to the console.
  */
 void dbg_print_epmp(void);

--- a/sw/device/silicon_creator/lib/dbg_print_unittest.cc
+++ b/sw/device/silicon_creator/lib/dbg_print_unittest.cc
@@ -83,6 +83,17 @@ TEST(LogTest, PrintfString) {
   EXPECT_EQ(*uart_buf, "ABC");
 }
 
+TEST(LogTest, PutsString) {
+  uart_buf->clear();
+  dbg_puts("Hello, %s!");
+  // It should NOT be formatted.
+  EXPECT_EQ(*uart_buf, "Hello, %s!");
+
+  uart_buf->clear();
+  dbg_puts("OpenTitan");
+  EXPECT_EQ(*uart_buf, "OpenTitan");
+}
+
 TEST(LogTest, PrintfMix) {
   uart_buf->clear();
   dbg_printf("%s%x", "OpenTitan", 0x0000000a);

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -96,7 +96,7 @@ static rom_error_t load_attestation_keygen_seed(uint32_t additional_seed_idx,
       // If we encountered a read error, this means the attestation seed page
       // has not been provisioned yet. In this case, we erase the page and
       // continue, which will simply result in generating an invalid identity.
-      dbg_printf(
+      dbg_puts(
           "Warning: Attestation key seed flash info page not provisioned. "
           "Erasing page to format.\r\n");
       HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(


### PR DESCRIPTION
Since immutable rom_ext only prints string literals, this commit replaced the `dbg_printf` by a simplified `dbg_puts` version. It saves about 480 Bytes.