### PR TITLE
[util/vendor] Allow patches to files

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -293,7 +293,13 @@ class Mapping1:
                         Path('.') if have_patch_dir else None)
 
     @staticmethod
-    def apply_patch(basedir, patchfile):
+    def apply_patch(basepath, patchfile):
+        # Sometimes basepath is actually a file to which the patch should be applied.
+        # In that case, make basedir point to the containing directory instead of the file.
+        if os.path.isfile(basepath):
+            basedir = os.path.dirname(basepath)
+        else:
+            basedir = basepath
         cmd = ['git', 'apply', '--directory', str(basedir), '-p1',
                str(patchfile)]
         if verbose:


### PR DESCRIPTION
Sometimes a mapping has a "from" and "to" field that is actually a file instead of a whole directory. Example of this can be found here: https://github.com/lowRISC/sonata-system/blob/06102a66aebdda1d42966b049409d8ddaa6cd53a/vendor/lowrisc_ip.vendor.hjson#L15 When also adding a patch directory this runs into a problem because git apply gets supplied the "to" field as a directory without checking whether it is a file. This commit fixes that by checking if it is a file before passing it along as the base directory.