### PR TITLE
[racl_ctrl] Waive auto generated long lines

### DIFF
--- a/hw/ip_templates/racl_ctrl/lint/racl_ctrl.waiver.tpl
+++ b/hw/ip_templates/racl_ctrl/lint/racl_ctrl.waiver.tpl
@@ -6,3 +6,5 @@
 
 waive -rules {HIER_NET_NOT_READ} -location {${module_instance_name}_reg_top.sv} -regexp {error_log_flds_we\[4:1\]' is not read from in module} ${"\\"}
       -comment "Internal register is accepted to not be read. Tracked in #25663."
+
+waive -rules {LINE_LENGTH} -location {${module_instance_name}_reg_pkg.sv} -comment "Auto generated lines may be too long"

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/lint/racl_ctrl.waiver
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/lint/racl_ctrl.waiver
@@ -6,3 +6,5 @@
 
 waive -rules {HIER_NET_NOT_READ} -location {racl_ctrl_reg_top.sv} -regexp {error_log_flds_we\[4:1\]' is not read from in module} \
       -comment "Internal register is accepted to not be read. Tracked in #25663."
+
+waive -rules {LINE_LENGTH} -location {racl_ctrl_reg_pkg.sv} -comment "Auto generated lines may be too long"


### PR DESCRIPTION
Depending on the RACL policy names lines that are too long may be generated. This PR waives such lines for ascent lint.