### PR TITLE
[dtgen] Add rstmgr extension

### DIFF
--- a/hw/ip_templates/pwrmgr/util/dt.py
+++ b/hw/ip_templates/pwrmgr/util/dt.py
@@ -110,7 +110,7 @@ class PwrmgrExt(Extension):
     WAKEUP_SOURCE_WAKEUP_FIELD_NAME = Name(["wakeup"])
     RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_pwrmgr_reset_req_src")
     RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
-    RSTREQ_SOURCE_WAKEUP_FIELD_NAME = Name(["reset", "req"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
     EXT_WAKEUP_SOURCES_FIELD_NAME = Name(["wakeup", "src"])
     EXT_RESET_REQS_FIELD_NAME = Name(["rst", "reqs"])
 
@@ -140,7 +140,7 @@ class PwrmgrExt(Extension):
             docstring = "Instance ID of the source of this reset request.",
         )
         self.reset_req_src_struct.add_field(
-            name = self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME,
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
             field_type = ScalarType("size_t"),
             docstring = "Index of the reset request signal for that instance.",
         )
@@ -204,7 +204,7 @@ class PwrmgrExt(Extension):
                 self.ip_helper.simplify_reset_request_name(reset["name"]))
             rst_reqs[str(idx)] = {
                 self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
-                self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME: rstreq.as_c_enum()
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq.as_c_enum()
             }
 
         return {

--- a/hw/ip_templates/rstmgr/defs.bzl.tpl
+++ b/hw/ip_templates/rstmgr/defs.bzl.tpl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RSTMGR = opentitan_ip(
     name = "rstmgr",
     hjson = "//hw/top_${topname}/ip_autogen/rstmgr:data/rstmgr.hjson",
+    ipconfig = "//hw/top_${topname}/ip_autogen/rstmgr:data/top_${topname}_rstmgr.ipconfig.hjson",
+    extension = "//hw/top_${topname}/ip_autogen/rstmgr/util:dt",
 )

--- a/hw/ip_templates/rstmgr/util/BUILD.bazel.tpl
+++ b/hw/ip_templates/rstmgr/util/BUILD.bazel.tpl
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/ip_templates/rstmgr/util/dt.py
+++ b/hw/ip_templates/rstmgr/util/dt.py
@@ -1,0 +1,197 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Optional
+from collections import OrderedDict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import IpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software resets.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of software resets.
+ */
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt);
+
+/**
+ * Get the reset ID of a software reset.
+ *
+ * The resets are ordered in the same way as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the software reset, between 0 and `dt_rstmgr_sw_reset_count(dt)-1`.
+ * @return Reset ID, or `kDtResetUnknown` for invalid parameters.
+ */
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx);
+
+/**
+ * Description of a reset request source.
+ *
+ * A reset request source is always identified by the instance ID of the module where it comes
+ * from. In principle, some instances could have several reset requests. If this is the case,
+ * the `rst_req` can be used to distinguish between those. It should be cast to the
+ * `dt_<ip>_reset_req_t` type of the corresponding IP.
+ *
+ * WARNING At the moment, three hardcoded reset requests are treated specially and have their
+ * `rst_req` field set to `0` because there is no corresponding reset request declared by those IPs:
+ * - the main power glitch reset request, coming from the `pwrmgr`,
+ * - the escalation reset request, coming from the `alert_handler`,
+ * - the non-debug-module reset request, coming from the `rv_dm`.
+ * ```
+ */
+%(reset_req_src_struct)s
+
+/**
+ * Get the number of hardware reset requests.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of reset requests.
+ */
+size_t dt_rstmgr_hw_reset_req_src_count(dt_rstmgr_t dt);
+
+/**
+ * Get the description of a reset request.
+ *
+ * The reset requests are ordered as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the reset request source, between 0 and
+ *            `dt_pwrmgr_hw_reset_req_src_count(dt)-1`.
+ * @return Description of the reset.
+ */
+dt_rstmgr_reset_req_src_t dt_rstmgr_hw_reset_req_src(dt_rstmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt) {
+  return %(sw_reset_count)d;
+}
+
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
+  if (idx >= %(sw_reset_count)d) {
+    return kDtResetUnknown;
+  }
+  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+}
+"""
+
+
+class RstmgrExt(Extension):
+    RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_rstmgr_reset_req_src")
+    RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
+
+    SW_RESETS_FIELD_NAME = Name(["sw", "rst"])
+    HW_REQS_FIELD_NAME = Name(["hw", "req"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the rstmgr extension requires the ipconfig to be provided")
+        self.ipconfig = IpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a reset request.
+        self.reset_req_src_struct = StructType(self.RSTREQ_SOURCE_STRUCT_NAME)
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_INST_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_INSTANCE_ID_NAME),
+            docstring = "Instance ID of the source of this reset request.",
+        )
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
+            field_type = ScalarType("size_t"),
+            docstring = "Index of the reset request signal for that instance.",
+        )
+
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "rstmgr":
+            return RstmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> Optional[StructType]:
+        sw_rsts_count = len(self.ipconfig.sw_rsts_list())
+        hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
+
+        st = StructType()
+        # Add field to list SW resets.
+        st.add_field(
+            name = self.SW_RESETS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(self.ip_helper.top_helper.DT_RESET_ENUM_NAME),
+                index_type = ScalarType("size_t"),
+                length = str(sw_rsts_count),
+            ),
+            docstring = "List of software resets, in the order of the register fields",
+        )
+        # Add field to list HW reset requests.
+        st.add_field(
+            name = self.HW_REQS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.reset_req_src_struct,
+                index_type = ScalarType("size_t"),
+                length = str(hw_reqs_count),
+            ),
+            docstring = "List of hardware reset requests, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> dict:
+        sw_rsts = {}
+        self._extra_includes = OrderedDict()
+        for (idx, rst) in enumerate(self.ipconfig.sw_rsts_list()):
+            sw_rsts[str(idx)] = Name.from_snake_case(rst)
+        hw_reqs = {}
+        for (idx, reset) in enumerate(self.ipconfig.hw_reset_req_list()):
+            # We need to create the reset name from another module.
+            module_type = self.ip_helper.top_helper.get_module_type(reset["module"])
+            self._extra_includes[module_type] = None
+            # Even though the ipconfig currently models internal and debug reset
+            # requests like peripherals, they are in reality hardcoded signals and
+            # therefore there is not correspondingly named reset requests coming from
+            # those blocks. For now, simply hardwire those to 0 to workaround the issue.
+            if reset["name"] not in ["Ndm", "MainPwr", "Esc"]:
+                rstreq = Name(["dt"])
+                rstreq += Name.from_snake_case(module_type)
+                rstreq += Name(["reset", "req"])
+                rstreq += Name.from_snake_case(
+                    self.ip_helper.simplify_reset_request_name(reset["name"]))
+                rstreq = rstreq.as_c_enum()
+            else:
+                rstreq = "0"
+            hw_reqs[str(idx)] = {
+                self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq,
+            }
+
+        return {
+            self.SW_RESETS_FIELD_NAME: sw_rsts,
+            self.HW_REQS_FIELD_NAME: hw_reqs,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        if pos == Extension.DtIpPos.HeaderEnd:
+            subs = {
+                'reset_req_src_struct': self.reset_req_src_struct.render_type_def(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            includes = ""
+            for ip in self._extra_includes:
+                includes += f"#include \"dt_{ip}.h\"\n"
+            return includes
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_reset_count': len(self.ipconfig.sw_rsts_list()),
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/ip_templates/rstmgr/util/ipconfig.py
+++ b/hw/ip_templates/rstmgr/util/ipconfig.py
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the rstmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class IpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_rsts_list(self) -> List[str]:
+        """
+        Return the list of SW resets: each reset is described by the name of its
+        signal.
+
+        The list is ordered in the same order as in the description.
+        """
+        return self.param_values["sw_rsts"]
+
+    def hw_reset_req_list(self) -> List[Dict]:
+        """
+        Return the list of all reset requests: each reset is described by
+        a dictionary with the following fields:
+        - `name`: name of the reset request.
+        - `module`: the module where the reset comes from.
+
+        The list is ordered as in the `HW_REQ` register.
+        """
+        reqs = self.param_values["reqs"]
+        return [
+            {
+                "name": rst["name"],
+                "module": rst["module"],
+            }
+            # Watch out for the order: this matches what is used in `pwrmgr.hjson.tpl`.
+            for rst in reqs["peripheral"] + reqs["int"] + reqs["debug"]
+        ]

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/util/dt.py
@@ -110,7 +110,7 @@ class PwrmgrExt(Extension):
     WAKEUP_SOURCE_WAKEUP_FIELD_NAME = Name(["wakeup"])
     RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_pwrmgr_reset_req_src")
     RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
-    RSTREQ_SOURCE_WAKEUP_FIELD_NAME = Name(["reset", "req"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
     EXT_WAKEUP_SOURCES_FIELD_NAME = Name(["wakeup", "src"])
     EXT_RESET_REQS_FIELD_NAME = Name(["rst", "reqs"])
 
@@ -140,7 +140,7 @@ class PwrmgrExt(Extension):
             docstring = "Instance ID of the source of this reset request.",
         )
         self.reset_req_src_struct.add_field(
-            name = self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME,
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
             field_type = ScalarType("size_t"),
             docstring = "Index of the reset request signal for that instance.",
         )
@@ -204,7 +204,7 @@ class PwrmgrExt(Extension):
                 self.ip_helper.simplify_reset_request_name(reset["name"]))
             rst_reqs[str(idx)] = {
                 self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
-                self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME: rstreq.as_c_enum()
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq.as_c_enum()
             }
 
         return {

--- a/hw/top_darjeeling/ip_autogen/rstmgr/defs.bzl
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/defs.bzl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RSTMGR = opentitan_ip(
     name = "rstmgr",
     hjson = "//hw/top_darjeeling/ip_autogen/rstmgr:data/rstmgr.hjson",
+    ipconfig = "//hw/top_darjeeling/ip_autogen/rstmgr:data/top_darjeeling_rstmgr.ipconfig.hjson",
+    extension = "//hw/top_darjeeling/ip_autogen/rstmgr/util:dt",
 )

--- a/hw/top_darjeeling/ip_autogen/rstmgr/util/BUILD.bazel
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/util/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/top_darjeeling/ip_autogen/rstmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/util/dt.py
@@ -1,0 +1,197 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Optional
+from collections import OrderedDict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import IpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software resets.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of software resets.
+ */
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt);
+
+/**
+ * Get the reset ID of a software reset.
+ *
+ * The resets are ordered in the same way as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the software reset, between 0 and `dt_rstmgr_sw_reset_count(dt)-1`.
+ * @return Reset ID, or `kDtResetUnknown` for invalid parameters.
+ */
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx);
+
+/**
+ * Description of a reset request source.
+ *
+ * A reset request source is always identified by the instance ID of the module where it comes
+ * from. In principle, some instances could have several reset requests. If this is the case,
+ * the `rst_req` can be used to distinguish between those. It should be cast to the
+ * `dt_<ip>_reset_req_t` type of the corresponding IP.
+ *
+ * WARNING At the moment, three hardcoded reset requests are treated specially and have their
+ * `rst_req` field set to `0` because there is no corresponding reset request declared by those IPs:
+ * - the main power glitch reset request, coming from the `pwrmgr`,
+ * - the escalation reset request, coming from the `alert_handler`,
+ * - the non-debug-module reset request, coming from the `rv_dm`.
+ * ```
+ */
+%(reset_req_src_struct)s
+
+/**
+ * Get the number of hardware reset requests.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of reset requests.
+ */
+size_t dt_rstmgr_hw_reset_req_src_count(dt_rstmgr_t dt);
+
+/**
+ * Get the description of a reset request.
+ *
+ * The reset requests are ordered as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the reset request source, between 0 and
+ *            `dt_pwrmgr_hw_reset_req_src_count(dt)-1`.
+ * @return Description of the reset.
+ */
+dt_rstmgr_reset_req_src_t dt_rstmgr_hw_reset_req_src(dt_rstmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt) {
+  return %(sw_reset_count)d;
+}
+
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
+  if (idx >= %(sw_reset_count)d) {
+    return kDtResetUnknown;
+  }
+  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+}
+"""
+
+
+class RstmgrExt(Extension):
+    RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_rstmgr_reset_req_src")
+    RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
+
+    SW_RESETS_FIELD_NAME = Name(["sw", "rst"])
+    HW_REQS_FIELD_NAME = Name(["hw", "req"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the rstmgr extension requires the ipconfig to be provided")
+        self.ipconfig = IpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a reset request.
+        self.reset_req_src_struct = StructType(self.RSTREQ_SOURCE_STRUCT_NAME)
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_INST_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_INSTANCE_ID_NAME),
+            docstring = "Instance ID of the source of this reset request.",
+        )
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
+            field_type = ScalarType("size_t"),
+            docstring = "Index of the reset request signal for that instance.",
+        )
+
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "rstmgr":
+            return RstmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> Optional[StructType]:
+        sw_rsts_count = len(self.ipconfig.sw_rsts_list())
+        hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
+
+        st = StructType()
+        # Add field to list SW resets.
+        st.add_field(
+            name = self.SW_RESETS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(self.ip_helper.top_helper.DT_RESET_ENUM_NAME),
+                index_type = ScalarType("size_t"),
+                length = str(sw_rsts_count),
+            ),
+            docstring = "List of software resets, in the order of the register fields",
+        )
+        # Add field to list HW reset requests.
+        st.add_field(
+            name = self.HW_REQS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.reset_req_src_struct,
+                index_type = ScalarType("size_t"),
+                length = str(hw_reqs_count),
+            ),
+            docstring = "List of hardware reset requests, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> dict:
+        sw_rsts = {}
+        self._extra_includes = OrderedDict()
+        for (idx, rst) in enumerate(self.ipconfig.sw_rsts_list()):
+            sw_rsts[str(idx)] = Name.from_snake_case(rst)
+        hw_reqs = {}
+        for (idx, reset) in enumerate(self.ipconfig.hw_reset_req_list()):
+            # We need to create the reset name from another module.
+            module_type = self.ip_helper.top_helper.get_module_type(reset["module"])
+            self._extra_includes[module_type] = None
+            # Even though the ipconfig currently models internal and debug reset
+            # requests like peripherals, they are in reality hardcoded signals and
+            # therefore there is not correspondingly named reset requests coming from
+            # those blocks. For now, simply hardwire those to 0 to workaround the issue.
+            if reset["name"] not in ["Ndm", "MainPwr", "Esc"]:
+                rstreq = Name(["dt"])
+                rstreq += Name.from_snake_case(module_type)
+                rstreq += Name(["reset", "req"])
+                rstreq += Name.from_snake_case(
+                    self.ip_helper.simplify_reset_request_name(reset["name"]))
+                rstreq = rstreq.as_c_enum()
+            else:
+                rstreq = "0"
+            hw_reqs[str(idx)] = {
+                self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq,
+            }
+
+        return {
+            self.SW_RESETS_FIELD_NAME: sw_rsts,
+            self.HW_REQS_FIELD_NAME: hw_reqs,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        if pos == Extension.DtIpPos.HeaderEnd:
+            subs = {
+                'reset_req_src_struct': self.reset_req_src_struct.render_type_def(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            includes = ""
+            for ip in self._extra_includes:
+                includes += f"#include \"dt_{ip}.h\"\n"
+            return includes
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_reset_count': len(self.ipconfig.sw_rsts_list()),
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/top_darjeeling/ip_autogen/rstmgr/util/ipconfig.py
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/util/ipconfig.py
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the rstmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class IpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_rsts_list(self) -> List[str]:
+        """
+        Return the list of SW resets: each reset is described by the name of its
+        signal.
+
+        The list is ordered in the same order as in the description.
+        """
+        return self.param_values["sw_rsts"]
+
+    def hw_reset_req_list(self) -> List[Dict]:
+        """
+        Return the list of all reset requests: each reset is described by
+        a dictionary with the following fields:
+        - `name`: name of the reset request.
+        - `module`: the module where the reset comes from.
+
+        The list is ordered as in the `HW_REQ` register.
+        """
+        reqs = self.param_values["reqs"]
+        return [
+            {
+                "name": rst["name"],
+                "module": rst["module"],
+            }
+            # Watch out for the order: this matches what is used in `pwrmgr.hjson.tpl`.
+            for rst in reqs["peripheral"] + reqs["int"] + reqs["debug"]
+        ]

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/util/dt.py
@@ -110,7 +110,7 @@ class PwrmgrExt(Extension):
     WAKEUP_SOURCE_WAKEUP_FIELD_NAME = Name(["wakeup"])
     RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_pwrmgr_reset_req_src")
     RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
-    RSTREQ_SOURCE_WAKEUP_FIELD_NAME = Name(["reset", "req"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
     EXT_WAKEUP_SOURCES_FIELD_NAME = Name(["wakeup", "src"])
     EXT_RESET_REQS_FIELD_NAME = Name(["rst", "reqs"])
 
@@ -140,7 +140,7 @@ class PwrmgrExt(Extension):
             docstring = "Instance ID of the source of this reset request.",
         )
         self.reset_req_src_struct.add_field(
-            name = self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME,
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
             field_type = ScalarType("size_t"),
             docstring = "Index of the reset request signal for that instance.",
         )
@@ -204,7 +204,7 @@ class PwrmgrExt(Extension):
                 self.ip_helper.simplify_reset_request_name(reset["name"]))
             rst_reqs[str(idx)] = {
                 self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
-                self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME: rstreq.as_c_enum()
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq.as_c_enum()
             }
 
         return {

--- a/hw/top_earlgrey/ip_autogen/rstmgr/defs.bzl
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/defs.bzl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RSTMGR = opentitan_ip(
     name = "rstmgr",
     hjson = "//hw/top_earlgrey/ip_autogen/rstmgr:data/rstmgr.hjson",
+    ipconfig = "//hw/top_earlgrey/ip_autogen/rstmgr:data/top_earlgrey_rstmgr.ipconfig.hjson",
+    extension = "//hw/top_earlgrey/ip_autogen/rstmgr/util:dt",
 )

--- a/hw/top_earlgrey/ip_autogen/rstmgr/util/BUILD.bazel
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/util/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/top_earlgrey/ip_autogen/rstmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/util/dt.py
@@ -1,0 +1,197 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Optional
+from collections import OrderedDict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import IpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software resets.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of software resets.
+ */
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt);
+
+/**
+ * Get the reset ID of a software reset.
+ *
+ * The resets are ordered in the same way as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the software reset, between 0 and `dt_rstmgr_sw_reset_count(dt)-1`.
+ * @return Reset ID, or `kDtResetUnknown` for invalid parameters.
+ */
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx);
+
+/**
+ * Description of a reset request source.
+ *
+ * A reset request source is always identified by the instance ID of the module where it comes
+ * from. In principle, some instances could have several reset requests. If this is the case,
+ * the `rst_req` can be used to distinguish between those. It should be cast to the
+ * `dt_<ip>_reset_req_t` type of the corresponding IP.
+ *
+ * WARNING At the moment, three hardcoded reset requests are treated specially and have their
+ * `rst_req` field set to `0` because there is no corresponding reset request declared by those IPs:
+ * - the main power glitch reset request, coming from the `pwrmgr`,
+ * - the escalation reset request, coming from the `alert_handler`,
+ * - the non-debug-module reset request, coming from the `rv_dm`.
+ * ```
+ */
+%(reset_req_src_struct)s
+
+/**
+ * Get the number of hardware reset requests.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of reset requests.
+ */
+size_t dt_rstmgr_hw_reset_req_src_count(dt_rstmgr_t dt);
+
+/**
+ * Get the description of a reset request.
+ *
+ * The reset requests are ordered as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the reset request source, between 0 and
+ *            `dt_pwrmgr_hw_reset_req_src_count(dt)-1`.
+ * @return Description of the reset.
+ */
+dt_rstmgr_reset_req_src_t dt_rstmgr_hw_reset_req_src(dt_rstmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt) {
+  return %(sw_reset_count)d;
+}
+
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
+  if (idx >= %(sw_reset_count)d) {
+    return kDtResetUnknown;
+  }
+  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+}
+"""
+
+
+class RstmgrExt(Extension):
+    RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_rstmgr_reset_req_src")
+    RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
+
+    SW_RESETS_FIELD_NAME = Name(["sw", "rst"])
+    HW_REQS_FIELD_NAME = Name(["hw", "req"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the rstmgr extension requires the ipconfig to be provided")
+        self.ipconfig = IpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a reset request.
+        self.reset_req_src_struct = StructType(self.RSTREQ_SOURCE_STRUCT_NAME)
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_INST_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_INSTANCE_ID_NAME),
+            docstring = "Instance ID of the source of this reset request.",
+        )
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
+            field_type = ScalarType("size_t"),
+            docstring = "Index of the reset request signal for that instance.",
+        )
+
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "rstmgr":
+            return RstmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> Optional[StructType]:
+        sw_rsts_count = len(self.ipconfig.sw_rsts_list())
+        hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
+
+        st = StructType()
+        # Add field to list SW resets.
+        st.add_field(
+            name = self.SW_RESETS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(self.ip_helper.top_helper.DT_RESET_ENUM_NAME),
+                index_type = ScalarType("size_t"),
+                length = str(sw_rsts_count),
+            ),
+            docstring = "List of software resets, in the order of the register fields",
+        )
+        # Add field to list HW reset requests.
+        st.add_field(
+            name = self.HW_REQS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.reset_req_src_struct,
+                index_type = ScalarType("size_t"),
+                length = str(hw_reqs_count),
+            ),
+            docstring = "List of hardware reset requests, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> dict:
+        sw_rsts = {}
+        self._extra_includes = OrderedDict()
+        for (idx, rst) in enumerate(self.ipconfig.sw_rsts_list()):
+            sw_rsts[str(idx)] = Name.from_snake_case(rst)
+        hw_reqs = {}
+        for (idx, reset) in enumerate(self.ipconfig.hw_reset_req_list()):
+            # We need to create the reset name from another module.
+            module_type = self.ip_helper.top_helper.get_module_type(reset["module"])
+            self._extra_includes[module_type] = None
+            # Even though the ipconfig currently models internal and debug reset
+            # requests like peripherals, they are in reality hardcoded signals and
+            # therefore there is not correspondingly named reset requests coming from
+            # those blocks. For now, simply hardwire those to 0 to workaround the issue.
+            if reset["name"] not in ["Ndm", "MainPwr", "Esc"]:
+                rstreq = Name(["dt"])
+                rstreq += Name.from_snake_case(module_type)
+                rstreq += Name(["reset", "req"])
+                rstreq += Name.from_snake_case(
+                    self.ip_helper.simplify_reset_request_name(reset["name"]))
+                rstreq = rstreq.as_c_enum()
+            else:
+                rstreq = "0"
+            hw_reqs[str(idx)] = {
+                self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq,
+            }
+
+        return {
+            self.SW_RESETS_FIELD_NAME: sw_rsts,
+            self.HW_REQS_FIELD_NAME: hw_reqs,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        if pos == Extension.DtIpPos.HeaderEnd:
+            subs = {
+                'reset_req_src_struct': self.reset_req_src_struct.render_type_def(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            includes = ""
+            for ip in self._extra_includes:
+                includes += f"#include \"dt_{ip}.h\"\n"
+            return includes
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_reset_count': len(self.ipconfig.sw_rsts_list()),
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/top_earlgrey/ip_autogen/rstmgr/util/ipconfig.py
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/util/ipconfig.py
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the rstmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class IpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_rsts_list(self) -> List[str]:
+        """
+        Return the list of SW resets: each reset is described by the name of its
+        signal.
+
+        The list is ordered in the same order as in the description.
+        """
+        return self.param_values["sw_rsts"]
+
+    def hw_reset_req_list(self) -> List[Dict]:
+        """
+        Return the list of all reset requests: each reset is described by
+        a dictionary with the following fields:
+        - `name`: name of the reset request.
+        - `module`: the module where the reset comes from.
+
+        The list is ordered as in the `HW_REQ` register.
+        """
+        reqs = self.param_values["reqs"]
+        return [
+            {
+                "name": rst["name"],
+                "module": rst["module"],
+            }
+            # Watch out for the order: this matches what is used in `pwrmgr.hjson.tpl`.
+            for rst in reqs["peripheral"] + reqs["int"] + reqs["debug"]
+        ]

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/util/dt.py
@@ -110,7 +110,7 @@ class PwrmgrExt(Extension):
     WAKEUP_SOURCE_WAKEUP_FIELD_NAME = Name(["wakeup"])
     RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_pwrmgr_reset_req_src")
     RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
-    RSTREQ_SOURCE_WAKEUP_FIELD_NAME = Name(["reset", "req"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
     EXT_WAKEUP_SOURCES_FIELD_NAME = Name(["wakeup", "src"])
     EXT_RESET_REQS_FIELD_NAME = Name(["rst", "reqs"])
 
@@ -140,7 +140,7 @@ class PwrmgrExt(Extension):
             docstring = "Instance ID of the source of this reset request.",
         )
         self.reset_req_src_struct.add_field(
-            name = self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME,
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
             field_type = ScalarType("size_t"),
             docstring = "Index of the reset request signal for that instance.",
         )
@@ -204,7 +204,7 @@ class PwrmgrExt(Extension):
                 self.ip_helper.simplify_reset_request_name(reset["name"]))
             rst_reqs[str(idx)] = {
                 self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
-                self.RSTREQ_SOURCE_WAKEUP_FIELD_NAME: rstreq.as_c_enum()
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq.as_c_enum()
             }
 
         return {

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/defs.bzl
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/defs.bzl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 RSTMGR = opentitan_ip(
     name = "rstmgr",
     hjson = "//hw/top_englishbreakfast/ip_autogen/rstmgr:data/rstmgr.hjson",
+    ipconfig = "//hw/top_englishbreakfast/ip_autogen/rstmgr:data/top_englishbreakfast_rstmgr.ipconfig.hjson",
+    extension = "//hw/top_englishbreakfast/ip_autogen/rstmgr/util:dt",
 )

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/util/BUILD.bazel
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/util/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/util/dt.py
@@ -1,0 +1,197 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Optional
+from collections import OrderedDict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import IpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software resets.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of software resets.
+ */
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt);
+
+/**
+ * Get the reset ID of a software reset.
+ *
+ * The resets are ordered in the same way as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the software reset, between 0 and `dt_rstmgr_sw_reset_count(dt)-1`.
+ * @return Reset ID, or `kDtResetUnknown` for invalid parameters.
+ */
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx);
+
+/**
+ * Description of a reset request source.
+ *
+ * A reset request source is always identified by the instance ID of the module where it comes
+ * from. In principle, some instances could have several reset requests. If this is the case,
+ * the `rst_req` can be used to distinguish between those. It should be cast to the
+ * `dt_<ip>_reset_req_t` type of the corresponding IP.
+ *
+ * WARNING At the moment, three hardcoded reset requests are treated specially and have their
+ * `rst_req` field set to `0` because there is no corresponding reset request declared by those IPs:
+ * - the main power glitch reset request, coming from the `pwrmgr`,
+ * - the escalation reset request, coming from the `alert_handler`,
+ * - the non-debug-module reset request, coming from the `rv_dm`.
+ * ```
+ */
+%(reset_req_src_struct)s
+
+/**
+ * Get the number of hardware reset requests.
+ *
+ * @param dt Instance of rstmgr.
+ * @return Number of reset requests.
+ */
+size_t dt_rstmgr_hw_reset_req_src_count(dt_rstmgr_t dt);
+
+/**
+ * Get the description of a reset request.
+ *
+ * The reset requests are ordered as they appear in the registers.
+ *
+ * @param dt Instance of rstmgr.
+ * @param idx Index of the reset request source, between 0 and
+ *            `dt_pwrmgr_hw_reset_req_src_count(dt)-1`.
+ * @return Description of the reset.
+ */
+dt_rstmgr_reset_req_src_t dt_rstmgr_hw_reset_req_src(dt_rstmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt) {
+  return %(sw_reset_count)d;
+}
+
+dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
+  if (idx >= %(sw_reset_count)d) {
+    return kDtResetUnknown;
+  }
+  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+}
+"""
+
+
+class RstmgrExt(Extension):
+    RSTREQ_SOURCE_STRUCT_NAME = Name.from_snake_case("dt_rstmgr_reset_req_src")
+    RSTREQ_SOURCE_INST_FIELD_NAME = Name(["inst", "id"])
+    RSTREQ_SOURCE_REQ_FIELD_NAME = Name(["reset", "req"])
+
+    SW_RESETS_FIELD_NAME = Name(["sw", "rst"])
+    HW_REQS_FIELD_NAME = Name(["hw", "req"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the rstmgr extension requires the ipconfig to be provided")
+        self.ipconfig = IpConfig(self.ip_helper.ipconfig)
+
+        # Create a type to represent a reset request.
+        self.reset_req_src_struct = StructType(self.RSTREQ_SOURCE_STRUCT_NAME)
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_INST_FIELD_NAME,
+            field_type = ScalarType(self.ip_helper.top_helper.DT_INSTANCE_ID_NAME),
+            docstring = "Instance ID of the source of this reset request.",
+        )
+        self.reset_req_src_struct.add_field(
+            name = self.RSTREQ_SOURCE_REQ_FIELD_NAME,
+            field_type = ScalarType("size_t"),
+            docstring = "Index of the reset request signal for that instance.",
+        )
+
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "rstmgr":
+            return RstmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> Optional[StructType]:
+        sw_rsts_count = len(self.ipconfig.sw_rsts_list())
+        hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
+
+        st = StructType()
+        # Add field to list SW resets.
+        st.add_field(
+            name = self.SW_RESETS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(self.ip_helper.top_helper.DT_RESET_ENUM_NAME),
+                index_type = ScalarType("size_t"),
+                length = str(sw_rsts_count),
+            ),
+            docstring = "List of software resets, in the order of the register fields",
+        )
+        # Add field to list HW reset requests.
+        st.add_field(
+            name = self.HW_REQS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = self.reset_req_src_struct,
+                index_type = ScalarType("size_t"),
+                length = str(hw_reqs_count),
+            ),
+            docstring = "List of hardware reset requests, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> dict:
+        sw_rsts = {}
+        self._extra_includes = OrderedDict()
+        for (idx, rst) in enumerate(self.ipconfig.sw_rsts_list()):
+            sw_rsts[str(idx)] = Name.from_snake_case(rst)
+        hw_reqs = {}
+        for (idx, reset) in enumerate(self.ipconfig.hw_reset_req_list()):
+            # We need to create the reset name from another module.
+            module_type = self.ip_helper.top_helper.get_module_type(reset["module"])
+            self._extra_includes[module_type] = None
+            # Even though the ipconfig currently models internal and debug reset
+            # requests like peripherals, they are in reality hardcoded signals and
+            # therefore there is not correspondingly named reset requests coming from
+            # those blocks. For now, simply hardwire those to 0 to workaround the issue.
+            if reset["name"] not in ["Ndm", "MainPwr", "Esc"]:
+                rstreq = Name(["dt"])
+                rstreq += Name.from_snake_case(module_type)
+                rstreq += Name(["reset", "req"])
+                rstreq += Name.from_snake_case(
+                    self.ip_helper.simplify_reset_request_name(reset["name"]))
+                rstreq = rstreq.as_c_enum()
+            else:
+                rstreq = "0"
+            hw_reqs[str(idx)] = {
+                self.RSTREQ_SOURCE_INST_FIELD_NAME: Name.from_snake_case(reset["module"]),
+                self.RSTREQ_SOURCE_REQ_FIELD_NAME: rstreq,
+            }
+
+        return {
+            self.SW_RESETS_FIELD_NAME: sw_rsts,
+            self.HW_REQS_FIELD_NAME: hw_reqs,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        if pos == Extension.DtIpPos.HeaderEnd:
+            subs = {
+                'reset_req_src_struct': self.reset_req_src_struct.render_type_def(),
+            }
+            return HEADER_EXT_TEMPLATE % subs
+        elif pos == Extension.DtIpPos.SourceIncludes:
+            includes = ""
+            for ip in self._extra_includes:
+                includes += f"#include \"dt_{ip}.h\"\n"
+            return includes
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_reset_count': len(self.ipconfig.sw_rsts_list()),
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/util/ipconfig.py
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/util/ipconfig.py
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the rstmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class IpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_rsts_list(self) -> List[str]:
+        """
+        Return the list of SW resets: each reset is described by the name of its
+        signal.
+
+        The list is ordered in the same order as in the description.
+        """
+        return self.param_values["sw_rsts"]
+
+    def hw_reset_req_list(self) -> List[Dict]:
+        """
+        Return the list of all reset requests: each reset is described by
+        a dictionary with the following fields:
+        - `name`: name of the reset request.
+        - `module`: the module where the reset comes from.
+
+        The list is ordered as in the `HW_REQ` register.
+        """
+        reqs = self.param_values["reqs"]
+        return [
+            {
+                "name": rst["name"],
+                "module": rst["module"],
+            }
+            # Watch out for the order: this matches what is used in `pwrmgr.hjson.tpl`.
+            for rst in reqs["peripheral"] + reqs["int"] + reqs["debug"]
+        ]

--- a/util/dtgen/dt_api.h.tpl
+++ b/util/dtgen/dt_api.h.tpl
@@ -107,6 +107,13 @@ ${helper.clock_enum.render()}
 uint32_t dt_clock_frequency(dt_clock_t clk);
 
 /**
+ * List of resets.
+ *
+ * Resets are guaranteed to be numbered consecutively from 0.
+ */
+${helper.reset_enum.render()}
+
+/**
  * List of pads names.
  */
 ${helper.pad_enum.render()}

--- a/util/dtgen/dt_ip.c.tpl
+++ b/util/dtgen/dt_ip.c.tpl
@@ -189,5 +189,24 @@ dt_clock_t dt_${module_name}_clock(
 }
 % endif
 
+% if helper.has_resets():
+/**
+ * Get the reset signal connected to a reset port of an instance.
+ *
+ * @param dt Instance of ${module_name}.
+ * @param sig Reset port.
+ * @return Reset signal.
+ */
+dt_reset_t dt_${module_name}_reset(
+    dt_${module_name}_t dt,
+    dt_${module_name}_reset_t rst) {
+  const dt_${module_name}_reset_t count = ${helper.reset_enum.name.as_c_enum()}Count;
+  if (rst >= count) {
+    return kDtResetUnknown;
+  }
+  return TRY_GET_DT(dt, kDtResetUnknown)->reset[rst];
+}
+% endif
+
 ## Extension
 ${helper.render_extension(Extension.DtIpPos.SourceEnd)}

--- a/util/dtgen/dt_ip.h.tpl
+++ b/util/dtgen/dt_ip.h.tpl
@@ -73,6 +73,15 @@ ${helper.clock_enum.render()}
 ${helper.reset_req_enum.render()}
 
 % endif
+% if helper.has_resets():
+/**
+ * List of reset ports.
+ *
+ * Reset ports are guaranteed to be numbered consecutively from 0.
+ */
+${helper.reset_enum.render()}
+
+% endif
 % if helper.has_periph_io():
 /**
  * List of peripheral I/O.
@@ -228,6 +237,19 @@ dt_periph_io_t dt_${device_name}_periph_io(
 dt_clock_t dt_${device_name}_clock(
     dt_${device_name}_t dt,
     dt_${device_name}_clock_t clk);
+
+% endif
+% if helper.has_resets():
+/**
+ * Get the reset signal connected to a reset port of an instance.
+ *
+ * @param dt Instance of ${device_name}.
+ * @param sig Reset port.
+ * @return Reset signal.
+ */
+dt_reset_t dt_${device_name}_reset(
+    dt_${device_name}_t dt,
+    dt_${device_name}_reset_t rst);
 % endif
 
 ## Extension


### PR DESCRIPTION
The intiial commits are from #26248. This PR adds information about the resets and provides a `rstmgr` extension.

**Additions to the DT**

The first requirement to expose the necessary information is that the list of resets for each IP needs to be exposed. This is done by creating a new list of reset nodes in `dt_api.h`:

```c
/**
 * List of resets.
 *
 * Resets are guaranteed to be numbered consecutively from 0.
 */
typedef enum dt_reset {
  kDtResetUnknown = 0, /**< Unknown reset */
  kDtResetPorAon = 1, /**<  */
  kDtResetLcSrc = 2, /**<  */
  kDtResetSysSrc = 3, /**<  */
  kDtResetPor = 4, /**<  */
  kDtResetPorIo = 5, /**<  */
  kDtResetPorIoDiv2 = 6, /**<  */
  kDtResetPorIoDiv4 = 7, /**<  */
  kDtResetPorUsb = 8, /**<  */
  kDtResetLc = 9, /**<  */
  kDtResetLcAon = 10, /**<  */
  kDtResetLcIo = 11, /**<  */
  kDtResetLcIoDiv2 = 12, /**<  */
  kDtResetLcIoDiv4 = 13, /**<  */
  kDtResetLcUsb = 14, /**<  */
  kDtResetSys = 15, /**<  */
  kDtResetSysIoDiv4 = 16, /**<  */
  kDtResetSpiDevice = 17, /**<  */
  kDtResetSpiHost0 = 18, /**<  */
  kDtResetSpiHost1 = 19, /**<  */
  kDtResetUsb = 20, /**<  */
  kDtResetUsbAon = 21, /**<  */
  kDtResetI2c0 = 22, /**<  */
  kDtResetI2c1 = 23, /**<  */
  kDtResetI2c2 = 24, /**<  */
  kDtResetCount = 25, /**< Number of resets */
} dt_reset_t;
```
Furthermore, each IP has a list of reset ports and a new function is provided to get the connection between the IP port and the global list of reset nodes:
```c
// dt_usbdev.h
/**
 * List of reset ports.
 *
 * Reset ports are guaranteed to be numbered consecutively from 0.
 */
typedef enum dt_usbdev_reset {
  kDtUsbdevResetRst = 0, /**<  */
  kDtUsbdevResetAon = 1, /**<  */
  kDtUsbdevResetCount = 2, /**< Number of reset ports */
} dt_usbdev_reset_t;

/**
 * Get the reset signal connected to a reset port of an instance.
 *
 * @param dt Instance of usbdev.
 * @param sig Reset port.
 * @return Reset signal.
 */
dt_reset_t dt_usbdev_reset(
    dt_usbdev_t dt,
    dt_usbdev_reset_t rst);
```
Under the hood, new fields are added to the DT to store this information, e.g.
```c
// dt_usbdev.c
static const dt_desc_usbdev_t usbdev_desc[kDtUsbdevCount] = {
  [kDtUsbdev] = {
    .inst_id = kDtInstanceIdUsbdev,
    // fields omitted, the new fields are:
    .reset = {
      [kDtUsbdevResetRst] = kDtResetUsb,
      [kDtUsbdevResetAon] = kDtResetUsbAon,
    },
  },
};

```

**Design of the `rstmgr` extension**

An important information needed to operate the `rstmgr` is the list of software triggerable resets and what they are connected to, since those are bits in several registers. With the DT information, exposing the information is easy:
- it is possible to query the number of software resets
- it is possible to query the reset node to which the `i`-th SW reset is connected to.

Example with earlgrey:
```c
// dt_rstmgr.h
/**
 * Get the number of software resets.
 *
 * @param dt Instance of rstmgr.
 * @return Number of software resets.
 */
size_t dt_rstmgr_sw_reset_count(dt_rstmgr_t dt);

/**
 * Get the reset ID of a software reset.
 *
 * The resets are ordered in the same way as they appear in the registers.
 *
 * @param dt Instance of rstmgr.
 * @param idx Index of the software reset, between 0 and `dt_rstmgr_sw_reset_count(dt)-1`.
 * @return Reset ID.
 */
dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx);
```
Under the hood, this is just a table:
```c
// dt_rstmgr.c
static const dt_desc_rstmgr_t rstmgr_desc[kDtRstmgrCount] = {
  [kDtRstmgrAon] = {
    .inst_id = kDtInstanceIdRstmgrAon,
    // fields omitted
   // Extension
    .ext = {
      .sw_rst = {
        [0] = kDtResetSpiDevice,
        [1] = kDtResetSpiHost0,
        [2] = kDtResetSpiHost1,
        [3] = kDtResetUsb,
        [4] = kDtResetUsbAon,
        [5] = kDtResetI2c0,
        [6] = kDtResetI2c1,
        [7] = kDtResetI2c2,
      },
     // fields omitted
    },
  },
};
```
On top of this, the `rstmgr` also exposes the reset request that triggered a reset in [RESET_INFO . HW_REQ](https://opentitan.org/book/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.html#reset_info--hw_req). In orde to be able to parse this field, the list of reset requests also needs to be available. Here there is a bit of a difficulty because the hjson has three groups: debug, internal and peripherals. The peripheral reset requests correspond to actual reset requests but the internal and debug ones are in fact hardcoded and do not correspond to actual signals:
```javascript
    reqs:
    {
      int:
      [
        {
          name: MainPwr // NOT a name of an actual signal
          desc: main power glitch reset request
          module: pwrmgr_aon
        }
        {
          name: Esc // NOT a name of an actual signal
          desc: escalation reset request
          module: alert_handler
        }
      ]
      debug:
      [
        {
          name: Ndm // NOT a name of an actual signal
          desc: non-debug-module reset request
          module: rv_dm
        }
      ]
      peripheral:
      [
        {
          name: rst_req
          width: "1"
          module: sysrst_ctrl_aon
          desc: OpenTitan reset request to `rstmgr` (running on AON clock).
        }
        {
          name: aon_timer_rst_req
          width: "1"
          module: aon_timer_aon
          desc: watchdog reset requestt
        }
      ]
    }
```
The strategy to deal with those at the moment is to special case those three special signals in the DT by keeping the module name but faking the signal index (see below).
```c
// dt_rstmgr.h
/**
 * Description of a reset request source.
 *
 * A reset request source is always identified by the instance ID of the module where it comes
 * from. In principle, some instances could have several reset requests. If this is the case,
 * the `rst_req` can be used to distinguish between those. It should be cast to the
 * `dt_<ip>_reset_req_t` type of the corresponding IP.
 * ```
 */
typedef struct dt_rstmgr_reset_req_src {
  dt_instance_id_t inst_id; /**< Instance ID of the source of this reset request. */
  size_t reset_req; /**< Index of the reset request signal for that instance. */
} dt_rstmgr_reset_req_src_t;


/**
 * Get the number of hardware reset requests.
 *
 * @param dt Instance of rstmgr.
 * @return Number of reset requests.
 */
size_t dt_rstmgr_hw_reset_req_src_count(dt_rstmgr_t dt);

/**
 * Get the description of a reset request.
 *
 * The reset requests are ordered as they appear in the registers.
 *
 * @param dt Instance of rstmgr.
 * @param idx Index of the reset request source, between 0 and
 *            `dt_pwrmgr_hw_reset_req_src_count(dt)-1`.
 * @return Description of the reset.
 */
dt_rstmgr_reset_req_src_t dt_rstmgr_hw_reset_req_src(dt_rstmgr_t dt, size_t idx);
```
and
```c
// dt_rstmgr.c

static const dt_desc_rstmgr_t rstmgr_desc[kDtRstmgrCount] = {
  [kDtRstmgrAon] = {
    .inst_id = kDtInstanceIdRstmgrAon,
    // fields omitted
    .ext = {
      // sw_rst omitted
      .hw_req = {
        [0] = {
          .inst_id = kDtInstanceIdSysrstCtrlAon,
          .reset_req = kDtSysrstCtrlResetReqRstReq,
        },
        [1] = {
          .inst_id = kDtInstanceIdAonTimerAon,
          .reset_req = kDtAonTimerResetReqAonTimer,
        },
        [2] = {
          .inst_id = kDtInstanceIdPwrmgrAon,
          .reset_req = 0, // There is no corresponding reset request exposed by the pwrmgr
        },
        [3] = {
          .inst_id = kDtInstanceIdAlertHandler,
          .reset_req = 0, // There is no corresponding reset request exposed by the pwrmgr
        },
        [4] = {
          .inst_id = kDtInstanceIdRvDm,
          .reset_req = 0, // There is no corresponding reset request exposed by the pwrmgr
        },
      },
    },
  },
};
```