### PR TITLE
[multitop] Port various tests to pwrmgr multitop

### DIFF
--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -201,6 +201,38 @@ typedef struct dif_pwrmgr_wakeup_reason {
 } dif_pwrmgr_wakeup_reason_t;
 
 /**
+ * Obtain a bit mask of wakeups/reset requests for a device.
+ *
+ * Given a module instance (identified by its instance ID) and a wakeup
+ * or reset request index from this module, return a bitmask of sources which
+ * can be used with the pwrmgr DIF or testutils.
+ *
+ * Example (find request source of the aon_timer wakeup):
+ * ```c
+ * dif_pwrmgr_request_sources_t wakeup_sources;
+ * CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+ *   pwrmgr,
+ *   kDifPwrmgrReqTypeWakeup,
+ *   dt_aon_timer_instance_id(kDtAonTimerAon),
+ *   kDtAonTimerWakeupWkupReq,
+ *   &wakeup_sources));
+ * ```
+ *
+ * @param pwrmgr A power manager handle.
+ * @param req_type Request type (wake up or reset request).
+ * @param inst_id An instance ID.
+ * @param idx Signal index.
+ * @param[out] sources The bitmask corresponding to the wakeup or reset
+ * requested.
+ * @return `kDifError` if no signal matches the description, `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_find_request_source(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    dt_instance_id_t inst_id, size_t idx,
+    dif_pwrmgr_request_sources_t *sources);
+
+/**
  * Enables or disables low power state.
  *
  * When enabled, the power manager transitions to low power state on the next

--- a/sw/device/silicon_creator/rom/e2e/retention_ram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/retention_ram/BUILD
@@ -76,7 +76,6 @@ opentitan_test(
         tags = maybe_skip_in_ci(CONST.LCV.RMA),
     ),
     deps = [
-        "//hw/top:pwrmgr_c_regs",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:pwrmgr",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3529,8 +3529,7 @@ opentitan_test(
         tags = ["manual"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:mmio",
+        "//hw/top:dt",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6325,7 +6325,6 @@ opentitan_test(
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/testing:i2c_testutils",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/json:command",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6119,7 +6119,6 @@ test_suite(
             test_harness = "//sw/host/tests/chip/rv_dm:access_after_wakeup",
         ),
         deps = [
-            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/dif:alert_handler",

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -13,7 +13,13 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static_assert(kDtPwrmgrCount == 1, "this test expects exactly one pwrmgr");
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects exactly one rstmgr");
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtAonTimerCount >= 1,
+              "this test expects at least one aon_timer");
+static const dt_aon_timer_t kAonTimerDt = 0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -31,17 +37,14 @@ bool test_main(void) {
 
   // Initialize pwrmgr
   dif_pwrmgr_t pwrmgr;
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   // Initialize rstmgr since this will check some registers.
   dif_rstmgr_t rstmgr;
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
 
   dif_aon_timer_t aon_timer;
-  CHECK_DIF_OK(dif_aon_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kAonTimerDt, &aon_timer));
 
   // Assuming the chip hasn't slept yet, wakeup reason should be empty.
 

--- a/sw/device/tests/rv_dm_access_after_wakeup.c
+++ b/sw/device/tests/rv_dm_access_after_wakeup.c
@@ -18,7 +18,6 @@
 #include "sw/device/lib/testing/test_framework/ottf_utils.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "pwrmgr_regs.h"
 
 /*
@@ -29,6 +28,7 @@ OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
 enum {
   kSoftwareBarrierTimeoutUsec = 1000000,
+  kPlicTarget = 0,
 };
 
 // This variable will be updated by the DV environment.
@@ -38,6 +38,16 @@ static volatile const uint8_t kSoftwareBarrierDv = 0;
 // This variable will be updated by the test host.
 OT_SECTION(".data")
 static volatile const uint8_t kSoftwareBarrierHost = 0;
+
+static_assert(kDtPwrmgrCount == 1, "this test expects exactly one pwrmgr");
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtRvPlicCount == 1, "this test expects exactly one rv_plic");
+static const dt_rv_plic_t kRvPlicDt = 0;
+static_assert(kDtSysrstCtrlCount >= 1,
+              "this test expects at least one sysrst_ctrl");
+static const dt_sysrst_ctrl_t kSysrtCtrlDt = 0;
+static_assert(kDtPinmuxCount == 1, "this test expects exactly one pinmux");
+static const dt_pinmux_t kPinmuxDt = 0;
 
 // Handle to the plic
 dif_rv_plic_t rv_plic;
@@ -49,8 +59,7 @@ dif_rv_plic_t rv_plic;
  */
 void ottf_external_isr(uint32_t *exc_info) {
   dif_rv_plic_irq_id_t plic_irq_id;
-  CHECK_DIF_OK(dif_rv_plic_irq_claim(&rv_plic, kTopEarlgreyPlicTargetIbex0,
-                                     &plic_irq_id));
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&rv_plic, kPlicTarget, &plic_irq_id));
 }
 
 /**
@@ -67,8 +76,12 @@ static void put_to_sleep(dif_pwrmgr_t *pwrmgr, bool deep_sleep) {
                 kDifPwrmgrDomainOptionUsbClockInActivePower)) |
         (!deep_sleep ? kDifPwrmgrDomainOptionMainPowerInLowPower : 0);
 
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceOne, cfg));
+  dif_pwrmgr_request_sources_t wakeup_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeWakeup, dt_sysrst_ctrl_instance_id(kSysrtCtrlDt),
+      kDtSysrstCtrlWakeupWkupReq, &wakeup_sources));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(pwrmgr, wakeup_sources, cfg));
   LOG_INFO("%s",
            deep_sleep ? "Entering deep sleep." : "Entering normal sleep.");
   wait_for_interrupt();
@@ -83,15 +96,10 @@ bool test_main(void) {
   dif_pwrmgr_t pwrmgr;
   dif_sysrst_ctrl_t sysrst_ctrl;
 
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
-  CHECK_DIF_OK(dif_rv_plic_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &rv_plic));
-  CHECK_DIF_OK(dif_sysrst_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
-      &sysrst_ctrl));
+  CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &rv_plic));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrtCtrlDt, &sysrst_ctrl));
 
   const volatile uint8_t *const software_barrier = (kDeviceType == kDeviceSimDV)
                                                        ? &kSoftwareBarrierDv
@@ -104,9 +112,10 @@ bool test_main(void) {
       OTTF_WAIT_FOR(*software_barrier == 1, kSoftwareBarrierTimeoutUsec);
 
       // Enable all the AON interrupts used in this test.
-      rv_plic_testutils_irq_range_enable(&rv_plic, kTopEarlgreyPlicTargetIbex0,
-                                         kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
-                                         kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+      dif_rv_plic_irq_id_t plic_id =
+          dt_pwrmgr_irq_to_plic_id(kPwrmgrDt, kDtPwrmgrIrqWakeup);
+      rv_plic_testutils_irq_range_enable(&rv_plic, kPlicTarget, plic_id,
+                                         plic_id);
 
       // Enable pwrmgr interrupt.
       CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, kDifPwrmgrIrqWakeup,
@@ -119,9 +128,10 @@ bool test_main(void) {
       };
       CHECK_DIF_OK(
           dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl, config));
-      CHECK_DIF_OK(dif_pinmux_input_select(
-          &pinmux, kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
-          kTopEarlgreyPinmuxInselIor13));
+      CHECK_DIF_OK(dif_pinmux_mio_select_input(
+          &pinmux,
+          dt_sysrst_ctrl_periph_io(kSysrtCtrlDt, kDtSysrstCtrlPeriphIoPwrbIn),
+          kDtPadIor13));
 
       // Put the device in a normal sleep.
       put_to_sleep(&pwrmgr, /*deep_sleep=*/false);

--- a/util/make_new_dif/templates/dif_autogen.c.tpl
+++ b/util/make_new_dif/templates/dif_autogen.c.tpl
@@ -63,6 +63,7 @@ dif_result_t dif_${ip.name_snake}_init(
     return kDifBadArg;
   }
 
+  ${ip.name_snake}->dt = kDt${ip.name_camel}Count;
   ${ip.name_snake}->base_addr = base_addr;
 
   return kDifOk;
@@ -76,8 +77,19 @@ dif_result_t dif_${ip.name_snake}_init_from_dt(
     return kDifBadArg;
   }
 
+  ${ip.name_snake}->dt = dt;
   ${ip.name_snake}->base_addr = mmio_region_from_addr(dt_${ip.name_snake}_primary_reg_block(dt));
 
+  return kDifOk;
+}
+
+dif_result_t dif_${ip.name_snake}_get_dt(
+  const dif_${ip.name_snake}_t *${ip.name_snake},
+  dt_${ip.name_snake}_t *dt) {
+  if (${ip.name_snake}->dt == kDt${ip.name_camel}Count || dt == NULL) {
+    return kDifBadArg;
+  }
+  *dt = ${ip.name_snake}->dt;
   return kDifOk;
 }
 

--- a/util/make_new_dif/templates/dif_autogen.h.tpl
+++ b/util/make_new_dif/templates/dif_autogen.h.tpl
@@ -49,6 +49,11 @@ typedef struct dif_${ip.name_snake} {
    * The base address for the ${ip.name_snake} hardware registers.
    */
   mmio_region_t base_addr;
+  /**
+   * The instance, set to `kDt${ip.name_camel}Count` if not initialized
+   * through `dif_${ip.name_snake}_init_from_dt`.
+   */
+  dt_${ip.name_snake}_t dt;
 } dif_${ip.name_snake}_t;
 
 /**
@@ -81,6 +86,21 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_${ip.name_snake}_init_from_dt(
   dt_${ip.name_snake}_t dt,
   dif_${ip.name_snake}_t *${ip.name_snake});
+
+/**
+ * Get the DT handle from this DIF.
+ *
+ * If this DIF was initialized by `dif_${ip.name_snake}_init_from_dt(dt, ..)`
+ * then this function will return `dt`. Otherwise it will return an error.
+ *
+ * @param dt A ${ip.name_snake} handle.
+ * @param[out] dt DT handle.
+ * @return `kDifBadArg` if the DIF has no DT information, `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_${ip.name_snake}_get_dt(
+  const dif_${ip.name_snake}_t *${ip.name_snake},
+  dt_${ip.name_snake}_t *dt);
 
 % if ip.alerts:
   /**


### PR DESCRIPTION
This PR continues the work of #26389 to get rid of all usage of hardcoded wakeup constants (e.g. `kDifPwrmgrWakeupRequestSourceFive`). This requires to go through tests one and by one and use the new DIF function to get the wakeup bitmap. At the same time, port (partially or totally) the tests to DT.

Uses #26279 and part of  #26389 