### PR TITLE
[hmac,dv] Add assertions excl back from PR #26163

### DIFF
--- a/hw/ip/hmac/dv/cov/hmac_cov_excl.el
+++ b/hw/ip/hmac/dv/cov/hmac_cov_excl.el
@@ -15,3 +15,17 @@ ANNOTATION: "shaf_rready_i == 1'b0 cannot occur in the StLenHi and StLenLo state
 Branch 8 "3400827115" "st_q" (17) "st_q StLenHi ,-,-,-,-,-,-,-,-,-,-,0,-"
 ANNOTATION: "shaf_rready_i == 1'b0 cannot occur in the StLenHi and StLenLo states thus the missing else is unavoidable."
 Branch 8 "3400827115" "st_q" (19) "st_q StLenLo ,-,-,-,-,-,-,-,-,-,-,-,0"
+CHECKSUM: "1785966602"
+INSTANCE: tb.dut.u_tlul_adapter.u_rspfifo
+ANNOTATION: "[INVALID] Disable this assertion as the FIFO is WO"
+Assert DataKnown_A "assertion"
+CHECKSUM: "1785966602"
+INSTANCE: tb.dut.u_tlul_adapter.u_sramreqfifo
+ANNOTATION: "[INVALID] Disable this assertion as the FIFO is WO"
+Assert DataKnown_A "assertion"
+CHECKSUM: "3919502532"
+INSTANCE: tb.dut.u_tlul_adapter
+ANNOTATION: "[INVALID] Disable this assertion as the FIFO is WO"
+Assert rvalidHighReqFifoEmpty "assertion"
+ANNOTATION: "[INVALID] Disable this assertion as the FIFO is WO"
+Assert rvalidHighWhenRspFifoFull "assertion"


### PR DESCRIPTION
- the PR #26163 was adding 4 assertions to the exclusion list which have been removed by the PR #25696. This commit adds them back.