### PR TITLE
[sw,multitop] Port `rstmgr_sw_rst_ctrl_test` to devicetables

### DIFF
--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -417,6 +417,17 @@ dif_result_t dif_rstmgr_software_device_reset(const dif_rstmgr_t *handle) {
   return kDifOk;
 }
 
+dif_result_t dif_rstmgr_get_sw_reset_index(dt_rstmgr_t dt, dt_reset_t reset,
+                                           size_t *sw_rst_idx) {
+  size_t sw_reset_count = dt_rstmgr_sw_reset_count(dt);
+  for (*sw_rst_idx = 0; *sw_rst_idx < sw_reset_count; ++(*sw_rst_idx)) {
+    if (dt_rstmgr_sw_reset(dt, *sw_rst_idx) == reset) {
+      return kDifOk;
+    }
+  }
+  return kDifBadArg;
+}
+
 dif_result_t dif_rstmgr_fatal_err_code_get_codes(
     const dif_rstmgr_t *rstmgr, dif_rstmgr_fatal_err_codes_t *codes) {
   if (rstmgr == NULL || codes == NULL) {

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -14,6 +14,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "dt/dt_rstmgr.h"  // Generated.
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
@@ -378,6 +379,20 @@ dif_result_t dif_rstmgr_software_reset_is_held(
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_rstmgr_software_device_reset(const dif_rstmgr_t *handle);
+
+/**
+ * Get the software reset index corresponding to a given DT rstmgr reset.
+ *
+ * Retrieved via a short linear search, due to the small number of sw resets.
+ *
+ * @param dt The rstmgr DT instance index
+ * @param reset The rstmgr DT reset index.
+ * @param[out] sw_rst_idx The corresponding software reset index.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rstmgr_get_sw_reset_index(dt_rstmgr_t dt, dt_reset_t reset,
+                                           size_t *sw_rst_idx);
 
 /**
  * Read the fatal error codes.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("//hw/top:defs.bzl", "opentitan_select_top")
 load(
     "//rules:const.bzl",
     "CONST",
@@ -3700,15 +3701,15 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
+        "//hw/top:dt",
         "//hw/top:i2c_c_regs",
         "//hw/top:spi_device_c_regs",
         "//hw/top:spi_host_c_regs",
-        "//hw/top:usbdev_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -3716,11 +3717,20 @@ opentitan_test(
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/dif:spi_host",
-        "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
+    ] + opentitan_select_top(
+        {
+            "earlgrey": [
+                "//hw/top:usbdev_c_regs",
+                "//sw/device/lib/dif:usbdev",
+            ],
+            # Darjeeling doesn't have a USB Device to test
+            "darjeeling": [],
+        },
+        ["@platforms//:incompatible"],
+    ),
 )
 
 opentitan_test(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -32,7 +32,7 @@ load(
     "verilator_params",
 )
 load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
-load("//hw/top:defs.bzl", "opentitan_select_top")
+load("//hw/top:defs.bzl", "opentitan_if_ip", "opentitan_select_top")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -3703,6 +3703,11 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
             "//hw/top_darjeeling:sim_dv": None,
         },
+    ),
+    local_defines = opentitan_if_ip(
+        "usbdev",
+        ["OT_HAS_USBDEV"],
+        [],
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [


### PR DESCRIPTION
Fix #26228

This PR ports the `rstmgr_sw_rst_ctrl_test` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey in an FPGA (`fpga_cw310_rom_with_fake_keys`) environment, and will compile for Darjeeling via
```sh
bazel build --build_tests_only //sw/device/tests:rstmgr_sw_rst_ctrl_test_sim_dv --//hw/top=darjeeling
```

This PR is marked as a draft because it currently requires hardcoding the rstmgr SW Reset Requests per top. Once support for retrieving this information is added (via a devicetables IP extension), this PR will be accordingly updated and marked as ready.