### PR TITLE
[python] add ignore for conflicting rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,3 +196,5 @@ extend-exclude = [
 preview = true
 explicit-preview-rules = true
 select = ["ALL", "E303", "W391"]
+# Ignore conflicting rules as recommended
+ignore = ["D203", "D213", "COM812", "ISC001"]


### PR DESCRIPTION
There are some warnings when running ruff format due to conflicting rules. This PR sets the ignore list as recommended. The behavior is not expected to change, but rather make the current behavior explicit and prevent the warning messages.

```
✦ ❯ ruff format
warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
1 file left unchanged
```