### PR TITLE
[bazel,otp] remove im_ext hash fusion into MANUF_STATE

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//rules:const.bzl", "CONST", "hex")
 
 _SEL_DEVICE_ID = 1
@@ -168,33 +167,3 @@ _manifest = rule(
 def manifest(d):
     _manifest(**d)
     return d["name"]
-
-def update_manifest(ctx, manifest, elf, update_manifest_json_tool):
-    """Update the `manuf_state_creator` field in a ROM_EXT manifest.
-
-    Args:
-        ctx: The rule context.
-        manifest: The input JSON manifest file.
-        elf: The input ROM_EXT ELF file.
-        update_manifest_json_tool: The path to the `update-manifest-json` tool.
-
-    Returns:
-        The updated JSON manifest file.
-    """
-    output_file = ctx.actions.declare_file(
-        "{}.{}.with_manuf_state_creator_updated.json".format(
-            ctx.attr.name,
-            paths.split_extension(manifest.basename)[0],
-        ),
-    )
-    args = ctx.actions.args()
-    args.add("--input", manifest)
-    args.add("--elf", elf)
-    args.add("--output", output_file)
-    ctx.actions.run(
-        outputs = [output_file],
-        inputs = [manifest, elf],
-        arguments = [args],
-        executable = update_manifest_json_tool,
-    )
-    return output_file

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -9,7 +9,6 @@ load(
     _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
     _opentitan_transition = "opentitan_transition",
 )
-load("@lowrisc_opentitan//rules:manifest.bzl", "update_manifest")
 load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
 load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
 load(
@@ -200,9 +199,6 @@ def _build_binary(ctx, exec_env, name, deps, kind):
     ecdsa_key = get_fallback(ctx, "attr.ecdsa_key", exec_env)
     rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
     spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
-    if manifest and ctx.attr.immutable_rom_ext_enabled:
-        manifest = update_manifest(ctx, manifest, elf, exec_env._update_manifest_json)
-
     if (manifest or rsa_key) and kind != "ram":
         if not (manifest and (rsa_key or ecdsa_key)):
             fail("Signing requires a manifest and an rsa_key or ecdsa_key, and optionally an spx_key")
@@ -340,10 +336,6 @@ common_binary_attrs = {
         default = "//hw/ip/rom_ctrl/util:scramble_image",
         executable = True,
         cfg = "exec",
-    ),
-    "immutable_rom_ext_enabled": attr.bool(
-        doc = "Indicates whether the binary is intended for a chip with the immutable ROM_EXT feature enabled.",
-        default = False,
     ),
 }
 

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -81,7 +81,6 @@ def exec_env_as_dict(ctx):
     tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
     result = {
         "_opentitantool": tc.tools.opentitantool,
-        "_update_manifest_json": tc.tools.update_manifest_json,
     }
     for field, (path, required) in _FIELDS.items():
         val = getattr_path(ctx, path)

--- a/rules/opentitan/toolchain.bzl
+++ b/rules/opentitan/toolchain.bzl
@@ -11,8 +11,6 @@ LocalToolInfo = provider(fields = [
     "gen_mem_image",
     "gen_otp_rot_auth_json",
     "gen_otp_immutable_rom_ext_json",
-    "gen_otp_creator_manuf_state_json",
-    "update_manifest_json",
 ])
 
 def _localtools_toolchain(ctx):
@@ -21,7 +19,6 @@ def _localtools_toolchain(ctx):
         gen_mem_image = ctx.attr.gen_mem_image[0].files_to_run,
         gen_otp_rot_auth_json = ctx.attr.gen_otp_rot_auth_json[0].files_to_run,
         gen_otp_immutable_rom_ext_json = ctx.attr.gen_otp_immutable_rom_ext_json[0].files_to_run,
-        update_manifest_json = ctx.attr.update_manifest_json[0].files_to_run,
     )
     return platform_common.ToolchainInfo(
         name = ctx.label.name,
@@ -48,11 +45,6 @@ localtools_toolchain = rule(
         ),
         "gen_otp_immutable_rom_ext_json": attr.label(
             default = "//util/design:gen-otp-immutable-rom-ext-json",
-            executable = True,
-            cfg = host_tools_transition,
-        ),
-        "update_manifest_json": attr.label(
-            default = "//util/design:update-manifest-json",
             executable = True,
             cfg = host_tools_transition,
         ),

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
@@ -5,10 +5,8 @@
 load(
     "//rules:const.bzl",
     "CONST",
-    "hex",
     "hex_digits",
 )
-load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -29,10 +27,6 @@ load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_TEMPLATE_BFV",
     "SLOTS",
-)
-load(
-    "//sw/device/silicon_creator/rom_ext:defs.bzl",
-    "ROM_EXT_VERSION",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -70,7 +64,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
         },
-        "immutable_rom_ext_enabled": True,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -80,7 +73,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
         },
-        "immutable_rom_ext_enabled": True,
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.ROM.IMM_SECTION)),
         "exit_failure": DEFAULT_TEST_SUCCESS_MSG,
     },
@@ -89,7 +81,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
         },
-        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -99,14 +90,12 @@ IMMUTABLE_PARTITION_TEST_CASES = [
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
         },
-        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     {
         "name": "exec_empty_hash_valid",
         "otp_fields": {},
-        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -115,7 +104,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
         },
-        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -125,7 +113,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET": otp_hex(0x4),
         },
-        "immutable_rom_ext_enabled": True,
         # The hash check should fail, since the offset is included in the hash,
         # triggering a hardened check fail (which executes an unimp; triggering
         # an exception and shutdown).
@@ -138,7 +125,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET": otp_hex(0x4),
         },
-        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -148,7 +134,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH": otp_hex(0x4),
         },
-        "immutable_rom_ext_enabled": True,
         # The hash check should fail, since the length is included in the hash,
         # triggering a hardened check fail (which executes an unimp; triggering
         # an exception and shutdown).
@@ -161,7 +146,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH": otp_hex(0x4),
         },
-        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -180,10 +164,7 @@ IMMUTABLE_PARTITION_TEST_CASES = [
                 items = t["otp_fields"],
             ),
         ],
-        rom_ext = ":immutable_rom_ext_section_test_{}_{}".format(
-            t["name"],
-            s["name"],
-        ),
+        rom_ext = ":immutable_rom_ext_section_test_{}".format(s["name"]),
         visibility = ["//visibility:private"],
     )
     for s in ROM_EXT_SLOTS
@@ -210,29 +191,15 @@ IMMUTABLE_PARTITION_TEST_CASES = [
     for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
-manifest(d = {
-    "name": "manifest",
-    "identifier": hex(CONST.ROM_EXT),
-    "visibility": ["//visibility:private"],
-    "version_major": ROM_EXT_VERSION.MAJOR,
-    "version_minor": ROM_EXT_VERSION.MINOR,
-    "security_version": ROM_EXT_VERSION.SECURITY,
-})
-
 [
     opentitan_binary(
-        name = "immutable_rom_ext_section_test_{}_{}".format(
-            t["name"],
-            s["name"],
-        ),
+        name = "immutable_rom_ext_section_test_{}".format(s["name"]),
         testonly = True,
         srcs = ["immutable_rom_ext_section_test.c"],
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310_sival",
         ],
-        immutable_rom_ext_enabled = t["immutable_rom_ext_enabled"],
         linker_script = s["linker_script"],
-        manifest = ":manifest",
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -245,7 +212,6 @@ manifest(d = {
         ],
     )
     for s in ROM_EXT_SLOTS
-    for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
 [
@@ -260,10 +226,7 @@ manifest(d = {
         fpga = fpga_params(
             assemble = "{firmware}@{offset}",
             binaries = {
-                ":immutable_rom_ext_section_test_{}_{}".format(
-                    t["name"],
-                    s["name"],
-                ): "firmware",
+                ":immutable_rom_ext_section_test_{}".format(s["name"]): "firmware",
             },
             exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],
@@ -317,11 +280,7 @@ BAD_SECTION_BINS = {
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310_sival",
         ],
-        # We set this to false because we don't care about manuf_state binding
-        # for this ROM_EXT.
-        immutable_rom_ext_enabled = False,
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_virtual",
-        manifest = ":manifest",
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -77,16 +77,6 @@ py_binary(
 )
 
 py_binary(
-    name = "update-manifest-json",
-    srcs = ["update-manifest-json.py"],
-    imports = ["."],
-    deps = [
-        "//util/design/lib:immutable_section_processor",
-        requirement("hjson"),
-    ],
-)
-
-py_binary(
     name = "sparse-fsm-encode",
     srcs = ["sparse-fsm-encode.py"],
     imports = ["."],

--- a/util/design/gen-otp-immutable-rom-ext-json.py
+++ b/util/design/gen-otp-immutable-rom-ext-json.py
@@ -17,7 +17,6 @@ _ENABLE_FIELD_NAME = "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN"
 _START_OFFSET_FIELD_NAME = "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET"
 _SIZE_FIELD_NAME = "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH"
 _HASH_FIELD_NAME = "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH"
-_CREATOR_MANUF_STATE_FIELD_NAME = "CREATOR_SW_CFG_MANUF_STATE"
 
 # This must match the definitions in hardened.h.
 _HARDENED_TRUE = 0x739
@@ -69,21 +68,6 @@ class RomExtImmutableSectionOtpFields(ImmutableSectionProcessor):
         self.insert_key_value(_SIZE_FIELD_NAME, f"{hex(self.size_in_bytes)}")
         self.insert_key_value(_HASH_FIELD_NAME, f"0x{self.hash.hex()}")
 
-    def update_json_with_creator_manuf_state_data(self) -> None:
-        """Update the JSON with the CREATOR_SW_CFG_MANUF_STATE data.
-        Args:
-            None
-        Returns:
-            None
-        """
-
-        new_creator_manuf_state = self.update_creator_manuf_state_data(
-            f"0x{self.hash.hex()}"
-        )
-        self.insert_key_value(
-            _CREATOR_MANUF_STATE_FIELD_NAME, new_creator_manuf_state
-        )
-
     def immutable_rom_ext_enable(self) -> bool:
         """Checks if immutable ROM extension is enabled.
 
@@ -133,7 +117,6 @@ def main() -> None:
 
     if imm_section_otp.immutable_rom_ext_enable():
         imm_section_otp.update_json_with_immutable_rom_ext_section_data()
-        imm_section_otp.update_json_with_creator_manuf_state_data()
 
     # Write out the OTP fields to a JSON file.
     with open(args.output, 'w') as f:


### PR DESCRIPTION
This PR removes the functionality of fusion immutable ROM_EXT hash into the `CREATOR_SW_CFG_MANUF_STATE` OTP field   from the OTP tooling and the manifest update tool.

With the fallback mechanism implemented in #25984, ROM can now attempt the alternative ROM_EXT slot if the immutable ROM_EXT hash is invalid. Consequently, the fusion of this hash into the  `CREATOR_SW_CFG_MANUF_STATE` OTP field and the binding of ROM_EXT to `creator_manuf_state` are no longer needed. 

This partially reverts #24948, #25106, and #25566.
