### PR TITLE
[pentest] Read single int instead of array for num_enc

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "//sw/device/sca/lib:prng",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/json:aes_sca_commands",
+        "//sw/device/tests/penetrationtests/json:commands",
     ],
 )
 
@@ -136,6 +137,7 @@ cc_library(
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:prng",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+        "//sw/device/tests/penetrationtests/json:commands",
         "//sw/device/tests/penetrationtests/json:kmac_sca_commands",
     ],
 )
@@ -194,6 +196,7 @@ cc_library(
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:prng",
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+        "//sw/device/tests/penetrationtests/json:commands",
         "//sw/device/tests/penetrationtests/json:sha3_sca_commands",
     ],
 )

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h"
+#include "sw/device/tests/penetrationtests/json/commands.h"
 #include "sw/device/tests/penetrationtests/json/kmac_sca_commands.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -653,20 +654,17 @@ status_t handle_kmac_sca_fixed_key_set(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_kmac_sca_batch(ujson_t *uj) {
-  cryptotest_kmac_sca_data_t uj_data;
-  TRY(ujson_deserialize_cryptotest_kmac_sca_data_t(uj, &uj_data));
+  penetrationtest_num_enc_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_num_enc_t(uj, &uj_data));
 
-  uint32_t num_encryptions = 0;
   uint32_t out[kDigestLength];
   uint32_t batch_digest[kDigestLength];
-
-  num_encryptions = read_32(uj_data.data);
 
   for (uint32_t j = 0; j < kDigestLength; ++j) {
     batch_digest[j] = 0;
   }
 
-  for (uint32_t i = 0; i < num_encryptions; ++i) {
+  for (uint32_t i = 0; i < uj_data.num_enc; ++i) {
     if (run_fixed) {
       memcpy(kmac_batch_keys[i], key_fixed, kKeyLength);
     } else {
@@ -676,7 +674,7 @@ status_t handle_kmac_sca_batch(ujson_t *uj) {
     run_fixed = batch_messages[i][0] & 0x1;
   }
 
-  for (uint32_t i = 0; i < num_encryptions; ++i) {
+  for (uint32_t i = 0; i < uj_data.num_enc; ++i) {
     kmac_reset();
     memcpy(kmac_key.share0, kmac_batch_keys[i], kKeyLength);
 

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h"
+#include "sw/device/tests/penetrationtests/json/commands.h"
 #include "sw/device/tests/penetrationtests/json/sha3_sca_commands.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -504,20 +505,18 @@ status_t handle_sha3_sca_fixed_message_set(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_sha3_sca_batch(ujson_t *uj) {
-  cryptotest_sha3_sca_data_t uj_data;
-  TRY(ujson_deserialize_cryptotest_sha3_sca_data_t(uj, &uj_data));
+  penetrationtest_num_enc_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_num_enc_t(uj, &uj_data));
 
-  uint32_t num_hashes = 0;
   uint32_t out[kDigestLength];
   uint32_t batch_digest[kDigestLength];
   uint8_t dummy_message[kMessageLength];
-  num_hashes = read_32(uj_data.data);
 
   for (uint32_t j = 0; j < kDigestLength; ++j) {
     batch_digest[j] = 0;
   }
 
-  for (uint32_t i = 0; i < num_hashes; ++i) {
+  for (uint32_t i = 0; i < uj_data.num_enc; ++i) {
     if (run_fixed) {
       memcpy(sha3_batch_messages[i], message_fixed, kMessageLength);
     } else {
@@ -527,7 +526,7 @@ status_t handle_sha3_sca_batch(ujson_t *uj) {
     run_fixed = dummy_message[0] & 0x1;
   }
 
-  for (uint32_t i = 0; i < num_hashes; ++i) {
+  for (uint32_t i = 0; i < uj_data.num_enc; ++i) {
     kmac_reset();
 
     if (sha3_serial_absorb(sha3_batch_messages[i], kMessageLength) !=

--- a/sw/device/tests/penetrationtests/json/aes_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/aes_sca_commands.h
@@ -61,6 +61,10 @@ UJSON_SERDE_STRUCT(CryptotestAesScaCiphertext, aes_sca_ciphertext_t, AES_SCA_CIP
 #define AES_SCA_FPGA_MODE(field, string) \
     field(fpga_mode, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaFpgaMode, aes_sca_fpga_mode_t, AES_SCA_FPGA_MODE);
+
+#define AES_SCA_CMD(field, string) \
+    field(cmd, uint32_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaCmd, aes_sca_cmd_t, AES_SCA_CMD);
 // clang-format on
 
 #ifdef __cplusplus

--- a/sw/device/tests/penetrationtests/json/commands.h
+++ b/sw/device/tests/penetrationtests/json/commands.h
@@ -31,6 +31,10 @@ extern "C" {
     value(_, TriggerSca)
 UJSON_SERDE_ENUM(PenetrationtestCommand, penetrationtest_cmd_t, COMMAND);
 
+#define PENTEST_NUM_ENC(field, string) \
+    field(num_enc, uint32_t)
+UJSON_SERDE_STRUCT(PenetrationtestCommandNumEnc, penetrationtest_num_enc_t, PENTEST_NUM_ENC);
+
 // clang-format on
 
 #ifdef __cplusplus


### PR DESCRIPTION
Before this commit, the number of encryptions for the batch mode was received, e.g., for AES, using the aes_sca_data_t data structure, which is a 16*uint8_t array. As this is unecessary, replace it with just a single uint32.