### PR TITLE
[sw,device] Make device definitions scale across tops

### DIFF
--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -78,7 +78,6 @@ cc_library(
         ":device",
         "//hw/top:rv_core_ibex_c_regs",
         "//hw/top:uart_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )
 
@@ -87,6 +86,7 @@ cc_library(
     srcs = ["device_sim_dv.c"],
     deps = [
         ":device",
+        "//hw/top:dt_rv_core_ibex",
         "//hw/top:rv_core_ibex_c_regs",
         "//hw/top:top_lib",
         "//hw/top:uart_c_regs",
@@ -98,9 +98,9 @@ cc_library(
     srcs = ["device_sim_verilator.c"],
     deps = [
         ":device",
+        "//hw/top:dt_rv_core_ibex",
         "//hw/top:rv_core_ibex_c_regs",
         "//hw/top:uart_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )
 
@@ -109,6 +109,7 @@ cc_library(
     srcs = ["device_sim_qemu.c"],
     deps = [
         ":device",
+        "//hw/top:dt_rv_core_ibex",
         "//hw/top:rv_core_ibex_c_regs",
         "//hw/top:uart_c_regs",
         "//sw/device/lib/base:macros",

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -194,7 +194,7 @@ extern const uint32_t kAstCheckPollCpuCycles;
  *
  * @see #test_status_set
  */
-extern const uintptr_t kDeviceTestStatusAddress;
+uintptr_t device_test_status_address(void);
 
 /**
  * An address to write use for UART logging bypass
@@ -203,7 +203,7 @@ extern const uintptr_t kDeviceTestStatusAddress;
  *
  * @see #LOG
  */
-extern const uintptr_t kDeviceLogBypassUartAddress;
+uintptr_t device_log_bypass_uart_address(void);
 
 /**
  * A platform-specific function to convert microseconds to cpu cycles.

--- a/sw/device/lib/arch/device_fpga_cw305.c
+++ b/sw/device/lib/arch/device_fpga_cw305.c
@@ -54,9 +54,9 @@ const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
 
-const uintptr_t kDeviceTestStatusAddress = 0;
+uintptr_t device_test_status_address(void) { return 0; }
 
-const uintptr_t kDeviceLogBypassUartAddress = 0;
+uintptr_t device_log_bypass_uart_address(void) { return 0; }
 
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -56,9 +56,9 @@ const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
 
-const uintptr_t kDeviceTestStatusAddress = 0;
+uintptr_t device_test_status_address(void) { return 0; }
 
-const uintptr_t kDeviceLogBypassUartAddress = 0;
+uintptr_t device_log_bypass_uart_address(void) { return 0; }
 
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -56,9 +56,9 @@ const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
 
-const uintptr_t kDeviceTestStatusAddress = 0;
+uintptr_t device_test_status_address(void) { return 0; }
 
-const uintptr_t kDeviceLogBypassUartAddress = 0;
+uintptr_t device_log_bypass_uart_address(void) { return 0; }
 
 const bool kJitterEnabled = false;
 

--- a/sw/device/lib/arch/device_silicon.c
+++ b/sw/device/lib/arch/device_silicon.c
@@ -6,7 +6,6 @@
 
 #include "sw/device/lib/arch/device.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
 #include "uart_regs.h"
 
@@ -54,8 +53,8 @@ const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
 
-const uintptr_t kDeviceTestStatusAddress = 0;
+uintptr_t device_test_status_address(void) { return 0; }
 
-const uintptr_t kDeviceLogBypassUartAddress = 0;
+uintptr_t device_log_bypass_uart_address(void) { return 0; }
 
 void device_fpga_version_print(void) {}

--- a/sw/device/lib/arch/device_sim_qemu.c
+++ b/sw/device/lib/arch/device_sim_qemu.c
@@ -4,14 +4,22 @@
 
 #include <stdbool.h>
 
+#include "dt/dt_rv_core_ibex.h"  // Generated
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated
-#include "rv_core_ibex_regs.h"                        // Generated
-#include "uart_regs.h"                                // Generated
+#include "rv_core_ibex_regs.h"  // Generated
+#include "uart_regs.h"          // Generated
+
+// Use the first dt_rv_core_ibex_t enum, i.e. the first Ibex core instance.
+static const dt_rv_core_ibex_t kRvCoreIbexDt = (dt_rv_core_ibex_t)0;
+static_assert(kDtRvCoreIbexCount == 1, "Only single core tops are supported");
+
+static inline uintptr_t rv_core_ibex_base(void) {
+  return (uintptr_t)dt_rv_core_ibex_primary_reg_block(kRvCoreIbexDt);
+}
 
 /**
  * @file
@@ -58,13 +66,11 @@ const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
 
-// QEMU supports the DV_SIM register for terminating when a test status has been
-// written.
-const uintptr_t kDeviceTestStatusAddress =
-    TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
-    RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET;
+uintptr_t device_test_status_address(void) {
+  return rv_core_ibex_base() + RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET;
+}
 
-const uintptr_t kDeviceLogBypassUartAddress = 0;
+uintptr_t device_log_bypass_uart_address(void) { return 0; }
 
 // Although QEMU isn't an FPGA, there's no harm in us printing the version here.
 void device_fpga_version_print(void) {

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -5,11 +5,19 @@
 #include <assert.h>
 #include <stdbool.h>
 
+#include "dt/dt_rv_core_ibex.h"
 #include "sw/device/lib/arch/device.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
 #include "uart_regs.h"
+
+// Use the first dt_rv_core_ibex_t enum, i.e. the first Ibex core instance.
+static const dt_rv_core_ibex_t kRvCoreIbexDt = (dt_rv_core_ibex_t)0;
+static_assert(kDtRvCoreIbexCount == 1, "Only single core tops are supported");
+
+static inline uintptr_t rv_core_ibex_base(void) {
+  return (uintptr_t)dt_rv_core_ibex_primary_reg_block(kRvCoreIbexDt);
+}
 
 /**
  * @file
@@ -64,10 +72,10 @@ const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);
 
-const uintptr_t kDeviceTestStatusAddress =
-    TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR +
-    RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET;
+uintptr_t device_test_status_address(void) {
+  return rv_core_ibex_base() + RV_CORE_IBEX_DV_SIM_WINDOW_REG_OFFSET;
+}
 
-const uintptr_t kDeviceLogBypassUartAddress = 0;
+uintptr_t device_log_bypass_uart_address(void) { return 0; }
 
 void device_fpga_version_print(void) {}

--- a/sw/device/lib/runtime/log.c
+++ b/sw/device/lib/runtime/log.c
@@ -83,7 +83,8 @@ void base_log_internal_core(const log_fields_t *log, ...) {
  * @param ... format parameters matching the format string.
  */
 void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...) {
-  mmio_region_t log_device = mmio_region_from_addr(kDeviceLogBypassUartAddress);
+  mmio_region_t log_device =
+      mmio_region_from_addr(device_log_bypass_uart_address());
   mmio_region_write32(log_device, 0x0, (uintptr_t)log);
 
   va_list args;

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -132,7 +132,7 @@ extern char _dv_log_offset[];
 #define LOG(severity, format, ...)                               \
   do {                                                           \
     OT_CHECK_VALID_LOG_ARGS(__VA_ARGS__);                        \
-    if (kDeviceLogBypassUartAddress != 0) {                      \
+    if (device_log_bypass_uart_address() != 0) {                 \
       /* clang-format off */                                     \
       /* Put DV-only log constants in .logs.* sections, which
        * the linker will dutifully discard.

--- a/sw/device/lib/testing/test_framework/check.h
+++ b/sw/device/lib/testing/test_framework/check.h
@@ -289,7 +289,7 @@
   ({                                                 \
     status_t status_ = expr;                         \
     if (!status_ok(status_)) {                       \
-      if (kDeviceLogBypassUartAddress) {             \
+      if (device_log_bypass_uart_address()) {        \
         _LOG_ERROR_STATUS_DV(status_);               \
       } else {                                       \
         LOG_ERROR("CHECK-STATUS-fail: %r", status_); \
@@ -310,7 +310,7 @@
   do {                                               \
     status_t status_ = expr;                         \
     if (!status_ok(status_)) {                       \
-      if (kDeviceLogBypassUartAddress) {             \
+      if (device_log_bypass_uart_address()) {        \
         _LOG_ERROR_STATUS_DV(status_);               \
       } else {                                       \
         LOG_ERROR("CHECK-STATUS-fail: %r", status_); \
@@ -330,7 +330,7 @@
   do {                                               \
     status_t status_ = expr;                         \
     if (status_ok(status_)) {                        \
-      if (kDeviceLogBypassUartAddress) {             \
+      if (device_log_bypass_uart_address()) {        \
         _LOG_ERROR_STATUS_DV(status_);               \
       } else {                                       \
         LOG_ERROR("CHECK-STATUS-fail: %r", status_); \

--- a/sw/device/lib/testing/test_framework/status.c
+++ b/sw/device/lib/testing/test_framework/status.c
@@ -15,9 +15,9 @@
  * @param test_status current status of the test.
  */
 static void test_status_device_write(test_status_t test_status) {
-  if (kDeviceTestStatusAddress != 0) {
-    mmio_region_t test_status_device_addr =
-        mmio_region_from_addr(kDeviceTestStatusAddress);
+  uintptr_t status_addr = device_test_status_address();
+  if (status_addr != 0) {
+    mmio_region_t test_status_device_addr = mmio_region_from_addr(status_addr);
     mmio_region_write32(test_status_device_addr, 0x0, (uint32_t)test_status);
   }
 }

--- a/sw/device/lib/testing/test_framework/status.h
+++ b/sw/device/lib/testing/test_framework/status.h
@@ -20,8 +20,8 @@ typedef enum test_status {
   /**
    * Indicates that the CPU has started executing the test_rom code.
    *
-   * Writing this value to #kDeviceTestStatusAddress must not stop simulation of
-   * the current device.
+   * Writing this value to #device_test_status_address() must not stop
+   * simulation of the current device.
    */
   kTestStatusInBootRom = 0xb090,  // 'bogo', BOotrom GO
 
@@ -29,24 +29,24 @@ typedef enum test_status {
    * Indicates that the CPU has seen ROM_EXEC_EN = 0 and will now stop
    * execution.
    *
-   * Writing this value to #kDeviceTestStatusAddress must not stop simulation of
-   * the current device.
+   * Writing this value to #device_test_status_address() must not stop
+   * simulation of the current device.
    */
   kTestStatusInBootRomHalt = 0xb057,  // 'bost', BOotrom STop
 
   /**
    * Indicates that the CPU has started executing the test code.
    *
-   * Writing this value to #kDeviceTestStatusAddress must not stop simulation of
-   * the current device.
+   * Writing this value to #device_test_status_address() must not stop
+   * simulation of the current device.
    */
   kTestStatusInTest = 0x4354,  // 'test'
 
   /**
    * Indicates that the CPU is in the WFI state.
    *
-   * Writing this value to #kDeviceTestStatusAddress must not stop simulation of
-   * the current device.
+   * Writing this value to #device_test_status_address() must not stop
+   * simulation of the current device.
    */
   kTestStatusInWfi = 0x1d1e,  // 'idle'
 
@@ -54,8 +54,8 @@ typedef enum test_status {
    * This indicates that the test has passed. This is a terminal state. Any code
    * appearing after this value is set is unreachable.
    *
-   * Writing this value to #kDeviceTestStatusAddress may stop simulation of the
-   * current device.
+   * Writing this value to #device_test_status_address() may stop simulation of
+   * the current device.
    */
   kTestStatusPassed = 0x900d,  // 'good'
 
@@ -63,8 +63,8 @@ typedef enum test_status {
    * This indicates that the test has failed. This is a terminal state. Any code
    * appearing after this value is set is unreachable.
    *
-   * Writing this value to #kDeviceTestStatusAddress may stop simulation of the
-   * current device.
+   * Writing this value to #device_test_status_address() may stop simulation of
+   * the current device.
    */
   kTestStatusFailed = 0xbaad  // 'baad'
 } test_status_t;
@@ -78,8 +78,9 @@ typedef enum test_status {
  * In simulated testing (Verilator, DV), this function writes `test_status` to
  * a specific address, which may cause the simulation to end.
  *
- * In environments with a null #kDeviceTestStatusAddress, this logs a message
- * for terminal states and calls abort. Otherwise, the function returns safely.
+ * In environments with a null #device_test_status_address(), this logs a
+ * message for terminal states and calls abort. Otherwise, the function returns
+ * safely.
  *
  * @param test_status current status of the test.
  */

--- a/sw/device/silicon_creator/lib/epmp_test_unlock.c
+++ b/sw/device/silicon_creator/lib/epmp_test_unlock.c
@@ -20,18 +20,19 @@ bool epmp_unlock_test_status(void) {
   const epmp_perm_t kPerm = kEpmpPermLockedReadWrite;
 
   // Check that address space is word aligned.
-  if (kDeviceTestStatusAddress % sizeof(uint32_t) != 0) {
+  uintptr_t status_addr = device_test_status_address();
+  if (status_addr % sizeof(uint32_t) != 0) {
     return false;
   }
 
   // Update the shadow register values.
-  epmp_region_t region = {.start = kDeviceTestStatusAddress,
-                          .end = kDeviceTestStatusAddress + sizeof(uint32_t)};
+  epmp_region_t region = {.start = status_addr,
+                          .end = status_addr + sizeof(uint32_t)};
   epmp_state_configure_na4(kEntry, region, kPerm);
 
   // Update the hardware registers.
   static_assert(kEntry == 6, "PMP entry has changed, update CSR operations.");
-  CSR_WRITE(CSR_REG_PMPADDR6, kDeviceTestStatusAddress / sizeof(uint32_t));
+  CSR_WRITE(CSR_REG_PMPADDR6, status_addr / sizeof(uint32_t));
   CSR_SET_BITS(CSR_REG_PMPCFG1, (kEpmpModeNa4 | kPerm)
                                     << ((kEntry % sizeof(uint32_t)) * 8));
 


### PR DESCRIPTION
By using the DT API for the Ibex core, we can make them work for all tops.