### PR TITLE
[hmac,dv] Adjust stress_all parameters

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -7,11 +7,18 @@
 class hmac_stress_all_vseq extends hmac_base_vseq;
   `uvm_object_utils(hmac_stress_all_vseq)
 
+  // Constraints
+  extern constraint num_trans_c;
+
   // Standard SV/UVM methods
   extern function new(string name="");
   extern task body();
 endclass : hmac_stress_all_vseq
 
+
+constraint hmac_stress_all_vseq::num_trans_c {
+  num_trans inside {[1:10]};
+}
 
 function hmac_stress_all_vseq::new(string name="");
   super.new(name);

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -146,7 +146,7 @@
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all_with_rand_reset
-      reseed: 10
+      reseed: 25
     }
 
     {


### PR DESCRIPTION
- Increase number of seeds for stress_all_with_rand_reset tests as it was reduced by this PR #23664, but now we are targeting V3.
- Reduce transactions range for stress_all tests to reduce regression duration.