### PR TITLE
[tlul,rtl] Explicitly zero some integrity bits from tlul_adapter_reg

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_dmi.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_dmi.sv
@@ -115,7 +115,8 @@ module tlul_adapter_dmi
   // outgoing integrity generation
   tlul_rsp_intg_gen #(
     .EnableRspIntgGen(EnableRspIntgGen),
-    .EnableDataIntgGen(EnableDataIntgGen)
+    .EnableDataIntgGen(EnableDataIntgGen),
+    .UserInIsZero(1'b1)
   ) u_rsp_intg_gen (
     .tl_i(tl_d2h_o_pre),
     .tl_o(tl_d2h_o)

--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -166,7 +166,8 @@ module tlul_adapter_reg
   // outgoing integrity generation
   tlul_rsp_intg_gen #(
     .EnableRspIntgGen(EnableRspIntgGen),
-    .EnableDataIntgGen(EnableDataIntgGen)
+    .EnableDataIntgGen(EnableDataIntgGen),
+    .UserInIsZero(1'b1)
   ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o(tl_o)


### PR DESCRIPTION
The existing behaviour of the tlul_rsp_intg_gen was to add rsp/data integrity bits if their generation was enabled and pass through the input integrity bits if not.

In some instantiations (in tlul_adapter_reg and tlul_adapter_dmi), these bits are actually always zero. One consequence is missing coverage in DV simulations. The problem is that e.g. the rsp_intg signal is driven with a continuous assignment:

    assign rsp_intg = tl_i.d_user.rsp_intg;

But the right hand side is zero, so constant and the assignment is not marked as covered.

This commit adds a UserInIsZero parameter. If this is true then we know the input d_user signal is zero and thus can wire the variable directly to zero.

This removes the cover point but will not change RTL behaviour at all.