### PR TITLE
[sw,multitop] Port `plic_sw_irq_test` to devicetables

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2979,13 +2979,13 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:math",
-        "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/plic_sw_irq_test.c
+++ b/sw/device/tests/plic_sw_irq_test.c
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_api.h"      // Generated
+#include "dt/dt_rv_plic.h"  // Generated
 #include "sw/device/lib/base/abs_mmio.h"
-#include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/irq.h"
@@ -12,12 +13,11 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_plic_regs.h"  // Generated.
 
 OTTF_DEFINE_TEST_CONFIG();
 
-static const dif_rv_plic_target_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static const dif_rv_plic_target_t kPlicTarget = 0;
 
 static dif_rv_plic_t plic0;
 
@@ -91,9 +91,8 @@ bool test_main(void) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
-  mmio_region_t plic_base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_plic_init(plic_base_addr, &plic0));
+  static_assert(kDtRvPlicCount >= 1, "This test requires an RV PLIC.");
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt((dt_rv_plic_t)0, &plic0));
 
   plic_configure_irqs(&plic0);
 


### PR DESCRIPTION
Fix #26205

This PR ports the `plic_sw_irq_test` to use the devicetables API. The test remains passing on Earlgrey in the `fpga_cw310_rom_with_fake_keys` environment, and will compile for Darjeeling via
```sh
bazel build //sw/device/tests:plic_sw_irq_test --//hw/top=darjeeling
```
I have also successfully run this test on Darjeeling DV using the latest WIP branch.