### PR TITLE
[hw,rom_ctrl,rtl] Remove stable assert on rom_cfg_i

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -567,5 +567,4 @@ module rom_ctrl
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ReqFifoRptrCheck_A,
       u_tl_adapter_rom.u_reqfifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
       alert_tx_o[AlertFatal])
-  `ASSERT(CfgStable_A, $stable(rom_cfg_i))
 endmodule


### PR DESCRIPTION
This assertion is makeing an assumption on an integrator specific signal. Placing this assertion in the technology agnostic rom_ctrl is not the right place. If needed, this assertion can be put in the technology specific prim_rom.