### PR TITLE
[sw,multitop] port clkmgr_testutils and dependant tests to multi-top

### DIFF
--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -67,6 +67,10 @@ typedef enum dif_clkmgr_measure_clock {
    * The Usb clock.
    */
   kDifClkmgrMeasureClockUsb,
+  /**
+   * Total number of clock measurements.
+   */
+  kDifClkmgrMeasureClockCount,
 } dif_clkmgr_measure_clock_t;
 
 typedef enum dif_clkmgr_recov_err_type {

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -468,7 +468,7 @@ TEST_F(MeasureCountTest, Enable) {
   bitfield_field32_t lo_field;
   bitfield_field32_t hi_field;
 
-  for (int i = kDifClkmgrMeasureClockIo; i <= kDifClkmgrMeasureClockUsb; ++i) {
+  for (int i = 0; i < kDifClkmgrMeasureClockCount; ++i) {
     dif_clkmgr_measure_clock_t clk = (dif_clkmgr_measure_clock_t)i;
     switch (clk) {
 #define PICK_COUNT_CTRL_FIELDS(kind_)                          \
@@ -533,7 +533,7 @@ TEST_F(MeasureCountTest, DisableLocked) {
 TEST_F(MeasureCountTest, Disable) {
   uint32_t en_offset;
 
-  for (int i = kDifClkmgrMeasureClockIo; i <= kDifClkmgrMeasureClockUsb; ++i) {
+  for (int i = 0; i < kDifClkmgrMeasureClockCount; ++i) {
     dif_clkmgr_measure_clock_t clk = (dif_clkmgr_measure_clock_t)i;
     switch (clk) {
 #define PICK_COUNT_CTRL_FIELDS(kind_)                   \
@@ -579,7 +579,7 @@ TEST_F(MeasureCountTest, GetEnableBadArgs) {
 TEST_F(MeasureCountTest, GetEnable) {
   uint32_t en_offset;
 
-  for (int i = kDifClkmgrMeasureClockIo; i <= kDifClkmgrMeasureClockUsb; ++i) {
+  for (int i = 0; i < kDifClkmgrMeasureClockCount; ++i) {
     dif_clkmgr_measure_clock_t clk = (dif_clkmgr_measure_clock_t)i;
     switch (clk) {
 #define PICK_COUNT_CTRL_FIELDS(kind_)                   \
@@ -647,7 +647,7 @@ TEST_F(MeasureCountTest, GetThresholds) {
   bitfield_field32_t lo_field;
   bitfield_field32_t hi_field;
 
-  for (int i = kDifClkmgrMeasureClockIo; i <= kDifClkmgrMeasureClockUsb; ++i) {
+  for (int i = 0; i < kDifClkmgrMeasureClockCount; ++i) {
     dif_clkmgr_measure_clock_t clk = (dif_clkmgr_measure_clock_t)i;
     switch (clk) {
 #define PICK_COUNT_CTRL_FIELDS(kind_)                          \

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2828,12 +2828,12 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
         ":otbn_randomness_impl",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:otbn",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -98,6 +98,7 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
     ),
     qemu = qemu_params(
@@ -107,7 +108,6 @@ opentitan_test(
     ),
     deps = [
         "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_otbn.h"     // Generated
+#include "dt/dt_rv_plic.h"  // Generated
 #include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_clkmgr.h"
 #include "sw/device/lib/dif/dif_otbn.h"
@@ -16,22 +18,28 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/tests/otbn_randomness_impl.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 OTTF_DEFINE_TEST_CONFIG();
+
+static const uint32_t kPlicTarget = 0;
 
 static dif_clkmgr_t clkmgr;
 static const dif_clkmgr_hintable_clock_t kOtbnClock =
-    kTopEarlgreyHintableClocksMainOtbn;
+#if defined(OPENTITAN_IS_EARLGREY)
+    kTopEarlgreyHintableClocksMainOtbn
+#elif defined(OPENTITAN_IS_DARJEELING)
+    kTopDarjeelingHintableClocksMainOtbn
+#else
+#error Unsupported top
+#endif
+    ;
 
 static dif_rv_plic_t plic;
 static dif_otbn_t otbn;
 /**
  * These variables are used for ISR communication hence they are volatile.
  */
-static volatile top_earlgrey_plic_peripheral_t plic_peripheral;
-static volatile dif_rv_plic_irq_id_t irq_id;
-static volatile dif_otbn_irq_t irq;
+static volatile dt_instance_id_t plic_peripheral;
+static volatile dt_otbn_irq_t irq;
 
 /**
  * Provides external IRQ handling for otbn tests.
@@ -46,14 +54,14 @@ static volatile dif_otbn_irq_t irq;
  * 5. Completes the IRQ service at PLIC.
  */
 void ottf_external_isr(uint32_t *exc_info) {
-  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kTopEarlgreyPlicTargetIbex0,
+  dif_rv_plic_irq_id_t irq_id;
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget,
                                      (dif_rv_plic_irq_id_t *)&irq_id));
 
-  plic_peripheral = (top_earlgrey_plic_peripheral_t)
-      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
-
-  irq = (dif_otbn_irq_t)(irq_id -
-                         (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdOtbnDone);
+  plic_peripheral = dt_plic_id_to_instance_id(irq_id);
+  if (plic_peripheral == dt_otbn_instance_id(kDtOtbn)) {
+    irq = dt_otbn_irq_from_plic_id(kDtOtbn, irq_id);
+  }
 
   // Otbn clock is disabled, so we can not acknowledge the irq. Disabling it to
   // avoid an infinite loop here.
@@ -61,52 +69,46 @@ void ottf_external_isr(uint32_t *exc_info) {
   irq_external_ctrl(false);
 
   // Complete the IRQ by writing the IRQ source to the Ibex register.
-  CHECK_DIF_OK(
-      dif_rv_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0, irq_id));
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
 }
 
 static void otbn_wait_for_done_irq(dif_otbn_t *otbn) {
   // Clear the otbn irq variable: we'll set it in the interrupt handler when
   // we see the Done interrupt fire.
   irq = UINT32_MAX;
-  irq_id = UINT32_MAX;
-  plic_peripheral = UINT32_MAX;
+  plic_peripheral = kDtInstanceIdUnknown;
   CHECK_DIF_OK(
       dif_otbn_irq_set_enabled(otbn, kDifOtbnIrqDone, kDifToggleEnabled));
 
   // OTBN should be running. Wait for an interrupt that says
   // it's done.
-  ATOMIC_WAIT_FOR_INTERRUPT(plic_peripheral != UINT32_MAX);
-  CHECK(plic_peripheral == kTopEarlgreyPlicPeripheralOtbn,
+  ATOMIC_WAIT_FOR_INTERRUPT(plic_peripheral != kDtInstanceIdUnknown);
+  CHECK(plic_peripheral == dt_otbn_instance_id(kDtOtbn),
         "Interrupt from incorrect peripheral: (exp: %d, obs: %s)",
-        kTopEarlgreyPlicPeripheralOtbn, plic_peripheral);
+        dt_otbn_instance_id(kDtOtbn), plic_peripheral);
 
   // Check this is the interrupt we expected.
-  CHECK(irq_id == kTopEarlgreyPlicIrqIdOtbnDone);
+  CHECK(irq == kDtOtbnIrqDone);
 }
 
 static void otbn_init_irq(void) {
-  mmio_region_t plic_base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_plic_init(plic_base_addr, &plic));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kDtRvPlic, &plic));
 
   // Set interrupt priority to be positive.
-  dif_rv_plic_irq_id_t irq_id = kTopEarlgreyPlicIrqIdOtbnDone;
+  dif_rv_plic_irq_id_t irq_id = dt_otbn_irq_to_plic_id(kDtOtbn, kDtOtbnIrqDone);
   CHECK_DIF_OK(dif_rv_plic_irq_set_priority(&plic, irq_id, 0x1));
 
-  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
-      &plic, irq_id, kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(&plic, irq_id, kPlicTarget,
+                                           kDifToggleEnabled));
 
-  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(
-      &plic, kTopEarlgreyPlicTargetIbex0, 0x0));
+  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(&plic, kPlicTarget, 0x0));
 
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 }
 
 status_t initialize_clkmgr(void) {
-  mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR);
-  CHECK_DIF_OK(dif_clkmgr_init(addr, &clkmgr));
+  CHECK_DIF_OK(dif_clkmgr_init_from_dt(kDtClkmgrAon, &clkmgr));
 
   // Get initial hint and enable for OTBN clock and check both are enabled.
   dif_toggle_t clock_hint_state;
@@ -159,8 +161,7 @@ bool test_main(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
   CHECK_STATUS_OK(initialize_clkmgr());
 
-  mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR);
-  CHECK_DIF_OK(dif_otbn_init(addr, &otbn));
+  CHECK_DIF_OK(dif_otbn_init_from_dt(kDtOtbn, &otbn));
 
   otbn_init_irq();
   return status_ok(execute_test());


### PR DESCRIPTION
Fix #26211
Fix #26222

Darjeeling has no external clock so use of the `external_clk` parameter of `clkmgr_testutils_enable_clock_counts_with_expected_thresholds` will cause a check failure on darjeeling.

This API isn't used by the ported tests (otbn_randomness_test, aes_idle_test); they use clkmgr for another API.
