### PR TITLE
[multitop, tests] port rv_core_ibex_rnd_test to darjeeling

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5268,13 +5268,11 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
-        "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:edn",
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",

--- a/sw/device/tests/rv_core_ibex_rnd_test.S
+++ b/sw/device/tests/rv_core_ibex_rnd_test.S
@@ -12,7 +12,6 @@
  * extent by using the assembly versions.
  */
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
 #include "rv_core_ibex_regs.h"
 
 /**
@@ -23,7 +22,7 @@
   .globl rv_core_ibex_rnd_read_and_immediately_check_status
   .type rv_core_ibex_rnd_read_and_immediately_check_status, @function
 rv_core_ibex_rnd_read_and_immediately_check_status:
-  li t0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR // Load ibex base address
+  mv t0, a0 // Load ibex base address
   lw t1, RV_CORE_IBEX_RND_DATA_REG_OFFSET(t0) // Read RND data
   lw a0, RV_CORE_IBEX_RND_STATUS_REG_OFFSET(t0) // Get RND status
   ret // Return status
@@ -41,7 +40,7 @@ rv_core_ibex_rnd_read_and_immediately_check_status:
   .globl rv_core_ibex_check_rnd_read_possible_while_status_invalid
   .type rv_core_ibex_check_rnd_read_possible_while_status_invalid, @function
 rv_core_ibex_check_rnd_read_possible_while_status_invalid:
-  li t0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR // Load ibex base address
+  mv t0, a0 // Load ibex base address
   lw t1, RV_CORE_IBEX_RND_DATA_REG_OFFSET(t0) // Read RND to invalidate status
   lw t2, RV_CORE_IBEX_RND_STATUS_REG_OFFSET(t0) // Get RND status
   lw t3, RV_CORE_IBEX_RND_DATA_REG_OFFSET(t0) // Read RND data

--- a/sw/device/tests/rv_core_ibex_rnd_test.c
+++ b/sw/device/tests/rv_core_ibex_rnd_test.c
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/lib/base/mmio.h"
-#include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
@@ -13,15 +11,16 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
 
 // Initialize OTTF.
 OTTF_DEFINE_TEST_CONFIG();
 
 // Declare two assembly functions defined in `rv_core_ibex_rnd_test.S`.
-extern uint32_t rv_core_ibex_rnd_read_and_immediately_check_status(void);
-extern uint32_t rv_core_ibex_check_rnd_read_possible_while_status_invalid(void);
+extern uint32_t rv_core_ibex_rnd_read_and_immediately_check_status(
+    volatile void *);
+extern uint32_t rv_core_ibex_check_rnd_read_possible_while_status_invalid(
+    volatile void *);
 
 enum {
   kRandomDataReads = 32,
@@ -46,9 +45,10 @@ bool test_main(void) {
 
   // Initialize Ibex.
   dif_rv_core_ibex_t rv_core_ibex;
-  CHECK_DIF_OK(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  dt_rv_core_ibex_t kRvCoreIbexDt = (dt_rv_core_ibex_t)0;
+  static_assert(kDtRvCoreIbexCount == 1,
+                "This test expects exactly one Ibex core");
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kRvCoreIbexDt, &rv_core_ibex));
 
   uint32_t data_reads_count = kRandomDataReads;
   if (kDeviceType == kDeviceSilicon) {
@@ -71,7 +71,8 @@ bool test_main(void) {
   // read. Make multiple attempts in a loop to avoid icache effects.
   bool quick_reads_success = true;
   for (int i = 0; i < kInvalidReadAttempts; ++i) {
-    quick_reads_success &= rv_core_ibex_rnd_read_and_immediately_check_status();
+    quick_reads_success &= rv_core_ibex_rnd_read_and_immediately_check_status(
+        rv_core_ibex.base_addr.base);
   }
   CHECK(!quick_reads_success);
 
@@ -87,7 +88,8 @@ bool test_main(void) {
                 kTimeoutUsec);
   uint32_t status_value = UINT32_MAX;
   for (int i = 0; i < kInvalidReadAttempts; ++i) {
-    status_value &= rv_core_ibex_check_rnd_read_possible_while_status_invalid();
+    status_value &= rv_core_ibex_check_rnd_read_possible_while_status_invalid(
+        rv_core_ibex.base_addr.base);
   }
   CHECK(status_value == 0);
 


### PR DESCRIPTION
The assembly use of EARLGREY constants are removed, and it is changed to accept an argument instead, which can be passed from C code.

Fix #26231 