### PR TITLE
[prim] Add flop without reset

### DIFF
--- a/hw/ip/prim/prim_flop_no_rst.core
+++ b/hw/ip/prim/prim_flop_no_rst.core
@@ -1,0 +1,46 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:flop_no_rst"
+description: "Generic flop without a reset"
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+      - lowrisc:prim:assert
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: flop_no_rst
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_flop_no_rst.core
+++ b/hw/ip/prim_generic/prim_generic_flop_no_rst.core
@@ -1,0 +1,35 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:flop_no_rst"
+description: "generic flop without a reset"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_flop_no_rst.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_no_rst.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_no_rst.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_generic_flop_no_rst #(
+  parameter int Width = 1
+) (
+  input                    clk_i,
+  input        [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
+);
+
+  always_ff @(posedge clk_i) begin
+    q_o <= d_i;
+  end
+
+endmodule


### PR DESCRIPTION
From the physical perspective its better to reduce the load on the reset network. This PR adds a new prim for a flop without reset It can be used where data is transmitted alongside some control signal. The control signals would use flops with reset and always have a known value, but the data is using a flop without a reset. Then, the data is only used for example when the valid control signal indicates that there is actually valid data available.