### PR TITLE
[multitop,clkmgr] Port clkmgr DIF to support DJ & port `kmac_idle_test` to DT

### DIFF
--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -372,10 +372,16 @@ dif_result_t dif_clkmgr_enable_measure_counts(const dif_clkmgr_t *clkmgr,
       lo_field = CLKMGR_##kind_##_MEAS_CTRL_SHADOWED_LO_FIELD;     \
       hi_field = CLKMGR_##kind_##_MEAS_CTRL_SHADOWED_HI_FIELD; break, break)
 
+#if defined(OPENTITAN_IS_EARLGREY)
     case kDifClkmgrMeasureClockIo:
       PICK_COUNT_CTRL_FIELDS(IO);
     case kDifClkmgrMeasureClockIoDiv2:
       PICK_COUNT_CTRL_FIELDS(IO_DIV2);
+#elif defined(OPENTITAN_IS_DARJEELING)
+// Darjeeling does not have Io / IoDiv2 clock measurements
+#else
+#error "dif_clkmgr does not support this top"
+#endif
     case kDifClkmgrMeasureClockIoDiv4:
       PICK_COUNT_CTRL_FIELDS(IO_DIV4);
     case kDifClkmgrMeasureClockMain:
@@ -422,12 +428,18 @@ dif_result_t dif_clkmgr_disable_measure_counts(
       en_offset = CLKMGR_##kind_##_MEAS_CTRL_EN_REG_OFFSET; \
       break, break)
 
+#if defined(OPENTITAN_IS_EARLGREY)
     case kDifClkmgrMeasureClockIo:
       PICK_EN_OFFSET(IO);
       break;
     case kDifClkmgrMeasureClockIoDiv2:
       PICK_EN_OFFSET(IO_DIV2);
       break;
+#elif defined(OPENTITAN_IS_DARJEELING)
+// Darjeeling does not have Io / IoDiv2 clock measurements
+#else
+#error "dif_clkmgr does not support this top"
+#endif
     case kDifClkmgrMeasureClockIoDiv4:
       PICK_EN_OFFSET(IO_DIV4);
       break;
@@ -460,10 +472,16 @@ dif_result_t dif_clkmgr_measure_counts_get_enable(
       en_offset = CLKMGR_##kind_##_MEAS_CTRL_EN_REG_OFFSET; \
       break, break)
 
+#if defined(OPENTITAN_IS_EARLGREY)
     case kDifClkmgrMeasureClockIo:
       PICK_EN_OFFSET(IO);
     case kDifClkmgrMeasureClockIoDiv2:
       PICK_EN_OFFSET(IO_DIV2);
+#elif defined(OPENTITAN_IS_DARJEELING)
+// Darjeeling does not have Io / IoDiv2 clock measurements
+#else
+#error "dif_clkmgr does not support this top"
+#endif
     case kDifClkmgrMeasureClockIoDiv4:
       PICK_EN_OFFSET(IO_DIV4);
     case kDifClkmgrMeasureClockMain:
@@ -497,10 +515,16 @@ dif_result_t dif_clkmgr_measure_counts_get_thresholds(
       reg_offset = CLKMGR_##kind_##_MEAS_CTRL_SHADOWED_REG_OFFSET; \
       lo_field = CLKMGR_##kind_##_MEAS_CTRL_SHADOWED_LO_FIELD;     \
       hi_field = CLKMGR_##kind_##_MEAS_CTRL_SHADOWED_HI_FIELD; break, break)
+#if defined(OPENTITAN_IS_EARLGREY)
     case kDifClkmgrMeasureClockIo:
       PICK_THRESHOLD_FIELDS(IO);
     case kDifClkmgrMeasureClockIoDiv2:
       PICK_THRESHOLD_FIELDS(IO_DIV2);
+#elif defined(OPENTITAN_IS_DARJEELING)
+// Darjeeling does not have Io / IoDiv2 clock measurements
+#else
+#error "dif_clkmgr does not support this top"
+#endif
     case kDifClkmgrMeasureClockIoDiv4:
       PICK_THRESHOLD_FIELDS(IO_DIV4);
     case kDifClkmgrMeasureClockMain:

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -41,6 +41,7 @@ typedef uint32_t dif_clkmgr_gateable_clock_t;
 typedef uint32_t dif_clkmgr_hintable_clock_t;
 
 typedef enum dif_clkmgr_measure_clock {
+#if defined(OPENTITAN_IS_EARLGREY)
   /**
    * The Io clock.
    */
@@ -49,6 +50,11 @@ typedef enum dif_clkmgr_measure_clock {
    * The Io_div2 clock.
    */
   kDifClkmgrMeasureClockIoDiv2,
+#elif defined(OPENTITAN_IS_DARJEELING)
+// Darjeeling doesn't have Io / Io_div2 clock measurements.
+#else
+#error "dif_clkmgr does not support this top"
+#endif
   /**
    * The Io div4 clock.
    */
@@ -64,6 +70,7 @@ typedef enum dif_clkmgr_measure_clock {
 } dif_clkmgr_measure_clock_t;
 
 typedef enum dif_clkmgr_recov_err_type {
+#if defined(OPENTITAN_IS_EARLGREY)
   /**
    * A recoverable update error for one of the clocks.
    */
@@ -108,6 +115,38 @@ typedef enum dif_clkmgr_recov_err_type {
    * A recoverable timeout error for USB clock.
    */
   kDifClkmgrRecovErrTypeUsbTimeout = 1u << 10,
+#elif defined(OPENTITAN_IS_DARJEELING)
+  /**
+   * A recoverable update error for one of the clocks.
+   */
+  kDifClkmgrRecovErrTypeShadowUpdate = 1u << 0,
+  /**
+   * A recoverable measurement error for IO_DIV4 clock.
+   */
+  kDifClkmgrRecovErrTypeIoDiv4Meas = 1u << 1,
+  /**
+   * A recoverable measurement error for MAIN clock.
+   */
+  kDifClkmgrRecovErrTypeMainMeas = 1u << 2,
+  /**
+   * A recoverable measurement error for USB clock.
+   */
+  kDifClkmgrRecovErrTypeUsbMeas = 1u << 3,
+  /**
+   * A recoverable timeout error for IO_DIV4 clock.
+   */
+  kDifClkmgrRecovErrTypeIoDiv4Timeout = 1u << 4,
+  /**
+   * A recoverable timeout error for MAIN clock.
+   */
+  kDifClkmgrRecovErrTypeMainTimeout = 1u << 5,
+  /**
+   * A recoverable timeout error for USB clock.
+   */
+  kDifClkmgrRecovErrTypeUsbTimeout = 1u << 6,
+#else
+#error "dif_clkmgr does not support this top"
+#endif
 } dif_clkmgr_recov_err_type_t;
 
 /**

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2604,11 +2604,12 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:mmio",
+        "//hw/top:dt",
+        "//hw/top:top_lib",
         "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/runtime:log",


### PR DESCRIPTION
Fix #26217

This PR ports the `kmac_idle_test` to use the devicetables API so that it no longer depends on Earlgrey-specific constants. The test remains passing on Earlgrey in the `fpga_cw310_rom_with_fake_keys` environment, and will compile for Darjeeling via
```sh
bazel build //sw/device/tests:kmac_idle_test --//hw/top=darjeeling
```

As part of porting this test, the clkmgr DIF has been updated using conditional compilation to match the changes made by Darjeeling's clkmgr. This test also still requires the use of a top-specific constant for the main KMAC hintable clock, since this information is not yet exposed through a clkmgr DT extension (see #26248)