### PR TITLE
[racl] Add generic RACL testplan

### DIFF
--- a/hw/dv/tools/dvsim/testplans/racl_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/racl_testplan.hjson
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: racl_rw
+      desc: '''
+          Precondiiton:
+            - Randomize the number of RACL policies and randomize its default policy values.
+            - Randomoize the policy selection vector of the CSRs.
+            - Randomize the ErrorRsp parameter
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+
+          Verify the correct access for each CSR:
+            - Loop through each CSR and perform a read and write request of using a
+              random RACL role and random CTN UID value.
+              If the request is allowed:
+                * No TL-UL error is expected
+              else if the request is denied
+                Verify the error log matches:
+                  - error_log_o.valid = 1
+                  - error_log_o.overflow = 0
+                  - error_log_o.racl_role = <role that caused the error>
+                  - error_log_o.ctn_uid = <ctn uid that caused the error>
+
+                Verify that a write did not show any effect.
+                Verify a read returns all 1
+                If ErrorRsp = 1:
+                  - Verify a TLUL error is returned
+            '''
+      stage: V1
+      tests: ["{name}{intf}_racl_rw"]
+    }
+  ]
+}


### PR DESCRIPTION
To be implement generically and being added to all IPs that support RACL.