### PR TITLE
[rom,e2e] disable ROM self hash test

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -7,12 +7,13 @@ load(
     "STD_OTP_OVERLAYS",
     "otp_image",
 )
-load(
-    "//rules/opentitan:defs.bzl",
-    "dv_params",
-    "fpga_params",
-    "opentitan_test",
-)
+# Uncomment when self hash test is re-enabled below.
+# load(
+#     "//rules/opentitan:defs.bzl",
+#     "dv_params",
+#     "fpga_params",
+#     "opentitan_test",
+# )
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,31 +27,31 @@ otp_image(
 )
 
 # The self hash test is disabled except when we're releasing a new ROM.
-opentitan_test(
-    name = "rom_e2e_self_hash_test",
-    srcs = ["rom_e2e_self_hash_test.c"],
-    dv = dv_params(
-        rom = "//sw/device/silicon_creator/rom:mask_rom",
-    ),
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:silicon_creator": None,  # This is added to support GLS and bringup environments.
-    },
-    fpga = fpga_params(
-        otp = ":otp_img_sigverify_spx_prod",
-    ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib:chip_info",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-    ],
-)
+# opentitan_test(
+#     name = "rom_e2e_self_hash_test",
+#     srcs = ["rom_e2e_self_hash_test.c"],
+#     dv = dv_params(
+#         rom = "//sw/device/silicon_creator/rom:mask_rom",
+#     ),
+#     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+#     exec_env = {
+#         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+#         "//hw/top_earlgrey:sim_dv": None,
+#         "//hw/top_earlgrey:silicon_creator": None,  # This is added to support GLS and bringup environments.
+#     },
+#     fpga = fpga_params(
+#         otp = ":otp_img_sigverify_spx_prod",
+#     ),
+#     manifest = "//sw/device/silicon_creator/rom_ext:manifest",
+#     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+#     deps = [
+#         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+#         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+#         "//sw/device/lib/base:status",
+#         "//sw/device/lib/runtime:print",
+#         "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+#         "//sw/device/lib/testing/test_framework:ottf_main",
+#         "//sw/device/silicon_creator/lib:chip_info",
+#         "//sw/device/silicon_creator/lib/drivers:hmac",
+#     ],
+# )


### PR DESCRIPTION
The test is only required for tapeout releases.