### PR TITLE
[rom_ctrl,dv] Slightly tweak an exclusion annotation

### DIFF
--- a/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_excl.el
+++ b/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_excl.el
@@ -40,7 +40,7 @@ INSTANCE: tb.dut.u_tl_adapter_rom.u_tlul_data_integ_enc_instr.u_data_gen
 Block 1 "3318159292" "data_o = 39'(data_i);"
 
 INSTANCE: tb.dut.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom.gen_generic.u_impl_generic
-ANNOTATION: "cfg_i is tied to rom_cfg_i in rom_ctrl.sv which is wired to a constant"
+ANNOTATION: "cfg_i is tied to rom_cfg_i in rom_ctrl.sv. This is opaque to DV code and may be constant (so the continuous assignment will never execute)."
 Block 1 "118728425" "assign unused_cfg = (^cfg_i);"
 
 INSTANCE: tb.dut.gen_rom_scramble_enabled.u_rom.u_seed_anchor.u_secure_anchor_buf.gen_generic.u_impl_generic


### PR DESCRIPTION
The excluded line is a continuous assignment. If the right hand side happens to be constant then it will never be marked as executing (and we don't care!)

I wrongly suggested that we should have an assertion saying that it *was* constant. But that's wrong, and was removed by a920ad246c. Tweak the text to avoid things being confusing next time.

This is a follow-up after #26310.