### PR TITLE
[dv][fix] Minor fix in the dv_base_sequencer.sv

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_sequencer.sv
@@ -24,8 +24,14 @@ class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
-    if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
+
+    // Avoid null pointer if the cfg is not defined.
+    if (cfg == null) begin
+      `uvm_fatal(`gfn, "cfg handle is null.")
+    end else begin
+      if (cfg.has_req_fifo) req_analysis_fifo = new("req_analysis_fifo", this);
+      if (cfg.has_rsp_fifo) rsp_analysis_fifo = new("rsp_analysis_fifo", this);
+    end
   endfunction : build_phase
 
 endclass


### PR DESCRIPTION
Just a small check to avoid null pointers if someone tries to create new agents and other components and forget to instantiate the configuration object.