### PR TITLE
[ci] Remove continue-on-error for check-countermeasures check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,8 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Countermeasures implemented (earlgrey)
         run: ./ci/scripts/check-countermeasures.sh earlgrey
-        continue-on-error: true
       - name: Countermeasures implemented (englishbreakfast)
         run: ./ci/scripts/check-countermeasures.sh englishbreakfast
-        continue-on-error: true
       - name: Bazel test suite tags
         run: ./ci/scripts/check_bazel_test_suites.py
         continue-on-error: true


### PR DESCRIPTION
Fix #26339

As discussed in lowRISC/opentitan#26339, when the check-countermeasures script fails, the Lint (slow) job continues without flagging this error. We should let the job failing when this check fails.