### PR TITLE
[sw] Simplify lifecycle checks in immutable rom ext

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.c
@@ -44,8 +44,6 @@ static const epmp_region_t kImmTextRegion = {
 };
 
 rom_error_t imm_rom_ext_epmp_reconfigure(void) {
-  lifecycle_state_t lc_state = lifecycle_state_get();
-
   // ePMP region 15 gives read/write access to RAM.
   // Leave it unchanged.
 
@@ -59,7 +57,7 @@ rom_error_t imm_rom_ext_epmp_reconfigure(void) {
 
   // ePMP region 12 allows RvDM access.
   // This RvDM region was in ePMP region 13.
-  if (lc_state == kLcStateProd || lc_state == kLcStateProdEnd) {
+  if (lifecycle_is_prod() == kHardenedBoolTrue) {
     // No RvDM access in Prod states, so we can clear the entry.
     epmp_clear(12);
   } else {

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -417,6 +417,7 @@ cc_test(
         dual_cc_device_library_of(":lifecycle"),
         "//hw/top:lc_ctrl_c_regs",
         "//hw/top:top_lib",
+        "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -65,6 +65,24 @@ lifecycle_state_t lifecycle_state_get(void) {
   }
 }
 
+hardened_bool_t lifecycle_is_prod(void) {
+  uint32_t raw_state = lifecycle_raw_state_get();
+
+  if (launder32(raw_state) == LC_CTRL_LC_STATE_STATE_VALUE_PROD) {
+    HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_PROD);
+    return kHardenedBoolTrue;
+  }
+  HARDENED_CHECK_NE(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_PROD);
+
+  if (launder32(raw_state) == LC_CTRL_LC_STATE_STATE_VALUE_PROD_END) {
+    HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_PROD_END);
+    return kHardenedBoolTrue;
+  }
+  HARDENED_CHECK_NE(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_PROD_END);
+
+  return kHardenedBoolFalse;
+}
+
 uint32_t lifecycle_raw_state_get(void) {
   uint32_t value = bitfield_field32_read(
       sec_mmio_read32(lc_ctrl_base() + LC_CTRL_LC_STATE_REG_OFFSET),

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -94,6 +94,16 @@ OT_WARN_UNUSED_RESULT
 lifecycle_state_t lifecycle_state_get(void);
 
 /**
+ * Check if the device is in prod state.
+ *
+ * Warning: This function also returns false when LCS is invalid.
+ *
+ * @return `kHardenedBoolTrue` if the device is in prod state.
+ */
+OT_WARN_UNUSED_RESULT
+hardened_bool_t lifecycle_is_prod(void);
+
+/**
  * Get the unprocessed life cycle state value read from the hardware.
  *
  * This function directly returns the `uint32_t` value read from the hardware.

--- a/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
@@ -7,6 +7,7 @@
 #include <array>
 
 #include "gtest/gtest.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
@@ -80,6 +81,10 @@ struct ValidStateTestCase {
    * Value returned by software.
    */
   lifecycle_state_t sw_state;
+  /**
+   * Whether the state is prod / prod_end.
+   */
+  hardened_bool_t is_prod;
 };
 
 class LifecycleValidStates
@@ -91,54 +96,71 @@ TEST_P(LifecycleValidStates, ValidState) {
   EXPECT_EQ(lifecycle_state_get(), GetParam().sw_state);
 }
 
+TEST_P(LifecycleValidStates, LifecycleIsProd) {
+  EXPECT_SEC_READ32(base_ + LC_CTRL_LC_STATE_REG_OFFSET, GetParam().hw_state);
+  EXPECT_EQ(lifecycle_is_prod(), GetParam().is_prod);
+}
+
 constexpr std::array<ValidStateTestCase, 12> kValidStateTestCases{{
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED4,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED5,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED6,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED7,
         .sw_state = kLcStateTest,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_DEV,
         .sw_state = kLcStateDev,
+        .is_prod = kHardenedBoolFalse,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_PROD,
         .sw_state = kLcStateProd,
+        .is_prod = kHardenedBoolTrue,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_PROD_END,
         .sw_state = kLcStateProdEnd,
+        .is_prod = kHardenedBoolTrue,
     },
     {
         .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_RMA,
         .sw_state = kLcStateRma,
+        .is_prod = kHardenedBoolFalse,
     },
 }};
 


### PR DESCRIPTION
The commit simplifies the existing check in immutable ROM_EXT, which determines whether to enable the RvDM ePMP region based on the lifecycle state (prod / non-prod). The simplified check only tests for PROD and PROD-END states to reduce space cost by eliminating TEST-UNLOCK states checks.

One potential downside is that invalid LCS states will be treated as non-prod, leading to the RvDM region being enabled. However, this is mitigated by the fact that debugging requires JTAG, which verifies LCS in hardware. Additionally, invalid LCS will be detected later in the mutable ROM_EXT stage when reading the lifecycle.