### PR TITLE
[cwt,dice,ot_certs] remove crate `cbor_reader_writer` from dice cert generation

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -149,10 +149,10 @@ cc_library(
 
 cc_library(
     name = "cbor",
+    srcs = ["cbor.c"],
     hdrs = ["cbor.h"],
     deps = [
         "//sw/device/lib/base:status",
-        "@open-dice//:cbor_reader_writer",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/cert/cbor.c
+++ b/sw/device/silicon_creator/lib/cert/cbor.c
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/cert/cbor.h"
+
+#include "sw/device/lib/base/memory.h"
+
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "CBOR library assumes that the system is little endian.");
+
+typedef enum {
+  Cbor_Type_Uint = 0,
+  Cbor_Type_Sint = 1,
+  Cbor_Type_Bstr = 2,
+  Cbor_Type_Tstr = 3,
+  Cbor_Type_Array = 4,
+  Cbor_Type_Map = 5,
+} cbor_type_t;
+
+typedef enum {
+  Cbor_Arg_Type_U8 = 24,
+  Cbor_Arg_Type_U16 = 25,
+  Cbor_Arg_Type_U32 = 26,
+  Cbor_Arg_Type_U64 = 27,
+} cbor_arg_type_t;
+
+size_t cbor_calc_arg_size(const uint64_t value) {
+  if (value <= 23) {
+    return 0;
+  } else if (value <= 0xff) {
+    return 1;
+  } else if (value <= 0xffff) {
+    return 2;
+  } else if (value <= 0xffffffff) {
+    return 4;
+  } else {
+    return 8;
+  };
+}
+
+static uint8_t cbor_calc_additional_info(const uint64_t value) {
+  if (value <= 23) {
+    return (uint8_t)value;
+  } else if (value <= 0xff) {
+    return Cbor_Arg_Type_U8;
+  } else if (value <= 0xffff) {
+    return Cbor_Arg_Type_U16;
+  } else if (value <= 0xffffffff) {
+    return Cbor_Arg_Type_U32;
+  } else {
+    return Cbor_Arg_Type_U64;
+  };
+}
+
+size_t cbor_calc_int_size(const int64_t value) {
+  if (value < 0)
+    return cbor_calc_arg_size((uint64_t)(-(value + 1)));
+  else
+    return cbor_calc_arg_size((uint64_t)value);
+}
+
+size_t cbor_write_raw_bytes(cbor_out_t *p, const uint8_t *raw,
+                            const size_t raw_size) {
+  if (p) {
+    memcpy(p->start + p->offset, raw, raw_size);
+    p->offset += raw_size;
+  }
+
+  return raw_size;
+}
+
+static size_t cbor_write_type(cbor_out_t *p, cbor_type_t type,
+                              const uint64_t arg) {
+  const size_t sz = cbor_calc_arg_size(arg);
+
+  if (p) {
+    const uint8_t add_info = cbor_calc_additional_info(arg);
+    const uint8_t *parg = (uint8_t *)&arg + sz;
+
+    p->start[p->offset++] = ((uint8_t)(type << 5) | add_info);
+    for (size_t i = 0; i < sz; ++i)
+      p->start[p->offset++] = *(--parg);
+  }
+
+  return 1 + sz;
+}
+
+size_t cbor_write_int(cbor_out_t *p, const int64_t value) {
+  if (value < 0)
+    return cbor_write_type(p, Cbor_Type_Sint, (uint64_t)(-(value + 1)));
+  else
+    return cbor_write_type(p, Cbor_Type_Uint, (uint64_t)value);
+}
+
+size_t cbor_write_bstr_header(cbor_out_t *p, const size_t bstr_size) {
+  return cbor_write_type(p, Cbor_Type_Bstr, bstr_size);
+}
+
+size_t cbor_write_tstr_header(cbor_out_t *p, const size_t tstr_size) {
+  return cbor_write_type(p, Cbor_Type_Tstr, tstr_size);
+}
+
+size_t cbor_write_array_header(cbor_out_t *p, const size_t num_elements) {
+  return cbor_write_type(p, Cbor_Type_Array, num_elements);
+}
+
+size_t cbor_write_map_header(cbor_out_t *p, const size_t num_pairs) {
+  return cbor_write_type(p, Cbor_Type_Map, num_pairs);
+}

--- a/sw/device/silicon_creator/lib/cert/cbor.h
+++ b/sw/device/silicon_creator/lib/cert/cbor.h
@@ -5,272 +5,135 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_
 
-#include "include/dice/cbor_writer.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-#define CBOR_RETURN_IF_OVERFLOWED(p) \
-  do {                               \
-    if (CborOutOverflowed(p)) {      \
-      return kErrorCertInvalidSize;  \
-    }                                \
-  } while (0)
+struct cbor_out {
+  uint8_t *start;
+  size_t offset;
+};
 
-#define CBOR_CHECK_OVERFLOWED_AND_RETURN(p) \
-  do {                                      \
-    CBOR_RETURN_IF_OVERFLOWED(p);           \
-    return kErrorOk;                        \
-  } while (0)
+typedef struct cbor_out cbor_out_t;
 
 /**
- * Initialize a CborOut structure.
+ * Initialize the cbor_out_t.
  *
- * @param[in,out] p The pointer to a CborOut structure
- * @param buf The buffer that can be used for CBOR encoding
- * @param buf_size The buffer size
- * @return kErrorOk, or kErrorCertInvalidSize if the buf_size exceeds the
- *         buffer size that is recorded in p.
+ * @param[in,out] p cbor_out structure
+ * @param buf buffer to be written
  */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_out_init(
-    struct CborOut *p, void *buf, const size_t buf_size) {
-  CborOutInit(buf, buf_size, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add a "map" header along with the elements count to a CborOut structure.
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param num_pairs The elements count in the map
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_map_init(
-    struct CborOut *p, const size_t num_pairs) {
-  CborWriteMap(num_pairs, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add a "array" header along with the elements count to a CborOut structure.
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param num_elements The elements count in the map
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_array_init(
-    struct CborOut *p, const size_t num_elements) {
-  CborWriteArray(num_elements, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add a "tstr" to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param str The string pointer
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_string(
-    struct CborOut *p, const char *str) {
-  CborWriteTstr(str, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add a "bstr" to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param data The pointer to the data that needs to be packed
- * @packed data_size Size of the data
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_bytes(
-    struct CborOut *p, const uint8_t *data, const size_t data_size) {
-  CborWriteBstr(data_size, data, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-
-/***********************************************
- * Wrappers to encode a pair of data for cbor-map
- ***********************************************/
-/**
- * Add 2 elements, "uint" and "uint", to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param key The first "uint" element
- * @param value The second "uint" element
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_uint(
-    struct CborOut *p, uint64_t key, uint64_t value) {
-  CborWriteUint(key, p);
-  CborWriteUint(value, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add 2 elements, "int" and "uint", to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param key The first "int" element
- * @param value The second "uint" element
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_uint(
-    struct CborOut *p, int64_t key, uint64_t value) {
-  CborWriteInt(key, p);
-  CborWriteUint(value, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add 2 elements, "uint" and "int", to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param key The first "uint" element
- * @param value The second "int" element
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_int(
-    struct CborOut *p, uint64_t key, int64_t value) {
-  CborWriteUint(key, p);
-  CborWriteInt(value, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add 2 elements, "int" and "bstr", to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param key The first "int" element
- * @param value The pointer of the second "bstr" element
- * @param value_size Size of the value
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_bytes(
-    struct CborOut *p, int64_t key, const uint8_t *value,
-    const size_t value_size) {
-  CborWriteInt(key, p);
-  CborWriteBstr(value_size, value, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add 2 elements, "uint" and "tstr", to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param key The first "uint" element
- * @param value The pointer of the second "tstr" element
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_tstr(
-    struct CborOut *p, uint64_t key, const char *value) {
-  CborWriteUint(key, p);
-  CborWriteTstr(value, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add 2 elements, "int" and "tstr", to a CborOut structure
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param key The first "int" element
- * @param value The pointer of the second "tstr" element
- * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
- *         overflowed
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_tstr(
-    struct CborOut *p, int64_t key, const char *value) {
-  CborWriteInt(key, p);
-  CborWriteTstr(value, p);
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-
-/***********************************************
- * Helpers for the auto-gen template
- ***********************************************/
-/**
- * Calculate how much space is needed in the header for an "unsigned interger"
- * type of CBOR argument.
- *
- * @param value An unsigned integer argument.
- * @return Size required in the header
- */
-static inline size_t cbor_calc_arg_size(uint64_t value) {
-  if (value <= 23) {
-    return 0;
-  } else if (value <= 0xff) {
-    return 1;
-  } else if (value <= 0xffff) {
-    return 2;
-  } else if (value <= 0xffffffff) {
-    return 4;
-  } else {
-    return 8;
-  };
-}
-/**
- * Calculate how much space is needed in the header for a "signed interger" type
- * of CBOR argument.
- *
- * @param value An signed integer argument.
- * @return Size required in the header
- */
-static inline size_t cbor_calc_int_size(int64_t value) {
-  if (value < 0)
-    return cbor_calc_arg_size((uint64_t)(-(value + 1)));
-
-  return cbor_calc_arg_size((uint64_t)value);
-}
-
-// Add a bstr/tstr header with size, and rewind the cursor
-/**
- * Add a "bstr" header along with the payload size, and rewind the cursor of
- * CborOut structure.
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param bstr_size The size of the payload
- * @return kErrorOk, or kErrorCertInvalidSize if the bstr_size exceeds the
- *         buffer size that is recorded in p.
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_bstr_header(
-    struct CborOut *p, const size_t bstr_size) {
-  if (NULL == CborAllocBstr(bstr_size, p))
-    return kErrorCertInvalidSize;
-  p->cursor -= bstr_size;
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
-}
-/**
- * Add a "tstr" header along with the payload size, and rewind the cursor of
- * CborOut structure.
- *
- * @param[in,out] p The pointer to a CborOut structure
- * @param tstr_size The size of the payload
- * @return kErrorOk, or kErrorCertInvalidSize if the tstr_size exceeds the
- *         buffer size that is recorded in p.
- */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_tstr_header(
-    struct CborOut *p, const size_t tstr_size) {
-  if (NULL == CborAllocTstr(tstr_size, p))
-    return kErrorCertInvalidSize;
-  p->cursor -= tstr_size;
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+static inline void cbor_out_init(cbor_out_t *p, void *buf) {
+  p->start = buf;
+  p->offset = 0;
 }
 
 /**
- * Fill in raw data to a given CborOut structure.
+ * Return the current written size in the cbor_out_t.
  *
- * @param[in,out] p The pointer to a CborOut structure
- * @param raw The pointer to the raw bytes
- * @param raw_size The size of the raw byptes
- * @return kErrorOk, or kErrorCertInvalidSize if the raw_size exceeds the
- *         buffer size that is recorded in p.
+ * @param[in] p cbor_out structure
+ * @return current written size
  */
-OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_raw_bytes(
-    struct CborOut *p, const uint8_t *raw, const size_t raw_size) {
-  if (p->cursor + raw_size > p->buffer_size)
-    return kErrorCertInvalidSize;
-  memcpy(&p->buffer[p->cursor], raw, raw_size);
-  p->cursor += raw_size;
-  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+static inline size_t cbor_out_size(cbor_out_t *p) { return p->offset; }
+
+/**
+ * Calculate the required size of "CBOR argument".
+ *
+ * @param value unsigned argument
+ * @return required size
+ */
+size_t cbor_calc_arg_size(uint64_t value);
+
+/**
+ * Calculate the required size to encode the signed integer as "CBOR argument".
+ *
+ * @param value signed integer
+ * @return required size
+ */
+size_t cbor_calc_int_size(int64_t value);
+
+/**
+ * Write the raw bytes if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param raw pointer to raw bytes
+ * @param raw_size the size of raw bytes
+ * @return size to be written
+ */
+size_t cbor_write_raw_bytes(cbor_out_t *p, const uint8_t *raw, size_t raw_size);
+
+/**
+ * Write the integer if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param value signed integer
+ * @return size to be written
+ */
+size_t cbor_write_int(cbor_out_t *p, int64_t value);
+
+/**
+ * Write the byte string header if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param bstr_size size of the bstr
+ * @return size to be written
+ */
+size_t cbor_write_bstr_header(cbor_out_t *p, size_t bstr_size);
+
+/**
+ * A helper function to write the byte string if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param bstr pointer to the bstr
+ * @param bstr_size size of the bstr
+ * @return size to be written
+ */
+static inline size_t cbor_write_bstr(cbor_out_t *p, const uint8_t *bstr,
+                                     size_t bstr_size) {
+  size_t sz = 0;
+  sz += cbor_write_bstr_header(p, bstr_size);
+  sz += cbor_write_raw_bytes(p, bstr, bstr_size);
+  return sz;
 }
+
+/**
+ * Write the text string header if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param bstr_size size of the tstr
+ * @return size to be written
+ */
+size_t cbor_write_tstr_header(cbor_out_t *p, size_t tstr_size);
+
+/**
+ * A helper function to write the text string if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param tstr pointer to the tstr
+ * @param bstr_size size of the tstr
+ * @return size to be written
+ */
+static inline size_t cbor_write_tstr(cbor_out_t *p, const uint8_t *tstr,
+                                     size_t tstr_size) {
+  size_t sz = 0;
+  sz += cbor_write_tstr_header(p, tstr_size);
+  sz += cbor_write_raw_bytes(p, tstr, tstr_size);
+  return sz;
+}
+
+/**
+ * Write the array header if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param num_elements the number of elements in the array
+ * @return size to be written
+ */
+size_t cbor_write_array_header(cbor_out_t *p, size_t num_elements);
+
+/**
+ * Write the map header if cbor_out is not NULL.
+ *
+ * @param[in,out] p cbor_out structure
+ * @param num_pairs the number of pairs in the map
+ * @return size to be written
+ */
+size_t cbor_write_map_header(cbor_out_t *p, size_t num_pairs);
+
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_

--- a/sw/host/ot_certs/src/cwt.rs
+++ b/sw/host/ot_certs/src/cwt.rs
@@ -683,7 +683,7 @@ fn generate_cbor_instructions(
 
     let call_wrapper = |func_call: String| {
         indoc::formatdoc! { r#"
-            {prefix}RETURN_IF_ERROR({func_call});
+            {prefix}{func_call};
             "#
         }
     };
@@ -869,11 +869,11 @@ fn generate_source(
         rom_error_t {template_name}_build({template_name}_values_t *values, uint8_t *buffer, size_t *inout_size) {{
         {size_computations}
         {input_size_checks}
-          struct CborOut cbor;
-          RETURN_IF_ERROR(cbor_write_out_init(&cbor, buffer, *inout_size));
+          cbor_out_t cbor;
+          cbor_out_init(&cbor, buffer);
 
         {cbor_instructions}
-          *inout_size = CborOutSize(&cbor);
+          *inout_size = cbor_out_size(&cbor);
         {output_size_checks}
           return kErrorOk;
         }}

--- a/third_party/open-dice/BUILD.open-dice.bazel
+++ b/third_party/open-dice/BUILD.open-dice.bazel
@@ -7,11 +7,9 @@ cc_library(
     name = "cbor_reader_writer",
     srcs = [
         "src/cbor_reader.c",
-        "src/cbor_writer.c",
     ],
     hdrs = [
         "include/dice/cbor_reader.h",
-        "include/dice/cbor_writer.h",
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
As part of the code size reduction process in CWT, this PR aims to provide a custom-made CBOR writer library for dice cert generation.

The core idea of this CBOR writer library is that we don't check if the destination buffer is large enough in every function call.
Instead, we require users to query the output size without writing to the actual buffer first.
If it doesn't exceed, then they run the process again to output to the target buffer.

For the codegen generated functions, we already calculate the size on our own, and thus we ignore the return values.