### PR TITLE
[sw,imm_rom_ext] Transfer DICE public keys to mutable ROM_EXT

### DIFF
--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -131,6 +131,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
     ],
     # This library provides a special symbol that the linker will find.
     alwayslink = True,

--- a/sw/device/silicon_creator/lib/base/static_dice.ld
+++ b/sw/device/silicon_creator/lib/base/static_dice.ld
@@ -20,6 +20,6 @@
   KEEP(*(.static_dice.cdi_0))
 
   ASSERT(
-    SIZEOF(.static_dice) == 1092,
+    SIZEOF(.static_dice) == 1220,
     "Error: .static_dice section size has changed");
 } > ram_main

--- a/sw/device/silicon_creator/lib/base/static_dice_cdi_0.h
+++ b/sw/device/silicon_creator/lib/base/static_dice_cdi_0.h
@@ -9,6 +9,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 
 enum {
   kCdi0CertStaticCriticalSizeBytes = 1024,
@@ -18,16 +19,20 @@ enum {
 // mutable ROM_EXT.
 typedef struct {
   hmac_digest_t uds_pubkey_id;
+  ecdsa_p256_public_key_t uds_pubkey;
   hmac_digest_t cdi_0_pubkey_id;
+  ecdsa_p256_public_key_t cdi_0_pubkey;
   uint32_t cert_size;
   uint8_t cert_data[kCdi0CertStaticCriticalSizeBytes];
 } static_dice_cdi_0_t;
 
 OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, uds_pubkey_id, 0);
-OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cdi_0_pubkey_id, 32);
-OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cert_size, 64);
-OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cert_data, 68);
-OT_ASSERT_SIZE(static_dice_cdi_0_t, 1092);
+OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, uds_pubkey, 32);
+OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cdi_0_pubkey_id, 96);
+OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cdi_0_pubkey, 128);
+OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cert_size, 192);
+OT_ASSERT_MEMBER_OFFSET(static_dice_cdi_0_t, cert_data, 196);
+OT_ASSERT_SIZE(static_dice_cdi_0_t, 1220);
 
 extern static_dice_cdi_0_t static_dice_cdi_0;
 

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -284,7 +284,7 @@ rom_error_t dice_chain_attestation_silicon(void) {
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateCreatorRootKey));
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyUds, &static_dice_cdi_0.uds_pubkey_id,
-      &dice_chain.subject_pubkey));
+      &static_dice_cdi_0.uds_pubkey));
 
   // Save UDS key for signing next stage cert.
   RETURN_IF_ERROR(otbn_boot_attestation_key_save(
@@ -308,7 +308,7 @@ rom_error_t dice_chain_attestation_creator(
       rom_ext_manifest->max_key_version));
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyCdi0, &static_dice_cdi_0.cdi_0_pubkey_id,
-      &dice_chain.subject_pubkey));
+      &static_dice_cdi_0.cdi_0_pubkey));
 
   // Switch page for the device generated CDI_0.
   RETURN_IF_ERROR(dice_chain_load_flash(&kFlashCtrlInfoPageDiceCerts));
@@ -325,7 +325,7 @@ rom_error_t dice_chain_attestation_creator(
     HARDENED_RETURN_IF_ERROR(dice_cdi_0_cert_build(
         (hmac_digest_t *)rom_ext_measurement->data,
         rom_ext_manifest->security_version, &dice_chain_cdi_0_key_ids,
-        &dice_chain.subject_pubkey, static_dice_cdi_0.cert_data,
+        &static_dice_cdi_0.cdi_0_pubkey, static_dice_cdi_0.cert_data,
         &static_dice_cdi_0.cert_size));
   } else {
     // Replace UDS with CDI_0 key for endorsing next stage cert.
@@ -348,6 +348,7 @@ static rom_error_t dice_chain_attestation_check_uds(void) {
   // Check if the UDS cert is valid.
   dice_chain.endorsement_pubkey_id = static_dice_cdi_0.uds_pubkey_id;
   dice_chain.subject_pubkey_id = static_dice_cdi_0.uds_pubkey_id;
+  dice_chain.subject_pubkey = static_dice_cdi_0.uds_pubkey;
   RETURN_IF_ERROR(dice_chain_load_cert_obj("UDS", /*name_size=*/4));
   if (dice_chain.cert_valid == kHardenedBoolFalse) {
     // The UDS key ID (and cert itself) should never change unless:
@@ -377,6 +378,7 @@ static rom_error_t dice_chain_attestation_check_cdi_0(void) {
   // Refresh cdi 0 if invalid
   dice_chain.endorsement_pubkey_id = static_dice_cdi_0.cdi_0_pubkey_id;
   dice_chain.subject_pubkey_id = static_dice_cdi_0.cdi_0_pubkey_id;
+  dice_chain.subject_pubkey = static_dice_cdi_0.cdi_0_pubkey;
   RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_0", /*name_size=*/6));
   if (dice_chain.cert_valid == kHardenedBoolFalse) {
     dbg_puts("warning: CDI_0 certificate not valid; updating\r\n");


### PR DESCRIPTION
The previous PR #26409 transferred the public key ID to mutable ROM_EXT to validate the certificate. This is sufficient for the x509 variant, but not for the CWT variant, which uses public key contents to validate the UDS COSE Key. The manual e2e provisioning test `//sw/host/provisioning/orchestrator/tests:e2e_emulation_dice_cwt_cw340_test` can catch this error.

This commit fixes the test by putting the public key contents into the static dice region with the public key ID.