### PR TITLE
[ipgen] Blockfile changes for ipgen blocks

### DIFF
--- a/BLOCKFILE
+++ b/BLOCKFILE
@@ -67,7 +67,7 @@ hw/ip/tlul/rtl/*
 hw/ip/uart/rtl/*
 hw/ip/usbdev/rtl/*
 
-# Individual HJSON files that effect RTL generation (no wildcard as it's
+# Individual HJSON files that affect RTL generation (no wildcard as it's
 # too broad and will also block DV-only files)
 hw/ip/lc_ctrl/data/lc_ctrl.hjson
 hw/ip/rv_timer/data/rv_timer.hjson
@@ -108,10 +108,25 @@ hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
 hw/ip/pwm/data/pwm.hjson
 hw/ip/aon_timer/data/aon_timer.hjson
 
+# ipgen RTL for existing designs; project the auto-generated RTL for the
+# specific top level(s), but permit changes in 'hw/ip_templates' if they impact
+# only targets that are under active development
+hw/top_earlgrey/ip/ast/rtl/*
+hw/top_earlgrey/ip_autogen/alert_handler/rtl/*
+hw/top_earlgrey/ip_autogen/clkmgr/rtl/*
+hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/*
+hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/*
+hw/top_earlgrey/ip_autogen/pinmux/rtl/*
+hw/top_earlgrey/ip_autogen/pwrmgr/rtl/*
+hw/top_earlgrey/ip_autogen/rstmgr/rtl/*
+hw/top_earlgrey/ip_autogen/rv_plic/rtl/*
+
+# HJSON files for ipgen blocks
 hw/top_earlgrey/ip/ast/data/ast.hjson
 hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
 hw/top_earlgrey/ip_autogen/clkmgr/data/clkmgr.hjson
 hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
+hw/top_earlgrey/ip_autogen/otp_ctrl/data/otp_ctrl.hjson
 hw/top_earlgrey/ip_autogen/pinmux/data/pinmux.hjson
 hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
 hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr.hjson


### PR DESCRIPTION
Protect established top-level targets against the impact of changes to the ipgen blocks in hw/ip_templates.

Protecting the files in the ip_autogen directory rather than the source files permits active development upon those components, provided that the changes impact only targets that are undergoing active development.