### PR TITLE
[python] Move uvmdvgen out of its own package

### DIFF
--- a/ci/lint/ruff.toml
+++ b/ci/lint/ruff.toml
@@ -106,6 +106,7 @@ extend-exclude = [
   "util/tlgen/*.py",
   "util/topgen.py",
   "util/topgen/*.py",
+  "util/uvmdvgen.py",
   "util/uvmdvgen/*.py",
   "util/validate_testplans.py",
   "util/vendor.py",

--- a/util/uvmdvgen.py
+++ b/util/uvmdvgen.py
@@ -11,10 +11,9 @@ import logging as log
 import re
 import sys
 
-import gen_agent
-import gen_env
-
-VENDOR_DEFAULT = "lowrisc"
+from uvmdvgen import gen_agent
+from uvmdvgen import gen_env
+from uvmdvgen import VENDOR_DEFAULT
 
 
 def main():

--- a/util/uvmdvgen/__init__.py
+++ b/util/uvmdvgen/__init__.py
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+VENDOR_DEFAULT = "lowrisc"


### PR DESCRIPTION
Without this, `importlib.resources` was not able to find the package it was in.