### PR TITLE
[sw,multitop] port hmac_enc_test to devicetables

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2103,15 +2103,15 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:hmac",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:hmac_testutils",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_hmac.h"     // Generated
+#include "dt/dt_rv_plic.h"  // Generated
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_hmac.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
@@ -12,19 +14,15 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "sw/device/lib/testing/autogen/isr_testutils.h"
+static const uint32_t kPlicTarget = 0;
+static dif_rv_plic_t rv_plic;
+static dt_rv_plic_t kRvPlicDt = kDtRvPlic;
+static dif_hmac_t hmac;
+static dt_hmac_t kHmacDt = (dt_hmac_t)0;
+static_assert(kDtHmacCount >= 1,
+              "This test requires at least one HMAC instance");
 
-static plic_isr_ctx_t plic_ctx = {
-    .hart_id = kTopEarlgreyPlicTargetIbex0,
-};
-
-static top_earlgrey_plic_peripheral_t peripheral_serviced;
-static dif_hmac_irq_t irq_serviced;
-static hmac_isr_ctx_t hmac_ctx = {
-    .plic_hmac_start_irq_id = kTopEarlgreyPlicIrqIdHmacHmacDone,
-    .is_only_irq = false,
-};
+static volatile dt_hmac_irq_t irq_serviced;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -34,81 +32,81 @@ static const dif_hmac_transaction_t kHmacTransactionConfig = {
 };
 
 /**
- * External ISR.
- *
- * Handles all peripheral interrupts on Ibex. PLIC asserts an external interrupt
- * line to the CPU, which results in a call to this OTTF ISR. This ISR
- * overrides the default OTTF implementation.
+ * Catch HMAC IRQs so they can be checked by the test body.
  */
-void ottf_external_isr(uint32_t *exc_info) {
-  isr_testutils_hmac_isr(plic_ctx, hmac_ctx, /* mute_status_irq */ false,
-                         &peripheral_serviced, &irq_serviced);
+bool ottf_handle_irq(uint32_t *exc_info, dt_instance_id_t devid,
+                     dif_rv_plic_irq_id_t irq_id) {
+  if (devid == dt_hmac_instance_id(kHmacDt)) {
+    irq_serviced = dt_hmac_irq_from_plic_id(kHmacDt, irq_id);
+
+    // Acknowledge the IRQ at the peripheral if the IRQ is of the event type.
+    dif_irq_type_t type;
+    CHECK_DIF_OK(dif_hmac_irq_get_type(&hmac, irq_serviced, &type));
+    if (type == kDifIrqTypeEvent) {
+      CHECK_DIF_OK(dif_hmac_irq_acknowledge(&hmac, irq_serviced));
+    }
+
+    return true;
+  }
+  return false;
 }
 
 /**
  * Enables interrupts required by this test.
  */
 static void irqs_init(void) {
-  mmio_region_t base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_plic_init(base_addr, plic_ctx.rv_plic));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &rv_plic));
 
   // Enable interrupts in HMAC IP.
-  CHECK_DIF_OK(dif_hmac_irq_set_enabled(hmac_ctx.hmac, kDifHmacIrqHmacDone,
-                                        kDifToggleEnabled));
-  CHECK_DIF_OK(dif_hmac_irq_set_enabled(hmac_ctx.hmac, kDifHmacIrqFifoEmpty,
-                                        kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_hmac_irq_set_enabled(&hmac, kDtHmacIrqHmacDone, kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_hmac_irq_set_enabled(&hmac, kDtHmacIrqFifoEmpty, kDifToggleEnabled));
 
   // Enable interrupts in PLIC.
-  rv_plic_testutils_irq_range_enable(plic_ctx.rv_plic, plic_ctx.hart_id,
-                                     kTopEarlgreyPlicIrqIdHmacHmacDone,
-                                     kTopEarlgreyPlicIrqIdHmacFifoEmpty);
+  rv_plic_testutils_irq_range_enable(
+      &rv_plic, kPlicTarget,
+      dt_hmac_irq_to_plic_id(kHmacDt, kDtHmacIrqHmacDone),
+      dt_hmac_irq_to_plic_id(kHmacDt, kDtHmacIrqFifoEmpty));
   // Enable interrupts in Ibex.
   irq_external_ctrl(true);
   irq_global_ctrl(true);
 }
 
 bool test_main(void) {
-  dif_hmac_t hmac;
-  dif_rv_plic_t plic;
-  plic_ctx.rv_plic = &plic;
-  hmac_ctx.hmac = &hmac;
-
-  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
-  CHECK_DIF_OK(dif_hmac_init(base_addr, &hmac));
+  CHECK_DIF_OK(dif_hmac_init_from_dt(kHmacDt, &hmac));
 
   irqs_init();
 
   // Use HMAC in SHA256 mode to generate a 256bit key from `kHmacRefLongKey`.
-  CHECK_DIF_OK(
-      dif_hmac_mode_sha256_start(hmac_ctx.hmac, kHmacTransactionConfig));
-  CHECK_STATUS_OK(hmac_testutils_push_message(
-      hmac_ctx.hmac, (char *)kHmacRefLongKey, sizeof(kHmacRefLongKey)));
-  CHECK_STATUS_OK(hmac_testutils_check_message_length(
-      hmac_ctx.hmac, sizeof(kHmacRefLongKey) * 8));
+  CHECK_DIF_OK(dif_hmac_mode_sha256_start(&hmac, kHmacTransactionConfig));
+  CHECK_STATUS_OK(hmac_testutils_push_message(&hmac, (char *)kHmacRefLongKey,
+                                              sizeof(kHmacRefLongKey)));
+  CHECK_STATUS_OK(
+      hmac_testutils_check_message_length(&hmac, sizeof(kHmacRefLongKey) * 8));
 
   // Expect the done irq after processing data.
-  hmac_ctx.expected_irq = kDifHmacIrqHmacDone;
+  dt_hmac_irq_t expected_irq = kDtHmacIrqHmacDone;
   irq_serviced = UINT32_MAX;
 
-  CHECK_DIF_OK(dif_hmac_process(hmac_ctx.hmac));
+  CHECK_DIF_OK(dif_hmac_process(&hmac));
   dif_hmac_digest_t key_digest;
-  CHECK_STATUS_OK(hmac_testutils_finish_polled(hmac_ctx.hmac, &key_digest));
+  CHECK_STATUS_OK(hmac_testutils_finish_polled(&hmac, &key_digest));
   CHECK_ARRAYS_EQ(key_digest.digest, kHmacRefExpectedLongKeyDigest.digest,
                   ARRAYSIZE(key_digest.digest));
 
-  CHECK(irq_serviced == hmac_ctx.expected_irq);
+  CHECK(irq_serviced == expected_irq);
 
   // Generate HMAC final digest, using the resulted SHA256 digest over the
   // `kHmacRefLongKey`.
-  CHECK_DIF_OK(dif_hmac_mode_hmac_start(
-      hmac_ctx.hmac, (uint8_t *)&key_digest.digest[0], kHmacTransactionConfig));
-  CHECK_STATUS_OK(hmac_testutils_push_message(hmac_ctx.hmac, kHmacRefData,
-                                              sizeof(kHmacRefData)));
-  CHECK_STATUS_OK(hmac_testutils_check_message_length(
-      hmac_ctx.hmac, sizeof(kHmacRefData) * 8));
-  CHECK_DIF_OK(dif_hmac_process(hmac_ctx.hmac));
+  CHECK_DIF_OK(dif_hmac_mode_hmac_start(&hmac, (uint8_t *)&key_digest.digest[0],
+                                        kHmacTransactionConfig));
+  CHECK_STATUS_OK(
+      hmac_testutils_push_message(&hmac, kHmacRefData, sizeof(kHmacRefData)));
+  CHECK_STATUS_OK(
+      hmac_testutils_check_message_length(&hmac, sizeof(kHmacRefData) * 8));
+  CHECK_DIF_OK(dif_hmac_process(&hmac));
   LOG_INFO("Waiting for HMAC pooling to finish");
-  return status_ok(hmac_testutils_finish_and_check_polled(
-      hmac_ctx.hmac, &kHmacRefExpectedDigest));
+  return status_ok(
+      hmac_testutils_finish_and_check_polled(&hmac, &kHmacRefExpectedDigest));
 }


### PR DESCRIPTION
Fix #26215

This PR ports the `hmac_enc_test` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey on FPGA (`fpga_cw310_rom_with_fake_keys`), and will compile for Darjeeling via
```sh
bazel build //sw/device/tests:hmac_enc_test_sim_dv --//hw/top=darjeeling
```

See the commit message for more details about replacing the `isr_testutils` API call.