### PR TITLE
[multitop, tests] port lc_ctrl_scrap_test & csrng_kat_test to darjeeling

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1172,6 +1172,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     silicon = silicon_params(

--- a/sw/device/tests/csrng_kat_test.c
+++ b/sw/device/tests/csrng_kat_test.c
@@ -11,8 +11,6 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 status_t test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
@@ -25,8 +23,9 @@ status_t test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
 
 bool test_main(void) {
   dif_csrng_t csrng;
-  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR);
-  CHECK_DIF_OK(dif_csrng_init(base_addr, &csrng));
+  dt_csrng_t kCsrngDt = (dt_csrng_t)0;
+  static_assert(kDtCsrngCount == 1, "This test expects exactly one CSRNG");
+  CHECK_DIF_OK(dif_csrng_init_from_dt(kCsrngDt, &csrng));
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 
   CHECK_STATUS_OK(test_ctr_drbg_ctr0(&csrng));

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -165,12 +165,13 @@ opentitan_test(
 opentitan_test(
     name = "lc_ctrl_scrap_test",
     srcs = ["lc_ctrl_scrap_test.c"],
-    exec_env = {"//hw/top_earlgrey:sim_dv": None},
+    exec_env = {
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_darjeeling:sim_dv": None,
+    },
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:memory",
-        "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:lc_ctrl_testutils",

--- a/sw/device/tests/sim_dv/lc_ctrl_scrap_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_scrap_test.c
@@ -7,14 +7,11 @@
 
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static dif_lc_ctrl_t lc;
 
@@ -41,9 +38,10 @@ bool execute_lc_ctrl_scrap_test(bool use_ext_clk) {
   if (kPerformTransitionBySW) {
     LOG_INFO("Start LC_CTRL scrap test");
 
-    mmio_region_t lc_reg =
-        mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_REGS_BASE_ADDR);
-    CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+    dt_lc_ctrl_t kLcCtrlDt = (dt_lc_ctrl_t)0;
+    static_assert(kDtLcCtrlCount == 1,
+                  "This test expects exactly one LC controller");
+    CHECK_DIF_OK(dif_lc_ctrl_init_from_dt(kLcCtrlDt, &lc));
 
     // Acquire the mutex and perform a transition to SCRAP
     CHECK_DIF_OK(dif_lc_ctrl_mutex_try_acquire(&lc));


### PR DESCRIPTION
Fix #26214
Fix #26221

These 2 tests are pretty simple to port.

I check for exact 1 instance instead of at least 1 since they should all be singleton IPs.