### PR TITLE
[sw,dif] Port rstmgr_cpu_info_test to DT & update pwrmgr/rstmgr difs for DJ

### DIFF
--- a/hw/top/defs.bzl
+++ b/hw/top/defs.bzl
@@ -66,7 +66,7 @@ def opentitan_select_top(values, default):
       name = "my_alias",
       actual = opentitan_select_top({
         "earlgrey": "//something:earlgrey",
-        ["english_breakfast", "darjeeling"]: "//something:else",
+        ("englishbreakfast", "darjeeling"): "//something:else",
       }, "//something:error")
     )
     """

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -66,6 +66,7 @@ static const bitfield_field32_t kDomainConfigBitfield = {
  * Relevant bits of the WAKEUP_EN and WAKE_INFO registers must start at `0` and
  * be in the same order as `dif_pwrmgr_wakeup_request_source_t` constants.
  */
+#if defined(OPENTITAN_IS_EARLGREY)
 static_assert(kDifPwrmgrWakeupRequestSourceOne ==
                   (1u << PWRMGR_WAKEUP_EN_EN_0_BIT),
               "Layout of WAKEUP_EN register changed.");
@@ -87,6 +88,22 @@ static_assert(kDifPwrmgrWakeupRequestSourceFive ==
 static_assert(kDifPwrmgrWakeupRequestSourceSix ==
                   (1u << PWRMGR_PARAM_SENSOR_CTRL_AON_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
+#elif defined(OPENTITAN_IS_DARJEELING)
+static_assert(kDifPwrmgrWakeupRequestSourceOne ==
+                  (1u << PWRMGR_PARAM_PINMUX_AON_PIN_WKUP_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceTwo ==
+                  (1u << PWRMGR_PARAM_AON_TIMER_AON_WKUP_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceThree ==
+                  (1u << PWRMGR_PARAM_SOC_PROXY_WKUP_INTERNAL_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceFour ==
+                  (1u << PWRMGR_PARAM_SOC_PROXY_WKUP_EXTERNAL_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
+#else
+#error "dif_pwrmgr does not support this top"
+#endif
 
 /**
  * Relevant bits of the RESET_EN register must start at `0` and be in the same
@@ -135,9 +152,15 @@ static const request_reg_info_t request_reg_infos[2] = {
                     .mask = kDifPwrmgrWakeupRequestSourceOne |
                             kDifPwrmgrWakeupRequestSourceTwo |
                             kDifPwrmgrWakeupRequestSourceThree |
+#if defined(OPENTITAN_IS_EARLGREY)
                             kDifPwrmgrWakeupRequestSourceFour |
                             kDifPwrmgrWakeupRequestSourceFive |
                             kDifPwrmgrWakeupRequestSourceSix,
+#elif defined(OPENTITAN_IS_DARJEELING)
+                            kDifPwrmgrWakeupRequestSourceFour,
+#else
+#error "dif_pwrmgr does not support this top"
+#endif
                     .index = 0,
                 },
         },

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -93,8 +93,14 @@ typedef enum dif_pwrmgr_wakeup_request_source {
   kDifPwrmgrWakeupRequestSourceTwo = (1u << 1),
   kDifPwrmgrWakeupRequestSourceThree = (1u << 2),
   kDifPwrmgrWakeupRequestSourceFour = (1u << 3),
+#if defined(OPENTITAN_IS_EARLGREY)
   kDifPwrmgrWakeupRequestSourceFive = (1u << 4),
   kDifPwrmgrWakeupRequestSourceSix = (1u << 5),
+#elif defined(OPENTITAN_IS_DARJEELING)
+// Darjeeling only has four wakeup request sources
+#else
+#error "dif_pwrmgr does not support this top"
+#endif
 } dif_pwrmgr_wakeup_request_source_t;
 
 /**

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -16,7 +16,7 @@
 #include "rstmgr_regs.h"  // Generated.
 
 // These assertions are only defined for the Earl Grey chip.
-#ifdef OPENTITAN_IS_EARLGREY
+#if defined(OPENTITAN_IS_EARLGREY)
 // This macro simplifies the `static_assert` check to make sure that the
 // public reset info register bitfield matches register bits.
 #define RSTMGR_RESET_INFO_CHECK(pub_name, priv_name)         \
@@ -53,7 +53,11 @@ static_assert(
 static_assert(
     DIF_RSTMGR_ALERT_INFO_MAX_SIZE == RSTMGR_ALERT_INFO_CTRL_INDEX_MASK,
     "Alert info dump max size has grown, please update the public define!");
-#endif  // OPENTITAN_IS_EARLGREY
+#elif defined(OPENTITAN_IS_DARJEELING)
+// TODO: equivalent assertations are not yet defined for Darjeeling
+#else
+#error "dif_rstmgr does not support this top"
+#endif
 
 /**
  * Checks whether alert_info capture is disabled.

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -83,6 +83,7 @@ typedef enum dif_rstmgr_reset_info {
    * escalation, watchdog or anything else.
    */
   kDifRstmgrResetInfoHwReq = (0x1f << 3),
+#if defined(OPENTITAN_IS_EARLGREY)
   /**
    * Device has reset due to the peripheral system reset control request.
    */
@@ -91,6 +92,18 @@ typedef enum dif_rstmgr_reset_info {
    * Device has reset due to watchdog bite.
    */
   kDifRstmgrResetInfoWatchdog = (1 << 4),
+#elif defined(OPENTITAN_IS_DARJEELING)
+  /**
+   * Device has reset due to watchdog bite.
+   */
+  kDifRstmgrResetInfoWatchdog = (1 << 3),
+  /**
+   * Device has reset due to an external reset request via soc_proxy.
+   */
+  kDifRstmgrResetInfoExternalRst = (1 << 4),
+#else
+#error "dif_rstmgr does not support this top"
+#endif
   /**
    * Device has reset due to power unstable.
    */

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -48,7 +48,6 @@ cc_library(
     hdrs = ["aon_timer_testutils.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:math",
         "//sw/device/lib/dif:aon_timer",

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -13,8 +13,6 @@
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 #define MODULE_ID MAKE_MODULE_ID('a', 'o', 't')
 
 status_t aon_timer_testutils_get_aon_cycles_32_from_us(uint64_t microseconds,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3594,6 +3594,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     verilator = verilator_params(
@@ -3601,7 +3602,7 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",

--- a/third_party/rust/patches/rules_rust.bindgen_defines.patch
+++ b/third_party/rust/patches/rules_rust.bindgen_defines.patch
@@ -1,0 +1,50 @@
+commit 27500d1eaa0e8e0f8c53b8ff5a0b9772417cdb3b
+Author: Gary Guo <gary.guo@lowrisc.org>
+Date:   Fri Feb 14 15:18:37 2025 +0000
+
+    Propagate cc_library defines to clang
+
+diff --git a/extensions/bindgen/private/bindgen.bzl b/extensions/bindgen/private/bindgen.bzl
+index 6fa53571..1ebe104c 100644
+--- a/extensions/bindgen/private/bindgen.bzl
++++ b/extensions/bindgen/private/bindgen.bzl
+@@ -307,6 +307,10 @@ def _rust_bindgen_impl(ctx):
+             open_arg = True
+             continue
+
++    # Propagated defines should be made visible to clang
++    for define in ctx.attr.cc_lib[CcInfo].compilation_context.defines.to_list():
++        args.add("-D" + define)
++
+     _, _, linker_env = get_linker_and_args(ctx, "bin", cc_toolchain, feature_configuration, None)
+     env.update(**linker_env)
+
+diff --git a/extensions/bindgen/test/integration/simple/BUILD.bazel b/extensions/bindgen/test/integration/simple/BUILD.bazel
+index 0a1162b1..c52e8272 100644
+--- a/extensions/bindgen/test/integration/simple/BUILD.bazel
++++ b/extensions/bindgen/test/integration/simple/BUILD.bazel
+@@ -11,5 +11,6 @@ cc_library(
+     name = "simple",
+     srcs = ["simple.cc"],
+     hdrs = ["simple.h"],
++    defines = ["SIMPLE_DEFINE=1"],
+     visibility = ["//test/integration:__pkg__"],
+ )
+diff --git a/extensions/bindgen/test/integration/simple/simple.h b/extensions/bindgen/test/integration/simple/simple.h
+index a7ca3f43..d68c739a 100644
+--- a/extensions/bindgen/test/integration/simple/simple.h
++++ b/extensions/bindgen/test/integration/simple/simple.h
+@@ -9,8 +9,12 @@
+
+ #include <stdint.h>
+
++#ifdef SIMPLE_DEFINE
++
+ static const int64_t SIMPLE_VALUE = 42;
+
++#endif
++
+ EXTERN_C const int64_t simple_function();
+
+ static inline int64_t simple_static_function() { return 84; }
+

--- a/third_party/rust/rust.MODULE.bazel
+++ b/third_party/rust/rust.MODULE.bazel
@@ -21,6 +21,7 @@ single_version_override(
     module_name = "rules_rust_bindgen",
     patches = [
         "//third_party/rust/patches:rules_rust.bindgen_static_lib.patch",
+        "//third_party/rust/patches:rules_rust.bindgen_defines.patch",
     ],
     patch_strip = 3,
     version = "0.56.0",


### PR DESCRIPTION
Fix #26226

This PR ports the `rstmgr_cpu_info_test` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey on FPGA (in `fpga_cw310_rom_with_fake_keys`) and will compile for Darjeeling via
```sh
bazel build --build_tests_only //sw/device/tests:rstmgr_cpu_info_test_sim_dv --//hw/top=darjeeling
```

As part of porting this test, the pwrmgr and rstmgr difs have been updated to support both Earglrey and Darjeeling's IP. This caused issues in bindgen when opentitanlib was compiled due an issue with upstream rules_rust where `rust_bindgen_library` does not understand defines set on `cc_libraries`. This is patched until support is merged [upstream](https://github.com/bazelbuild/rules_rust/pull/3271). It also fixes the documentation of an unrelated Bazel function which I encountered issues with whilst debugging the aforementioned bindgen issue, though now unrelated to this PR.