### PR TITLE
[sw,imm_rom_ext] Print hash enforcement status in boot message

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -25,7 +25,9 @@ cc_library(
     deps = [
         ":imm_rom_ext_epmp",
         "//hw/top:flash_ctrl_c_regs",
+        "//hw/top:otp_ctrl_c_regs",
         "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:epmp_state",

--- a/sw/device/silicon_creator/imm_rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/imm_rom_ext/defs.bzl
@@ -40,3 +40,7 @@ SLOT_VIRTUAL_IMM_ROM_EXT_SECTIONS = {
         "//sw/device/silicon_creator/imm_rom_ext:main_section_slot_virtual_silicon_creator",
     ],
 }
+
+# CAUTION: The message below should match the message defined in:
+#   //sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
+IMMUTABLE_HASH_UNENFORCED_MSG = "hash unenforced"

--- a/sw/device/silicon_creator/imm_rom_ext/e2e/boot_message/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/e2e/boot_message/BUILD
@@ -7,6 +7,10 @@ load(
     "fpga_params",
     "opentitan_test",
 )
+load(
+    "//sw/device/silicon_creator/imm_rom_ext:defs.bzl",
+    "IMMUTABLE_HASH_UNENFORCED_MSG",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -19,6 +23,21 @@ opentitan_test(
     },
     fpga = fpga_params(
         exit_success = "\nIMM_ROM_EXT:",
+    ),
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
+    name = "hash_unenforced_test",
+    srcs = ["//sw/device/silicon_creator/imm_rom_ext/e2e:empty_test"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        exit_success = IMMUTABLE_HASH_UNENFORCED_MSG,
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -24,6 +24,7 @@ load(
 )
 load(
     "//sw/device/silicon_creator/imm_rom_ext:defs.bzl",
+    "IMMUTABLE_HASH_UNENFORCED_MSG",
     "SLOT_VIRTUAL_IMM_ROM_EXT_SECTIONS",
 )
 
@@ -138,6 +139,7 @@ _POSITIONS = {
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",
         "success": "rom_ext_slot = AA__\r\n",
+        "failure": IMMUTABLE_HASH_UNENFORCED_MSG,
         "otp_img": ":otp_img_with_{}_imm_romext_enabled".format(name),
     }
     for name in SLOT_VIRTUAL_IMM_ROM_EXT_SECTIONS
@@ -156,6 +158,7 @@ _POSITIONS = {
             binaries = {
                 position["romext"]: "romext",
             },
+            exit_failure = position.get("failure", DEFAULT_TEST_FAILURE_MSG),
             exit_success = position["success"],
             otp = position["otp_img"],
             owner_offset = position["owner_offset"],


### PR DESCRIPTION
This commit adds a boot message that indicates whether the immutable rom_ext section is invoked by ROM (hash enforced) or by the fallback in ROM_EXT (hash unenforced).

This message can help identify the device mode for both manual and automated testing.