### PR TITLE
[hw,soc_dbg_ctrl,doc] Properly define SEC_CM countermeasures

### DIFF
--- a/hw/ip/soc_dbg_ctrl/data/soc_dbg_ctrl.hjson
+++ b/hw/ip/soc_dbg_ctrl/data/soc_dbg_ctrl.hjson
@@ -56,8 +56,11 @@
     { name: "DEBUG_POLICY_VALID.CONFIG.SHADOW",
       desc: "Debug policy valid register is shadowed."
     }
-    { name: "DEBUG_POLICY_RELOCKED.CONFIG.SHADOW",
-      desc: "Debug policy relocked register is shadowed."
+    { name: "DEBUG_POLICY_CATEGORY.CONFIG.SHADOW",
+      desc: "Debug policy category register is shadowed."
+    }
+    { name: "HALT.FSM.SPARSE",
+      desc: "The halt FSM uses a sparse state encoding."
     }
   ]
 

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
@@ -85,6 +85,7 @@ module soc_dbg_ctrl
 
   // SEC_CM: BUS.INTEGRITY
   // SEC_CM: DEBUG_POLICY_VALID.CONFIG.SHADOW
+  // SEC_CM: DEBUG_POLICY_CATEGORY.CONFIG.SHADOW
   soc_dbg_ctrl_core_reg_top u_core_reg (
     .clk_i,
     .rst_ni,
@@ -369,7 +370,7 @@ module soc_dbg_ctrl
     endcase
   end
 
-  // SEC_CM: FSM.SPARSE
+  // SEC_CM: HALT.FSM.SPARSE
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, halt_state_d, halt_state_q, halt_state_e, Idle)
 
   logic unused_signals;


### PR DESCRIPTION
This removes the offenses for `soc_dbg_ctrl` from https://github.com/lowRISC/opentitan/issues/26362