### PR TITLE
[sw] Port rom_ctrl_integrity_check_test to devicetables

### DIFF
--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -474,9 +474,12 @@ opentitan_test(
 opentitan_test(
     name = "rom_ctrl_integrity_check_test",
     srcs = ["rom_ctrl_integrity_check_test.c"],
-    exec_env = {"//hw/top_earlgrey:sim_dv": None},
+    exec_env = {
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_darjeeling:sim_dv": None,
+    },
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",

--- a/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
+++ b/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_lc_ctrl.h"   // Generated
+#include "dt/dt_rom_ctrl.h"  // Generated
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
@@ -11,10 +13,13 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 static dif_lc_ctrl_t lc;
+static dt_lc_ctrl_t kLcCtrlDt = (dt_lc_ctrl_t)0;
+static_assert(kDtLcCtrlCount >= 1, "This test needs a lifecycle controller");
 static dif_rom_ctrl_t rom_ctrl;
+static dt_rom_ctrl_t kRomCtrlDt = (dt_rom_ctrl_t)0;
+static_assert(kDtRomCtrlCount >= 1,
+              "This test requires at least one rom_ctrl instance");
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -27,12 +32,8 @@ OTTF_DEFINE_TEST_CONFIG();
 // not expect a successful boot with the failed integrity check.
 
 bool test_main(void) {
-  mmio_region_t lc_reg =
-      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_REGS_BASE_ADDR);
-  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
-  mmio_region_t rom_ctrl_reg =
-      mmio_region_from_addr(TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR);
-  CHECK_DIF_OK(dif_rom_ctrl_init(rom_ctrl_reg, &rom_ctrl));
+  CHECK_DIF_OK(dif_lc_ctrl_init_from_dt(kLcCtrlDt, &lc));
+  CHECK_DIF_OK(dif_rom_ctrl_init_from_dt(kRomCtrlDt, &rom_ctrl));
 
   // Check that the LC_STATE is not PROD as the boot is not
   // expected to be successful in that state.


### PR DESCRIPTION
Fix #26224

This PR ports the `rom_ctrl_integrity_check_test` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey in the `sim_dv` environment, and will compile for Darjeeling via
```sh
bazel build //sw/device/tests/sim_dv:rom_ctrl_integrity_check_test_sim_dv --//hw/top=darjeeling
```

As with `kmac_app_rom_test`, because Darjeeling has two ROM partitions, it isn't entirely clear to me whether this test will actually be functional when ported to Darjeeling, or whether it will need some extra handling conditional on Darjeeling; for now, this PR aims to complete the work to port this test to devicetables and get it compiling independent of the Earlgrey top at least. Perhaps this test should check *all* available ROMs instead of just the first one?