### PR TITLE
[pentest] Add missing exec environment

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -142,14 +142,12 @@ opentitan_test(
 opentitan_test(
     name = "chip_pen_test_fi_otbn",
     srcs = [":firmware_fi_otbn.c"],
-    exec_env = {
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:sim_dv": None,
-    },
-    silicon_owner = silicon_params(
+    exec_env = PENTEST_EXEC_ENVS,
+    fpga = fpga_params(tags = ["skip_in_ci"]),
+    silicon = silicon_params(
         tags = [
-            "broken",
             "manual",
+            "skip_in_ci",
         ],
     ),
     deps = FIRMWARE_DEPS_FI_OTBN,


### PR DESCRIPTION
PR #26261 added the SiliconOwner exec environments to the pentesting framework. This commit adds this env to chip_pen_test_fi_otbn as well.