### PR TITLE
[opentitantool] Ship updated firmware for HyperDebug

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240529_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "1ed9231800d6bf42ad28b5e44708bbcb63bb9611191be8886861970b0c58909d",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20250131_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "8595340b347531438ce07f7d678ec24038b4fa2edd7f4a620bd8c5130d72c2ce",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Support 48Mhz clock generation, and bugfixes

Add ability to change HyperDebug core clock frequency.  Choosing 96 MHz will allow any PWM capable pin to produce a 48 MHz clock suitable for driving a NuvoTitan chip.  (CN10.31 is the only pin that can output 96 MHz.)

Also included are a few bugfixes to HyperDebug polling the "GSC ready" signal when passing through TPM operations.

Relevant CLs:
d090a07063 chip/stm32: Avoid stuck UART to USB forwarding b3c959b5c5 board/hyperdebug: Avoid clobbering CCR_CFGR register 765b8a9d2b chip/stm32: Wait for core voltage to stabilize on STM32L4/5 6e9f274d2c board/hyperdebug: Improve GSC ready pulse detection 843d7ee9a6 board/hyperdebug: Expect GSC ready pulse after transaction 1b9f351528 board/hyperdebug: Properly set system timer tick rate 3962928140 board/hyperdebug: Allow runtime changes to system clock 821e9349d2 chip/stm32: Consolidate clock enums
e7f8842e93 chip/stm32: Rename STM32_HSE_CLOCK to CONFIG_STM32_CLOCK_HSE_HZ a8fc0258fe board/hyperdebug: Fast clock output on CN10.31 6265770002 board/hyperdebug: Add support for PWM via low power timers 195271c11d board/hyperdebug: Refactor PWM
fbf583383f board/hyperdebug: Fix off-by-one and rounding errors

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I212c1a249249470601d667a72b29244f26bcd6c5 (cherry picked from commit 8c999f9e6d117ee717d96dd8fcec81cf2da3752c)