### PR TITLE
[top_darjeeling,lint] Temporarily exclude blocks with problems

### DIFF
--- a/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
@@ -63,17 +63,17 @@
                     }
                   ]
              },
-             {    name: clkmgr
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_clkmgr
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
-                  rel_path: "hw/top_darjeeling/ip_autogen/clkmgr/lint/{tool}",
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
-             },
+             //{    name: clkmgr
+             //     fusesoc_core: lowrisc:opentitan:top_darjeeling_clkmgr
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
+             //     rel_path: "hw/top_darjeeling/ip_autogen/clkmgr/lint/{tool}",
+             //     overrides: [
+             //       {
+             //         name: design_level
+             //         value: "top"
+             //       }
+             //     ]
+             //},
              {    name: csrng
                   fusesoc_core: lowrisc:ip:csrng
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
@@ -141,17 +141,17 @@
                     }
                   ]
              },
-             {    name: pinmux
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_pinmux
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  rel_path: "hw/top_darjeeling/ip_autogen/pinmux/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
-             },
+             //{    name: pinmux
+             //     fusesoc_core: lowrisc:opentitan:top_darjeeling_pinmux
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     rel_path: "hw/top_darjeeling/ip_autogen/pinmux/lint/{tool}"
+             //     overrides: [
+             //       {
+             //         name: design_level
+             //         value: "top"
+             //       }
+             //     ]
+             //},
              {    name: pwm
                   fusesoc_core: lowrisc:ip:pwm
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
@@ -205,11 +205,11 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/soc_dbg_ctrl/lint/{tool}"
              },
-             {    name: soc_dbg_ctrl_decode
-                  fusesoc_core: lowrisc:ip:soc_dbg_ctrl_decode
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/socdbg_ctrl/lint/{tool}"
-             },
+             //{    name: soc_dbg_ctrl_decode
+             //     fusesoc_core: lowrisc:ip:soc_dbg_ctrl_decode
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     rel_path: "hw/ip/socdbg_ctrl/lint/{tool}"
+             //},
              {    name: top_darjeeling_rv_plic
                   fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
@@ -220,11 +220,11 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path:  "hw/ip/rv_timer/lint/{tool}"
              },
-             {    name: soc_proxy
-                  fusesoc_core: lowrisc:systems:soc_proxy
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  rel_path: "hw/top_darjeeling/ip/soc_proxy/lint/{tool}"
-             },
+             //{    name: soc_proxy
+             //     fusesoc_core: lowrisc:systems:soc_proxy
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     rel_path: "hw/top_darjeeling/ip/soc_proxy/lint/{tool}"
+             //},
              {    name: spi_device
                   fusesoc_core: lowrisc:ip:spi_device
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
@@ -266,16 +266,16 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/tlul/adapter_reg/lint/{tool}"
              },
-             {    name: adapter_dmi
-                  fusesoc_core: lowrisc:tlul:adapter_dmi
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/adapter_dmi/lint/{tool}"
-             },
-             {    name: jtag_dtm
-                  fusesoc_core: lowrisc:tlul:jtag_dtm
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/jtag_dtm/lint/{tool}"
-             },
+             //{    name: adapter_dmi
+             //     fusesoc_core: lowrisc:tlul:adapter_dmi
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     rel_path: "hw/ip/tlul/adapter_dmi/lint/{tool}"
+             //},
+             //{    name: jtag_dtm
+             //     fusesoc_core: lowrisc:tlul:jtag_dtm
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     rel_path: "hw/ip/tlul/jtag_dtm/lint/{tool}"
+             //},
              {    name: adapter_sram
                   fusesoc_core: lowrisc:tlul:adapter_sram
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
@@ -297,17 +297,17 @@
                     }
                   ]
              },
-             {    name: chip_darjeeling_asic
-                  fusesoc_core: lowrisc:systems:chip_darjeeling_asic
-                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-                  rel_path: "hw/top_darjeeling/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
-             },
+             //{    name: chip_darjeeling_asic
+             //     fusesoc_core: lowrisc:systems:chip_darjeeling_asic
+             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+             //     rel_path: "hw/top_darjeeling/lint/{tool}"
+             //     overrides: [
+             //       {
+             //         name: design_level
+             //         value: "top"
+             //       }
+             //     ]
+             //},
             ]
 
 }


### PR DESCRIPTION
This temporarily excludes the few blocks that have currently known lint problems from the overall Darjeeling configuration, so that we can activate the overall Darjeeling lint CI check.  The excluded blocks will be fixed and re-enabled in lint shortly (#26245)