### PR TITLE
[rtl,clkmgr] Fix missing jitter regwen

### DIFF
--- a/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
@@ -422,6 +422,7 @@
       ''',
       swaccess: "rw",
       hwaccess: "hro",
+      regwen: "JITTER_REGWEN"
       fields: [
         {
           mubi: true,

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -299,6 +299,32 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  function control_meas_saturation_assert(clk_mesr_e clk, bit enable);
+    case (clk)
+      ClkMesrIo: begin
+        if (enable) $asserton(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv2: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv4: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrMain: begin
+        if (enable) $asserton(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrUsb: begin
+        if (enable) $asserton(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+      end
+      default: `uvm_error(`gfn, $sformatf("unexpected clock index '%0d'", clk))
+    endcase
+  endfunction
+
   local function void control_sync_pulse_assert(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIo: begin

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -80,7 +80,10 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   local task maybe_saturate_count(bit saturate, clk_mesr_e clk_tested);
     forever begin
       @cfg.aon_clk_rst_vif.cbn;
-      if (saturate) cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      if (saturate) begin
+        control_meas_saturation_assert(clk_tested, 0);
+        cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      end
     end
   endtask
 
@@ -190,6 +193,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
             wait_before_read_recov_err_code(expect_alert);
           join_any
           disable fork;
+          control_meas_saturation_assert(clk_tested, 1);
         end
       join
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr.hjson
@@ -418,6 +418,7 @@
       ''',
       swaccess: "rw",
       hwaccess: "hro",
+      regwen: "JITTER_REGWEN"
       fields: [
         {
           mubi: true,

--- a/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
@@ -154,6 +154,7 @@ Enable jittery clock
 - Offset: `0x14`
 - Reset default: `0x9`
 - Reset mask: `0xf`
+- Register enable: [`JITTER_REGWEN`](#jitter_regwen)
 
 ### Fields
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -299,6 +299,32 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  function control_meas_saturation_assert(clk_mesr_e clk, bit enable);
+    case (clk)
+      ClkMesrIo: begin
+        if (enable) $asserton(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv2: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv4: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrMain: begin
+        if (enable) $asserton(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrUsb: begin
+        if (enable) $asserton(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+      end
+      default: `uvm_error(`gfn, $sformatf("unexpected clock index '%0d'", clk))
+    endcase
+  endfunction
+
   local function void control_sync_pulse_assert(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIo: begin

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -80,7 +80,10 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   local task maybe_saturate_count(bit saturate, clk_mesr_e clk_tested);
     forever begin
       @cfg.aon_clk_rst_vif.cbn;
-      if (saturate) cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      if (saturate) begin
+        control_meas_saturation_assert(clk_tested, 0);
+        cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      end
     end
   endtask
 
@@ -190,6 +193,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
             wait_before_read_recov_err_code(expect_alert);
           join_any
           disable fork;
+          control_meas_saturation_assert(clk_tested, 1);
         end
       join
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -655,6 +655,9 @@ module clkmgr_reg_top (
 
 
   // R[jitter_enable]: V(False)
+  // Create REGWEN-gated WE signal
+  logic jitter_enable_gated_we;
+  assign jitter_enable_gated_we = jitter_enable_we & jitter_regwen_qs;
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -665,7 +668,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (jitter_enable_we),
+    .we     (jitter_enable_gated_we),
     .wd     (jitter_enable_wd),
 
     // from internal hardware
@@ -1891,7 +1894,7 @@ module clkmgr_reg_top (
     reg_we_check[2] = extclk_ctrl_gated_we;
     reg_we_check[3] = 1'b0;
     reg_we_check[4] = jitter_regwen_we;
-    reg_we_check[5] = jitter_enable_we;
+    reg_we_check[5] = jitter_enable_gated_we;
     reg_we_check[6] = clk_enables_we;
     reg_we_check[7] = clk_hints_we;
     reg_we_check[8] = 1'b0;

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -187,8 +187,10 @@
             jitter_o clkmgr output to toggle. Verify this output is connected to AST's
             clk_src_sys_jen_i input using formal.
 
+            If jitter_regwen is enabled check that jitter_enable can be toggled.
+            If jitter_regwen is disabled check that jitter_enable cannot be changed.
             X-ref with various specific jitter enable tests.
-            SiVal: This is a connectivity test only, not suitable for sival.
+            SiVal: CPU must be enabled, but no other OTP or lifecycle dependencies.
             '''
       stage: V2
       si_stage: SV3
@@ -210,7 +212,19 @@
       name: chip_sw_clkmgr_jitter_cycle_measurements
       desc: '''Verify jitter via clock cycle measurements after calibration.
             The clock count thresholds for main clk need to be set wider than when jitter is disabled.
-            SiVal: This is only useful on real silicon.
+
+            Check when jitter is enabled:
+            - using jitter thresholds no errors are detected
+            - using normal thresholds results in recoverable errors
+            - don't test normal thresholds for FPGAs since they don't support jitter and no errors will occur
+            Check when jitter is disabled:
+            - using either sets of thresholds result in no errors
+
+            The test flow should depend on jitter enable lock:
+            - if it is locked only tests for the given jitter configuration
+            - if it is unlocked test for both jitter enabled and disabled
+
+            SiVal: This is only useful on real silicon since FPGAs don't support jitter.
             Should be done after clock calibration.
             '''
       stage: V3

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr.hjson
@@ -427,6 +427,7 @@
       ''',
       swaccess: "rw",
       hwaccess: "hro",
+      regwen: "JITTER_REGWEN"
       fields: [
         {
           mubi: true,

--- a/hw/top_earlgrey/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/doc/registers.md
@@ -158,6 +158,7 @@ Enable jittery clock
 - Offset: `0x14`
 - Reset default: `0x9`
 - Reset mask: `0xf`
+- Register enable: [`JITTER_REGWEN`](#jitter_regwen)
 
 ### Fields
 

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -299,6 +299,32 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  function control_meas_saturation_assert(clk_mesr_e clk, bit enable);
+    case (clk)
+      ClkMesrIo: begin
+        if (enable) $asserton(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv2: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv4: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrMain: begin
+        if (enable) $asserton(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrUsb: begin
+        if (enable) $asserton(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+      end
+      default: `uvm_error(`gfn, $sformatf("unexpected clock index '%0d'", clk))
+    endcase
+  endfunction
+
   local function void control_sync_pulse_assert(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIo: begin

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -80,7 +80,10 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   local task maybe_saturate_count(bit saturate, clk_mesr_e clk_tested);
     forever begin
       @cfg.aon_clk_rst_vif.cbn;
-      if (saturate) cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      if (saturate) begin
+        control_meas_saturation_assert(clk_tested, 0);
+        cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      end
     end
   endtask
 
@@ -190,6 +193,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
             wait_before_read_recov_err_code(expect_alert);
           join_any
           disable fork;
+          control_meas_saturation_assert(clk_tested, 1);
         end
       join
 

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -863,6 +863,9 @@ module clkmgr_reg_top (
 
 
   // R[jitter_enable]: V(False)
+  // Create REGWEN-gated WE signal
+  logic jitter_enable_gated_we;
+  assign jitter_enable_gated_we = jitter_enable_we & jitter_regwen_qs;
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -873,7 +876,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (jitter_enable_we),
+    .we     (jitter_enable_gated_we),
     .wd     (jitter_enable_wd),
 
     // from internal hardware
@@ -2579,7 +2582,7 @@ module clkmgr_reg_top (
     reg_we_check[2] = extclk_ctrl_gated_we;
     reg_we_check[3] = 1'b0;
     reg_we_check[4] = jitter_regwen_we;
-    reg_we_check[5] = jitter_enable_we;
+    reg_we_check[5] = jitter_enable_gated_we;
     reg_we_check[6] = clk_enables_we;
     reg_we_check[7] = clk_hints_we;
     reg_we_check[8] = 1'b0;

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/clkmgr.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/clkmgr.hjson
@@ -415,6 +415,7 @@
       ''',
       swaccess: "rw",
       hwaccess: "hro",
+      regwen: "JITTER_REGWEN"
       fields: [
         {
           mubi: true,

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/doc/registers.md
@@ -156,6 +156,7 @@ Enable jittery clock
 - Offset: `0x14`
 - Reset default: `0x9`
 - Reset mask: `0xf`
+- Register enable: [`JITTER_REGWEN`](#jitter_regwen)
 
 ### Fields
 

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -299,6 +299,32 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  function control_meas_saturation_assert(clk_mesr_e clk, bit enable);
+    case (clk)
+      ClkMesrIo: begin
+        if (enable) $asserton(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv2: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div2_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrIoDiv4: begin
+        if (enable) $asserton(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_io_div4_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrMain: begin
+        if (enable) $asserton(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_main_meas.u_meas.MaxWidth_A");
+      end
+      ClkMesrUsb: begin
+        if (enable) $asserton(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+        else $assertoff(0, "tb.dut.u_usb_meas.u_meas.MaxWidth_A");
+      end
+      default: `uvm_error(`gfn, $sformatf("unexpected clock index '%0d'", clk))
+    endcase
+  endfunction
+
   local function void control_sync_pulse_assert(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIo: begin

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -80,7 +80,10 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   local task maybe_saturate_count(bit saturate, clk_mesr_e clk_tested);
     forever begin
       @cfg.aon_clk_rst_vif.cbn;
-      if (saturate) cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      if (saturate) begin
+        control_meas_saturation_assert(clk_tested, 0);
+        cfg.clkmgr_vif.force_high_starting_count(clk_mesr_e'(clk_tested));
+      end
     end
   endtask
 
@@ -190,6 +193,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
             wait_before_read_recov_err_code(expect_alert);
           join_any
           disable fork;
+          control_meas_saturation_assert(clk_tested, 1);
         end
       join
 

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -751,6 +751,9 @@ module clkmgr_reg_top (
 
 
   // R[jitter_enable]: V(False)
+  // Create REGWEN-gated WE signal
+  logic jitter_enable_gated_we;
+  assign jitter_enable_gated_we = jitter_enable_we & jitter_regwen_qs;
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -761,7 +764,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (jitter_enable_we),
+    .we     (jitter_enable_gated_we),
     .wd     (jitter_enable_wd),
 
     // from internal hardware
@@ -2071,7 +2074,7 @@ module clkmgr_reg_top (
     reg_we_check[2] = extclk_ctrl_gated_we;
     reg_we_check[3] = 1'b0;
     reg_we_check[4] = jitter_regwen_we;
-    reg_we_check[5] = jitter_enable_we;
+    reg_we_check[5] = jitter_enable_gated_we;
     reg_we_check[6] = clk_enables_we;
     reg_we_check[7] = clk_hints_we;
     reg_we_check[8] = 1'b0;

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -42,6 +42,35 @@ static bool clkmgr_measure_ctrl_regwen(const dif_clkmgr_t *clkmgr) {
                              CLKMGR_MEASURE_CTRL_REGWEN_EN_BIT);
 }
 
+/**
+ * Checks if the jitter enable register is locked.
+ *
+ * The jitter enable register is locked by CLKMGR_JITTER_REGWEN.
+ */
+OT_WARN_UNUSED_RESULT
+static bool jitter_enable_register_is_locked(const dif_clkmgr_t *clkmgr) {
+  // Jitter enable register is locked when `CLKMGR_JITTER_REGWEN_EN_BIT` bit
+  // is 0.
+  return !bitfield_bit32_read(
+      mmio_region_read32(clkmgr->base_addr, CLKMGR_JITTER_REGWEN_REG_OFFSET),
+      CLKMGR_JITTER_REGWEN_EN_BIT);
+}
+
+/**
+ * Checks if the external clock control register is locked.
+ *
+ * The external clock control register is locked by CLKMGR_EXTCLK_CTRL_REGWEN.
+ */
+OT_WARN_UNUSED_RESULT
+static bool extclk_control_register_is_locked(const dif_clkmgr_t *clkmgr) {
+  // External clock control register is locked when
+  // `CLKMGR_EXTCLK_CTRL_REGWEN_EN_BIT` bit is 0.
+  return !bitfield_bit32_read(
+      mmio_region_read32(clkmgr->base_addr,
+                         CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET),
+      CLKMGR_EXTCLK_CTRL_REGWEN_EN_BIT);
+}
+
 dif_result_t dif_clkmgr_external_clock_is_settled(const dif_clkmgr_t *clkmgr,
                                                   bool *status) {
   if (clkmgr == NULL || status == NULL) {
@@ -56,6 +85,25 @@ dif_result_t dif_clkmgr_external_clock_is_settled(const dif_clkmgr_t *clkmgr,
   return kDifOk;
 }
 
+dif_result_t dif_clkmgr_jitter_enable_is_locked(const dif_clkmgr_t *clkmgr,
+                                                bool *is_locked) {
+  if (clkmgr == NULL || is_locked == NULL) {
+    return kDifBadArg;
+  }
+
+  *is_locked = jitter_enable_register_is_locked(clkmgr);
+
+  return kDifOk;
+}
+
+dif_result_t dif_clkmgr_lock_jitter_enable(const dif_clkmgr_t *clkmgr) {
+  if (clkmgr == NULL) {
+    return kDifBadArg;
+  }
+  mmio_region_write32(clkmgr->base_addr, CLKMGR_JITTER_REGWEN_REG_OFFSET, 0);
+  return kDifOk;
+}
+
 dif_result_t dif_clkmgr_jitter_get_enabled(const dif_clkmgr_t *clkmgr,
                                            dif_toggle_t *state) {
   if (clkmgr == NULL || state == NULL) {
@@ -66,7 +114,8 @@ dif_result_t dif_clkmgr_jitter_get_enabled(const dif_clkmgr_t *clkmgr,
       mmio_region_read32(clkmgr->base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET);
   // The documentation states that kMultiBitBool4False disables the jittery
   // clock and all other values enable the jittery clock.
-  *state = clk_jitter_val != kMultiBitBool4False;
+  *state = clk_jitter_val != kMultiBitBool4False ? kDifToggleEnabled
+                                                 : kDifToggleDisabled;
 
   return kDifOk;
 }
@@ -76,6 +125,9 @@ dif_result_t dif_clkmgr_jitter_set_enabled(const dif_clkmgr_t *clkmgr,
   multi_bit_bool_t new_jitter_enable_val;
   if (clkmgr == NULL) {
     return kDifBadArg;
+  }
+  if (jitter_enable_register_is_locked(clkmgr)) {
+    return kDifLocked;
   }
 
   switch (new_state) {
@@ -172,12 +224,37 @@ dif_result_t dif_clkmgr_hintable_clock_get_hint(
   return kDifOk;
 }
 
+dif_result_t dif_clkmgr_external_clock_control_is_locked(
+    const dif_clkmgr_t *clkmgr, bool *is_locked) {
+  if (clkmgr == NULL || is_locked == NULL) {
+    return kDifBadArg;
+  }
+
+  *is_locked = extclk_control_register_is_locked(clkmgr);
+
+  return kDifOk;
+}
+
+dif_result_t dif_clkmgr_lock_external_clock_control(
+    const dif_clkmgr_t *clkmgr) {
+  if (clkmgr == NULL) {
+    return kDifBadArg;
+  }
+  mmio_region_write32(clkmgr->base_addr, CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET,
+                      0);
+  return kDifOk;
+}
+
 dif_result_t dif_clkmgr_external_clock_set_enabled(const dif_clkmgr_t *clkmgr,
                                                    bool is_low_speed) {
   uint32_t extclk_ctrl_reg = 0;
 
   if (clkmgr == NULL) {
     return kDifBadArg;
+  }
+
+  if (extclk_control_register_is_locked(clkmgr)) {
+    return kDifLocked;
   }
 
   extclk_ctrl_reg = bitfield_field32_write(
@@ -196,6 +273,10 @@ dif_result_t dif_clkmgr_external_clock_set_disabled(
 
   if (clkmgr == NULL) {
     return kDifBadArg;
+  }
+
+  if (extclk_control_register_is_locked(clkmgr)) {
+    return kDifLocked;
   }
 
   extclk_ctrl_reg = bitfield_field32_write(

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -140,6 +140,24 @@ typedef enum dif_clkmgr_fatal_err_type {
 typedef uint32_t dif_clkmgr_fatal_err_codes_t;
 
 /**
+ * Check if jitter enable is locked.
+ * @param clkmgr Clock Manager Handle.
+ * @param[out] is_locked whether jitter is locked or not.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_jitter_enable_is_locked(const dif_clkmgr_t *clkmgr,
+                                                bool *is_locked);
+
+/**
+ * Lock jitter enable.
+ * @param clkmgr Clock Manager Handle.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_lock_jitter_enable(const dif_clkmgr_t *clkmgr);
+
+/**
  * Check if jitter is Enabled.
  * @param clkmgr Clock Manager Handle.
  * @param[out] is_enabled whether jitter is enabled or not.
@@ -246,6 +264,24 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_hintable_clock_get_hint(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_hintable_clock_t clock,
     dif_toggle_t *state);
+
+/**
+ * Check if external clock control is locked.
+ * @param clkmgr Clock Manager Handle.
+ * @param[out] is_locked whether external clock control is locked or not.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_external_clock_control_is_locked(
+    const dif_clkmgr_t *clkmgr, bool *is_locked);
+
+/**
+ * Lock external clock control.
+ * @param clkmgr Clock Manager Handle.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_lock_external_clock_control(const dif_clkmgr_t *clkmgr);
 
 /**
  * Enable chip to use the external clock.

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -27,23 +27,70 @@ class ClkMgrTest : public Test, public MmioTest {
   dif_clkmgr_t clkmgr_ = {.base_addr = dev().region()};
 };
 
+class JitterRegwenTest : public ClkMgrTest {};
+
+TEST_F(JitterRegwenTest, GetLocked) {
+  // Get regwen locked
+  {
+    bool locked = false;
+    EXPECT_READ32(CLKMGR_JITTER_REGWEN_REG_OFFSET, 0);
+    EXPECT_DIF_OK(dif_clkmgr_jitter_enable_is_locked(&clkmgr_, &locked));
+    EXPECT_EQ(locked, true);
+  }
+  // Get regwen unlocked
+  {
+    bool locked = true;
+    EXPECT_READ32(CLKMGR_JITTER_REGWEN_REG_OFFSET, 1);
+    EXPECT_DIF_OK(dif_clkmgr_jitter_enable_is_locked(&clkmgr_, &locked));
+    EXPECT_EQ(locked, false);
+  }
+}
+
+TEST_F(JitterRegwenTest, GetLockedError) {
+  bool locked;
+  EXPECT_DIF_BADARG(dif_clkmgr_jitter_enable_is_locked(nullptr, nullptr));
+  EXPECT_DIF_BADARG(dif_clkmgr_jitter_enable_is_locked(nullptr, &locked));
+  EXPECT_DIF_BADARG(dif_clkmgr_jitter_enable_is_locked(&clkmgr_, nullptr));
+}
+
+TEST_F(JitterRegwenTest, SetLocked) {
+  EXPECT_WRITE32(CLKMGR_JITTER_REGWEN_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_clkmgr_lock_jitter_enable(&clkmgr_));
+  // There is no support for unlock in the hardware.
+}
+
+TEST_F(JitterRegwenTest, SetLockedError) {
+  EXPECT_DIF_BADARG(dif_clkmgr_lock_jitter_enable(nullptr));
+}
+
 class JitterEnableTest : public ClkMgrTest {};
 
 // SetEnabled uses EXPECT_WRITE32 instead of EXPECT_MASK32 because
 // dif_clkmgr_jitter_set_enabled doesn't perform a read, just a write.
 TEST_F(JitterEnableTest, SetEnabled) {
-  // Disable jitter.
-  EXPECT_WRITE32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4False);
-  EXPECT_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleDisabled));
-
-  // Enable jitter.
-  EXPECT_WRITE32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4True);
-  EXPECT_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleEnabled));
+  // Disable jitter with jitter unlocked.
+  {
+    EXPECT_READ32(CLKMGR_JITTER_REGWEN_REG_OFFSET, 1);
+    EXPECT_WRITE32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4False);
+    EXPECT_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleDisabled));
+  }
+  // Enable jitter with jitter unlocked.
+  {
+    EXPECT_READ32(CLKMGR_JITTER_REGWEN_REG_OFFSET, 1);
+    EXPECT_WRITE32(CLKMGR_JITTER_ENABLE_REG_OFFSET, kMultiBitBool4True);
+    EXPECT_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleEnabled));
+  }
 }
 
 TEST_F(JitterEnableTest, SetEnabledError) {
   // Null handle.
   EXPECT_DIF_BADARG(dif_clkmgr_jitter_set_enabled(nullptr, kDifToggleEnabled));
+}
+
+TEST_F(JitterEnableTest, SetEnabledLocked) {
+  // Lock the register via regwen, and check no change occurs.
+  EXPECT_READ32(CLKMGR_JITTER_REGWEN_REG_OFFSET, 0);
+  EXPECT_DIF_LOCKED(dif_clkmgr_jitter_set_enabled(&clkmgr_, kDifToggleEnabled));
 }
 
 TEST_F(JitterEnableTest, GetEnabled) {
@@ -256,6 +303,47 @@ TEST_F(HintableClockTest, GetEnabledError) {
       &clkmgr_, CLKMGR_PARAM_NUM_HINTABLE_CLOCKS, &state));
 }
 
+class ExternalClkRegwenTest : public ClkMgrTest {};
+
+TEST_F(ExternalClkRegwenTest, GetLocked) {
+  // Get regwen locked
+  {
+    bool locked = false;
+    EXPECT_READ32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 0);
+    EXPECT_DIF_OK(
+        dif_clkmgr_external_clock_control_is_locked(&clkmgr_, &locked));
+    EXPECT_EQ(locked, true);
+  }
+  // Get regwen unlocked
+  {
+    bool locked = true;
+    EXPECT_READ32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 1);
+    EXPECT_DIF_OK(
+        dif_clkmgr_external_clock_control_is_locked(&clkmgr_, &locked));
+    EXPECT_EQ(locked, false);
+  }
+}
+
+TEST_F(ExternalClkRegwenTest, GetLockedError) {
+  bool locked;
+  EXPECT_DIF_BADARG(
+      dif_clkmgr_external_clock_control_is_locked(nullptr, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_clkmgr_external_clock_control_is_locked(nullptr, &locked));
+  EXPECT_DIF_BADARG(
+      dif_clkmgr_external_clock_control_is_locked(&clkmgr_, nullptr));
+}
+
+TEST_F(ExternalClkRegwenTest, SetLocked) {
+  EXPECT_WRITE32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_clkmgr_lock_external_clock_control(&clkmgr_));
+  // There is no support for unlock in the hardware.
+}
+
+TEST_F(ExternalClkRegwenTest, SetLockedError) {
+  EXPECT_DIF_BADARG(dif_clkmgr_lock_external_clock_control(nullptr));
+}
+
 class ExternalClkTest : public ClkMgrTest {};
 
 TEST_F(ExternalClkTest, EnableError) {
@@ -277,12 +365,14 @@ TEST_F(ExternalClkTest, Enable) {
        .offset = CLKMGR_EXTCLK_CTRL_HI_SPEED_SEL_OFFSET,               \
        .value = low_speed_ ? kMultiBitBool4False : kMultiBitBool4True, \
    }}
-  {  // low speed
+  {  // low speed with control unlocked
+    EXPECT_READ32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 1);
     EXPECT_WRITE32(CLKMGR_EXTCLK_CTRL_REG_OFFSET,
                    EXTCLK_CTRL_REG_VALUE(true, true));
     EXPECT_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr_, true));
   }
-  {  // high speed
+  {  // high speed with control unlocked
+    EXPECT_READ32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 1);
     EXPECT_WRITE32(CLKMGR_EXTCLK_CTRL_REG_OFFSET,
                    EXTCLK_CTRL_REG_VALUE(true, false));
     EXPECT_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr_, false));
@@ -290,6 +380,8 @@ TEST_F(ExternalClkTest, Enable) {
 }
 
 TEST_F(ExternalClkTest, Disable) {
+  // disable with control unlocked
+  EXPECT_READ32(CLKMGR_EXTCLK_CTRL_REGWEN_REG_OFFSET, 1);
   EXPECT_WRITE32(CLKMGR_EXTCLK_CTRL_REG_OFFSET,
                  EXTCLK_CTRL_REG_VALUE(false, false));
   EXPECT_DIF_OK(dif_clkmgr_external_clock_set_disabled(&clkmgr_));

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -221,6 +221,7 @@ status_t clkmgr_testutils_disable_clock_counts(const dif_clkmgr_t *clkmgr) {
     dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
     TRY(dif_clkmgr_disable_measure_counts(clkmgr, clock));
   }
+  LOG_INFO("Disabling all clock count done");
   return OK_STATUS();
 }
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -850,6 +850,7 @@ opentitan_test(
     verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:clkmgr",

--- a/sw/device/tests/clkmgr_jitter_frequency_test.c
+++ b/sw/device/tests/clkmgr_jitter_frequency_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_sensor_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
@@ -28,6 +29,19 @@ OTTF_DEFINE_TEST_CONFIG();
  * - for simulation it requires overriding the hardware behavior via plusargs
  *   so it runs with calibrated USB clock, or the USB clock frequency will be
  *   incorrect.
+ *
+ * When jitter is enabled it checks that using jitter thresholds the checks
+ * pass, and with normal thresholds we encounter recoverable errors.
+ *
+ * When jitter is disabled it checks that neither sets of thresholds cause
+ * errors.
+ *
+ * The test flow depends on jitter enable lock:
+ * - if it is locked this only tests for the given jitter configuration.
+ * - if it is unlocked this tests for both jitter enabled and disabled.
+ *
+ * FPGA emulation platforms don't support jittery clocks so some of the
+ * checks are bypassed for them.
  */
 enum {
   kMeasurementsPerRound = 100,
@@ -35,6 +49,54 @@ enum {
 
 static dif_clkmgr_t clkmgr;
 static dif_pwrmgr_t pwrmgr;
+
+// Test with thresholds for jitter enabled expecting no failures, and then
+// with thresholds for jitter disabled expecting failures.
+static void test_clock_frequencies_with_jitter_enabled(uint32_t delay_micros) {
+  LOG_INFO("Testing frequencies with jitter enabled");
+  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+      &clkmgr, /*jitter_enabled=*/true, /*external_clk=*/false,
+      /*low_speed=*/false));
+  busy_spin_micros(delay_micros);
+  // This checks there are no errors.
+  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
+  CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
+  if (kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSilicon) {
+    // Set thresholds for jitter disabled expecting failures.
+    CHECK_STATUS_OK(
+        clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+            &clkmgr, /*jitter_enabled=*/false, /*external_clk=*/false,
+            /*low_speed=*/false));
+    busy_spin_micros(delay_micros);
+    dif_clkmgr_recov_err_codes_t err_codes;
+    CHECK_DIF_OK(dif_clkmgr_recov_err_code_get_codes(&clkmgr, &err_codes));
+    CHECK(err_codes != 0);
+    // Clear errors.
+    CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
+    CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(&clkmgr, err_codes));
+  } else {
+    LOG_INFO("Testing with jitter enabled but no-jitter thresholds %s",
+             "is not viable for FPGAs");
+  }
+}
+
+static void test_clock_frequencies_with_jitter_disabled(uint32_t delay_micros) {
+  LOG_INFO("Testing frequencies with jitter disabled");
+  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+      &clkmgr, /*jitter_enabled=*/false, /*external_clk=*/false,
+      /*low_speed=*/false));
+  busy_spin_micros(delay_micros);
+  // This checks there are no errors.
+  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
+  CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
+  // Set thresholds for jitter disabled expecting no ailures.
+  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
+      &clkmgr, /*jitter_enabled=*/true, /*external_clk=*/false,
+      /*low_speed=*/false));
+  busy_spin_micros(delay_micros);
+  LOG_INFO("Checking measurement counts");
+  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
+}
 
 bool test_main(void) {
   dif_sensor_ctrl_t sensor_ctrl;
@@ -57,14 +119,21 @@ bool test_main(void) {
 
   CHECK(UNWRAP(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) == true);
 
-  CHECK_STATUS_OK(clkmgr_testutils_enable_clock_counts_with_expected_thresholds(
-      &clkmgr, /*jitter_enabled=*/true, /*external_clk=*/false,
-      /*low_speed=*/false));
-  busy_spin_micros(delay_micros);
-
-  // check results
-  CHECK_STATUS_OK(clkmgr_testutils_check_measurement_counts(&clkmgr));
-  CHECK_STATUS_OK(clkmgr_testutils_disable_clock_counts(&clkmgr));
-
+  bool jitter_locked;
+  CHECK_DIF_OK(dif_clkmgr_jitter_enable_is_locked(&clkmgr, &jitter_locked));
+  if (jitter_locked) {
+    dif_toggle_t jitter_status;
+    CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(&clkmgr, &jitter_status));
+    if (jitter_status == kDifToggleEnabled) {
+      test_clock_frequencies_with_jitter_enabled(delay_micros);
+    } else {
+      test_clock_frequencies_with_jitter_disabled(delay_micros);
+    }
+  } else {
+    CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
+    test_clock_frequencies_with_jitter_enabled(delay_micros);
+    CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleDisabled));
+    test_clock_frequencies_with_jitter_disabled(delay_micros);
+  }
   return true;
 }

--- a/sw/device/tests/clkmgr_jitter_test.c
+++ b/sw/device/tests/clkmgr_jitter_test.c
@@ -8,27 +8,59 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
+#include "clkmgr_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
+
+void test_jitter_locked(const dif_clkmgr_t *clkmgr,
+                        dif_toggle_t initial_state) {
+  // Lock jitter enable.
+  CHECK_DIF_OK(dif_clkmgr_lock_jitter_enable(clkmgr));
+  // To make sure the write is performed the dif function must be bypassed
+  // since it blocks the write if regwen is off.
+  dif_toggle_t opposite_state = initial_state == kDifToggleEnabled
+                                    ? kDifToggleDisabled
+                                    : kDifToggleEnabled;
+  multi_bit_bool_t opposite_mubi_state = opposite_state == kDifToggleEnabled
+                                             ? kMultiBitBool4True
+                                             : kMultiBitBool4False;
+  mmio_region_write32(clkmgr->base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET,
+                      opposite_mubi_state);
+
+  dif_toggle_t actual_state = opposite_state;
+  CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(clkmgr, &actual_state));
+  CHECK(actual_state == initial_state);
+}
 
 bool test_main(void) {
   dif_clkmgr_t clkmgr;
   CHECK_DIF_OK(dif_clkmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
   // Get the initial jitter state. It might be enabled or disabled depending
   // on reset behavior - either is fine for the purposes of this test.
   dif_toggle_t state;
   CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(&clkmgr, &state));
 
-  // Toggle the enable twice so that it ends up in its original state.
-  for (int j = 0; j < 2; ++j) {
-    dif_toggle_t expected_state =
-        state == kDifToggleEnabled ? kDifToggleDisabled : kDifToggleEnabled;
-    dif_toggle_t actual_state = state;
-    CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, expected_state));
-    CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(&clkmgr, &actual_state));
-    CHECK(actual_state == expected_state);
+  bool locked;
+  CHECK_DIF_OK(dif_clkmgr_jitter_enable_is_locked(&clkmgr, &locked));
+
+  // If it is unlocked check the state can be modified.
+  if (!locked) {
+    // Toggle the enable twice so that it ends up in its original state.
+    for (int j = 0; j < 2; ++j) {
+      dif_toggle_t expected_state =
+          state == kDifToggleEnabled ? kDifToggleDisabled : kDifToggleEnabled;
+      dif_toggle_t actual_state = state;
+      CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, expected_state));
+      CHECK_DIF_OK(dif_clkmgr_jitter_get_enabled(&clkmgr, &actual_state));
+      CHECK(actual_state == expected_state);
+      state = actual_state;
+    }
   }
+  // Check jitter_regwen disabled, so jitter_enable is locked. Do it at the end
+  // since jitter_regwen will remain locked until reset.
+  test_jitter_locked(&clkmgr, state);
   return true;
 }


### PR DESCRIPTION
This has two commits:
- Fix the clkmgr hjson file to connect jitter_regwen to jitter_enable
- Enhance unit an top level tests for this feature
  - Add dif support for this as required
  - Fix clkmgr_frequency block level test to disable an assertion that is intentionally violated
 
Fixes #26258