### PR TITLE
[ci] fix bazel target name warnings and turn it into hard error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
         run: ./ci/scripts/check-bazel-banned-rules.sh
       - name: Bazel target names
         run: ./ci/scripts/check_bazel_target_names.py
-        continue-on-error: true
       - name: DV software images
         run: ./ci/scripts/check_dv_sw_images.sh
         continue-on-error: true

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -29,7 +29,7 @@ cc_import(
 )
 
 cc_import(
-    name = "libc++",
+    name = "libcxx",
     shared_library = "@llvm_toolchain_llvm//:lib/libc++.so",
 )
 
@@ -38,7 +38,7 @@ rust_bindgen_toolchain(
     bindgen = "@rules_rust_bindgen//3rdparty:bindgen",
     clang = "@llvm_toolchain_llvm//:bin/clang",
     libclang = ":libclang",
-    libstdcxx = ":libc++",
+    libstdcxx = ":libcxx",
 )
 
 toolchain(


### PR DESCRIPTION
An effort to remove `continue-on-error` since nobody actually checks them.