### PR TITLE
[sw,multitop] Port `rstmgr_sw_req_test` to devicetables

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3620,6 +3620,7 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     qemu = qemu_params(
@@ -3629,8 +3630,7 @@ opentitan_test(
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:mmio",
+        "//hw/top:dt",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:rstmgr_testutils",

--- a/sw/device/tests/rstmgr_sw_req_test.c
+++ b/sw/device/tests/rstmgr_sw_req_test.c
@@ -2,22 +2,21 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/base/mmio.h"
+#include "dt/dt_rstmgr.h"  // Generated
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 static dif_rstmgr_t rstmgr;
+static dt_rstmgr_t kRstmgrDt = (dt_rstmgr_t)0;
+static_assert(kDtRstmgrCount == 1, "This test requires 1 rstmgr");
 
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
 
   dif_rstmgr_reset_info_bitfield_t reason;
   reason = rstmgr_testutils_reason_get();


### PR DESCRIPTION
Fix #26227

This PR ports the `rstmgr_sw_req_test` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey in an FPGA (`cw310_rom_with_fake_keys`) environment, and will compile for Darjeeling via
```sh
bazel build --build_tests_only //sw/device/tests:rstmgr_sw_req_test_sim_dv --//hw/top=darjeeling
```

Note: for this test to function as intended on Darjeeling, it likely requires the Darjeeling rstmgr dif changes from #26270 to be merged (specifically 9b1416a62b3e80a75ad3358893991770d45ed124).