### PR TITLE
[racl,reggen] reg_top.sv.tpl Fix _re signals in reg_enable_gen

### DIFF
--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -813,33 +813,33 @@ module gpio_reg_top
   assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
   assign alert_test_wd = reg_wdata[0];
-  assign direct_out_re = racl_addr_hit_write[5] & reg_re & !reg_error;
+  assign direct_out_re = racl_addr_hit_read[5] & reg_re & !reg_error;
   assign direct_out_we = racl_addr_hit_write[5] & reg_we & !reg_error;
 
   assign direct_out_wd = reg_wdata[31:0];
-  assign masked_out_lower_re = racl_addr_hit_write[6] & reg_re & !reg_error;
+  assign masked_out_lower_re = racl_addr_hit_read[6] & reg_re & !reg_error;
   assign masked_out_lower_we = racl_addr_hit_write[6] & reg_we & !reg_error;
 
   assign masked_out_lower_data_wd = reg_wdata[15:0];
 
   assign masked_out_lower_mask_wd = reg_wdata[31:16];
-  assign masked_out_upper_re = racl_addr_hit_write[7] & reg_re & !reg_error;
+  assign masked_out_upper_re = racl_addr_hit_read[7] & reg_re & !reg_error;
   assign masked_out_upper_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign masked_out_upper_data_wd = reg_wdata[15:0];
 
   assign masked_out_upper_mask_wd = reg_wdata[31:16];
-  assign direct_oe_re = racl_addr_hit_write[8] & reg_re & !reg_error;
+  assign direct_oe_re = racl_addr_hit_read[8] & reg_re & !reg_error;
   assign direct_oe_we = racl_addr_hit_write[8] & reg_we & !reg_error;
 
   assign direct_oe_wd = reg_wdata[31:0];
-  assign masked_oe_lower_re = racl_addr_hit_write[9] & reg_re & !reg_error;
+  assign masked_oe_lower_re = racl_addr_hit_read[9] & reg_re & !reg_error;
   assign masked_oe_lower_we = racl_addr_hit_write[9] & reg_we & !reg_error;
 
   assign masked_oe_lower_data_wd = reg_wdata[15:0];
 
   assign masked_oe_lower_mask_wd = reg_wdata[31:16];
-  assign masked_oe_upper_re = racl_addr_hit_write[10] & reg_re & !reg_error;
+  assign masked_oe_upper_re = racl_addr_hit_read[10] & reg_re & !reg_error;
   assign masked_oe_upper_we = racl_addr_hit_write[10] & reg_we & !reg_error;
 
   assign masked_oe_upper_data_wd = reg_wdata[15:0];

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -3620,8 +3620,8 @@ module i2c_reg_top
   assign ctrl_multi_controller_monitor_en_wd = reg_wdata[5];
 
   assign ctrl_tx_stretch_ctrl_en_wd = reg_wdata[6];
-  assign status_re = racl_addr_hit_write[5] & reg_re & !reg_error;
-  assign rdata_re = racl_addr_hit_write[6] & reg_re & !reg_error;
+  assign status_re = racl_addr_hit_read[5] & reg_re & !reg_error;
+  assign rdata_re = racl_addr_hit_read[6] & reg_re & !reg_error;
   assign fdata_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign fdata_fbyte_wd = reg_wdata[7:0];
@@ -3654,8 +3654,8 @@ module i2c_reg_top
   assign target_fifo_config_tx_thresh_wd = reg_wdata[11:0];
 
   assign target_fifo_config_acq_thresh_wd = reg_wdata[27:16];
-  assign host_fifo_status_re = racl_addr_hit_write[11] & reg_re & !reg_error;
-  assign target_fifo_status_re = racl_addr_hit_write[12] & reg_re & !reg_error;
+  assign host_fifo_status_re = racl_addr_hit_read[11] & reg_re & !reg_error;
+  assign target_fifo_status_re = racl_addr_hit_read[12] & reg_re & !reg_error;
   assign ovrd_we = racl_addr_hit_write[13] & reg_we & !reg_error;
 
   assign ovrd_txovrden_wd = reg_wdata[0];
@@ -3663,7 +3663,7 @@ module i2c_reg_top
   assign ovrd_sclval_wd = reg_wdata[1];
 
   assign ovrd_sdaval_wd = reg_wdata[2];
-  assign val_re = racl_addr_hit_write[14] & reg_re & !reg_error;
+  assign val_re = racl_addr_hit_read[14] & reg_re & !reg_error;
   assign timing0_we = racl_addr_hit_write[15] & reg_we & !reg_error;
 
   assign timing0_thigh_wd = reg_wdata[12:0];
@@ -3705,7 +3705,7 @@ module i2c_reg_top
   assign target_id_address1_wd = reg_wdata[20:14];
 
   assign target_id_mask1_wd = reg_wdata[27:21];
-  assign acqdata_re = racl_addr_hit_write[22] & reg_re & !reg_error;
+  assign acqdata_re = racl_addr_hit_read[22] & reg_re & !reg_error;
   assign txdata_we = racl_addr_hit_write[23] & reg_we & !reg_error;
 
   assign txdata_wd = reg_wdata[7:0];
@@ -3717,16 +3717,16 @@ module i2c_reg_top
   assign target_timeout_ctrl_val_wd = reg_wdata[30:0];
 
   assign target_timeout_ctrl_en_wd = reg_wdata[31];
-  assign target_nack_count_re = racl_addr_hit_write[26] & reg_re & !reg_error;
+  assign target_nack_count_re = racl_addr_hit_read[26] & reg_re & !reg_error;
 
   assign target_nack_count_wd = '1;
-  assign target_ack_ctrl_re = racl_addr_hit_write[27] & reg_re & !reg_error;
+  assign target_ack_ctrl_re = racl_addr_hit_read[27] & reg_re & !reg_error;
   assign target_ack_ctrl_we = racl_addr_hit_write[27] & reg_we & !reg_error;
 
   assign target_ack_ctrl_nbytes_wd = reg_wdata[8:0];
 
   assign target_ack_ctrl_nack_wd = reg_wdata[31];
-  assign acq_fifo_next_data_re = racl_addr_hit_write[28] & reg_re & !reg_error;
+  assign acq_fifo_next_data_re = racl_addr_hit_read[28] & reg_re & !reg_error;
   assign host_nack_handler_timeout_we = racl_addr_hit_write[29] & reg_we & !reg_error;
 
   assign host_nack_handler_timeout_val_wd = reg_wdata[30:0];

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -542,7 +542,7 @@ module mbx_soc_reg_top
   end
 
   // Generate write-enables
-  assign soc_control_re = racl_addr_hit_write[0] & reg_re & !reg_error;
+  assign soc_control_re = racl_addr_hit_read[0] & reg_re & !reg_error;
   assign soc_control_we = racl_addr_hit_write[0] & reg_we & !reg_error;
 
   assign soc_control_abort_wd = reg_wdata[0];

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -19746,7 +19746,7 @@ module spi_device_reg_top
   assign cfg_rx_order_wd = reg_wdata[3];
 
   assign cfg_mailbox_en_wd = reg_wdata[24];
-  assign status_re = racl_addr_hit_write[6] & reg_re & !reg_error;
+  assign status_re = racl_addr_hit_read[6] & reg_re & !reg_error;
   assign intercept_en_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign intercept_en_status_wd = reg_wdata[0];
@@ -19756,12 +19756,12 @@ module spi_device_reg_top
   assign intercept_en_sfdp_wd = reg_wdata[2];
 
   assign intercept_en_mbx_wd = reg_wdata[3];
-  assign addr_mode_re = racl_addr_hit_write[8] & reg_re & !reg_error;
+  assign addr_mode_re = racl_addr_hit_read[8] & reg_re & !reg_error;
   assign addr_mode_we = racl_addr_hit_write[8] & reg_we & !reg_error;
 
   assign addr_mode_addr_4b_en_wd = reg_wdata[0];
-  assign last_read_addr_re = racl_addr_hit_write[9] & reg_re & !reg_error;
-  assign flash_status_re = racl_addr_hit_write[10] & reg_re & !reg_error;
+  assign last_read_addr_re = racl_addr_hit_read[9] & reg_re & !reg_error;
+  assign flash_status_re = racl_addr_hit_read[10] & reg_re & !reg_error;
   assign flash_status_we = racl_addr_hit_write[10] & reg_we & !reg_error;
 
   assign flash_status_busy_wd = reg_wdata[0];
@@ -19785,8 +19785,8 @@ module spi_device_reg_top
   assign mailbox_addr_we = racl_addr_hit_write[14] & reg_we & !reg_error;
 
   assign mailbox_addr_wd = reg_wdata[31:0];
-  assign upload_cmdfifo_re = racl_addr_hit_write[17] & reg_re & !reg_error;
-  assign upload_addrfifo_re = racl_addr_hit_write[18] & reg_re & !reg_error;
+  assign upload_cmdfifo_re = racl_addr_hit_read[17] & reg_re & !reg_error;
+  assign upload_addrfifo_re = racl_addr_hit_read[18] & reg_re & !reg_error;
   assign cmd_filter_0_we = racl_addr_hit_write[19] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
@@ -20998,7 +20998,7 @@ module spi_device_reg_top
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_status_re = racl_addr_hit_write[61] & reg_re & !reg_error;
+  assign tpm_status_re = racl_addr_hit_read[61] & reg_re & !reg_error;
   assign tpm_status_we = racl_addr_hit_write[61] & reg_we & !reg_error;
 
   assign tpm_status_wrfifo_pending_wd = reg_wdata[1];
@@ -21037,7 +21037,7 @@ module spi_device_reg_top
   assign tpm_rid_we = racl_addr_hit_write[70] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = racl_addr_hit_write[71] & reg_re & !reg_error;
+  assign tpm_cmd_addr_re = racl_addr_hit_read[71] & reg_re & !reg_error;
   assign tpm_read_fifo_we = racl_addr_hit_write[72] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[31:0];

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1734,8 +1734,8 @@ module uart_reg_top
   assign ctrl_rxblvl_wd = reg_wdata[9:8];
 
   assign ctrl_nco_wd = reg_wdata[31:16];
-  assign status_re = racl_addr_hit_write[5] & reg_re & !reg_error;
-  assign rdata_re = racl_addr_hit_write[6] & reg_re & !reg_error;
+  assign status_re = racl_addr_hit_read[5] & reg_re & !reg_error;
+  assign rdata_re = racl_addr_hit_read[6] & reg_re & !reg_error;
   assign wdata_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign wdata_wd = reg_wdata[7:0];
@@ -1748,13 +1748,13 @@ module uart_reg_top
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
   assign fifo_ctrl_txilvl_wd = reg_wdata[7:5];
-  assign fifo_status_re = racl_addr_hit_write[9] & reg_re & !reg_error;
+  assign fifo_status_re = racl_addr_hit_read[9] & reg_re & !reg_error;
   assign ovrd_we = racl_addr_hit_write[10] & reg_we & !reg_error;
 
   assign ovrd_txen_wd = reg_wdata[0];
 
   assign ovrd_txval_wd = reg_wdata[1];
-  assign val_re = racl_addr_hit_write[11] & reg_re & !reg_error;
+  assign val_re = racl_addr_hit_read[11] & reg_re & !reg_error;
   assign timeout_ctrl_we = racl_addr_hit_write[12] & reg_we & !reg_error;
 
   assign timeout_ctrl_val_wd = reg_wdata[23:0];

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -12935,193 +12935,193 @@ module ac_range_check_reg_top
   assign range_perm_31_execute_access_31_wd = reg_wdata[15:12];
 
   assign range_perm_31_log_denied_access_31_wd = reg_wdata[19:16];
-  assign range_racl_policy_shadowed_0_re = racl_addr_hit_write[135] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_0_re = racl_addr_hit_read[135] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_0_we = racl_addr_hit_write[135] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_0_read_perm_0_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_0_write_perm_0_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_1_re = racl_addr_hit_write[136] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_1_re = racl_addr_hit_read[136] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_1_we = racl_addr_hit_write[136] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_1_read_perm_1_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_1_write_perm_1_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_2_re = racl_addr_hit_write[137] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_2_re = racl_addr_hit_read[137] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_2_we = racl_addr_hit_write[137] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_2_read_perm_2_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_2_write_perm_2_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_3_re = racl_addr_hit_write[138] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_3_re = racl_addr_hit_read[138] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_3_we = racl_addr_hit_write[138] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_3_read_perm_3_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_3_write_perm_3_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_4_re = racl_addr_hit_write[139] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_4_re = racl_addr_hit_read[139] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_4_we = racl_addr_hit_write[139] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_4_read_perm_4_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_4_write_perm_4_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_5_re = racl_addr_hit_write[140] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_5_re = racl_addr_hit_read[140] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_5_we = racl_addr_hit_write[140] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_5_read_perm_5_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_5_write_perm_5_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_6_re = racl_addr_hit_write[141] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_6_re = racl_addr_hit_read[141] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_6_we = racl_addr_hit_write[141] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_6_read_perm_6_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_6_write_perm_6_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_7_re = racl_addr_hit_write[142] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_7_re = racl_addr_hit_read[142] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_7_we = racl_addr_hit_write[142] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_7_read_perm_7_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_7_write_perm_7_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_8_re = racl_addr_hit_write[143] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_8_re = racl_addr_hit_read[143] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_8_we = racl_addr_hit_write[143] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_8_read_perm_8_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_8_write_perm_8_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_9_re = racl_addr_hit_write[144] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_9_re = racl_addr_hit_read[144] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_9_we = racl_addr_hit_write[144] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_9_read_perm_9_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_9_write_perm_9_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_10_re = racl_addr_hit_write[145] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_10_re = racl_addr_hit_read[145] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_10_we = racl_addr_hit_write[145] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_10_read_perm_10_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_10_write_perm_10_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_11_re = racl_addr_hit_write[146] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_11_re = racl_addr_hit_read[146] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_11_we = racl_addr_hit_write[146] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_11_read_perm_11_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_11_write_perm_11_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_12_re = racl_addr_hit_write[147] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_12_re = racl_addr_hit_read[147] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_12_we = racl_addr_hit_write[147] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_12_read_perm_12_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_12_write_perm_12_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_13_re = racl_addr_hit_write[148] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_13_re = racl_addr_hit_read[148] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_13_we = racl_addr_hit_write[148] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_13_read_perm_13_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_13_write_perm_13_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_14_re = racl_addr_hit_write[149] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_14_re = racl_addr_hit_read[149] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_14_we = racl_addr_hit_write[149] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_14_read_perm_14_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_14_write_perm_14_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_15_re = racl_addr_hit_write[150] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_15_re = racl_addr_hit_read[150] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_15_we = racl_addr_hit_write[150] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_15_read_perm_15_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_15_write_perm_15_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_16_re = racl_addr_hit_write[151] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_16_re = racl_addr_hit_read[151] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_16_we = racl_addr_hit_write[151] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_16_read_perm_16_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_16_write_perm_16_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_17_re = racl_addr_hit_write[152] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_17_re = racl_addr_hit_read[152] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_17_we = racl_addr_hit_write[152] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_17_read_perm_17_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_17_write_perm_17_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_18_re = racl_addr_hit_write[153] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_18_re = racl_addr_hit_read[153] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_18_we = racl_addr_hit_write[153] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_18_read_perm_18_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_18_write_perm_18_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_19_re = racl_addr_hit_write[154] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_19_re = racl_addr_hit_read[154] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_19_we = racl_addr_hit_write[154] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_19_read_perm_19_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_19_write_perm_19_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_20_re = racl_addr_hit_write[155] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_20_re = racl_addr_hit_read[155] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_20_we = racl_addr_hit_write[155] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_20_read_perm_20_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_20_write_perm_20_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_21_re = racl_addr_hit_write[156] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_21_re = racl_addr_hit_read[156] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_21_we = racl_addr_hit_write[156] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_21_read_perm_21_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_21_write_perm_21_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_22_re = racl_addr_hit_write[157] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_22_re = racl_addr_hit_read[157] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_22_we = racl_addr_hit_write[157] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_22_read_perm_22_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_22_write_perm_22_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_23_re = racl_addr_hit_write[158] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_23_re = racl_addr_hit_read[158] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_23_we = racl_addr_hit_write[158] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_23_read_perm_23_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_23_write_perm_23_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_24_re = racl_addr_hit_write[159] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_24_re = racl_addr_hit_read[159] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_24_we = racl_addr_hit_write[159] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_24_read_perm_24_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_24_write_perm_24_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_25_re = racl_addr_hit_write[160] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_25_re = racl_addr_hit_read[160] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_25_we = racl_addr_hit_write[160] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_25_read_perm_25_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_25_write_perm_25_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_26_re = racl_addr_hit_write[161] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_26_re = racl_addr_hit_read[161] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_26_we = racl_addr_hit_write[161] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_26_read_perm_26_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_26_write_perm_26_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_27_re = racl_addr_hit_write[162] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_27_re = racl_addr_hit_read[162] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_27_we = racl_addr_hit_write[162] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_27_read_perm_27_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_27_write_perm_27_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_28_re = racl_addr_hit_write[163] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_28_re = racl_addr_hit_read[163] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_28_we = racl_addr_hit_write[163] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_28_read_perm_28_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_28_write_perm_28_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_29_re = racl_addr_hit_write[164] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_29_re = racl_addr_hit_read[164] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_29_we = racl_addr_hit_write[164] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_29_read_perm_29_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_29_write_perm_29_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_30_re = racl_addr_hit_write[165] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_30_re = racl_addr_hit_read[165] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_30_we = racl_addr_hit_write[165] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_30_read_perm_30_wd = reg_wdata[15:0];
 
   assign range_racl_policy_shadowed_30_write_perm_30_wd = reg_wdata[31:16];
-  assign range_racl_policy_shadowed_31_re = racl_addr_hit_write[166] & reg_re & !reg_error;
+  assign range_racl_policy_shadowed_31_re = racl_addr_hit_read[166] & reg_re & !reg_error;
   assign range_racl_policy_shadowed_31_we = racl_addr_hit_write[166] & reg_we & !reg_error;
 
   assign range_racl_policy_shadowed_31_read_perm_31_wd = reg_wdata[15:0];

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -669,19 +669,19 @@ module racl_ctrl_reg_top
   assign error_log_we = racl_addr_hit_write[1] & reg_we & !reg_error;
 
   assign error_log_valid_wd = reg_wdata[0];
-  assign policy_all_rd_wr_shadowed_re = racl_addr_hit_write[2] & reg_re & !reg_error;
+  assign policy_all_rd_wr_shadowed_re = racl_addr_hit_read[2] & reg_re & !reg_error;
   assign policy_all_rd_wr_shadowed_we = racl_addr_hit_write[2] & reg_we & !reg_error;
 
   assign policy_all_rd_wr_shadowed_read_perm_wd = reg_wdata[15:0];
 
   assign policy_all_rd_wr_shadowed_write_perm_wd = reg_wdata[31:16];
-  assign policy_rot_private_shadowed_re = racl_addr_hit_write[3] & reg_re & !reg_error;
+  assign policy_rot_private_shadowed_re = racl_addr_hit_read[3] & reg_re & !reg_error;
   assign policy_rot_private_shadowed_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
   assign policy_rot_private_shadowed_read_perm_wd = reg_wdata[15:0];
 
   assign policy_rot_private_shadowed_write_perm_wd = reg_wdata[31:16];
-  assign policy_soc_rot_shadowed_re = racl_addr_hit_write[4] & reg_re & !reg_error;
+  assign policy_soc_rot_shadowed_re = racl_addr_hit_read[4] & reg_re & !reg_error;
   assign policy_soc_rot_shadowed_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign policy_soc_rot_shadowed_read_perm_wd = reg_wdata[15:0];

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -1180,8 +1180,9 @@ ${bits.msb}\
 </%def>\
 <%def name="reg_enable_gen(reg, idx)">\
 <% wr_addr_hit = 'racl_addr_hit_write' if racl_support else 'addr_hit'%>\
+<% re_addr_hit = 'racl_addr_hit_read'  if racl_support else 'addr_hit'%>\
   % if reg.needs_re():
-  assign ${reg.name.lower()}_re = ${wr_addr_hit}[${idx}] & reg_re & !reg_error;
+  assign ${reg.name.lower()}_re = ${re_addr_hit}[${idx}] & reg_re & !reg_error;
   % endif
   % if reg.needs_we():
   assign ${reg.name.lower()}_we = ${wr_addr_hit}[${idx}] & reg_we & !reg_error;


### PR DESCRIPTION
This PR fixes a small issue in `reg_top.sv.tpl`:

With the introduction of RACL the `_re` and `_we` signals in `reg_enable_gen` were changed from `addr_hit` to `wr_addr_hit`, which depends on `racl_addr_hit_write`. However, `_we` should use `racl_addr_hit_read` instead.