### PR TITLE
[crypto] Separate P-256 and P-384 key generation.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -334,7 +334,7 @@ All ECC operations may be run [asynchronously](#asynchronous-operations) through
 ### Supported Curves
 
 Elliptic curves of the short Weierstrass form, Montgomery form, and twisted Edward form are supported.
-- For short Weierstrass form three predefined named curves are supported (NIST P-256, NIST P-384 and brainpool 256) along with support for user-defined generic curves.
+- For short Weierstrass form, NIST P-256 and P-384 are supported.
 - For the Montgomery form, only X25519 is supported.
 - For twisted Edwards form only Ed25519 is supported.
 
@@ -367,7 +367,8 @@ The two curves are birationally equivalent, in mathematical terms, so it is poss
 
 For ECDSA, the cryptography library supports keypair generation, signing, and signature verification.
 
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_keygen }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_keygen }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_keygen }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_sign }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_verify }}
 
@@ -376,13 +377,13 @@ For ECDSA, the cryptography library supports keypair generation, signing, and si
 For ECDH (elliptic-curve Diffie-Hellman) key exchange, the cryptography library supports keypair generation and shared-key generation.
 Each party should generate a key pair, exchange public keys, and then generate the shared key using their own private key and the other party's public key.
 
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_keygen }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_p256_keygen }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_p384_keygen }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh }}
 
 #### Ed25519
 
 For Ed25519 (a curve-specialized version of EdDSA, the Edwards curve digital signature algorithm), the cryptography library supports keypair generation, signature generation, and signature verification.
-There is **no need to specify curve parameters for Ed25519**, since it operates on a specific curve already.
 
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ed25519_keygen }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ed25519_sign }}
@@ -400,8 +401,10 @@ Each party should generate a key pair, exchange public keys, and then generate t
 
 #### ECDSA
 
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_keygen_async_start }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_keygen_async_finalize }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_keygen_async_start }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_keygen_async_finalize }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_keygen_async_start }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_keygen_async_finalize }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_sign_async_start }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_sign_async_finalize }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_verify_async_start }}
@@ -409,8 +412,8 @@ Each party should generate a key pair, exchange public keys, and then generate t
 
 #### ECDH
 
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_keygen_async_start }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_keygen_async_finalize }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_p256_keygen_async_start }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_p384_keygen_async_finalize }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_async_start }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdh_async_finalize }}
 

--- a/sw/device/lib/crypto/impl/ecc.c
+++ b/sw/device/lib/crypto/impl/ecc.c
@@ -15,12 +15,16 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('e', 'c', 'c')
 
-otcrypto_status_t otcrypto_ecdsa_keygen(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  HARDENED_TRY(otcrypto_ecdsa_keygen_async_start(elliptic_curve, private_key));
-  return otcrypto_ecdsa_keygen_async_finalize(elliptic_curve, private_key,
-                                              public_key);
+  HARDENED_TRY(otcrypto_ecdsa_p256_keygen_async_start(private_key));
+  return otcrypto_ecdsa_p256_keygen_async_finalize(private_key, public_key);
+}
+
+otcrypto_status_t otcrypto_ecdsa_p384_keygen(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+  HARDENED_TRY(otcrypto_ecdsa_p384_keygen_async_start(private_key));
+  return otcrypto_ecdsa_p384_keygen_async_finalize(private_key, public_key);
 }
 
 otcrypto_status_t otcrypto_ecdsa_sign(
@@ -45,12 +49,16 @@ otcrypto_status_t otcrypto_ecdsa_verify(
                                               verification_result);
 }
 
-otcrypto_status_t otcrypto_ecdh_keygen(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdh_p256_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  HARDENED_TRY(otcrypto_ecdh_keygen_async_start(elliptic_curve, private_key));
-  return otcrypto_ecdh_keygen_async_finalize(elliptic_curve, private_key,
-                                             public_key);
+  HARDENED_TRY(otcrypto_ecdh_p256_keygen_async_start(private_key));
+  return otcrypto_ecdh_p256_keygen_async_finalize(private_key, public_key);
+}
+
+otcrypto_status_t otcrypto_ecdh_p384_keygen(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+  HARDENED_TRY(otcrypto_ecdh_p384_keygen_async_start(private_key));
+  return otcrypto_ecdh_p384_keygen_async_finalize(private_key, public_key);
 }
 
 otcrypto_status_t otcrypto_ecdh(const otcrypto_blinded_key_t *private_key,
@@ -114,67 +122,90 @@ static status_t sideload_key_seed(const otcrypto_blinded_key_t *private_key) {
   return keymgr_generate_key_otbn(diversification);
 }
 
-otcrypto_status_t otcrypto_ecdsa_keygen_async_start(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+/**
+ * Calls P-256 key generation.
+ *
+ * Can be used for both ECDSA and ECDH. If the key is hardware-backed, loads
+ * the data from key manager and calls the sideloaded key generation routine.
+ *
+ * @param private_key Sideloaded key handle.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t internal_p256_keygen_start(
     const otcrypto_blinded_key_t *private_key) {
-  if (elliptic_curve == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
+  // Check that the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+    HARDENED_TRY(sideload_key_seed(private_key));
+    return p256_sideload_keygen_start();
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+    return p256_keygen_start();
+  } else {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
+    const otcrypto_blinded_key_t *private_key) {
+  if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   // Check the key mode.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsa) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsa);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
 
+  return internal_p256_keygen_start(private_key);
+}
+
+/**
+ * Calls P-384 key generation.
+ *
+ * Can be used for both ECDSA and ECDH. If the key is hardware-backed, loads
+ * the data from key manager and calls the sideloaded key generation routine.
+ *
+ * @param private_key Sideloaded key handle.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+static status_t internal_p384_keygen_start(
+    const otcrypto_blinded_key_t *private_key) {
   // Check that the entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
-  // Select the correct keygen operation and start it.
-  switch (launder32(elliptic_curve->curve_type)) {
-    case kOtcryptoEccCurveTypeNistP256:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP256);
-      if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
-        HARDENED_TRY(sideload_key_seed(private_key));
-        return p256_sideload_keygen_start();
-      } else if (launder32(private_key->config.hw_backed) ==
-                 kHardenedBoolFalse) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
-        return p256_keygen_start();
-      } else {
-        return OTCRYPTO_BAD_ARGS;
-      }
-      return OTCRYPTO_OK;
-    case kOtcryptoEccCurveTypeNistP384:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP384);
-      if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
-        HARDENED_TRY(sideload_key_seed(private_key));
-        return p384_sideload_keygen_start();
-      } else if (launder32(private_key->config.hw_backed) ==
-                 kHardenedBoolFalse) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
-        return p384_keygen_start();
-      } else {
-        return OTCRYPTO_BAD_ARGS;
-      }
-      return OTCRYPTO_OK;
-    case kEccCurveTypeBrainpoolP256R1:
-      OT_FALLTHROUGH_INTENDED;
-    case kOtcryptoEccCurveTypeCustom:
-      // TODO: Implement support for other curves.
-      return OTCRYPTO_NOT_IMPLEMENTED;
-    default:
-      return OTCRYPTO_BAD_ARGS;
+  if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
+    HARDENED_TRY(sideload_key_seed(private_key));
+    return p384_sideload_keygen_start();
+  } else if (launder32(private_key->config.hw_backed) == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+    return p384_keygen_start();
+  } else {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
+    const otcrypto_blinded_key_t *private_key) {
+  if (private_key == NULL || private_key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
   }
 
-  // Should never get here.
-  HARDENED_TRAP();
-  return OTCRYPTO_FATAL_ERR;
+  // Check the key mode.
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
+
+  return internal_p384_keygen_start(private_key);
 }
 
 /**
@@ -328,8 +359,8 @@ static status_t p384_public_key_length_check(
  *
  * This function assumes that space is already allocated for all key material
  * and that the length parameters on the structs are set accordingly, in the
- * same way as for `otcrypto_ecdh_keygen_async_finalize` and
- * `otcrypto_ecdsa_keygen_async_finalize`.
+ * same way as for `otcrypto_ecdh_p256_keygen_async_finalize` and
+ * `otcrypto_ecdsa_p256_keygen_async_finalize`.
  *
  * @param[out] private_key Private key to populate.
  * @param[out] public_key Public key to populate.
@@ -372,8 +403,8 @@ static status_t internal_p256_keygen_finalize(
  *
  * This function assumes that space is already allocated for all key material
  * and that the length parameters on the structs are set accordingly, in the
- * same way as for `otcrypto_ecdh_keygen_async_finalize` and
- * `otcrypto_ecdsa_keygen_async_finalize`.
+ * same way as for `otcrypto_ecdh_p384_keygen_async_finalize` and
+ * `otcrypto_ecdsa_p384_keygen_async_finalize`.
  *
  * @param[out] private_key Private key to populate.
  * @param[out] public_key Public key to populate.
@@ -413,43 +444,42 @@ static status_t internal_p384_keygen_finalize(
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t otcrypto_ecdsa_keygen_async_finalize(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   // Check for any NULL pointers.
-  if (elliptic_curve == NULL || private_key == NULL || public_key == NULL ||
+  if (private_key == NULL || public_key == NULL ||
       private_key->keyblob == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   // Check the key modes.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsa ||
-      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsa) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP256 ||
+      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsa);
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsa);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP256);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP256);
 
-  // Select the correct keygen operation and finalize it.
-  switch (launder32(elliptic_curve->curve_type)) {
-    case kOtcryptoEccCurveTypeNistP256:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP256);
-      HARDENED_TRY(internal_p256_keygen_finalize(private_key, public_key));
-      break;
-    case kOtcryptoEccCurveTypeNistP384:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP384);
-      HARDENED_TRY(internal_p384_keygen_finalize(private_key, public_key));
-      break;
-    case kEccCurveTypeBrainpoolP256R1:
-      OT_FALLTHROUGH_INTENDED;
-    case kOtcryptoEccCurveTypeCustom:
-      // TODO: Implement support for other curves.
-      return OTCRYPTO_NOT_IMPLEMENTED;
-    default:
-      return OTCRYPTO_BAD_ARGS;
+  return internal_p256_keygen_finalize(private_key, public_key);
+}
+
+otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+  // Check for any NULL pointers.
+  if (private_key == NULL || public_key == NULL ||
+      private_key->keyblob == NULL || public_key->key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
   }
+
+  // Check the key modes.
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsaP384 ||
+      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP384) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsaP384);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP384);
+
+  HARDENED_TRY(internal_p384_keygen_finalize(private_key, public_key));
 
   // Clear the OTBN sideload slot (in case the seed was sideloaded).
   return keymgr_sideload_clear_otbn();
@@ -544,12 +574,6 @@ otcrypto_status_t otcrypto_ecdsa_sign_async_start(
   HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
                     kHardenedBoolTrue);
 
-  // Check the private key mode.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdsa) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdsa);
-
   // Check that the entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
@@ -558,11 +582,23 @@ otcrypto_status_t otcrypto_ecdsa_sign_async_start(
     case kOtcryptoEccCurveTypeNistP256:
       HARDENED_CHECK_EQ(elliptic_curve->curve_type,
                         kOtcryptoEccCurveTypeNistP256);
+      if (launder32(private_key->config.key_mode) !=
+          kOtcryptoKeyModeEcdsaP256) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(private_key->config.key_mode,
+                        kOtcryptoKeyModeEcdsaP256);
       HARDENED_TRY(internal_ecdsa_p256_sign_start(private_key, message_digest));
       return OTCRYPTO_OK;
     case kOtcryptoEccCurveTypeNistP384:
       HARDENED_CHECK_EQ(elliptic_curve->curve_type,
                         kOtcryptoEccCurveTypeNistP384);
+      if (launder32(private_key->config.key_mode) !=
+          kOtcryptoKeyModeEcdsaP384) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(private_key->config.key_mode,
+                        kOtcryptoKeyModeEcdsaP384);
       HARDENED_TRY(internal_ecdsa_p384_sign_start(private_key, message_digest));
       return OTCRYPTO_OK;
     case kEccCurveTypeBrainpoolP256R1:
@@ -735,12 +771,6 @@ otcrypto_status_t otcrypto_ecdsa_verify_async_start(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // Check the public key mode.
-  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsa) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsa);
-
   // Check the integrity of the public key.
   if (launder32(integrity_unblinded_key_check(public_key)) !=
       kHardenedBoolTrue) {
@@ -754,12 +784,20 @@ otcrypto_status_t otcrypto_ecdsa_verify_async_start(
     case kOtcryptoEccCurveTypeNistP256:
       HARDENED_CHECK_EQ(elliptic_curve->curve_type,
                         kOtcryptoEccCurveTypeNistP256);
+      if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP256) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP256);
       HARDENED_TRY(internal_ecdsa_p256_verify_start(public_key, message_digest,
                                                     signature));
       return OTCRYPTO_OK;
     case kOtcryptoEccCurveTypeNistP384:
       HARDENED_CHECK_EQ(elliptic_curve->curve_type,
                         kOtcryptoEccCurveTypeNistP384);
+      if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdsaP384) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdsaP384);
       HARDENED_TRY(internal_ecdsa_p384_verify_start(public_key, message_digest,
                                                     signature));
       return OTCRYPTO_OK;
@@ -815,104 +853,64 @@ otcrypto_status_t otcrypto_ecdsa_verify_async_finalize(
   return OTCRYPTO_FATAL_ERR;
 }
 
-otcrypto_status_t otcrypto_ecdh_keygen_async_start(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
     const otcrypto_blinded_key_t *private_key) {
-  if (elliptic_curve == NULL || private_key == NULL ||
-      private_key->keyblob == NULL) {
+  if (private_key == NULL || private_key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // Check the key mode.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdh) {
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdh);
-
-  // Check that the entropy complex is initialized.
-  HARDENED_TRY(entropy_complex_check());
-
-  // Select the correct keygen operation and start it.
-  switch (launder32(elliptic_curve->curve_type)) {
-    case kOtcryptoEccCurveTypeNistP256:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP256);
-      if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
-        HARDENED_TRY(sideload_key_seed(private_key));
-        return p256_sideload_keygen_start();
-      } else if (launder32(private_key->config.hw_backed) ==
-                 kHardenedBoolFalse) {
-        return p256_keygen_start();
-      }
-      return OTCRYPTO_BAD_ARGS;
-    case kOtcryptoEccCurveTypeNistP384:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP384);
-      if (launder32(private_key->config.hw_backed) == kHardenedBoolTrue) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolTrue);
-        HARDENED_TRY(sideload_key_seed(private_key));
-        return p384_sideload_keygen_start();
-      } else if (launder32(private_key->config.hw_backed) ==
-                 kHardenedBoolFalse) {
-        HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
-        return p384_keygen_start();
-      }
-      return OTCRYPTO_BAD_ARGS;
-    case kEccCurveTypeBrainpoolP256R1:
-      OT_FALLTHROUGH_INTENDED;
-    case kOtcryptoEccCurveTypeCustom:
-      // TODO: Implement support for other curves.
-      return OTCRYPTO_NOT_IMPLEMENTED;
-    default:
-      return OTCRYPTO_BAD_ARGS;
-  }
-
-  // Should never get here.
-  HARDENED_TRAP();
-  return OTCRYPTO_FATAL_ERR;
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
+  return internal_p256_keygen_start(private_key);
 }
 
-otcrypto_status_t otcrypto_ecdh_keygen_async_finalize(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
+    const otcrypto_blinded_key_t *private_key) {
+  if (private_key == NULL || private_key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
+  return internal_p384_keygen_start(private_key);
+}
+
+otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
   // Check for any NULL pointers.
-  if (elliptic_curve == NULL || private_key == NULL || public_key == NULL ||
+  if (private_key == NULL || public_key == NULL ||
       private_key->keyblob == NULL || public_key->key == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  // Check the key modes.
-  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdh ||
-      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdh) {
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP256 ||
+      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdh);
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdh);
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP256);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
+  return internal_p256_keygen_finalize(private_key, public_key);
+}
 
-  // Select the correct keygen operation and finalize it.
-  switch (launder32(elliptic_curve->curve_type)) {
-    case kOtcryptoEccCurveTypeNistP256:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP256);
-      HARDENED_TRY(internal_p256_keygen_finalize(private_key, public_key));
-      break;
-    case kOtcryptoEccCurveTypeNistP384:
-      HARDENED_CHECK_EQ(elliptic_curve->curve_type,
-                        kOtcryptoEccCurveTypeNistP384);
-      HARDENED_TRY(internal_p384_keygen_finalize(private_key, public_key));
-      break;
-    case kEccCurveTypeBrainpoolP256R1:
-      OT_FALLTHROUGH_INTENDED;
-    case kOtcryptoEccCurveTypeCustom:
-      // TODO: Implement support for other curves.
-      return OTCRYPTO_NOT_IMPLEMENTED;
-    default:
-      return OTCRYPTO_BAD_ARGS;
+otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
+  // Check for any NULL pointers.
+  if (private_key == NULL || public_key == NULL ||
+      private_key->keyblob == NULL || public_key->key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
   }
 
-  // Clear the OTBN sideload slot (in case the key was sideloaded).
-  return keymgr_sideload_clear_otbn();
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP384 ||
+      launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP384);
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
+  return internal_p384_keygen_finalize(private_key, public_key);
 }
 
 /**
@@ -994,24 +992,28 @@ otcrypto_status_t otcrypto_ecdh_async_start(
   HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
                     kHardenedBoolTrue);
 
-  // Check the key modes.
-  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdh ||
-      launder32(public_key->key_mode) != kOtcryptoKeyModeEcdh) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdh);
-  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdh);
-
   // Select the correct ECDH operation and start it.
   switch (launder32(elliptic_curve->curve_type)) {
     case kOtcryptoEccCurveTypeNistP256:
       HARDENED_CHECK_EQ(elliptic_curve->curve_type,
                         kOtcryptoEccCurveTypeNistP256);
+      if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP256 ||
+          launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP256) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP256);
+      HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP256);
       HARDENED_TRY(internal_ecdh_p256_start(private_key, public_key));
       return OTCRYPTO_OK;
     case kOtcryptoEccCurveTypeNistP384:
       HARDENED_CHECK_EQ(elliptic_curve->curve_type,
                         kOtcryptoEccCurveTypeNistP384);
+      if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEcdhP384 ||
+          launder32(public_key->key_mode) != kOtcryptoKeyModeEcdhP384) {
+        return OTCRYPTO_BAD_ARGS;
+      }
+      HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEcdhP384);
+      HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEcdhP384);
       HARDENED_TRY(internal_ecdh_p384_start(private_key, public_key));
       return OTCRYPTO_OK;
     case kEccCurveTypeBrainpoolP256R1:

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -243,14 +243,18 @@ typedef enum otcrypto_rsa_key_mode {
  * Values are hardened.
  */
 typedef enum otcrypto_ecc_key_mode {
-  // Mode ECDSA.
-  kOtcryptoEccKeyModeEcdsa = 0x4e5,
-  // Mode ECDH.
-  kOtcryptoEccKeyModeEcdh = 0x6bb,
+  // Mode ECDSA/P-256.
+  kOtcryptoEccKeyModeEcdsaP256 = 0x31e,
+  // Mode ECDSA/P-384.
+  kOtcryptoEccKeyModeEcdsaP384 = 0x695,
+  // Mode ECDH/P-256.
+  kOtcryptoEccKeyModeEcdhP256 = 0x5fc,
+  // Mode ECDH/P-384.
+  kOtcryptoEccKeyModeEcdhP384 = 0x1c7,
   // Mode Ed25519.
-  kOtcryptoEccKeyModeEd25519 = 0xd32,
+  kOtcryptoEccKeyModeEd25519 = 0x663,
   // Mode X25519.
-  kOtcryptoEccKeyModeX25519 = 0x276,
+  kOtcryptoEccKeyModeX25519 = 0x0bb,
 } otcrypto_ecc_key_mode_t;
 
 /**
@@ -318,10 +322,18 @@ typedef enum otcrypto_key_mode {
   // Key is intended for RSA encryption RSAES-OAEP mode.
   kOtcryptoKeyModeRsaEncryptOaep =
       kOtcryptoKeyTypeRsa << 16 | kOtcryptoRsaKeyModeEncryptOaep,
-  // Key is intended for ECDSA mode.
-  kOtcryptoKeyModeEcdsa = kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdsa,
-  // Key is intended for ECDH mode.
-  kOtcryptoKeyModeEcdh = kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdh,
+  // Key is intended for ECDSA with P-256.
+  kOtcryptoKeyModeEcdsaP256 =
+      kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdsaP256,
+  // Key is intended for ECDSA with P-384.
+  kOtcryptoKeyModeEcdsaP384 =
+      kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdsaP384,
+  // Key is intended for ECDH with P-256.
+  kOtcryptoKeyModeEcdhP256 =
+      kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdhP256,
+  // Key is intended for ECDH with P-384.
+  kOtcryptoKeyModeEcdhP384 =
+      kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEcdhP384,
   // Key is intended for Ed25519 mode.
   kOtcryptoKeyModeEd25519 =
       kOtcryptoKeyTypeEcc << 16 | kOtcryptoEccKeyModeEd25519,

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -82,32 +82,39 @@ typedef struct otcrypto_ecc_curve {
 } otcrypto_ecc_curve_t;
 
 /**
- * Performs the key generation for ECDSA operation.
- *
- * Computes private key (d) and public key (Q) keys for ECDSA operation.
+ * Generates a key pair for ECDSA with curve P-256.
  *
  * The caller should allocate and partially populate the blinded key struct,
  * including populating the key configuration and allocating space for the
- * keyblob. The caller should indicate the length of the allocated keyblob;
- * this function will return an error if the keyblob length does not match
- * expectations. If the key is hardware-backed, the caller should pass a fully
- * populated private key handle as returned by `otcrypto_hw_backed_key`. For
- * non-hardware-backed keys, the keyblob should be twice the length of the key.
- * The value in the `checksum` field of the blinded key struct will be
- * populated by the key generation function.
+ * keyblob. For a hardware-backed key, use the private key handle returned by
+ * `otcrypto_hw_backed_key`. Otherwise, the mode should indicate ECDSA with
+ * P-256 and the keyblob should be 80 bytes. The value in the `checksum` field
+ * of the blinded key struct will be populated by the key generation function.
  *
- * The `domain_parameter` field of the `elliptic_curve` is required only for a
- * custom curve. For named curves this field is ignored and can be set to
- * `NULL`.
- *
- * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param[out] private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of the ECDSA key generation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_keygen(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_keygen(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
+
+/**
+ * Generates a key pair for ECDSA with curve P-384.
+ *
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. For a hardware-backed key, use the private key handle returned by
+ * `otcrypto_hw_backed_key`. Otherwise, the mode should indicate ECDSA with
+ * P-384 and the keyblob should be 112 bytes. The value in the `checksum` field
+ * of the blinded key struct will be populated by the key generation function.
+ *
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of the ECDSA key generation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
 
 /**
@@ -166,32 +173,39 @@ otcrypto_status_t otcrypto_ecdsa_verify(
     hardened_bool_t *verification_result);
 
 /**
- * Performs the key generation for ECDH key agreement.
- *
- * Computes private key (d) and public key (Q) keys for ECDSA operation.
- *
- * The `domain_parameter` field of the `elliptic_curve` is required only for a
- * custom curve. For named curves this field is ignored and can be set to
- * `NULL`.
+ * Generates a key pair for ECDH with curve P-256.
  *
  * The caller should allocate and partially populate the blinded key struct,
  * including populating the key configuration and allocating space for the
- * keyblob. The caller should indicate the length of the allocated keyblob;
- * this function will return an error if the keyblob length does not match
- * expectations. If the key is hardware-backed, the caller should pass a fully
- * populated private key handle as returned by `otcrypto_hw_backed_key`. For
- * non-hardware-backed keys, the keyblob should be twice the length of the key.
- * The value in the `checksum` field of the blinded key struct will be
- * populated by the key generation function.
+ * keyblob. For a hardware-backed key, use the private key handle returned by
+ * `otcrypto_hw_backed_key`. Otherwise, the mode should indicate ECDH with
+ * P-256 and the keyblob should be 80 bytes. The value in the `checksum` field
+ * of the blinded key struct will be populated by the key generation function.
  *
- * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param[out] private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of the ECDH key generation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdh_keygen(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdh_p256_keygen(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
+
+/**
+ * Generates a key pair for ECDH with curve P-384.
+ *
+ * The caller should allocate and partially populate the blinded key struct,
+ * including populating the key configuration and allocating space for the
+ * keyblob. For a hardware-backed key, use the private key handle returned by
+ * `otcrypto_hw_backed_key`. Otherwise, the mode should indicate ECDH with
+ * P-384 and the keyblob should be 112 bytes. The value in the `checksum` field
+ * of the blinded key struct will be populated by the key generation function.
+ *
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of the ECDH key generation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdh_p384_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
 
 /**
@@ -312,52 +326,63 @@ otcrypto_status_t otcrypto_x25519(const otcrypto_blinded_key_t *private_key,
                                   otcrypto_blinded_key_t *shared_secret);
 
 /**
- * Starts the asynchronous key generation for ECDSA operation.
+ * Starts asynchronous key generation for ECDSA/P-256.
  *
- * Initializes OTBN and begins generating an ECDSA key pair. The caller should
- * set the `config` field of `private_key` with their desired key configuration
- * options. If the key is hardware-backed, the caller should pass a fully
- * populated private key handle such as the kind returned by
- * `otcrypto_hw_backed_key`.
+ * See `otcrypto_ecdsa_p256_keygen` for requirements on input values.
  *
- * The `domain_parameter` field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to `NULL`.
- *
- * Returns `kOtcryptoStatusValueOk` if the operation was successfully
- * started, or`kOtcryptoStatusValueInternalError` if the operation cannot be
- * started.
- *
- * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param private_key Destination structure for private key, or key handle.
  * @return Result of asynchronous ECDSA keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_keygen_async_start(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_start(
     const otcrypto_blinded_key_t *private_key);
 
 /**
- * Finalizes the asynchronous key generation for ECDSA operation.
+ * Finalizes asynchronous key generation for ECDSA/P-256.
  *
- * Returns `kOtcryptoStatusValueOk` and copies the private key (d) and public
- * key (Q), if the OTBN status is done, or
- * `kOtcryptoStatusValueAsyncIncomplete` if the OTBN is busy or
- * `kOtcryptoStatusValueInternalError` if there is an error.
+ * See `otcrypto_ecdsa_p256_keygen` for requirements on input values.
  *
- * The caller must ensure that the `elliptic_curve` parameter matches the one
- * that was previously passed to the corresponding `_start` function; a
- * mismatch will cause inconsistencies. Similarly, the private key
- * configuration must match the one originally passed to `_start`.
+ * May block until the operation is complete.
  *
- * @param elliptic_curve Pointer to the elliptic curve that is being used.
+ * The caller should ensure that the private key configuration matches that
+ * passed to the `_start` function.
+ *
  * @param[out] private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of asynchronous ECDSA keygen finalize operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_keygen_async_finalize(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_keygen_async_finalize(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
+
+/**
+ * Starts asynchronous key generation for ECDSA/P-384.
+ *
+ * See `otcrypto_ecdsa_p384_keygen` for requirements on input values.
+ *
+ * @param private_key Destination structure for private key, or key handle.
+ * @return Result of asynchronous ECDSA keygen start operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_start(
+    const otcrypto_blinded_key_t *private_key);
+
+/**
+ * Finalizes asynchronous key generation for ECDSA/P-384.
+ *
+ * See `otcrypto_ecdsa_p384_keygen` for requirements on input values.
+ *
+ * May block until the operation is complete.
+ *
+ * The caller should ensure that the private key configuration matches that
+ * passed to the `_start` function.
+ *
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of asynchronous ECDSA keygen finalize operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
 
 /**
@@ -445,52 +470,63 @@ otcrypto_status_t otcrypto_ecdsa_verify_async_finalize(
     hardened_bool_t *verification_result);
 
 /**
- * Starts the asynchronous key generation for ECDH operation.
+ * Starts asynchronous key generation for ECDH/P-256.
  *
- * Initializes OTBN and begins generating an ECDH key pair. The caller should
- * set the `config` field of `private_key` with their desired key configuration
- * options. If the key is hardware-backed, the caller should pass a fully
- * populated private key handle such as the kind returned by
- * `otcrypto_hw_backed_key`.
+ * See `otcrypto_ecdh_p256_keygen` for requirements on input values.
  *
- * The `domain_parameter` field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to `NULL`.
- *
- * Returns `kOtcryptoStatusValueOk` if the operation was successfully
- * started, or`kOtcryptoStatusValueInternalError` if the operation cannot be
- * started.
- *
- * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param private_key Destination structure for private key, or key handle.
  * @return Result of asynchronous ECDH keygen start operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdh_keygen_async_start(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdh_p256_keygen_async_start(
     const otcrypto_blinded_key_t *private_key);
 
 /**
- * Finalizes the asynchronous key generation for ECDSA operation.
+ * Finalizes asynchronous key generation for ECDH/P-256.
  *
- * Returns `kOtcryptoStatusValueOk` and copies the private key (d) and public
- * key (Q), if the OTBN status is done, or
- * `kOtcryptoStatusValueAsyncIncomplete` if the OTBN is busy or
- * `kOtcryptoStatusValueInternalError` if there is an error.
+ * See `otcrypto_ecdh_p256_keygen` for requirements on input values.
  *
- * The caller must ensure that the `elliptic_curve` parameter matches the one
- * that was previously passed to the corresponding `_start` function; a
- * mismatch will cause inconsistencies. Similarly, the private key
- * configuration must match the one originally passed to `_start`.
+ * May block until the operation is complete.
  *
- * @param elliptic_curve Pointer to the elliptic curve that is being used.
+ * The caller should ensure that the private key configuration matches that
+ * passed to the `_start` function.
+ *
  * @param[out] private_key Pointer to the blinded private key (d) struct.
  * @param[out] public_key Pointer to the unblinded public key (Q) struct.
  * @return Result of asynchronous ECDH keygen finalize operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdh_keygen_async_finalize(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdh_p256_keygen_async_finalize(
+    otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
+
+/**
+ * Starts asynchronous key generation for ECDH/P-384.
+ *
+ * See `otcrypto_ecdh_p384_keygen` for requirements on input values.
+ *
+ * @param private_key Destination structure for private key, or key handle.
+ * @return Result of asynchronous ECDH keygen start operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdh_p384_keygen_async_start(
+    const otcrypto_blinded_key_t *private_key);
+
+/**
+ * Finalizes asynchronous key generation for ECDH/P-384.
+ *
+ * See `otcrypto_ecdh_p384_keygen` for requirements on input values.
+ *
+ * May block until the operation is complete.
+ *
+ * The caller should ensure that the private key configuration matches that
+ * passed to the `_start` function.
+ *
+ * @param[out] private_key Pointer to the blinded private key (d) struct.
+ * @param[out] public_key Pointer to the unblinded public key (Q) struct.
+ * @return Result of asynchronous ECDH keygen finalize operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdh_p384_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
 
 /**

--- a/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
@@ -40,7 +40,6 @@ status_t handle_ecdh(ujson_t *uj) {
 
   otcrypto_key_config_t key_config = {
       .version = kOtcryptoLibVersion1,
-      .key_mode = kOtcryptoKeyModeEcdh,
       .hw_backed = kHardenedBoolFalse,
       .security_level = kOtcryptoKeySecurityLevelLow,
   };
@@ -54,10 +53,11 @@ status_t handle_ecdh(ujson_t *uj) {
       memcpy(pub_p256.x, uj_qx.coordinate, uj_qx.coordinate_len);
       memset(pub_p256.y, 0, kP256CoordWords * 4);
       memcpy(pub_p256.y, uj_qy.coordinate, uj_qy.coordinate_len);
-      public_key.key_mode = kOtcryptoKeyModeEcdh;
+      public_key.key_mode = kOtcryptoKeyModeEcdhP256;
       public_key.key_length = sizeof(p256_point_t);
       public_key.key = (uint32_t *)&pub_p256;
       key_config.key_length = P256_KEY_BYTES;
+      key_config.key_mode = kOtcryptoKeyModeEcdhP256,
       shared_key_words = P256_KEY_BYTES / sizeof(uint32_t);
       memset(private_key_masked_p256.share0, 0, kP256MaskedScalarShareBytes);
       memcpy(private_key_masked_p256.share0, uj_private_key.d0,
@@ -75,10 +75,11 @@ status_t handle_ecdh(ujson_t *uj) {
       memcpy(pub_p384.x, uj_qx.coordinate, uj_qx.coordinate_len);
       memset(pub_p384.y, 0, kP384CoordWords * 4);
       memcpy(pub_p384.y, uj_qy.coordinate, uj_qy.coordinate_len);
-      public_key.key_mode = kOtcryptoKeyModeEcdh;
+      public_key.key_mode = kOtcryptoKeyModeEcdhP384;
       public_key.key_length = sizeof(p384_point_t);
       public_key.key = (uint32_t *)&pub_p384;
       key_config.key_length = P384_KEY_BYTES;
+      key_config.key_mode = kOtcryptoKeyModeEcdhP384,
       shared_key_words = P384_KEY_BYTES / sizeof(uint32_t);
       memset(private_key_masked_p384.share0, 0, kP384MaskedScalarShareBytes);
       memcpy(private_key_masked_p384.share0, uj_private_key.d0,

--- a/sw/device/tests/crypto/cryptotest/firmware/ecdsa.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdsa.c
@@ -25,7 +25,7 @@ enum {
 
 static const otcrypto_key_config_t kP256PrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_mode = kOtcryptoKeyModeEcdsaP256,
     .key_length = kP256PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -33,7 +33,7 @@ static const otcrypto_key_config_t kP256PrivateKeyConfig = {
 
 static const otcrypto_key_config_t kP384PrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_mode = kOtcryptoKeyModeEcdsaP384,
     .key_length = kP384PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -64,7 +64,7 @@ int set_nist_p256_params(
   memcpy(pub_p256->x, uj_qx.coordinate, uj_qx.coordinate_len);
   memset(pub_p256->y, 0, kP256CoordBytes);
   memcpy(pub_p256->y, uj_qy.coordinate, uj_qy.coordinate_len);
-  public_key->key_mode = kOtcryptoKeyModeEcdsa;
+  public_key->key_mode = kOtcryptoKeyModeEcdsaP256;
   public_key->key_length = sizeof(p256_point_t);
   public_key->key = (uint32_t *)pub_p256;
   *digest_len = kP256ScalarWords;
@@ -117,7 +117,7 @@ int set_nist_p384_params(
   memcpy(pub_p384->x, uj_qx.coordinate, uj_qx.coordinate_len);
   memset(pub_p384->y, 0, kP384CoordBytes);
   memcpy(pub_p384->y, uj_qy.coordinate, uj_qy.coordinate_len);
-  public_key->key_mode = kOtcryptoKeyModeEcdsa;
+  public_key->key_mode = kOtcryptoKeyModeEcdsaP384;
   public_key->key_length = sizeof(p384_point_t);
   public_key->key = (uint32_t *)pub_p384;
   *digest_len = kP384ScalarWords;

--- a/sw/device/tests/crypto/ecdh_p256_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_functest.c
@@ -31,7 +31,7 @@ static const otcrypto_ecc_curve_t kCurveP256 = {
 // Configuration for the private key.
 static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdh,
+    .key_mode = kOtcryptoKeyModeEcdhP256,
     .key_length = kP256PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -69,23 +69,23 @@ status_t key_exchange_test(void) {
   uint32_t pkA[kP256PublicKeyWords] = {0};
   uint32_t pkB[kP256PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_keyA = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP256,
       .key_length = sizeof(pkA),
       .key = pkA,
   };
   otcrypto_unblinded_key_t public_keyB = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP256,
       .key_length = sizeof(pkB),
       .key = pkB,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair A...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP256, &private_keyA, &public_keyA));
+  TRY(otcrypto_ecdh_p256_keygen(&private_keyA, &public_keyA));
 
   // Generate a second keypair.
   LOG_INFO("Generating keypair B...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP256, &private_keyB, &public_keyB));
+  TRY(otcrypto_ecdh_p256_keygen(&private_keyB, &public_keyB));
 
   // Sanity check; public keys should be different from each other.
   CHECK_ARRAYS_NE(pkA, pkB, ARRAYSIZE(pkA));

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -50,7 +50,7 @@ static const uint32_t kPrivateKeyBSalt[7] = {0xa0a1a2a3, 0xa4a5a6a7, 0xa8a9aaab,
 // Configuration for the private key.
 static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdh,
+    .key_mode = kOtcryptoKeyModeEcdhP256,
     .key_length = kP256PrivateKeyBytes,
     .hw_backed = kHardenedBoolTrue,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -90,23 +90,23 @@ status_t key_exchange_test(void) {
   uint32_t pkA[kP256PublicKeyWords] = {0};
   uint32_t pkB[kP256PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_keyA = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP256,
       .key_length = sizeof(pkA),
       .key = pkA,
   };
   otcrypto_unblinded_key_t public_keyB = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP256,
       .key_length = sizeof(pkB),
       .key = pkB,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair A...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP256, &private_keyA, &public_keyA));
+  TRY(otcrypto_ecdh_p256_keygen(&private_keyA, &public_keyA));
 
   // Generate a second keypair.
   LOG_INFO("Generating keypair B...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP256, &private_keyB, &public_keyB));
+  TRY(otcrypto_ecdh_p256_keygen(&private_keyB, &public_keyB));
 
   // Sanity check; public keys should be different from each other.
   CHECK_ARRAYS_NE(pkA, pkB, ARRAYSIZE(pkA));

--- a/sw/device/tests/crypto/ecdh_p384_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_functest.c
@@ -31,7 +31,7 @@ static const otcrypto_ecc_curve_t kCurveP384 = {
 // Configuration for the private key.
 static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdh,
+    .key_mode = kOtcryptoKeyModeEcdhP384,
     .key_length = kP384PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -69,23 +69,23 @@ status_t key_exchange_test(void) {
   uint32_t pkA[kP384PublicKeyWords] = {0};
   uint32_t pkB[kP384PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_keyA = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP384,
       .key_length = sizeof(pkA),
       .key = pkA,
   };
   otcrypto_unblinded_key_t public_keyB = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP384,
       .key_length = sizeof(pkB),
       .key = pkB,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair A...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP384, &private_keyA, &public_keyA));
+  TRY(otcrypto_ecdh_p384_keygen(&private_keyA, &public_keyA));
 
   // Generate a second keypair.
   LOG_INFO("Generating keypair B...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP384, &private_keyB, &public_keyB));
+  TRY(otcrypto_ecdh_p384_keygen(&private_keyB, &public_keyB));
 
   // Sanity check; public keys should be different from each other.
   CHECK_ARRAYS_NE(pkA, pkB, ARRAYSIZE(pkA));

--- a/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p384_sideload_functest.c
@@ -47,7 +47,7 @@ static const uint32_t kPrivateKeyBSalt[7] = {0xa0a1a2a3, 0xa4a5a6a7, 0xa8a9aaab,
 // Configuration for the private key.
 static const otcrypto_key_config_t kEcdhPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdh,
+    .key_mode = kOtcryptoKeyModeEcdhP384,
     .key_length = kP384PrivateKeyBytes,
     .hw_backed = kHardenedBoolTrue,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -87,23 +87,23 @@ status_t key_exchange_test(void) {
   uint32_t pkA[kP384PublicKeyWords] = {0};
   uint32_t pkB[kP384PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_keyA = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP384,
       .key_length = sizeof(pkA),
       .key = pkA,
   };
   otcrypto_unblinded_key_t public_keyB = {
-      .key_mode = kOtcryptoKeyModeEcdh,
+      .key_mode = kOtcryptoKeyModeEcdhP384,
       .key_length = sizeof(pkB),
       .key = pkB,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair A...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP384, &private_keyA, &public_keyA));
+  TRY(otcrypto_ecdh_p384_keygen(&private_keyA, &public_keyA));
 
   // Generate a second keypair.
   LOG_INFO("Generating keypair B...");
-  TRY(otcrypto_ecdh_keygen(&kCurveP384, &private_keyB, &public_keyB));
+  TRY(otcrypto_ecdh_p384_keygen(&private_keyB, &public_keyB));
 
   // Sanity check; public keys should be different from each other.
   CHECK_ARRAYS_NE(pkA, pkB, ARRAYSIZE(pkA));

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -32,7 +32,7 @@ static const otcrypto_ecc_curve_t kCurveP256 = {
 
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_mode = kOtcryptoKeyModeEcdsaP256,
     .key_length = kP256PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -50,15 +50,14 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
   // Allocate space for a public key.
   uint32_t pk[kP256PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_key = {
-      .key_mode = kOtcryptoKeyModeEcdsa,
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = sizeof(pk),
       .key = pk,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair...");
-  CHECK_STATUS_OK(
-      otcrypto_ecdsa_keygen(&kCurveP256, &private_key, &public_key));
+  CHECK_STATUS_OK(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg = {

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -35,7 +35,7 @@ static const otcrypto_ecc_curve_t kCurveP256 = {
 
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_mode = kOtcryptoKeyModeEcdsaP256,
     .key_length = kP256PrivateKeyBytes,
     .hw_backed = kHardenedBoolTrue,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -63,14 +63,14 @@ status_t sign_then_verify_test(void) {
   // Allocate space for a public key.
   uint32_t pk[kP256PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_key = {
-      .key_mode = kOtcryptoKeyModeEcdsa,
+      .key_mode = kOtcryptoKeyModeEcdsaP256,
       .key_length = sizeof(pk),
       .key = pk,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair...");
-  TRY(otcrypto_ecdsa_keygen(&kCurveP256, &private_key, &public_key));
+  TRY(otcrypto_ecdsa_p256_keygen(&private_key, &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t message = {

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -32,7 +32,7 @@ static const otcrypto_ecc_curve_t kCurveP384 = {
 
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_mode = kOtcryptoKeyModeEcdsaP384,
     .key_length = kP384PrivateKeyBytes,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -50,15 +50,14 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
   // Allocate space for a public key.
   uint32_t pk[kP384PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_key = {
-      .key_mode = kOtcryptoKeyModeEcdsa,
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = sizeof(pk),
       .key = pk,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair...");
-  CHECK_STATUS_OK(
-      otcrypto_ecdsa_keygen(&kCurveP384, &private_key, &public_key));
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg = {

--- a/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
@@ -35,7 +35,7 @@ static const otcrypto_ecc_curve_t kCurveP384 = {
 
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
-    .key_mode = kOtcryptoKeyModeEcdsa,
+    .key_mode = kOtcryptoKeyModeEcdsaP384,
     .key_length = kP384PrivateKeyBytes,
     .hw_backed = kHardenedBoolTrue,
     .security_level = kOtcryptoKeySecurityLevelLow,
@@ -63,15 +63,14 @@ status_t sign_then_verify_test(void) {
   // Allocate space for a public key.
   uint32_t pk[kP384PublicKeyWords] = {0};
   otcrypto_unblinded_key_t public_key = {
-      .key_mode = kOtcryptoKeyModeEcdsa,
+      .key_mode = kOtcryptoKeyModeEcdsaP384,
       .key_length = sizeof(pk),
       .key = pk,
   };
 
   // Generate a keypair.
   LOG_INFO("Generating keypair...");
-  CHECK_STATUS_OK(
-      otcrypto_ecdsa_keygen(&kCurveP384, &private_key, &public_key));
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_keygen(&private_key, &public_key));
 
   // Hash the message.
   otcrypto_const_byte_buf_t msg = {


### PR DESCRIPTION
This change is part of a larger separation of the two curves' operations, so that we can remove the complicated curve specification parameters and save some code size on hardened switch statements and linker efficiency.

While I was here, I also edited some of the documentation comments to be more consistent and readable.

Part of https://github.com/lowRISC/opentitan/pull/26322