### PR TITLE
[racl] Create a parameter defining the error response

### DIFF
--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -2201,7 +2201,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX0_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX0_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX0_SOC_WIN_RDATA),
@@ -2237,7 +2237,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX1_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX1_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX1_SOC_WIN_RDATA),
@@ -2273,7 +2273,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX2_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX2_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX2_SOC_WIN_RDATA),
@@ -2340,7 +2340,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX4_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX4_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX4_SOC_WIN_RDATA),
@@ -2376,7 +2376,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX5_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX5_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX5_SOC_WIN_RDATA),
@@ -2443,7 +2443,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX_JTAG_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_RDATA),
@@ -2479,7 +2479,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX_PCIE0_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_RDATA),
@@ -2515,7 +2515,7 @@ module top_darjeeling #(
   );
   mbx #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX_PCIE1_SOC),
     .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_WDATA),
     .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_RDATA),
@@ -2601,7 +2601,7 @@ module top_darjeeling #(
   );
   ac_range_check #(
     .EnableRacl(1'b1),
-    .RaclErrorRsp(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVec(RACL_POLICY_SEL_AC_RANGE_CHECK),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[98:97])
   ) u_ac_range_check (

--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -21,6 +21,9 @@ package top_racl_pkg;
   // RACL Policy selector type
   typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
 
+  // Enable TLUL error response on RACL denied accesses
+  parameter bit ErrorRsp = 1;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = 4;
 

--- a/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
@@ -21,6 +21,9 @@ package top_racl_pkg;
   // RACL Policy selector type
   typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
 
+  // Enable TLUL error response on RACL denied accesses
+  parameter bit ErrorRsp = 0;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = 1;
 

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -21,6 +21,9 @@ package top_racl_pkg;
   // RACL Policy selector type
   typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
 
+  // Enable TLUL error response on RACL denied accesses
+  parameter bit ErrorRsp = 0;
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = 1;
 

--- a/util/raclgen/lib.py
+++ b/util/raclgen/lib.py
@@ -51,6 +51,7 @@ range_required = {
 # Default configuration to render the RACL package for systems that don't use RACL but need the
 # type definitions
 DEFAULT_RACL_CONFIG = {
+    'error_response': False,
     'role_bit_lsb': 0,
     'role_bit_msb': 0,
     'ctn_uid_bit_lsb': 0,

--- a/util/topgen/templates/top_racl_pkg.sv.tpl
+++ b/util/topgen/templates/top_racl_pkg.sv.tpl
@@ -15,6 +15,9 @@ package top_racl_pkg;
   // RACL Policy selector type
   typedef logic [RaclPolicySelLen-1:0] racl_policy_sel_t;
 
+  // Enable TLUL error response on RACL denied accesses
+  parameter bit ErrorRsp = ${int(racl_config['error_response'])};
+
   // Number of RACL bits transferred
   parameter int unsigned NrRaclBits = ${racl_config['nr_role_bits']};
 

--- a/util/topgen/templates/toplevel_racl.tpl
+++ b/util/topgen/templates/toplevel_racl.tpl
@@ -4,7 +4,7 @@
 <%page args="m, top"/>\
 % if m.get('racl_mappings'):
     .EnableRacl(1'b1),
-    .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
   % for if_name, mappings in m['racl_mappings'].items():
 <%
       register_mapping = mappings.get('register_mapping', {})


### PR DESCRIPTION
Having this config in a parameter makes it easier for out-of-tree integration and to keep the behaviour in sync