### PR TITLE
[crypto] Separate P-256 and P-384 sign/verify operations.

### DIFF
--- a/doc/security/cryptolib/cryptolib_api.md
+++ b/doc/security/cryptolib/cryptolib_api.md
@@ -369,8 +369,10 @@ For ECDSA, the cryptography library supports keypair generation, signing, and si
 
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_keygen }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_keygen }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_sign }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_verify }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_sign }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_sign }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_verify }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_verify }}
 
 #### ECDH
 
@@ -405,10 +407,12 @@ Each party should generate a key pair, exchange public keys, and then generate t
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_keygen_async_finalize }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_keygen_async_start }}
 {{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_keygen_async_finalize }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_sign_async_start }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_sign_async_finalize }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_verify_async_start }}
-{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_verify_async_finalize }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_sign_async_start }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_sign_async_finalize }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_sign_async_start }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p384_sign_async_finalize }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_verify_async_start }}
+{{#header-snippet sw/device/lib/crypto/include/ecc.h otcrypto_ecdsa_p256_verify_async_finalize }}
 
 #### ECDH
 

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -118,58 +118,97 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
 
 /**
- * Performs the ECDSA digital signature generation.
+ * Generates an ECDSA signature with curve P-256.
  *
- * The `domain_parameter` field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to `NULL`.
- *
- * The message digest must be exactly the right length for the curve in use
- * (e.g. 256 bits for P-256), but may use any hash mode. The caller is
- * responsible for ensuring that the security strength of the hash function is
- * at least equal to the security strength of the curve. See FIPS 186-5 for
+ * The message digest must be exactly 256 bits (32 bytes) long, but may use any
+ * hash mode.  The caller is responsible for ensuring that the security
+ * strength of the hash function is at least equal to the security strength of
+ * the curve, but in some cases it may be truncated. See FIPS 186-5 for
  * details.
  *
  * @param private_key Pointer to the blinded private key (d) struct.
  * @param message_digest Message digest to be signed (pre-hashed).
- * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param[out] signature Pointer to the signature struct with (r,s) values.
  * @return Result of the ECDSA signature generation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_sign(
+otcrypto_status_t otcrypto_ecdsa_p256_sign(
     const otcrypto_blinded_key_t *private_key,
     const otcrypto_hash_digest_t message_digest,
-    const otcrypto_ecc_curve_t *elliptic_curve,
     otcrypto_word32_buf_t signature);
 
 /**
- * Performs the ECDSA digital signature verification.
- *
- * The `domain_parameter` field of the `elliptic_curve` is required
- * only for a custom curve. For named curves this field is ignored
- * and can be set to `NULL`.
- *
- * The message digest must be exactly the right length for the curve in use
- * (e.g. 256 bits for P-256), but may use any hash mode. The caller is
- * responsible for ensuring that the security strength of the hash function is
- * at least equal to the security strength of the curve. See FIPS 186-5 for
+ * Generates an ECDSA signature with curve P-384.
+
+ * The message digest must be exactly 384 bits (48 bytes) long, but may use any
+ * hash mode.  The caller is responsible for ensuring that the security
+ * strength of the hash function is at least equal to the security strength of
+ * the curve, but in some cases it may be truncated. See FIPS 186-5 for
  * details.
+ *
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param message_digest Message digest to be signed (pre-hashed).
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of the ECDSA signature generation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_sign(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_word32_buf_t signature);
+
+/**
+ * Verifies an ECDSA/P-256 signature.
+ *
+ * The message digest must be exactly 256 bits (32 bytes) long, but may use any
+ * hash mode.  The caller is responsible for ensuring that the security
+ * strength of the hash function is at least equal to the security strength of
+ * the curve, but in some cases it may be truncated. See FIPS 186-5 for
+ * details.
+ *
+ * The caller must check the `verification_result` parameter, NOT only the
+ * returned status code, to know if the signature passed verification. The
+ * status code, as for other operations, only indicates whether errors were
+ * encountered, and may return OK even when the signature is invalid.
  *
  * @param public_key Pointer to the unblinded public key (Q) struct.
  * @param message_digest Message digest to be verified (pre-hashed).
  * @param signature Pointer to the signature to be verified.
- * @param elliptic_curve Pointer to the elliptic curve to be used.
- * @param[out] verification_result Result of signature verification
- * (Pass/Fail).
+ * @param[out] verification_result Whether the signature passed verification.
  * @return Result of the ECDSA verification operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_verify(
+otcrypto_status_t otcrypto_ecdsa_p256_verify(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
     otcrypto_const_word32_buf_t signature,
-    const otcrypto_ecc_curve_t *elliptic_curve,
+    hardened_bool_t *verification_result);
+
+/**
+ * Verifies an ECDSA/P-384 signature.
+ *
+ * The message digest must be exactly 384 bits (48 bytes) long, but may use any
+ * hash mode.  The caller is responsible for ensuring that the security
+ * strength of the hash function is at least equal to the security strength of
+ * the curve, but in some cases it may be truncated. See FIPS 186-5 for
+ * details.
+ *
+ * The caller must check the `verification_result` parameter, NOT only the
+ * returned status code, to know if the signature passed verification. The
+ * status code, as for other operations, only indicates whether errors were
+ * encountered, and may return OK even when the signature is invalid.
+ *
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param message_digest Message digest to be verified (pre-hashed).
+ * @param signature Pointer to the signature to be verified.
+ * @param[out] verification_result Whether the signature passed verification.
+ * @return Result of the ECDSA verification operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result);
 
 /**
@@ -386,12 +425,9 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key);
 
 /**
- * Starts the asynchronous ECDSA digital signature generation.
+ * Starts asynchronous signature generation for ECDSA/P-256.
  *
- * Initializes OTBN and starts the OTBN routine to compute the digital
- * signature on the input message. The `domain_parameter` field of the
- * `elliptic_curve` is required only for a custom curve. For named
- * curves this field is ignored and can be set to `NULL`.
+ * See `otcrypto_ecdsa_p256_sign` for requirements on input values.
  *
  * @param private_key Pointer to the blinded private key (d) struct.
  * @param message_digest Message digest to be signed (pre-hashed).
@@ -399,73 +435,112 @@ otcrypto_status_t otcrypto_ecdsa_p384_keygen_async_finalize(
  * @return Result of async ECDSA start operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_sign_async_start(
+otcrypto_status_t otcrypto_ecdsa_p256_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
-    const otcrypto_hash_digest_t message_digest,
-    const otcrypto_ecc_curve_t *elliptic_curve);
+    const otcrypto_hash_digest_t message_digest);
 
 /**
- * Finalizes the asynchronous ECDSA digital signature generation.
+ * Finalizes asynchronous signature generation for ECDSA/P-256.
  *
- * Returns `kOtcryptoStatusValueOk` and copies the signature if the OTBN
- * status is done, or `kOtcryptoStatusValueAsyncIncomplete` if the OTBN is
- * busy or `kOtcryptoStatusValueInternalError` if there is an error.
+ * See `otcrypto_ecdsa_p256_sign` for requirements on input values.
  *
- * The caller must ensure that the `elliptic_curve` parameter matches the one
- * that was previously passed to the corresponding `_start` function; a
- * mismatch will cause inconsistencies.
+ * May block until the operation is complete.
  *
- * @param elliptic_curve Pointer to the elliptic curve that is being used.
  * @param[out] signature Pointer to the signature struct with (r,s) values.
  * @return Result of async ECDSA finalize operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_sign_async_finalize(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_sign_async_finalize(
     otcrypto_word32_buf_t signature);
 
 /**
- * Starts the asynchronous ECDSA digital signature verification.
+ * Starts asynchronous signature generation for ECDSA/P-384.
  *
- * Initializes OTBN and starts the OTBN routine to recover ‘r’ value
- * from the input signature ‘s’ value. The `domain_parameter` field of
- * `elliptic_curve` is required only for a custom curve. For named
- * curves this field is ignored and can be set to `NULL`.
+ * See `otcrypto_ecdsa_p384_sign` for requirements on input values.
+ *
+ * @param private_key Pointer to the blinded private key (d) struct.
+ * @param message_digest Message digest to be signed (pre-hashed).
+ * @param elliptic_curve Pointer to the elliptic curve to be used.
+ * @return Result of async ECDSA start operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_sign_async_start(
+    const otcrypto_blinded_key_t *private_key,
+    const otcrypto_hash_digest_t message_digest);
+
+/**
+ * Finalizes asynchronous signature generation for ECDSA/P-384.
+ *
+ * See `otcrypto_ecdsa_p384_sign` for requirements on input values.
+ *
+ * May block until the operation is complete.
+ *
+ * @param[out] signature Pointer to the signature struct with (r,s) values.
+ * @return Result of async ECDSA finalize operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_sign_async_finalize(
+    otcrypto_word32_buf_t signature);
+
+/**
+ * Starts asynchronous signature verification for ECDSA/P-256.
+ *
+ * See `otcrypto_ecdsa_p256_verify` for requirements on input values.
  *
  * @param public_key Pointer to the unblinded public key (Q) struct.
  * @param message_digest Message digest to be verified (pre-hashed).
  * @param signature Pointer to the signature to be verified.
- * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @return Result of async ECDSA verify start function.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_verify_async_start(
+otcrypto_status_t otcrypto_ecdsa_p256_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
     const otcrypto_hash_digest_t message_digest,
-    otcrypto_const_word32_buf_t signature,
-    const otcrypto_ecc_curve_t *elliptic_curve);
+    otcrypto_const_word32_buf_t signature);
 
 /**
- * Finalizes the asynchronous ECDSA digital signature verification.
+ * Finalizes asynchronous signature verification for ECDSA/P-256.
  *
- * Returns `kOtcryptoStatusValueOk` and populates the `verification result`
- * if the OTBN status is done. `kOtcryptoStatusValueAsyncIncomplete` if the
- * OTBN is busy or `kOtcryptoStatusValueInternalError` if there is an error.
- * The computed signature is compared against the input signature
- * and a PASS or FAIL is returned.
+ * See `otcrypto_ecdsa_p256_verify` for requirements on input values.
  *
- * The caller must ensure that the `elliptic_curve` and `signature` parameters
- * matches the ones that were previously passed to the corresponding `_start`
- * function; a mismatch will cause inconsistencies.
+ * May block until the operation is complete.
  *
- * @param elliptic_curve Pointer to the elliptic curve that is being used.
- * @param[out] verification_result Result of signature verification
- * (Pass/Fail).
+ * @param[out] verification_result Whether the signature passed verification.
  * @return Result of async ECDSA verify finalize operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_ecdsa_verify_async_finalize(
-    const otcrypto_ecc_curve_t *elliptic_curve,
+otcrypto_status_t otcrypto_ecdsa_p256_verify_async_finalize(
+    otcrypto_const_word32_buf_t signature,
+    hardened_bool_t *verification_result);
+
+/**
+ * Starts asynchronous signature verification for ECDSA/P-384.
+ *
+ * See `otcrypto_ecdsa_p384_verify` for requirements on input values.
+ *
+ * @param public_key Pointer to the unblinded public key (Q) struct.
+ * @param message_digest Message digest to be verified (pre-hashed).
+ * @param signature Pointer to the signature to be verified.
+ * @return Result of async ECDSA verify start function.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_verify_async_start(
+    const otcrypto_unblinded_key_t *public_key,
+    const otcrypto_hash_digest_t message_digest,
+    otcrypto_const_word32_buf_t signature);
+
+/**
+ * Finalizes asynchronous signature verification for ECDSA/P-384.
+ *
+ * See `otcrypto_ecdsa_p384_verify` for requirements on input values.
+ *
+ * May block until the operation is complete.
+ *
+ * @param[out] verification_result Whether the signature passed verification.
+ * @return Result of async ECDSA verify finalize operation.
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_ecdsa_p384_verify_async_finalize(
     otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result);
 

--- a/sw/device/tests/crypto/ecdsa_p256_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_functest.c
@@ -25,11 +25,6 @@ enum {
 // Message
 static const char kMessage[] = "test message";
 
-static const otcrypto_ecc_curve_t kCurveP256 = {
-    .curve_type = kOtcryptoEccCurveTypeNistP256,
-    .domain_parameter = NULL,
-};
-
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
     .key_mode = kOtcryptoKeyModeEcdsaP256,
@@ -77,16 +72,16 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
 
   // Generate a signature for the message.
   LOG_INFO("Signing...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_sign(
-      &private_key, msg_digest, &kCurveP256,
+  CHECK_STATUS_OK(otcrypto_ecdsa_p256_sign(
+      &private_key, msg_digest,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_verify(
+  CHECK_STATUS_OK(otcrypto_ecdsa_p256_verify(
       &public_key, msg_digest,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
-      &kCurveP256, verification_result));
+      verification_result));
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -28,11 +28,6 @@ enum {
 // Message
 static const char kMessage[] = "test message";
 
-static const otcrypto_ecc_curve_t kCurveP256 = {
-    .curve_type = kOtcryptoEccCurveTypeNistP256,
-    .domain_parameter = NULL,
-};
-
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
     .key_mode = kOtcryptoKeyModeEcdsaP256,
@@ -90,17 +85,17 @@ status_t sign_then_verify_test(void) {
 
   // Generate a signature for the message.
   LOG_INFO("Signing...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_sign(
-      &private_key, message_digest, &kCurveP256,
+  CHECK_STATUS_OK(otcrypto_ecdsa_p256_sign(
+      &private_key, message_digest,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   hardened_bool_t verification_result;
-  CHECK_STATUS_OK(otcrypto_ecdsa_verify(
+  CHECK_STATUS_OK(otcrypto_ecdsa_p256_verify(
       &public_key, message_digest,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
-      &kCurveP256, &verification_result));
+      &verification_result));
 
   // The signature should pass verification.
   TRY_CHECK(verification_result == kHardenedBoolTrue);

--- a/sw/device/tests/crypto/ecdsa_p384_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_functest.c
@@ -25,11 +25,6 @@ enum {
 // Message
 static const char kMessage[] = "test message";
 
-static const otcrypto_ecc_curve_t kCurveP384 = {
-    .curve_type = kOtcryptoEccCurveTypeNistP384,
-    .domain_parameter = NULL,
-};
-
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
     .key_mode = kOtcryptoKeyModeEcdsaP384,
@@ -77,16 +72,16 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
 
   // Generate a signature for the message.
   LOG_INFO("Signing...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_sign(
-      &private_key, msg_digest, &kCurveP384,
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_sign(
+      &private_key, msg_digest,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_verify(
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_verify(
       &public_key, msg_digest,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
-      &kCurveP384, verification_result));
+      verification_result));
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p384_sideload_functest.c
@@ -28,11 +28,6 @@ enum {
 // Message
 static const char kMessage[] = "test message";
 
-static const otcrypto_ecc_curve_t kCurveP384 = {
-    .curve_type = kOtcryptoEccCurveTypeNistP384,
-    .domain_parameter = NULL,
-};
-
 static const otcrypto_key_config_t kPrivateKeyConfig = {
     .version = kOtcryptoLibVersion1,
     .key_mode = kOtcryptoKeyModeEcdsaP384,
@@ -90,17 +85,17 @@ status_t sign_then_verify_test(void) {
 
   // Generate a signature for the message.
   LOG_INFO("Signing...");
-  CHECK_STATUS_OK(otcrypto_ecdsa_sign(
-      &private_key, msg_digest, &kCurveP384,
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_sign(
+      &private_key, msg_digest,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   hardened_bool_t verification_result;
-  CHECK_STATUS_OK(otcrypto_ecdsa_verify(
+  CHECK_STATUS_OK(otcrypto_ecdsa_p384_verify(
       &public_key, msg_digest,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
-      &kCurveP384, &verification_result));
+      &verification_result));
 
   // The signature should pass verification.
   TRY_CHECK(verification_result == kHardenedBoolTrue);


### PR DESCRIPTION
Part of a larger change to separate the curves' operations so that we can remove the complicated curve specification parameters and save some code size on hardened switch statements and linker efficiency.

While I was here, I also edited some of the documentation comments to be more consistent and readable.

Part of https://github.com/lowRISC/opentitan/pull/26322