### PR TITLE
[sw,multitop] port rv_timer_smoketest to dt & add missing dt clocks

### DIFF
--- a/hw/top_darjeeling/BUILD
+++ b/hw/top_darjeeling/BUILD
@@ -28,6 +28,7 @@ sim_dv(
     libs = [
         "//sw/device/lib/arch:boot_stage_rom_ext",
         "//sw/device/lib/arch:sim_dv",
+        "//hw/top_darjeeling/sw/dt:sim_dv",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rom_scramble_config = "//hw/top_darjeeling/data/autogen:top_darjeeling.gen.hjson",

--- a/hw/top_darjeeling/sw/BUILD
+++ b/hw/top_darjeeling/sw/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_darjeeling/sw/dt/BUILD
+++ b/hw/top_darjeeling/sw/dt/BUILD
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
+
+package(default_visibility = ["//visibility:public"])
+
+TARGETS = [
+    "sim_dv",
+]
+
+[
+    cc_library(
+        name = target,
+        srcs = [
+            "{}.c".format(target),
+        ],
+        deps = [
+            "//hw/top:dt_api",
+            "//sw/device/lib/base:macros",
+        ],
+    )
+    for target in TARGETS
+]

--- a/hw/top_darjeeling/sw/dt/sim_dv.c
+++ b/hw/top_darjeeling/sw/dt/sim_dv.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dt/dt_api.h"  // Generated
+
+static const uint32_t clock_freqs[kDtClockCount] = {
+    [kDtClockMain] = 1 * 1000 * 1000 * 1000,
+    [kDtClockIo] = 1 * 1000 * 1000 * 1000,
+    [kDtClockUsb] = 1 * 1000 * 1000 * 1000,
+    [kDtClockAon] = 625 * 100 * 1000,
+    [kDtClockIoDiv2] = 500 * 1000 * 1000,
+    [kDtClockIoDiv4] = 250 * 1000 * 1000,
+};
+
+uint32_t dt_clock_frequency(dt_clock_t clk) {
+  if (clk < kDtClockCount) {
+    return clock_freqs[clk];
+  }
+  return 0;
+}

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -106,6 +106,7 @@ sim_qemu(
     libs = [
         "//sw/device/lib/arch:boot_stage_rom_ext",
         "//sw/device/lib/arch:sim_qemu",
+        "//hw/top_earlgrey/sw/dt:sim_qemu",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/top_earlgrey/data/otp:img_rma",
@@ -131,6 +132,7 @@ fpga_cw310(
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw310",
+        "//hw/top_earlgrey/sw/dt:fpga_cw310",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = "//sw/device/silicon_owner:manifest",
@@ -184,6 +186,7 @@ fpga_cw310(
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw310",
+        "//hw/top_earlgrey/sw/dt:fpga_cw310",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = "//sw/device/silicon_owner:manifest",
@@ -230,6 +233,7 @@ fpga_cw310(
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw310",
+        "//hw/top_earlgrey/sw/dt:fpga_cw310",
     ],
     otp = "//hw/top_earlgrey/data/otp/sival_skus:otp_img_prod_manuf_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
@@ -337,6 +341,7 @@ fpga_cw340(
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw340",
+        "//hw/top_earlgrey/sw/dt:fpga_cw340",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = "//sw/device/silicon_owner:manifest",
@@ -383,6 +388,7 @@ fpga_cw340(
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw340",
+        "//hw/top_earlgrey/sw/dt:fpga_cw340",
     ],
     otp = "//hw/top_earlgrey/data/otp/sival_skus:otp_img_prod_manuf_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
@@ -444,6 +450,7 @@ silicon(
     libs = [
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:silicon",
+        "//hw/top_earlgrey/sw/dt:silicon",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = "//sw/device/silicon_owner:manifest",
@@ -542,7 +549,7 @@ sim_dv(
     libs = [
         "//sw/device/lib/arch:boot_stage_rom_ext",
         "//sw/device/lib/arch:sim_dv",
-        "//hw/top_earlgrey/sw/dt:sim_verilator",
+        "//hw/top_earlgrey/sw/dt:sim_dv",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/top_earlgrey/data/otp:img_rma",

--- a/hw/top_earlgrey/sw/dt/BUILD
+++ b/hw/top_earlgrey/sw/dt/BUILD
@@ -10,6 +10,7 @@ TARGETS = [
     "fpga_cw310",
     "fpga_cw340",
     "sim_dv",
+    "sim_qemu",
     "sim_verilator",
     "silicon",
 ]

--- a/hw/top_earlgrey/sw/dt/sim_qemu.c
+++ b/hw/top_earlgrey/sw/dt/sim_qemu.c
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dt/dt_api.h"  // Generated
+
+static const uint32_t clock_freqs[kDtClockCount] = {
+    [kDtClockMain] = 24 * 1000 * 1000,   [kDtClockIo] = 24 * 1000 * 1000,
+    [kDtClockUsb] = 48 * 1000 * 1000,    [kDtClockAon] = 250 * 1000,
+    [kDtClockIoDiv2] = 12 * 1000 * 1000, [kDtClockIoDiv4] = 6 * 1000 * 1000,
+};
+
+uint32_t dt_clock_frequency(dt_clock_t clk) {
+  if (clk < kDtClockCount) {
+    return clock_freqs[clk];
+  }
+  return 0;
+}

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3664,10 +3664,11 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/dif:rv_timer",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:ibex",


### PR DESCRIPTION
Fix #26232

This PR ports the `rv_timer_smoketest` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey on FPGA (`fpga_cw310_rom_with_fake_keys`), and will compile for Darjeeling via
```sh
bazel build //sw/device/tests:rv_timer_smoketest_sim_dv --//hw/top=darjeeling
```

See the commit message for more details. Includes a couple of commits (slightly modified) from #26158 to get better support for clock speeds in multitop tests.