### PR TITLE
[hw,sram_ctrl,rtl] Ability to correct single-bit errors and log error

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -83,7 +83,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
   output logic [Width-1:0]                 rdata_o,
   output logic                             rvalid_o, // Read response (rdata_o) is valid
   output logic [1:0]                       rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
-  output logic [31:0]                      raddr_o,  // Read address for error reporting.
+  output logic [AddrWidth-1:0]             raddr_o,  // Read address for error reporting.
 
   // config
   input  ram_1p_cfg_t     [NumRamInst-1:0] cfg_i,
@@ -234,7 +234,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
 
   // We latch the non-scrambled address for error reporting.
   logic [AddrWidth-1:0] raddr_q;
-  assign raddr_o = 32'(raddr_q);
+  assign raddr_o = raddr_q;
 
   //////////////////////////////////////////////
   // Keystream Generation for Data Scrambling //

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -113,6 +113,13 @@
       local:     "true",
       expose:    "true",
       default:   "2"
+    }
+    { name:      "EccCorrection",
+      desc:      "Enable single-bit error correction and error logging",
+      type:      "bit",
+      local:     "false",
+      expose:    "true",
+      default:   "0"
     },
     { name:      "RaclPolicySelRangesRamNum",
       desc:      "Number of Racl Policy Selection Ranges for the Ram interface",
@@ -247,6 +254,16 @@
         Incoming array of RACL policy ranges.
       '''
     }
+    { struct:  "sram_error_t",
+      package: "sram_ctrl_pkg",
+      width:   "1"
+      type:    "uni",
+      name:    "sram_rerror",
+      act:     "req",
+      desc:    '''
+               SRAM read error indicating correctable and uncorrectable ECC errors.
+               '''
+    },
   ]
 
   /////////////////////

--- a/hw/ip/sram_ctrl/doc/interfaces.md
+++ b/hw/ip/sram_ctrl/doc/interfaces.md
@@ -38,6 +38,7 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | racl_policies              | top_racl_pkg::racl_policy_vec   | uni     | rcv   | 1                         | Incoming RACL policy vector from a racl_ctrl instance. The policy selection vector (parameter) selects the policy for each register. |
 | racl_error                 | top_racl_pkg::racl_error_log    | uni     | req   | 1                         | RACL error log information of this module.                                                                                           |
 | racl_policy_sel_ranges_ram | top_racl_pkg::racl_range_t      | uni     | rcv   | RaclPolicySelRangesRamNum | Incoming array of RACL policy ranges.                                                                                                |
+| sram_rerror                | sram_ctrl_pkg::sram_error_t     | uni     | req   | 1                         | SRAM read error indicating correctable and uncorrectable ECC errors.                                                                 |
 | regs_tl                    | tlul_pkg::tl                    | req_rsp | rsp   | 1                         |                                                                                                                                      |
 | ram_tl                     | tlul_pkg::tl                    | req_rsp | rsp   | 1                         |                                                                                                                                      |
 

--- a/hw/ip/sram_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/sram_ctrl/doc/theory_of_operation.md
@@ -99,3 +99,22 @@ Read accesses however always take 1 cycle, no matter whether the access is a ful
 
 Note that this has been implemented in this way to not overly complicate the design, and since it is assumed that sub-word write operations happen relatively infrequently.
 For full write throughput, a more elaborate write buffering scheme would be required.
+
+### ECC Error Handling and Correction
+
+This memory utilizes a SECDED ECC code stored alongside the data in the underlying memory primitive to enhance data integrity.
+Error correction for single-bit errors can be enabled by setting the top-level parameter `EccCorrection` to 1.
+When enabled and a correctable single-bit error is detected, the memory automatically corrects the data before providing it.
+If an uncorrectable multi-bit error is detected, the data is not corrected.
+Instead, the invalid data word is returned to the requester, which must then implement its own error handling or escalation strategy.
+
+Regardless of whether an error is correctable or not, the `sram_rerror_o` output port signals its detection.
+This output also indicates whether the error was corrected (if correction is enabled) and provides the memory location where the error occurred.
+This information is valuable for system-level Reliability, Availability, and Serviceability (RAS) monitoring and management.
+
+#### Important Considerations
+
+* Activating the single-bit correction mechanism slightly reduces the overall probability of detecting multi-bit errors compared to detection-only mode.
+* The correction process involves internal decoding and re-encoding steps, during which unencoded, non-redundant data exists temporarily on internal wires.
+* Dedicated DV support for this specific correction feature is not yet available.
+* By default, the `EccCorrection` feature is disabled.

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
@@ -31,4 +31,15 @@ package sram_ctrl_pkg;
   parameter lfsr_perm_t RndCnstLfsrPermDefault = {
     160'h438131ae2cb71ffdd2e4c29a1f412231747cd7b2
   };
+
+  //////////////////////
+  // Type definitions //
+  //////////////////////
+
+  typedef struct packed {
+    logic                      valid;
+    logic                      correctable;
+    logic [top_pkg::TL_AW-1:0] address;
+  } sram_error_t;
+
 endpackage : sram_ctrl_pkg

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4356,6 +4356,15 @@
           name_top: SramCtrlRetAonOutstanding
         }
         {
+          name: EccCorrection
+          desc: Enable single-bit error correction and error logging
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlRetAonEccCorrection
+        }
+        {
           name: RaclPolicySelRangesRamNum
           desc: Number of Racl Policy Selection Ranges for the Ram interface
           type: int
@@ -4505,6 +4514,17 @@
             expose: true
             name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
           }
+          inst_name: sram_ctrl_ret_aon
+          index: -1
+        }
+        {
+          name: sram_rerror
+          desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+          struct: sram_error_t
+          package: sram_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -6671,6 +6691,15 @@
           name_top: SramCtrlMainOutstanding
         }
         {
+          name: EccCorrection
+          desc: Enable single-bit error correction and error logging
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMainEccCorrection
+        }
+        {
           name: RaclPolicySelRangesRamNum
           desc: Number of Racl Policy Selection Ranges for the Ram interface
           type: int
@@ -6822,6 +6851,17 @@
             expose: true
             name_top: SramCtrlMainRaclPolicySelRangesRamNum
           }
+          inst_name: sram_ctrl_main
+          index: -1
+        }
+        {
+          name: sram_rerror
+          desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+          struct: sram_error_t
+          package: sram_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -7008,6 +7048,15 @@
           name_top: SramCtrlMboxOutstanding
         }
         {
+          name: EccCorrection
+          desc: Enable single-bit error correction and error logging
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMboxEccCorrection
+        }
+        {
           name: RaclPolicySelRangesRamNum
           desc: Number of Racl Policy Selection Ranges for the Ram interface
           type: int
@@ -7157,6 +7206,17 @@
             expose: true
             name_top: SramCtrlMboxRaclPolicySelRangesRamNum
           }
+          inst_name: sram_ctrl_mbox
+          index: -1
+        }
+        {
+          name: sram_rerror
+          desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+          struct: sram_error_t
+          package: sram_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
           inst_name: sram_ctrl_mbox
           index: -1
         }
@@ -22691,6 +22751,17 @@
         index: -1
       }
       {
+        name: sram_rerror
+        desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+        struct: sram_error_t
+        package: sram_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: sram_ctrl_ret_aon
+        index: -1
+      }
+      {
         name: regs_tl
         struct: tl
         package: tlul_pkg
@@ -23862,6 +23933,17 @@
         index: -1
       }
       {
+        name: sram_rerror
+        desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+        struct: sram_error_t
+        package: sram_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: sram_ctrl_main
+        index: -1
+      }
+      {
         name: regs_tl
         struct: tl
         package: tlul_pkg
@@ -24025,6 +24107,17 @@
           expose: true
           name_top: SramCtrlMboxRaclPolicySelRangesRamNum
         }
+        inst_name: sram_ctrl_mbox
+        index: -1
+      }
+      {
+        name: sram_rerror
+        desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+        struct: sram_error_t
+        package: sram_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
         inst_name: sram_ctrl_mbox
         index: -1
       }

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -50,6 +50,7 @@ module top_darjeeling #(
   parameter int SramCtrlRetAonNumRamInst = 1,
   parameter bit SramCtrlRetAonInstrExec = 0,
   parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
+  parameter bit SramCtrlRetAonEccCorrection = 0,
   parameter int SramCtrlRetAonRaclPolicySelRangesRamNum = 1,
   // parameters for rv_dm
   parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
@@ -91,12 +92,14 @@ module top_darjeeling #(
   parameter int SramCtrlMainNumRamInst = 1,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
+  parameter bit SramCtrlMainEccCorrection = 0,
   parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for sram_ctrl_mbox
   parameter int SramCtrlMboxInstSize = 4096,
   parameter int SramCtrlMboxNumRamInst = 1,
   parameter bit SramCtrlMboxInstrExec = 0,
   parameter int SramCtrlMboxNumPrinceRoundsHalf = 3,
+  parameter bit SramCtrlMboxEccCorrection = 0,
   parameter int SramCtrlMboxRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl0
   parameter RomCtrl0BootRomInitFile = "",
@@ -1695,6 +1698,7 @@ module top_darjeeling #(
     .InstrExec(SramCtrlRetAonInstrExec),
     .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf),
     .Outstanding(SramCtrlRetAonOutstanding),
+    .EccCorrection(SramCtrlRetAonEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_ret_aon (
       // [50]: fatal_error
@@ -1712,6 +1716,7 @@ module top_darjeeling #(
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
       .racl_policy_sel_ranges_ram_i({SramCtrlRetAonRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
+      .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_ret_aon_ram_tl_req),
@@ -2068,6 +2073,7 @@ module top_darjeeling #(
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMainOutstanding),
+    .EccCorrection(SramCtrlMainEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
       // [68]: fatal_error
@@ -2085,6 +2091,7 @@ module top_darjeeling #(
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
       .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
+      .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_main_ram_tl_req),
@@ -2108,6 +2115,7 @@ module top_darjeeling #(
     .InstrExec(SramCtrlMboxInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMboxNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMboxOutstanding),
+    .EccCorrection(SramCtrlMboxEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlMboxRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_mbox (
       // [69]: fatal_error
@@ -2125,6 +2133,7 @@ module top_darjeeling #(
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
       .racl_policy_sel_ranges_ram_i({SramCtrlMboxRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
+      .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_mbox_regs_tl_req),
       .regs_tl_o(sram_ctrl_mbox_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_mbox_ram_tl_req),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5731,6 +5731,15 @@
           name_top: SramCtrlRetAonOutstanding
         }
         {
+          name: EccCorrection
+          desc: Enable single-bit error correction and error logging
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlRetAonEccCorrection
+        }
+        {
           name: RaclPolicySelRangesRamNum
           desc: Number of Racl Policy Selection Ranges for the Ram interface
           type: int
@@ -5877,6 +5886,17 @@
             expose: true
             name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
           }
+          inst_name: sram_ctrl_ret_aon
+          index: -1
+        }
+        {
+          name: sram_rerror
+          desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+          struct: sram_error_t
+          package: sram_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -8702,6 +8722,15 @@
           name_top: SramCtrlMainOutstanding
         }
         {
+          name: EccCorrection
+          desc: Enable single-bit error correction and error logging
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMainEccCorrection
+        }
+        {
           name: RaclPolicySelRangesRamNum
           desc: Number of Racl Policy Selection Ranges for the Ram interface
           type: int
@@ -8850,6 +8879,17 @@
             expose: true
             name_top: SramCtrlMainRaclPolicySelRangesRamNum
           }
+          inst_name: sram_ctrl_main
+          index: -1
+        }
+        {
+          name: sram_rerror
+          desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+          struct: sram_error_t
+          package: sram_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -21501,6 +21541,17 @@
         index: -1
       }
       {
+        name: sram_rerror
+        desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+        struct: sram_error_t
+        package: sram_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: sram_ctrl_ret_aon
+        index: -1
+      }
+      {
         name: regs_tl
         struct: tl
         package: tlul_pkg
@@ -23056,6 +23107,17 @@
           expose: true
           name_top: SramCtrlMainRaclPolicySelRangesRamNum
         }
+        inst_name: sram_ctrl_main
+        index: -1
+      }
+      {
+        name: sram_rerror
+        desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+        struct: sram_error_t
+        package: sram_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
         inst_name: sram_ctrl_main
         index: -1
       }

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -64,6 +64,7 @@ module top_earlgrey #(
   parameter int SramCtrlRetAonNumRamInst = 1,
   parameter bit SramCtrlRetAonInstrExec = 0,
   parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
+  parameter bit SramCtrlRetAonEccCorrection = 0,
   parameter int SramCtrlRetAonRaclPolicySelRangesRamNum = 1,
   // parameters for flash_ctrl
   parameter bit SecFlashCtrlScrambleEn = 1,
@@ -111,6 +112,7 @@ module top_earlgrey #(
   parameter int SramCtrlMainNumRamInst = 1,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 2,
+  parameter bit SramCtrlMainEccCorrection = 0,
   parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
@@ -2170,6 +2172,7 @@ module top_earlgrey #(
     .InstrExec(SramCtrlRetAonInstrExec),
     .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf),
     .Outstanding(SramCtrlRetAonOutstanding),
+    .EccCorrection(SramCtrlRetAonEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_ret_aon (
       // [34]: fatal_error
@@ -2187,6 +2190,7 @@ module top_earlgrey #(
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
       .racl_policy_sel_ranges_ram_i({SramCtrlRetAonRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
+      .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_ret_aon_ram_tl_req),
@@ -2660,6 +2664,7 @@ module top_earlgrey #(
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMainOutstanding),
+    .EccCorrection(SramCtrlMainEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
       // [59]: fatal_error
@@ -2677,6 +2682,7 @@ module top_earlgrey #(
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
       .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
+      .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_main_ram_tl_req),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3852,6 +3852,15 @@
           name_top: SramCtrlMainOutstanding
         }
         {
+          name: EccCorrection
+          desc: Enable single-bit error correction and error logging
+          type: bit
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMainEccCorrection
+        }
+        {
           name: RaclPolicySelRangesRamNum
           desc: Number of Racl Policy Selection Ranges for the Ram interface
           type: int
@@ -3993,6 +4002,17 @@
             expose: true
             name_top: SramCtrlMainRaclPolicySelRangesRamNum
           }
+          inst_name: sram_ctrl_main
+          index: -1
+        }
+        {
+          name: sram_rerror
+          desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+          struct: sram_error_t
+          package: sram_ctrl_pkg
+          type: uni
+          act: req
+          width: 1
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -11175,6 +11195,17 @@
           expose: true
           name_top: SramCtrlMainRaclPolicySelRangesRamNum
         }
+        inst_name: sram_ctrl_main
+        index: -1
+      }
+      {
+        name: sram_rerror
+        desc: SRAM read error indicating correctable and uncorrectable ECC errors.
+        struct: sram_error_t
+        package: sram_ctrl_pkg
+        type: uni
+        act: req
+        width: 1
         inst_name: sram_ctrl_main
         index: -1
       }

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -51,6 +51,7 @@ module top_englishbreakfast #(
   parameter int SramCtrlMainNumRamInst = 1,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
+  parameter bit SramCtrlMainEccCorrection = 0,
   parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
@@ -1195,6 +1196,7 @@ module top_englishbreakfast #(
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMainOutstanding),
+    .EccCorrection(SramCtrlMainEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
       // [22]: fatal_error
@@ -1212,6 +1214,7 @@ module top_englishbreakfast #(
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
       .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
+      .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_main_ram_tl_req),


### PR DESCRIPTION
This PR adds the ability to correct single-bit errors using the ECC on the data. Double bit errors are only detected.

When there is a single bit error, it is corrected and logged via the new error log, which can be connected to a RAS error log for example. Double errors are passed to the requester but also logged to the error log. The error correction happens via a new piped ECC stage, which increases the latency of the sram_ctrl adapter.

In DJ and EG, this feature is not not used. The error log is tied off.