### PR TITLE
[topgen] No inplace edits, it's not indepodent for multiple passes

### DIFF
--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -1046,11 +1046,12 @@ def amend_interrupt(top: OrderedDict,
     for irqs in top['incoming_interrupt'].values():
         for irq in irqs:
             # Qualify name with module name
-            irq["name"] = f"{irq['module_name']}_{irq['name']}"
-            irq["desc"] = f"{irq['module_name']} {irq['name']} incoming interrupt"
-            irq["incoming"] = True
-            irq["width"] = 1
-            interrupts.append(irq)
+            qual_irq = deepcopy(irq)
+            qual_irq["name"] = f"{irq['module_name']}_{irq['name']}"
+            qual_irq["desc"] = f"{irq['module_name']} {irq['name']} incoming interrupt"
+            qual_irq["incoming"] = True
+            qual_irq["width"] = 1
+            interrupts.append(qual_irq)
 
     top["interrupt"] = interrupts
 


### PR DESCRIPTION
The interrupt name for incoming IRQs would grow for multiple invocations due to in-place edits. `add_module_prefix_to_signal` for the normal interrupts does a `deepcopy` internally.