### PR TITLE
[sw,dice] Remove direct deps from dice_chain lib to x509 template

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -227,8 +227,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:boot_measurements",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:util",
-        "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
-        "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
         "//sw/device/silicon_creator/lib/cert:dice",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -11,8 +11,6 @@
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
-#include "sw/device/silicon_creator/lib/cert/cdi_0.h"  // Generated.
-#include "sw/device/silicon_creator/lib/cert/cdi_1.h"  // Generated.
 #include "sw/device/silicon_creator/lib/cert/dice.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
@@ -29,9 +27,7 @@ enum {
    * The size of the scratch buffer that is large enough for constructing the
    * CDI certs.
    */
-  kScratchCertSizeBytes =
-      (kCdi0MaxCertSizeBytes > kCdi1MaxCertSizeBytes ? kCdi0MaxCertSizeBytes
-                                                     : kCdi1MaxCertSizeBytes),
+  kScratchCertSizeBytes = FLASH_CTRL_PARAM_BYTES_PER_PAGE,
 };
 
 /**


### PR DESCRIPTION
The dice_chain library currently determines the certificate buffer size based on x509 codegen constants, which is not suitable for the CWT variant.

This commit eliminates the dependency on x509 codegen constants and instead chooses the largest buffer size (i.e. Flash page size).