### PR TITLE
[ci] Add countermeasures check for darjeeling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Countermeasures implemented (englishbreakfast)
         run: ./ci/scripts/check-countermeasures.sh englishbreakfast
         continue-on-error: true
+      - name: Countermeasures implemented (darjeeling)
+        run: ./ci/scripts/check-countermeasures.sh darjeeling
       - name: Bazel test suite tags
         run: ./ci/scripts/check_bazel_test_suites.py
         continue-on-error: true


### PR DESCRIPTION
All tops except darjeeling execute the check-countermeasures in CI to check, whether all countermeasure labels defined in the hjson are present in the RTL.

This commit enables this check also for darjeeling.