### PR TITLE
[sw,multitop] port kmac_{app_rom,mode_cshake,mode_kmac}_test to devicetables

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2641,10 +2641,11 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2618,11 +2618,12 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2421,13 +2421,43 @@ opentitan_test(
     ],
 )
 
+# TODO(lowrisc/opentitan#26250): it would be good if execution environments
+# could provide a mechanism for obtaining their hashfiles, rather than us
+# hardcoding all these hashfile mappings here.
 _KMAC_APP_ROM_LIST = [
-    ("//sw/device/lib/testing/test_rom:test_rom_sim_verilator_hashfile", "sim_verilator"),
-    ("//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_hashfile", "fpga_cw310_test_rom"),
-    ("//sw/device/silicon_creator/rom:mask_rom_fpga_cw310_hashfile", "fpga_cw310_rom_with_fake_keys"),
-    ("//sw/device/silicon_creator/rom:mask_rom_fpga_cw310_hashfile", "fpga_cw310_sival"),
-    ("//sw/device/silicon_creator/rom:mask_rom_fpga_cw340_hashfile", "fpga_cw340_sival"),
-    ("//sw/device/lib/testing/test_rom:test_rom_sim_dv_hashfile", "sim_dv"),
+    (
+        "//sw/device/lib/testing/test_rom:test_rom_sim_verilator_hashfile",
+        "sim_verilator",
+        ["//hw/top_earlgrey"],
+    ),
+    (
+        "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_hashfile",
+        "fpga_cw310_test_rom",
+        ["//hw/top_earlgrey"],
+    ),
+    (
+        "//sw/device/silicon_creator/rom:mask_rom_fpga_cw310_hashfile",
+        "fpga_cw310_rom_with_fake_keys",
+        ["//hw/top_earlgrey"],
+    ),
+    (
+        "//sw/device/silicon_creator/rom:mask_rom_fpga_cw310_hashfile",
+        "fpga_cw310_sival",
+        ["//hw/top_earlgrey"],
+    ),
+    (
+        "//sw/device/silicon_creator/rom:mask_rom_fpga_cw340_hashfile",
+        "fpga_cw340_sival",
+        ["//hw/top_earlgrey"],
+    ),
+    (
+        "//sw/device/lib/testing/test_rom:test_rom_sim_dv_hashfile",
+        "sim_dv",
+        [
+            "//hw/top_earlgrey",
+            "//hw/top_darjeeling",
+        ],
+    ),
 ]
 
 [
@@ -2438,24 +2468,25 @@ _KMAC_APP_ROM_LIST = [
             hashfile,
         ],
         exec_env = {
-            "//hw/top_earlgrey:{}".format(exec_env): None,
+            "{}:{}".format(top, exec_env): None
+            for top in tops
         },
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//hw/top:dt",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/dif:rom_ctrl",
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for (hashfile, exec_env) in _KMAC_APP_ROM_LIST
+    for (hashfile, exec_env, tops) in _KMAC_APP_ROM_LIST
 ]
 
 test_suite(
     name = "kmac_app_rom_test",
     tests = [
         "kmac_app_rom_test_{}".format(exec_env)
-        for (_, exec_env) in _KMAC_APP_ROM_LIST
+        for (_, exec_env, _) in _KMAC_APP_ROM_LIST
     ],
 )
 

--- a/sw/device/tests/kmac_app_rom_test.c
+++ b/sw/device/tests/kmac_app_rom_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_rom_ctrl.h"  // Generated
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_rom_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
@@ -9,11 +10,12 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 extern const uint32_t kRomImageHash[ROM_CTRL_DIGEST_MULTIREG_COUNT];
 
 static dif_rom_ctrl_t rom_ctrl;
+static dt_rom_ctrl_t kRomCtrlDt = (dt_rom_ctrl_t)0;
+static_assert(kDtRomCtrlCount >= 1,
+              "This test requires at least one rom_ctrl instance");
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -22,9 +24,7 @@ bool test_main(void) {
   dif_rom_ctrl_digest_t expected_digest;
 
   // initialize rom_ctrl
-  mmio_region_t rom_ctrl_reg =
-      mmio_region_from_addr(TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR);
-  CHECK_DIF_OK(dif_rom_ctrl_init(rom_ctrl_reg, &rom_ctrl));
+  CHECK_DIF_OK(dif_rom_ctrl_init_from_dt(kRomCtrlDt, &rom_ctrl));
 
   // get computed and expected digests and check that they match
   CHECK_DIF_OK(dif_rom_ctrl_get_digest(&rom_ctrl, &computed_digest));

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_kmac.h"  // Generated
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
@@ -9,8 +10,6 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -92,9 +91,11 @@ bool test_main(void) {
 
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
+  dt_kmac_t kKmacDt = (dt_kmac_t)0;
+  static_assert(kDtKmacCount >= 1,
+                "This test requires at least one KMAC instance");
   dif_kmac_operation_state_t kmac_operation_state;
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kKmacDt, &kmac));
 
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_kmac.h"  // Generated
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
@@ -9,8 +10,6 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -193,9 +192,11 @@ bool test_main(void) {
 
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
+  dt_kmac_t kKmacDt = (dt_kmac_t)0;
+  static_assert(kDtKmacCount >= 1,
+                "This test requires at least one KMAC instance");
   dif_kmac_operation_state_t kmac_operation_state;
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kKmacDt, &kmac));
 
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){


### PR DESCRIPTION
Fix #26216
Fix #26218
Fix #26219
Fix #26220

This PR ports 3 KMAC tests to use the devicetables API so that they no longer depend on Earlgrey-specific constants. All three tests remain passing on Earlgrey on FPGA (`fpga_cw310_rom_with_fake_keys`), and will compile for Darjeeling using e.g.
```sh
bazel build //sw/device/tests:kmac_app_rom_test_sim_dv --//hw/top=darjeeling 
```

It might be worth updating `kmac_app_rom_test` in the future so that each exec_env provides a way to get the hashfile of its ROM, so the information here is not hard-coded. But that is out of scope for this PR.

Edit: I've also now tested chip_sw_kmac_mode_kmac_jitter_en is passing on Earlgrey via DVsim so I'm marking this as closing that issue as well.