### PR TITLE
[alert_handler,rtl] Fix esc_ping_en widening cast

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv.tpl
@@ -276,7 +276,7 @@ module ${module_instance_name}_ping_timer import ${module_instance_name}_pkg::*;
 
   // generate ping enable vector
   assign alert_ping_req_o = NAlerts'(alert_ping_en) << id_to_ping_q;
-  assign esc_ping_req_o   = EscSenderIdxWidth'(esc_ping_en) << esc_cnt;
+  assign esc_ping_req_o   = N_ESC_SEV'(esc_ping_en) << esc_cnt;
 
   // under normal operation, these signals should never be asserted.
   // we place hand instantiated buffers here such that these signals are not

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -276,7 +276,7 @@ module alert_handler_ping_timer import alert_handler_pkg::*; #(
 
   // generate ping enable vector
   assign alert_ping_req_o = NAlerts'(alert_ping_en) << id_to_ping_q;
-  assign esc_ping_req_o   = EscSenderIdxWidth'(esc_ping_en) << esc_cnt;
+  assign esc_ping_req_o   = N_ESC_SEV'(esc_ping_en) << esc_cnt;
 
   // under normal operation, these signals should never be asserted.
   // we place hand instantiated buffers here such that these signals are not

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -276,7 +276,7 @@ module alert_handler_ping_timer import alert_handler_pkg::*; #(
 
   // generate ping enable vector
   assign alert_ping_req_o = NAlerts'(alert_ping_en) << id_to_ping_q;
-  assign esc_ping_req_o   = EscSenderIdxWidth'(esc_ping_en) << esc_cnt;
+  assign esc_ping_req_o   = N_ESC_SEV'(esc_ping_en) << esc_cnt;
 
   // under normal operation, these signals should never be asserted.
   // we place hand instantiated buffers here such that these signals are not


### PR DESCRIPTION
Caught this with Verilator linting -- esc_ping_en is a N_ESC_SEV-wide (currently 4) one-hot signal that is shifted by esc_cnt (which goes up to 3). As a-will observes in https://github.com/lowRISC/opentitan/pull/22568#discussion_r1962486432, the too-narrow cast didn't cause a problem because the LHS causes us to widen again to N_ESC_SEV anyway.