### PR TITLE
[dv] Remove unused intr_exp_at_addr_phase variables

### DIFF
--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -19,7 +19,6 @@ class pattgen_scoreboard extends cip_base_scoreboard #(
   local pattgen_item exp_item_q[NUM_PATTGEN_CHANNELS][$];
   // local variables
   local pattgen_channel_cfg channel_cfg[NUM_PATTGEN_CHANNELS-1:0];
-  local bit [NumPattgenIntr-1:0] intr_exp_at_addr_phase;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -19,7 +19,6 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
 
   // Intr checks
   local bit [NUM_MAX_INTERRUPTS-1:0] intr_exp;
-  local bit [NUM_MAX_INTERRUPTS-1:0] intr_exp_at_addr_phase;
 
   virtual  sysrst_ctrl_cov_if   cov_if;           // handle to sysrst_ctrl coverage interface
 


### PR DESCRIPTION
These aren't actually used in the pattgen or sysrst_ctrl DV environments.