### PR TITLE
[tools,tlgen] Allow multiple address ranges in tlgen templates

### DIFF
--- a/util/tlgen/xbar.pkg.sv.tpl
+++ b/util/tlgen/xbar.pkg.sv.tpl
@@ -24,12 +24,11 @@ package tl_${xbar.name}_pkg;
   lname = uname.ljust(name_len)
 %>\
     ## Address
-    % if device.xbar == False:
+    % if len(device.addr_ranges[asid]) == 1 and not device.xbar:
   ## TODO: Add support for xbars with multiple ASIDs.
   ## localparam logic [31:0] ADDR_SPACE_${aname}__${lname} = 32'h ${"%08x" % device.addr_ranges[asid][0][0]};
   localparam logic [31:0] ADDR_SPACE_${lname} = 32'h ${"%08x" % device.addr_ranges[asid][0][0]};
     % else:
-    ## Xbar device
   ## TODO: Add support for xbars with multiple ASIDs.
   ## localparam logic [${len(device.addr_ranges[asid])-1}:0][31:0] ADDR_SPACE_${aname}__${lname} = {
   localparam logic [${len(device.addr_ranges[asid])-1}:0][31:0] ADDR_SPACE_${lname} = {
@@ -48,10 +47,9 @@ package tl_${xbar.name}_pkg;
   asid = list(device.addr_spaces)[0]
 %>\
   ## Mask
-  % if device.xbar == False:
+  % if len(device.addr_ranges[asid]) == 1 and not device.xbar:
   localparam logic [31:0] ADDR_MASK_${lname} = 32'h ${"%08x" % (device.addr_ranges[asid][0][1] - device.addr_ranges[asid][0][0])};
   % else:
-  ## Xbar
   localparam logic [${len(device.addr_ranges[asid])-1}:0][31:0] ADDR_MASK_${lname} = {
     % for addr in list(reversed(device.addr_ranges[asid])):
     32'h ${"%08x" % (addr[1] - addr[0])}${"," if not loop.last else ""}

--- a/util/tlgen/xbar.rtl.sv.tpl
+++ b/util/tlgen/xbar.rtl.sv.tpl
@@ -191,7 +191,7 @@ ${"end" if loop.last else ""}
 %>\
     ${prefix}
     % for i in range(num_range):
-      % if lib.is_pow2(leaf.addr_ranges[asid][i][1]-leaf.addr_ranges[asid][0][0]+1):
+      % if lib.is_pow2(leaf.addr_ranges[asid][i][1]-leaf.addr_ranges[asid][i][0]+1):
       ((${addr_sig} & ~(${name_mask}[${i}])) == ${name_space}[${i}])${" ||" if not loop.last else ""}
       % else:
       ((${addr_sig} <= (${name_mask}[${i}] + ${name_space}[${i}])) &&


### PR DESCRIPTION
This PR
* fixes a typo/copy-paste error in xbar.rtl.sv.tpl
* and allows for multiple addr_ranges for all devices.

The latter is a new feature that allows e.g., to map parts of the address space of one subsystem into another subsystem's address space.
E.g., if one subsystem has a large range with a hole in the middle, it may be split into two ranges and something else can be mapped into that hole.