### PR TITLE
[multitop] Remove pwrmgr hardcoded wakeup constants from various tests

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top:defs.bzl", "opentitan_require_top")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -55,7 +57,9 @@ DIFS = {
     "pattgen": {},
     "pinmux": {},
     "pwm": {},
-    "pwrmgr": {},
+    "pwrmgr": {
+        "ut_target_compatible_with": opentitan_require_top("earlgrey"),
+    },
     "rom_ctrl": {},
     "rstmgr": {},
     "rv_core_ibex": {},
@@ -103,6 +107,7 @@ DIFS = {
             "dif_{}_unittest.cc".format(ip),
             "//sw/device/lib/dif/autogen:{}_unittest".format(ip),
         ],
+        target_compatible_with = cfg.get("ut_target_compatible_with", []),
         deps = [
             ":{}".format(ip),
             ":test_base",

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -170,6 +170,17 @@ static dif_result_t request_reg_bitfield(const dif_pwrmgr_t *pwrmgr,
   return kDifOk;
 }
 
+dif_result_t dif_pwrmgr_get_all_request_sources(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    dif_pwrmgr_request_sources_t *sources) {
+  bitfield_field32_t bitfield;
+  dif_result_t res = request_reg_bitfield(pwrmgr, req_type, &bitfield);
+  if (res == kDifOk) {
+    *sources = bitfield.mask;
+  }
+  return res;
+}
+
 /**
  * Checks if a value is a valid `dif_pwrmgr_req_type_t`.
  */

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -195,10 +195,7 @@ dif_result_t dif_pwrmgr_find_request_source(
     return kDifBadArg;
   }
   dt_pwrmgr_t dt;
-  dif_result_t res = dif_pwrmgr_get_dt(pwrmgr, &dt);
-  if (res != kDifOk) {
-    return res;
-  }
+  DIF_RETURN_IF_ERROR(dif_pwrmgr_get_dt(pwrmgr, &dt));
   // Query the DT to find the information.
   if (req_type == kDifPwrmgrReqTypeWakeup) {
     for (size_t i = 0; i < dt_pwrmgr_wakeup_src_count(dt); i++) {
@@ -221,6 +218,33 @@ dif_result_t dif_pwrmgr_find_request_source(
   } else {
     return kDifBadArg;
   }
+}
+
+/**
+ * Obtain the bitfield in PWRMGR_{WAKEUP,RESET}_EN_REG_OFFSET which
+ * represents all wakeup/reset sources.
+ */
+OT_WARN_UNUSED_RESULT
+static dif_result_t request_reg_bitfield(const dif_pwrmgr_t *pwrmgr,
+                                         dif_pwrmgr_req_type_t req_type,
+                                         bitfield_field32_t *bitfield) {
+  dt_pwrmgr_t dt;
+  dif_result_t res = dif_pwrmgr_get_dt(pwrmgr, &dt);
+  if (res != kDifOk) {
+    return res;
+  }
+
+  size_t count = 0;
+  if (req_type == kDifPwrmgrReqTypeWakeup) {
+    count = dt_pwrmgr_wakeup_src_count(dt);
+  } else if (req_type == kDifPwrmgrReqTypeReset) {
+    count = dt_pwrmgr_reset_request_src_count(dt);
+  } else {
+    return kDifBadArg;
+  }
+  bitfield->index = 0;
+  bitfield->mask = (1 << count) - 1;
+  return kDifOk;
 }
 
 /**

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -134,8 +134,8 @@ typedef enum dif_pwrmgr_reset_request_source {
  * particular request type, i.e. wakeup or reset, as well querying wakeup
  * reasons.
  *
- * See also: `dif_pwrmgr_wakeup_request_source_t`,
- * `dif_pwrmgr_reset_request_source_t`.
+ * See also: `dt_pwrmgr_wakeup_src_t`, `dt_pwrmgr_reset_req_src_t` and
+ * associated functions.
  */
 typedef uint32_t dif_pwrmgr_request_sources_t;
 

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -88,31 +88,6 @@ typedef enum dif_pwrmgr_domain_option {
 typedef uint8_t dif_pwrmgr_domain_config_t;
 
 /**
- * A wakeup request source.
- *
- * Constants below are bitmasks that can be used to define sets of wakeup
- * request sources.
- *
- * See also: `dif_pwrmgr_request_sources_t`.
- *
- * Note: This needs to be updated once the HW is finalized.
- */
-typedef enum dif_pwrmgr_wakeup_request_source {
-  kDifPwrmgrWakeupRequestSourceOne = (1u << 0),
-  kDifPwrmgrWakeupRequestSourceTwo = (1u << 1),
-  kDifPwrmgrWakeupRequestSourceThree = (1u << 2),
-  kDifPwrmgrWakeupRequestSourceFour = (1u << 3),
-#if defined(OPENTITAN_IS_EARLGREY)
-  kDifPwrmgrWakeupRequestSourceFive = (1u << 4),
-  kDifPwrmgrWakeupRequestSourceSix = (1u << 5),
-#elif defined(OPENTITAN_IS_DARJEELING)
-// Darjeeling only has four wakeup request sources
-#else
-#error "dif_pwrmgr does not support this top"
-#endif
-} dif_pwrmgr_wakeup_request_source_t;
-
-/**
  * A reset request source.
  *
  * Constants below are bitmasks that can be used to define sets of reset

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -233,7 +233,8 @@ typedef struct dif_pwrmgr_wakeup_reason {
  * @param idx Signal index.
  * @param[out] sources The bitmask corresponding to the wakeup or reset
  * requested.
- * @return `kDifError` if no signal matches the description, `kDifOk` otherwise.
+ * @return `kDifError` if no signal matches the description or the DIF
+ * was not initialized by DT, `kDifOk` otherwise.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_find_request_source(

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -243,6 +243,19 @@ dif_result_t dif_pwrmgr_find_request_source(
     dif_pwrmgr_request_sources_t *sources);
 
 /**
+ * Obtain a bit mask of all wakeups/reset requests.
+ *
+ * @param pwrmgr A power manager handle.
+ * @param req_type Request type (wake up or reset request).
+ * @param[out] sources The bitmask corresponding to all wakeups or resets
+ * @return `kDifError` if no DIF was not initialized by DT, `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_get_all_request_sources(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    dif_pwrmgr_request_sources_t *sources);
+
+/**
  * Enables or disables low power state.
  *
  * When enabled, the power manager transitions to low power state on the next

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -18,6 +18,18 @@ namespace dif_pwrmgr_unittest {
 namespace {
 
 /**
+ * The following values are for Earlgrey.
+ */
+typedef enum dif_pwrmgr_wakeup_request_source {
+  kDifPwrmgrWakeupRequestSourceOne = (1u << 0),
+  kDifPwrmgrWakeupRequestSourceTwo = (1u << 1),
+  kDifPwrmgrWakeupRequestSourceThree = (1u << 2),
+  kDifPwrmgrWakeupRequestSourceFour = (1u << 3),
+  kDifPwrmgrWakeupRequestSourceFive = (1u << 4),
+  kDifPwrmgrWakeupRequestSourceSix = (1u << 5),
+} dif_pwrmgr_wakeup_request_source_t;
+
+/**
  * Returns a `uint32_t` with a single zero bit.
  */
 uint32_t AllOnesExcept(uint32_t index) { return ~(1u << index); }

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -80,6 +80,13 @@ dif_result_t dif_spi_device_init_handle(mmio_region_t base_addr,
   return dif_spi_device_init(base_addr, &spi->dev);
 }
 
+dif_result_t dif_spi_device_init_handle_from_dt(dt_spi_device_t dt,
+                                                dif_spi_device_handle_t *spi) {
+  mmio_region_t addr =
+      mmio_region_from_addr(dt_spi_device_primary_reg_block(dt));
+  return dif_spi_device_init_handle(addr, spi);
+}
+
 dif_result_t dif_spi_device_configure(dif_spi_device_handle_t *spi,
                                       dif_spi_device_config_t config) {
   if (spi == NULL) {

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -98,12 +98,23 @@ extern const uint16_t kDifSpiDeviceBufferLen;
  * Initializes a SPI device handle for use.
  *
  * @param base_addr The MMIO base address of the spi_device peripheral.
- * @param[out] Out param for the initialized handle.
+ * @param[out] spi Out param for the initialized handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_device_init_handle(mmio_region_t base_addr,
                                         dif_spi_device_handle_t *spi);
+
+/**
+ * Initializes a SPI device handle for use.
+ *
+ * @param dt The DT handle of the spi_device peripheral.
+ * @param[out] spi Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_init_handle_from_dt(dt_spi_device_t dt,
+                                                dif_spi_device_handle_t *spi);
 
 /**
  * Configures SPI with runtime information.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -623,6 +623,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
@@ -630,7 +631,6 @@ opentitan_test(
     ),
     verilator = verilator_params(tags = ["broken"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -557,7 +557,6 @@ opentitan_test(
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/dif:alert_handler",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -704,12 +704,12 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
     ),
     # This test can take > 40 minutes, so mark it manual as it shouldn't run
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:pwrmgr",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -656,7 +656,6 @@ opentitan_test(
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3369,7 +3369,6 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3626,7 +3626,6 @@ opentitan_test(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4067,7 +4067,6 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_sleep_test",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
@@ -4080,7 +4079,6 @@ opentitan_test(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aon_timer_testutils",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7370,7 +7370,6 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:pwrmgr_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4835,7 +4835,6 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4282,7 +4282,6 @@ opentitan_test(
     ),
     deps = [
         "//hw/top:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
@@ -4293,7 +4292,6 @@ opentitan_test(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6778,7 +6778,6 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_reset",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:pinmux",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5561,7 +5561,6 @@ opentitan_test(
         tags = ["broken"],
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:sensor_ctrl",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5060,7 +5060,6 @@ cc_library(
         "//sw/device/lib/dif:usbdev",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7495,7 +7495,6 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:pinmux",
@@ -7503,7 +7502,6 @@ opentitan_test(
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3410,7 +3410,6 @@ opentitan_test(
     # in CI/nightlies.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pinmux",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6736,7 +6736,6 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_ulp_z3_wakeup",
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:gpio",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4357,7 +4357,6 @@ cc_library(
     hdrs = ["sram_ctrl_sleep_sram_ret_contents_impl.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:flash_ctrl",
@@ -4367,7 +4366,6 @@ cc_library(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aon_timer_testutils",
         "//sw/device/lib/testing:flash_ctrl_testutils",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1770,7 +1770,6 @@ opentitan_test(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -39,7 +39,7 @@ static const dt_aon_timer_t kAonTimerDt = 0;
 static_assert(kDtAonTimerCount >= 1,
               "this test expects at least one aon_timer");
 static const dt_rstmgr_t kRstmgrDt = 0;
-static_assert(kDtPwrmgrCount == 1, "this test expects a rstmgr");
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
 static const dt_alert_handler_t kAlertHandlerDt = 0;
 static_assert(kDtAlertHandlerCount == 1, "this test expects an alert_handler");
 static const dt_rv_core_ibex_t kRvCoreIbexDt = 0;

--- a/sw/device/tests/alert_handler_ping_ok_test.c
+++ b/sw/device/tests/alert_handler_ping_ok_test.c
@@ -27,6 +27,15 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_rv_timer_t kRvTimerDt = 0;
+static_assert(kDtRvTimerCount >= 1, "this test expects at least one rv_timer");
+static const dt_alert_handler_t kAlertHandlerDt = 0;
+static_assert(kDtAlertHandlerCount == 1, "this test expects an alert_handler");
+static const dt_rv_core_ibex_t kRvCoreIbexDt = 0;
+static_assert(kDtRvCoreIbexCount == 1, "this test expects exactly one Ibex");
+
 typedef struct counters {
   uint32_t alert_raised;
   uint32_t wdog_barked;
@@ -210,18 +219,13 @@ void ottf_external_nmi_handler(uint32_t *exc_info) {
 void ottf_external_isr(uint32_t *exc_info) { ext_irq_fired = true; }
 
 void init_peripherals(void) {
-  mmio_region_t addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_core_ibex_init(addr, &rv_core_ibex));
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kRvCoreIbexDt, &rv_core_ibex));
 
-  addr = mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
-  CHECK_DIF_OK(dif_alert_handler_init(addr, &alert_handler));
+  CHECK_DIF_OK(dif_alert_handler_init_from_dt(kAlertHandlerDt, &alert_handler));
 
-  addr = mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR);
-  CHECK_DIF_OK(dif_pwrmgr_init(addr, &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
-  CHECK_DIF_OK(dif_rv_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_TIMER_BASE_ADDR), &timer));
+  CHECK_DIF_OK(dif_rv_timer_init_from_dt(kRvTimerDt, &timer));
   CHECK_DIF_OK(dif_rv_timer_reset(&timer));
 }
 

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -18,9 +18,18 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this library expects exactly one pwrmgr");
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this library expects exactly one rstmgr");
+static const dt_aon_timer_t kAonTimerDt = 0;
+static_assert(kDtAonTimerCount == 1,
+              "this library expects exactly one aon_timer");
 
 OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pwrmgr_request_sources_t wakeup_sources;
+static dif_pwrmgr_request_sources_t reset_sources;
 
 /**
  * Configure the wdog.
@@ -39,9 +48,8 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);
 
   // Set wdog as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
 
   // Setup the wdog bark and bite timeouts.
   CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(
@@ -60,9 +68,12 @@ static void wdog_bite_test(const dif_aon_timer_t *aon_timer,
 
   // The `intr_state` takes 3 aon clock cycles to rise plus 2 extra cycles as a
   // precaution.
-  uint32_t wait_us = (uint32_t)bark_time_us +
-                     (uint32_t)udiv64_slow(5 * 1000000 + kClockFreqAonHz - 1,
-                                           kClockFreqAonHz, NULL);
+  uint64_t aon_timer_clock_freq_hz = dt_clock_frequency(
+      dt_aon_timer_clock(kDtAonTimerAon, kDtAonTimerClockAon));
+  uint32_t wait_us =
+      (uint32_t)bark_time_us +
+      (uint32_t)udiv64_slow(5 * 1000000 + aon_timer_clock_freq_hz - 1,
+                            aon_timer_clock_freq_hz, NULL);
 
   // Wait bark time and check that the bark interrupt requested.
   busy_spin_micros(wait_us);
@@ -88,8 +99,7 @@ static void sleep_wdog_bite_test(const dif_aon_timer_t *aon_timer,
   config_wdog(aon_timer, pwrmgr, bark_time_us, bite_time_us);
 
   // Program the pwrmgr to go to deep sleep state (clocks off).
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceTwo, 0));
+  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(pwrmgr, wakeup_sources, 0));
   // Enter in low power mode.
   wait_for_interrupt();
   // If we arrive here the test must fail.
@@ -99,18 +109,23 @@ static void sleep_wdog_bite_test(const dif_aon_timer_t *aon_timer,
 bool test_main(void) {
   // Initialize pwrmgr.
   dif_pwrmgr_t pwrmgr;
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
+
+  // Find wakeup and reset sources.
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kAonTimerDt),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_aon_timer_instance_id(kAonTimerDt),
+      kDtAonTimerWakeupWkupReq, &wakeup_sources));
 
   // Initialize rstmgr to check the reset reason.
   dif_rstmgr_t rstmgr;
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
 
   // Initialize aon timer to use the wdog.
   dif_aon_timer_t aon_timer;
-  CHECK_DIF_OK(dif_aon_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kAonTimerDt, &aon_timer));
 
   // Check if there was a HW reset caused by the wdog bite.
   dif_rstmgr_reset_info_bitfield_t rst_info;

--- a/sw/device/tests/chip_power_idle_load_test.c
+++ b/sw/device/tests/chip_power_idle_load_test.c
@@ -26,7 +26,6 @@
 
 #include "alert_handler_regs.h"
 #include "aon_timer_regs.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "pwm_regs.h"
 
 typedef void (*isr_handler)(void);
@@ -45,6 +44,30 @@ static dif_pwm_t pwm;
 static dif_pinmux_t pinmux;
 static dif_otp_ctrl_t otp_ctrl;
 static dif_gpio_t gpio;
+
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this library expects exactly one pwrmgr");
+static const dt_rv_core_ibex_t kRvCoreIbexDt = 0;
+static_assert(kDtRvCoreIbexCount == 1,
+              "this library expects exactly one rv_core_ibex");
+static const dt_alert_handler_t kAlertHandlerDt = 0;
+static_assert(kDtAlertHandlerCount == 1,
+              "this library expects exactly one alert_handler");
+static const dt_rv_timer_t kRvTimerDt = 0;
+static_assert(kDtRvTimerCount >= 1,
+              "this library expects at least one rv_timer");
+static const dt_aon_timer_t kAonTimerDt = 0;
+static_assert(kDtAonTimerCount == 1,
+              "this library expects exactly one aon_timer");
+static const dt_pinmux_t kPinmuxDt = 0;
+static_assert(kDtPinmuxCount == 1, "this library expects exactly one pinmux");
+static const dt_gpio_t kGpioDt = 0;
+static_assert(kDtGpioCount == 1, "this library expects exactly one gpio");
+static const dt_otp_ctrl_t kOtpCtrlDt = 0;
+static_assert(kDtOtpCtrlCount == 1,
+              "this library expects exactly one otp_ctrl");
+static const dt_pwm_t kPwmDt = 0;
+static_assert(kDtPwmCount >= 1, "this library expects at least one pwm");
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -86,26 +109,15 @@ static void wdog_irq_handler(void) {
 
 bool test_main(void) {
   // Define access to DUT IPs:
-  CHECK_DIF_OK(dif_aon_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
-  CHECK_DIF_OK(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
-  CHECK_DIF_OK(dif_rv_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_TIMER_BASE_ADDR), &rv_timer));
-  CHECK_DIF_OK(dif_alert_handler_init(
-      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
-      &alert_handler));
-  CHECK_DIF_OK(dif_pwm_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWM_AON_BASE_ADDR), &pwm));
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
-  CHECK_DIF_OK(
-      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kAonTimerDt, &aon_timer));
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kRvCoreIbexDt, &rv_core_ibex));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
+  CHECK_DIF_OK(dif_rv_timer_init_from_dt(kRvTimerDt, &rv_timer));
+  CHECK_DIF_OK(dif_alert_handler_init_from_dt(kAlertHandlerDt, &alert_handler));
+  CHECK_DIF_OK(dif_pwm_init_from_dt(kPwmDt, &pwm));
+  CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kOtpCtrlDt, &otp_ctrl));
+  CHECK_DIF_OK(dif_gpio_init_from_dt(kGpioDt, &gpio));
 
   LOG_INFO("Running CHIP Power Idle Load test");
 

--- a/sw/device/tests/clkmgr_jitter_frequency_test.c
+++ b/sw/device/tests/clkmgr_jitter_frequency_test.c
@@ -47,6 +47,11 @@ enum {
   kMeasurementsPerRound = 100,
 };
 
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_clkmgr_t kClkmgrDt = 0;
+static_assert(kDtClkmgrCount == 1, "this test expects a clkmgr");
+
 static dif_clkmgr_t clkmgr;
 static dif_pwrmgr_t pwrmgr;
 
@@ -105,13 +110,11 @@ bool test_main(void) {
   CHECK_STATUS_OK(aon_timer_testutils_get_us_from_aon_cycles(
       kMeasurementsPerRound, &delay_micros));
 
-  CHECK_DIF_OK(dif_clkmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+  CHECK_DIF_OK(dif_clkmgr_init_from_dt(kClkmgrDt, &clkmgr));
   CHECK_DIF_OK(dif_sensor_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR),
       &sensor_ctrl));
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   LOG_INFO("TEST: wait for ast init");
   IBEX_SPIN_FOR(sensor_ctrl_ast_init_done(&sensor_ctrl), 1000);

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -25,6 +25,9 @@
 #include "uart_regs.h"
 #include "usbdev_regs.h"
 
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+
 /**
  * The peripherals used to test when the peri clocks are disabled are
  * bit 0: clk_io_div4_peri: uart0
@@ -134,8 +137,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_clkmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
 
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   // Initialize aon timer.
   CHECK_DIF_OK(dif_aon_timer_init(

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_adc_ctrl.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
@@ -18,29 +19,34 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "sw/device/lib/testing/autogen/isr_testutils.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 static dif_rv_plic_t plic;
 static dif_aon_timer_t aon;
 static dif_rv_core_ibex_t rv_core_ibex;
 
-static plic_isr_ctx_t plic_ctx = {
-    .rv_plic = &plic,
-    .hart_id = kTopEarlgreyPlicTargetIbex0,
+enum {
+  kPlicTarget = 0,
 };
 
-static aon_timer_isr_ctx_t aon_timer_ctx = {
-    .aon_timer = &aon,
-    .plic_aon_timer_start_irq_id =
-        kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
-    .is_only_irq = false,
-};
+static const dt_adc_ctrl_t kAdcCtrlDt = 0;
+static_assert(kDtAdcCtrlCount == 1, "this test expects a adc_ctrl");
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_aon_timer_t kAonTimerDt = 0;
+static_assert(kDtAonTimerCount == 1, "this test expects an aon_timer");
+static const dt_rv_plic_t kRvPlicDt = 0;
+static_assert(kDtRvPlicCount == 1, "this test expects exactly one rv_plic");
+static const dt_rv_core_ibex_t kRvCoreIbexDt = 0;
+static_assert(kDtRvCoreIbexCount == 1,
+              "this test expects exactly one rv_core_ibex");
+static const dt_flash_ctrl_t kFlashCtrlDt = 0;
+static_assert(kDtFlashCtrlCount >= 1,
+              "this test expects at least one flash_ctrl");
 
-static top_earlgrey_plic_peripheral_t peripheral_serviced;
-static dif_aon_timer_irq_t irq_serviced;
+static volatile bool irq_serviced = false;
 
 enum {
   kFlashDataRegion = 0,
@@ -55,9 +61,18 @@ enum {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(uint32_t *exc_info) {
-  isr_testutils_aon_timer_isr(plic_ctx, aon_timer_ctx, &peripheral_serviced,
-                              &irq_serviced);
+bool ottf_handle_irq(uint32_t *exc_info, dt_instance_id_t devid,
+                     dif_rv_plic_irq_id_t irq_id) {
+  if (devid == dt_aon_timer_instance_id(kAonTimerDt) &&
+      irq_id == dt_aon_timer_irq_to_plic_id(kAonTimerDt,
+                                            kDtAonTimerIrqWdogTimerBark)) {
+    CHECK_DIF_OK(
+        dif_aon_timer_irq_acknowledge(&aon, kDtAonTimerIrqWdogTimerBark));
+    irq_serviced = true;
+    return true;
+  } else {
+    return false;
+  }
 }
 
 /**
@@ -83,14 +98,13 @@ void ottf_external_nmi_handler(void) {
 
 static void enable_irqs(void) {
   // Enable the AON bark interrupt.
-  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
-      &plic, kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark,
-      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
-  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
-      &plic, kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark,
-      kDifRvPlicMaxPriority));
-  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(
-      &plic, kTopEarlgreyPlicTargetIbex0, 0x0));
+  dif_rv_plic_irq_id_t plic_id =
+      dt_aon_timer_irq_to_plic_id(kAonTimerDt, kDtAonTimerIrqWdogTimerBark);
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(&plic, plic_id, kPlicTarget,
+                                           kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_set_priority(&plic, plic_id, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(&plic, kPlicTarget, 0x0));
   // Enable the external IRQ at Ibex.
   irq_global_ctrl(true);
   irq_external_ctrl(true);
@@ -101,25 +115,27 @@ bool test_main(void) {
   dif_pwrmgr_t pwrmgr;
   dif_rstmgr_t rstmgr;
 
-  CHECK_DIF_OK(dif_rv_plic_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
-  CHECK_DIF_OK(dif_flash_ctrl_init_state(
-      &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
-  CHECK_DIF_OK(dif_aon_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon));
-  CHECK_DIF_OK(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &plic));
+  CHECK_DIF_OK(dif_flash_ctrl_init_state_from_dt(&flash, kFlashCtrlDt));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kAonTimerDt, &aon));
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kRvCoreIbexDt, &rv_core_ibex));
   enable_irqs();
 
+  dif_pwrmgr_request_sources_t wakeup_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_adc_ctrl_instance_id(kAdcCtrlDt),
+      kDtAdcCtrlWakeupWkupReq, &wakeup_sources));
+
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kAonTimerDt),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+
   CHECK_DIF_OK(dif_aon_timer_watchdog_stop(&aon));
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
 
   dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
   rstmgr_reset_info = rstmgr_testutils_reason_get();
@@ -148,10 +164,10 @@ bool test_main(void) {
     CHECK_ARRAYS_EQ(data, readback_data, kNumWords);
 
     // Setting up low power hint and starting watchdog timer followed by
-    // a flash operation (page erase) and WFI. This will create a bite
+    // a flash operation (page erase) and WFI. This will create a bark
     // interrupt at some time following the start of the flash operation.
-    CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-        &pwrmgr, kDifPwrmgrWakeupRequestSourceTwo, 0));
+    CHECK_STATUS_OK(
+        pwrmgr_testutils_enable_low_power(&pwrmgr, wakeup_sources, 0));
 
     CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr));
 

--- a/sw/device/tests/pwrmgr_deep_sleep_por_reset_test.c
+++ b/sw/device/tests/pwrmgr_deep_sleep_por_reset_test.c
@@ -21,7 +21,14 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_sysrst_ctrl_t kSysrstCtrlDt = 0;
+static_assert(kDtSysrstCtrlCount == 1, "this test expects a sysrst_ctrl");
+static const dt_pinmux_t kPinmuxDt = 0;
+static_assert(kDtPinmuxCount == 1, "this test expects a pinmux");
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
@@ -37,17 +44,13 @@ static dif_rstmgr_t rstmgr;
  */
 void init_peripherals(void) {
   // Initialize pwrmgr.
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   // Initialize sysrst_ctrl.
-  CHECK_DIF_OK(dif_sysrst_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
-      &sysrst_ctrl_aon));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrstCtrlDt, &sysrst_ctrl_aon));
 
   // Initialize rstmgr to check the reset reason.
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
 }
 
 /**
@@ -58,10 +61,13 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
   LOG_INFO("sysrst enabled");
 
   // Set sysrst as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
-                                              kDifToggleEnabled));
-  LOG_INFO("Reset Request SourceOne is set");
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_sysrst_ctrl_instance_id(kSysrstCtrlDt),
+      kDtSysrstCtrlResetReqRstReq, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
+  LOG_INFO("syrst_ctrl Reset Request is set");
 
   // Configure sysrst key combo
   // reset pulse : 50 us
@@ -82,15 +88,15 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
 
   // Configure pinmux
   dif_pinmux_t pinmux;
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
 
   CHECK_DIF_OK(dif_sysrst_ctrl_input_change_detect_configure(
       sysrst_ctrl_aon, sysrst_ctrl_input_change_config));
 
-  CHECK_DIF_OK(dif_pinmux_input_select(
-      &pinmux, kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
-      kTopEarlgreyPinmuxInselIor13));
+  CHECK_DIF_OK(dif_pinmux_mio_select_input(
+      &pinmux,
+      dt_sysrst_ctrl_periph_io(kSysrstCtrlDt, kDtSysrstCtrlPeriphIoKey0In),
+      kDtPadIor13));
 }
 
 static void low_power_por(const dif_pwrmgr_t *pwrmgr) {

--- a/sw/device/tests/pwrmgr_normal_sleep_por_reset_test.c
+++ b/sw/device/tests/pwrmgr_normal_sleep_por_reset_test.c
@@ -21,7 +21,14 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_pinmux_t kPinmuxDt = 0;
+static_assert(kDtPinmuxCount == 1, "this test expects a pinmux");
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
+static const dt_sysrst_ctrl_t kSysrstCtrlDt = 0;
+static_assert(kDtSysrstCtrlCount == 1, "this test expects a sysrst_ctrl");
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
@@ -37,17 +44,13 @@ static dif_rstmgr_t rstmgr;
  */
 static void init_peripherals(void) {
   // Initialize pwrmgr.
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   // Initialize sysrst_ctrl.
-  CHECK_DIF_OK(dif_sysrst_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
-      &sysrst_ctrl_aon));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrstCtrlDt, &sysrst_ctrl_aon));
 
   // Initialize rstmgr to check the reset reason.
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
 }
 
 /**
@@ -58,9 +61,12 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
   LOG_INFO("sysrst enabled");
 
   // Set sysrst as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_sysrst_ctrl_instance_id(kSysrstCtrlDt),
+      kDtSysrstCtrlResetReqRstReq, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   LOG_INFO("Reset Request SourceOne is set");
 
   // Configure sysrst key combo
@@ -82,15 +88,15 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
 
   // Configure pinmux
   dif_pinmux_t pinmux;
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
 
   CHECK_DIF_OK(dif_sysrst_ctrl_input_change_detect_configure(
       sysrst_ctrl_aon, sysrst_ctrl_input_change_config));
 
-  CHECK_DIF_OK(dif_pinmux_input_select(
-      &pinmux, kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
-      kTopEarlgreyPinmuxInselIor13));
+  CHECK_DIF_OK(dif_pinmux_mio_select_input(
+      &pinmux,
+      dt_sysrst_ctrl_periph_io(kSysrstCtrlDt, kDtSysrstCtrlPeriphIoKey0In),
+      kDtPadIor13));
 }
 
 static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {

--- a/sw/device/tests/pwrmgr_sensor_ctrl_deep_sleep_wake_up.c
+++ b/sw/device/tests/pwrmgr_sensor_ctrl_deep_sleep_wake_up.c
@@ -92,8 +92,13 @@ bool test_main(void) {
         &pwrmgr, kDifToggleEnabled));
     // This enters deep sleep, so the clock control bits are irrelevant since
     // they are reset on wakeup.
-    CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-        &pwrmgr, kDifPwrmgrWakeupRequestSourceSix, 0));
+    dif_pwrmgr_request_sources_t wakeup_sources;
+    CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+        &pwrmgr, kDifPwrmgrReqTypeWakeup,
+        dt_sensor_ctrl_instance_id(kSensorCtrlDt), kDtSensorCtrlWakeupWkupReq,
+        &wakeup_sources));
+    CHECK_STATUS_OK(
+        pwrmgr_testutils_enable_low_power(&pwrmgr, wakeup_sources, 0));
     LOG_INFO("Issue WFI to enter sensor_ctrl sleep");
     wait_for_interrupt();
 

--- a/sw/device/tests/rv_dm_access_after_wakeup.c
+++ b/sw/device/tests/rv_dm_access_after_wakeup.c
@@ -45,7 +45,7 @@ static_assert(kDtRvPlicCount == 1, "this test expects exactly one rv_plic");
 static const dt_rv_plic_t kRvPlicDt = 0;
 static_assert(kDtSysrstCtrlCount >= 1,
               "this test expects at least one sysrst_ctrl");
-static const dt_sysrst_ctrl_t kSysrtCtrlDt = 0;
+static const dt_sysrst_ctrl_t kSysrstCtrlDt = 0;
 static_assert(kDtPinmuxCount == 1, "this test expects exactly one pinmux");
 static const dt_pinmux_t kPinmuxDt = 0;
 
@@ -79,8 +79,9 @@ static void put_to_sleep(dif_pwrmgr_t *pwrmgr, bool deep_sleep) {
 
   dif_pwrmgr_request_sources_t wakeup_sources;
   CHECK_DIF_OK(dif_pwrmgr_find_request_source(
-      pwrmgr, kDifPwrmgrReqTypeWakeup, dt_sysrst_ctrl_instance_id(kSysrtCtrlDt),
-      kDtSysrstCtrlWakeupWkupReq, &wakeup_sources));
+      pwrmgr, kDifPwrmgrReqTypeWakeup,
+      dt_sysrst_ctrl_instance_id(kSysrstCtrlDt), kDtSysrstCtrlWakeupWkupReq,
+      &wakeup_sources));
   CHECK_STATUS_OK(
       pwrmgr_testutils_enable_low_power(pwrmgr, wakeup_sources, cfg));
   LOG_INFO("%s",
@@ -100,7 +101,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
   CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
   CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &rv_plic));
-  CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrtCtrlDt, &sysrst_ctrl));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrstCtrlDt, &sysrst_ctrl));
 
   const volatile uint8_t *const software_barrier = (kDeviceType == kDeviceSimDV)
                                                        ? &kSoftwareBarrierDv
@@ -131,7 +132,7 @@ bool test_main(void) {
           dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl, config));
       CHECK_DIF_OK(dif_pinmux_mio_select_input(
           &pinmux,
-          dt_sysrst_ctrl_periph_io(kSysrtCtrlDt, kDtSysrstCtrlPeriphIoPwrbIn),
+          dt_sysrst_ctrl_periph_io(kSysrstCtrlDt, kDtSysrstCtrlPeriphIoPwrbIn),
           kDtPadIor13));
 
       // Put the device in a normal sleep.

--- a/sw/device/tests/sensor_ctrl_wakeup_test.c
+++ b/sw/device/tests/sensor_ctrl_wakeup_test.c
@@ -14,22 +14,24 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sensor_ctrl_regs.h"  // Generated.
-#include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 OTTF_DEFINE_TEST_CONFIG();
 
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_rv_plic_t kRvPlicDt = 0;
+static_assert(kDtRvPlicCount == 1, "this test expects exactly one rv_plic");
+static const dt_sensor_ctrl_t kSensorCtrlDt = 0;
+static_assert(kDtSensorCtrlCount == 1,
+              "this test expects exactly one sensor_ctrl");
+
+enum {
+  kPlicTarget = 0,
+};
+
 static dif_pwrmgr_t pwrmgr;
 static dif_rv_plic_t plic;
-static plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
-                                  .hart_id = kTopEarlgreyPlicTargetIbex0};
-
-static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
-    .pwrmgr = &pwrmgr,
-    .plic_pwrmgr_start_irq_id = kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
-    .expected_irq = kDifPwrmgrIrqWakeup,
-    .is_only_irq = true};
 
 static bool get_wakeup_status(void) {
   dif_pwrmgr_request_sources_t wake_req = ~0u;
@@ -41,16 +43,15 @@ static bool get_wakeup_status(void) {
 /**
  * External interrupt handler.
  */
-void ottf_external_isr(uint32_t *exc_info) {
-  dif_pwrmgr_irq_t irq_id;
-  top_earlgrey_plic_peripheral_t peripheral;
-
-  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
-
-  // Check that both the peripheral and the irq id is correct
-  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
-        "IRQ peripheral: %d is incorrect", peripheral);
-  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+bool ottf_handle_irq(uint32_t *exc_info, dt_instance_id_t devid,
+                     dif_rv_plic_irq_id_t irq_id) {
+  if (devid == dt_pwrmgr_instance_id(kPwrmgrDt) &&
+      irq_id == dt_pwrmgr_irq_to_plic_id(kPwrmgrDt, kDtPwrmgrIrqWakeup)) {
+    CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(&pwrmgr, kDtPwrmgrIrqWakeup));
+    return true;
+  } else {
+    return false;
+  }
 }
 
 bool test_main(void) {
@@ -61,23 +62,18 @@ bool test_main(void) {
   irq_external_ctrl(true);
 
   // Initialize the PLIC.
-  mmio_region_t plic_base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_plic_init(plic_base_addr, &plic));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &plic));
 
   // Initialize pwrmgr
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   // Initialize sensor_ctrl
-  CHECK_DIF_OK(dif_sensor_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR),
-      &sensor_ctrl));
+  CHECK_DIF_OK(dif_sensor_ctrl_init_from_dt(kSensorCtrlDt, &sensor_ctrl));
 
   // Enable all the AON interrupts used in this test.
-  rv_plic_testutils_irq_range_enable(&plic, kTopEarlgreyPlicTargetIbex0,
-                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
-                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+  dif_rv_plic_irq_id_t plic_id =
+      dt_pwrmgr_irq_to_plic_id(kPwrmgrDt, kDtPwrmgrIrqWakeup);
+  rv_plic_testutils_irq_range_enable(&plic, kPlicTarget, plic_id, plic_id);
 
   // Enable pwrmgr interrupt
   CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
@@ -105,8 +101,13 @@ bool test_main(void) {
                                                        kDifToggleEnabled));
 
     // Normal sleep.
-    CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-        &pwrmgr, kDifPwrmgrWakeupRequestSourceSix, sleep_config));
+    dif_pwrmgr_request_sources_t wakeup_sources;
+    CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+        &pwrmgr, kDifPwrmgrReqTypeWakeup,
+        dt_sensor_ctrl_instance_id(kSensorCtrlDt), kDtSensorCtrlWakeupWkupReq,
+        &wakeup_sources));
+    CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(&pwrmgr, wakeup_sources,
+                                                      sleep_config));
 
     // Enter low power mode.
     LOG_INFO("Issue WFI to enter sleep");

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -594,7 +594,6 @@ opentitan_test(
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
         "//hw/top:aon_timer_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -396,7 +396,6 @@ opentitan_test(
     srcs = ["pwrmgr_sleep_power_glitch_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -412,7 +412,6 @@ opentitan_test(
     srcs = ["pwrmgr_deep_sleep_power_glitch_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rstmgr",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -571,7 +571,6 @@ opentitan_test(
     srcs = ["adc_ctrl_sleep_debug_cable_wakeup_test.c"],
     exec_env = {"//hw/top_earlgrey:sim_dv": None},
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:adc_ctrl",
         "//sw/device/lib/dif:pwrmgr",
@@ -580,7 +579,6 @@ opentitan_test(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:isr_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -55,7 +55,6 @@ static dif_sensor_ctrl_t sensor_ctrl;
 static dif_alert_handler_t alert_handler;
 static dif_aon_timer_t aon_timer;
 static dif_rv_plic_t rv_plic;
-static dif_rv_plic_t plic;
 static dif_pwrmgr_t pwrmgr;
 static dif_rstmgr_t rstmgr;
 static dif_entropy_src_t entropy_src;
@@ -206,7 +205,6 @@ void init_units(void) {
   CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &rv_plic));
   CHECK_DIF_OK(dif_sensor_ctrl_init_from_dt(kSensorCtrlDt, &sensor_ctrl));
   CHECK_DIF_OK(dif_alert_handler_init_from_dt(kAlertHandlerDt, &alert_handler));
-  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &plic));
   CHECK_DIF_OK(dif_clkmgr_init_from_dt(kClkmgrDt, &clkmgr));
   CHECK_DIF_OK(dif_adc_ctrl_init_from_dt(kAdcCtrlDt, &adc_ctrl));
 }
@@ -272,7 +270,7 @@ void adc_setup(bool first_adc_setup) {
     CHECK_DIF_OK(dif_adc_ctrl_reset(&adc_ctrl));
   }
 
-  en_plic_irqs(&plic);
+  en_plic_irqs(&rv_plic);
   // Setup ADC filters. There is one filter for each channel.
   CHECK_DIF_OK(dif_adc_ctrl_configure_filter(
       &adc_ctrl, kDifAdcCtrlChannel0,
@@ -528,7 +526,7 @@ void set_edn_auto_mode(void) {
 }
 
 void ottf_external_isr(uint32_t *exc_info) {
-  plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
+  plic_isr_ctx_t plic_ctx = {.rv_plic = &rv_plic,
                              .hart_id = kTopEarlgreyPlicTargetIbex0};
 
   adc_ctrl_isr_ctx_t adc_ctrl_ctx = {

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "dt/dt_adc_ctrl.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/mmio.h"
@@ -48,6 +49,27 @@ static dif_alert_handler_t alert_handler;
 static dif_aon_timer_t aon_timer;
 static dif_pwrmgr_t pwrmgr;
 static dif_rstmgr_t rstmgr;
+
+static const dt_adc_ctrl_t kAdcCtrlDt = 0;
+static_assert(kDtAdcCtrlCount == 1, "this test expects an adc_ctrl");
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_aon_timer_t kAonTimerDt = 0;
+static_assert(kDtAonTimerCount == 1, "this test expects an aon_timer");
+static const dt_rv_plic_t kRvPlicDt = 0;
+static_assert(kDtRvPlicCount >= 1, "this test expects at least one rv_plic");
+static const dt_flash_ctrl_t kFlashCtrlDt = 0;
+static_assert(kDtFlashCtrlCount >= 1,
+              "this test expects at least one flash_ctrl");
+static const dt_alert_handler_t kAlertHandlerDt = 0;
+static_assert(kDtAlertHandlerCount == 1,
+              "this library expects exactly one alert_handler");
+
+dif_pwrmgr_request_sources_t aon_timer_wakeup_sources;
+dif_pwrmgr_request_sources_t adc_ctrl_wakeup_sources;
+dif_pwrmgr_request_sources_t all_wakeup_sources;
 
 /**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
@@ -132,34 +154,36 @@ void ottf_external_isr(uint32_t *exc_info) {
  */
 void init_peripherals(void) {
   // Initialize pwrmgr.
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
 
   // Initialize rstmgr to check the reset reason.
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
 
   // Initialize aon timer to use the wdog.
-  CHECK_DIF_OK(dif_aon_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kAonTimerDt, &aon_timer));
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_aon_timer_instance_id(kAonTimerDt),
+      kDtAonTimerWakeupWkupReq, &aon_timer_wakeup_sources));
 
   // Initialize flash_ctrl
-  CHECK_DIF_OK(dif_flash_ctrl_init_state(
-      &flash_ctrl,
-      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+  CHECK_DIF_OK(dif_flash_ctrl_init_state_from_dt(&flash_ctrl, kFlashCtrlDt));
 
   // Initialize plic.
-  CHECK_DIF_OK(dif_rv_plic_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &plic));
 
   rv_plic_testutils_irq_range_enable(
       &plic, kPlicTarget, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
       kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
 
   // Initialize alert handler.
-  CHECK_DIF_OK(dif_alert_handler_init(
-      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
-      &alert_handler));
+  CHECK_DIF_OK(dif_alert_handler_init_from_dt(kAlertHandlerDt, &alert_handler));
+
+  // Other wakeups.
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_adc_ctrl_instance_id(kAdcCtrlDt),
+      kDtAdcCtrlWakeupWkupReq, &adc_ctrl_wakeup_sources));
+  CHECK_DIF_OK(dif_pwrmgr_get_all_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, &all_wakeup_sources));
 }
 
 /**
@@ -251,8 +275,8 @@ static void config_escalate(dif_aon_timer_t *aon_timer,
 
 static void low_power_glitch_reset(const dif_pwrmgr_t *pwrmgr) {
   // Program the pwrmgr to go to deep sleep state (clocks off).
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceFive, 0));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(pwrmgr, aon_timer_wakeup_sources, 0));
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -265,7 +289,7 @@ static void normal_sleep_glitch_reset(const dif_pwrmgr_t *pwrmgr) {
            kDifPwrmgrDomainOptionIoClockInLowPower |
            kDifPwrmgrDomainOptionMainPowerInLowPower;
   CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceFive, config));
+      pwrmgr, aon_timer_wakeup_sources, config));
   // Enter in low power mode.
   wait_for_interrupt();
 }
@@ -314,8 +338,8 @@ static void sleep_wdog_bite_test(const dif_aon_timer_t *aon_timer,
 static void low_power_wdog(const dif_pwrmgr_t *pwrmgr) {
   // Program the pwrmgr to go to deep sleep state (clocks off).
   // Enter in low power mode.
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceTwo, 0));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(pwrmgr, adc_ctrl_wakeup_sources, 0));
   LOG_INFO("Low power set for watch dog");
   wait_for_interrupt();
   // If we arrive here the test must fail.
@@ -332,7 +356,7 @@ static void normal_sleep_wdog(const dif_pwrmgr_t *pwrmgr) {
 
   // Enter in low power mode.
   CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr, kDifPwrmgrWakeupRequestSourceTwo, config));
+      pwrmgr, adc_ctrl_wakeup_sources, config));
   LOG_INFO("Normal sleep set for watchdog");
   wait_for_interrupt();
 }
@@ -344,12 +368,8 @@ static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
                                               kDifToggleEnabled));
 
   // Program the pwrmgr to go to deep sleep state (clocks off).
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr,
-      (kDifPwrmgrWakeupRequestSourceOne | kDifPwrmgrWakeupRequestSourceTwo |
-       kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
-       kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
-      0));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(pwrmgr, all_wakeup_sources, 0));
   // Enter in low power mode.
   wait_for_interrupt();
   // If we arrive here the test must fail.
@@ -370,12 +390,8 @@ static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {
            kDifPwrmgrDomainOptionMainPowerInLowPower;
 
   // Program the pwrmgr to go to swallow sleep state (clocks on).
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      pwrmgr,
-      (kDifPwrmgrWakeupRequestSourceOne | kDifPwrmgrWakeupRequestSourceTwo |
-       kDifPwrmgrWakeupRequestSourceThree | kDifPwrmgrWakeupRequestSourceFour |
-       kDifPwrmgrWakeupRequestSourceFive | kDifPwrmgrWakeupRequestSourceSix),
-      config));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(pwrmgr, all_wakeup_sources, config));
   // Enter in low power mode.
   wait_for_interrupt();
 }

--- a/sw/device/tests/sleep_pin_mio_dio_val_test.c
+++ b/sw/device/tests/sleep_pin_mio_dio_val_test.c
@@ -207,8 +207,11 @@ bool test_main(void) {
     result = lowpower_prep(&pwrmgr, &pinmux, deepsleep);
   }
 
-  if (UNWRAP(pwrmgr_testutils_is_wakeup_reason(
-          &pwrmgr, kDifPwrmgrWakeupRequestSourceThree)) == true) {
+  dif_pwrmgr_request_sources_t wakeup_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_pinmux_instance_id(kDtPinmuxAon),
+      kDtPinmuxWakeupPinWkupReq, &wakeup_sources));
+  if (UNWRAP(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, wakeup_sources))) {
     // TODO: change PINMUX wakeup, not pin detector
     /**
      *  Usually this part won't be hit. UVM testbench checks the PAD output

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
@@ -18,33 +18,29 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "sw/device/lib/testing/autogen/isr_testutils.h"
-
 enum {
-  /**
-   * Retention SRAM start address (inclusive).
-   */
-  kRetSramBaseAddr = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
-
-  kRetSramOwnerAddr = kRetSramBaseAddr + offsetof(retention_sram_t, owner),
-  kRetRamLastAddr =
-      kRetSramBaseAddr + TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES - 1,
-
   kTestBufferSizeWords = 16,
+  kPlicTarget = 0,
 };
 
 static dif_rv_plic_t rv_plic;
 static dif_aon_timer_t aon_timer;
 static dif_pwrmgr_t pwrmgr;
 static dif_rstmgr_t rstmgr;
-static plic_isr_ctx_t plic_ctx = {.rv_plic = &rv_plic,
-                                  .hart_id = kTopEarlgreyPlicTargetIbex0};
-static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
-    .pwrmgr = &pwrmgr,
-    .plic_pwrmgr_start_irq_id = kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
-    .expected_irq = kDifPwrmgrIrqWakeup,
-    .is_only_irq = true};
+
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this library expects exactly one pwrmgr");
+static const dt_aon_timer_t kAonTimerDt = 0;
+static_assert(kDtAonTimerCount == 1,
+              "this library expects exactly one aon_timer");
+static const dt_rv_plic_t kRvPlicDt = 0;
+static_assert(kDtRvPlicCount >= 1, "this test expects at least one rv_plic");
+
+static const dt_sram_ctrl_t kRetSramCtrlDt = kDtSramCtrlRetAon;
+
+static dif_pwrmgr_request_sources_t aon_timer_wakeup_sources;
 
 // Random data to read/write to/from retention SRAM.
 const uint32_t kTestData[kTestBufferSizeWords] = {
@@ -59,15 +55,19 @@ typedef struct {
 } check_config_t;
 
 static void retention_sram_check(check_config_t config) {
+  uintptr_t ret_sram_owner_addr =
+      dt_sram_ctrl_reg_block(kRetSramCtrlDt, kDtSramCtrlRegBlockRam) +
+      offsetof(retention_sram_t, owner);
+
   if (config.do_write) {
     sram_ctrl_testutils_write(
-        kRetSramOwnerAddr,
+        ret_sram_owner_addr,
         (sram_ctrl_testutils_data_t){.words = kTestData,
                                      .len = kTestBufferSizeWords});
   }
 
   uint32_t tmp_buffer[kTestBufferSizeWords];
-  memcpy(tmp_buffer, (uint8_t *)kRetSramOwnerAddr, sizeof(tmp_buffer));
+  memcpy(tmp_buffer, (uint8_t *)ret_sram_owner_addr, sizeof(tmp_buffer));
 
   if (config.is_equal) {
     CHECK_ARRAYS_EQ(tmp_buffer, kTestData, kTestBufferSizeWords);
@@ -87,17 +87,16 @@ void ottf_internal_isr(uint32_t *exc_info) {}
 /**
  * Override external interrupt handler to handle the normal sleep IRQ.
  */
-void ottf_external_isr(uint32_t *exc_info) {
-  dif_pwrmgr_irq_t irq_id;
-  top_earlgrey_plic_peripheral_t peripheral;
-
-  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
-
-  LOG_INFO("Receive irq in normal sleep");
-  // Check that both the peripheral and the irq id are correct.
-  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
-        "IRQ peripheral: %d is incorrect", peripheral);
-  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+bool ottf_handle_irq(uint32_t *exc_info, dt_instance_id_t devid,
+                     dif_rv_plic_irq_id_t irq_id) {
+  if (devid == dt_pwrmgr_instance_id(kPwrmgrDt) &&
+      irq_id == dt_pwrmgr_irq_to_plic_id(kPwrmgrDt, kDtPwrmgrIrqWakeup)) {
+    LOG_INFO("Receive irq in normal sleep");
+    CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(&pwrmgr, kDtPwrmgrIrqWakeup));
+    return true;
+  } else {
+    return false;
+  }
 }
 
 // test these 2 cases:
@@ -110,14 +109,14 @@ void test_ret_sram_in_normal_sleep(void) {
   // set up wakeup timer
   CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(&aon_timer, 20));
   // Enable all the AON interrupts used in this test.
-  rv_plic_testutils_irq_range_enable(&rv_plic, kTopEarlgreyPlicTargetIbex0,
-                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
-                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+  dif_rv_plic_irq_id_t irq_id =
+      dt_pwrmgr_irq_to_plic_id(kPwrmgrDt, kDtPwrmgrIrqWakeup);
+  rv_plic_testutils_irq_range_enable(&rv_plic, kPlicTarget, irq_id, irq_id);
   CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
 
   // Normal sleep.
   CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      &pwrmgr, /*wakeups=*/kDifPwrmgrWakeupRequestSourceFive,
+      &pwrmgr, /*wakeups=*/aon_timer_wakeup_sources,
       /*domain_config=*/kDifPwrmgrDomainOptionCoreClockInLowPower |
           kDifPwrmgrDomainOptionUsbClockInActivePower |
           kDifPwrmgrDomainOptionMainPowerInLowPower));
@@ -137,8 +136,8 @@ void enter_deep_sleep(void) {
   // set up wakeup timer
   CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(&aon_timer, 20));
   // Deep sleep.
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      &pwrmgr, kDifPwrmgrWakeupRequestSourceFive, 0));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(&pwrmgr, aon_timer_wakeup_sources, 0));
 
   // Enter low power mode.
   LOG_INFO("Issue WFI to enter deep sleep");
@@ -169,14 +168,14 @@ bool execute_sram_ctrl_sleep_ret_sram_contents_test(bool scramble) {
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
-  mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR);
-  CHECK_DIF_OK(dif_pwrmgr_init(addr, &pwrmgr));
-  addr = mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR);
-  CHECK_DIF_OK(dif_rstmgr_init(addr, &rstmgr));
-  addr = mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR);
-  CHECK_DIF_OK(dif_aon_timer_init(addr, &aon_timer));
-  addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_plic_init(addr, &rv_plic));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kAonTimerDt, &aon_timer));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kRvPlicDt, &rv_plic));
+
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_aon_timer_instance_id(kAonTimerDt),
+      kDtAonTimerWakeupWkupReq, &aon_timer_wakeup_sources));
 
   dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
   rstmgr_reset_info = rstmgr_testutils_reason_get();
@@ -190,9 +189,7 @@ bool execute_sram_ctrl_sleep_ret_sram_contents_test(bool scramble) {
 
     if (scramble) {
       dif_sram_ctrl_t ret_sram;
-      addr =
-          mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR);
-      CHECK_DIF_OK(dif_sram_ctrl_init(addr, &ret_sram));
+      CHECK_DIF_OK(dif_sram_ctrl_init_from_dt(kRetSramCtrlDt, &ret_sram));
       LOG_INFO("Wiping ret_sram...");
       CHECK_STATUS_OK(sram_ctrl_testutils_wipe(&ret_sram));
       LOG_INFO("Scrambling ret_sram...");
@@ -205,7 +202,7 @@ bool execute_sram_ctrl_sleep_ret_sram_contents_test(bool scramble) {
     LOG_INFO("Wake up from deep sleep");
 
     CHECK(UNWRAP(pwrmgr_testutils_is_wakeup_reason(
-              &pwrmgr, kDifPwrmgrWakeupRequestSourceFive)) == true);
+              &pwrmgr, aon_timer_wakeup_sources)) == true);
     // data preserved
     retention_sram_check((check_config_t){.do_write = false, .is_equal = true});
 

--- a/sw/device/tests/sysrst_ctrl_reset_test.c
+++ b/sw/device/tests/sysrst_ctrl_reset_test.c
@@ -15,14 +15,26 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 OTTF_DEFINE_TEST_CONFIG();
 
 static dif_pwrmgr_t pwrmgr;
 static dif_rstmgr_t rstmgr;
 static dif_sysrst_ctrl_t sysrst_ctrl;
 static dif_gpio_t gpio;
+
+static dif_pwrmgr_request_sources_t reset_sources, wakeup_sources,
+    other_wakeup_sources;
+
+static const dt_pwrmgr_t kPwrmgrDt = 0;
+static_assert(kDtPwrmgrCount == 1, "this test expects a pwrmgr");
+static const dt_pinmux_t kPinmuxDt = 0;
+static_assert(kDtPinmuxCount == 1, "this test expects a pinmux");
+static const dt_rstmgr_t kRstmgrDt = 0;
+static_assert(kDtRstmgrCount == 1, "this test expects a rstmgr");
+static const dt_gpio_t kGpioDt = 0;
+static_assert(kDtGpioCount == 1, "this test expects a gpio");
+static const dt_sysrst_ctrl_t kSysrstCtrlDt = 0;
+static_assert(kDtSysrstCtrlCount == 1, "this test expects a sysrst_ctrl");
 
 enum {
   kTestPhaseCheckComboReset = 0,
@@ -44,27 +56,20 @@ enum {
   kOutputNumMioPads = 6,
 };
 
-static const dif_pinmux_index_t kPeripheralInputs[] = {
-    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
-    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
-    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey2In,
-    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonPwrbIn,
-    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonAcPresent,
-    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonLidOpen,
+static const dt_sysrst_ctrl_periph_io_t kPeripheralInputs[] = {
+    kDtSysrstCtrlPeriphIoKey0In,    kDtSysrstCtrlPeriphIoKey1In,
+    kDtSysrstCtrlPeriphIoKey2In,    kDtSysrstCtrlPeriphIoPwrbIn,
+    kDtSysrstCtrlPeriphIoAcPresent, kDtSysrstCtrlPeriphIoLidOpen,
 };
 
-static const dif_pinmux_index_t kInputPadsDV[] = {
-    kTopEarlgreyPinmuxInselIob3, kTopEarlgreyPinmuxInselIob6,
-    kTopEarlgreyPinmuxInselIob8, kTopEarlgreyPinmuxInselIob9,
-    kTopEarlgreyPinmuxInselIoc7, kTopEarlgreyPinmuxInselIoc9,
+static const dt_pad_t kInputPadsDV[] = {
+    kDtPadIob3, kDtPadIob6, kDtPadIob8, kDtPadIob9, kDtPadIoc7, kDtPadIoc9,
 };
 
 // We need different pins on the hyperdebug boards since certain
 // pins are not routed to the hyperdebug.
-static const dif_pinmux_index_t kInputPadsReal[] = {
-    kTopEarlgreyPinmuxInselIor10, kTopEarlgreyPinmuxInselIor11,
-    kTopEarlgreyPinmuxInselIor12, kTopEarlgreyPinmuxInselIor5,
-    kTopEarlgreyPinmuxInselIor6,  kTopEarlgreyPinmuxInselIor7,
+static const dt_pad_t kInputPadsReal[] = {
+    kDtPadIor10, kDtPadIor11, kDtPadIor12, kDtPadIor5, kDtPadIor6, kDtPadIor7,
 };
 
 // On DV this device is in the flash and written by the testbench.
@@ -95,9 +100,8 @@ static void check_combo_reset(void) {
                                      .override_value = true}));
   // Prepare rstmgr for a reset with sysrst_ctrl (source one).
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   // Issue WFI and wait for reset condition.
   test_status_set(kTestStatusInWfi);
   wait_for_interrupt();
@@ -113,8 +117,8 @@ static void check_deep_sleep_wakeup(void) {
   // Setup low power.
   // Wakeup source is from sysrst_ctrl (source one).
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      &pwrmgr, kDifPwrmgrWakeupRequestSourceOne, 0));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(&pwrmgr, wakeup_sources, 0));
   // Issue WFI and wait for reset condition.
   test_status_set(kTestStatusInWfi);
   wait_for_interrupt();
@@ -143,52 +147,57 @@ static void check_deep_sleep_reset(void) {
   // Setup low power.
   // Reset source is from sysrst_ctrl (source one).
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   // Enable low power with wakeup source other than
   // sysrst_ctrl (e.g. source two) as we don't want
   // a wakeup request but instead a reset.
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      &pwrmgr, kDifPwrmgrWakeupRequestSourceTwo, 0));
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(&pwrmgr, other_wakeup_sources, 0));
   // Issue WFI and wait for reset condition.
   test_status_set(kTestStatusInWfi);
   wait_for_interrupt();
 }
 
 bool test_main(void) {
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
-  CHECK_DIF_OK(dif_sysrst_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
-      &sysrst_ctrl));
-  CHECK_DIF_OK(
-      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kPwrmgrDt, &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kRstmgrDt, &rstmgr));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrstCtrlDt, &sysrst_ctrl));
+  CHECK_DIF_OK(dif_gpio_init_from_dt(kGpioDt, &gpio));
+
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup,
+      dt_sysrst_ctrl_instance_id(kSysrstCtrlDt), kDtSysrstCtrlWakeupWkupReq,
+      &wakeup_sources));
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset,
+      dt_sysrst_ctrl_instance_id(kSysrstCtrlDt), kDtSysrstCtrlResetReqRstReq,
+      &reset_sources));
+  // Any wakeup source different from sysrst_ctrl.
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_pinmux_instance_id(kPinmuxDt),
+      kDtPinmuxWakeupPinWkupReq, &other_wakeup_sources));
 
   dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
   rstmgr_reset_info = rstmgr_testutils_reason_get();
 
   dif_pinmux_t pinmux;
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
-  const dif_pinmux_index_t *kInputPads =
+  CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
+  const dt_pad_t *kInputPads =
       kDeviceType == kDeviceSimDV ? kInputPadsDV : kInputPadsReal;
   for (int i = 0; i < kOutputNumMioPads; ++i) {
-    CHECK_DIF_OK(
-        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+    CHECK_DIF_OK(dif_pinmux_mio_select_input(
+        &pinmux, dt_sysrst_ctrl_periph_io(kSysrstCtrlDt, kPeripheralInputs[i]),
+        kInputPads[i]));
   }
   // On real devices, we also need to configure the DIO pins and two more pins
   // to read the test phase.
   if (kDeviceType != kDeviceSimDV) {
     sysrst_ctrl_testutils_setup_dio(&pinmux);
-    CHECK_DIF_OK(dif_pinmux_input_select(
-        &pinmux, kTopEarlgreyPinmuxPeripheralInGpioGpio0,
-        kTopEarlgreyPinmuxInselIob0));
-    CHECK_DIF_OK(dif_pinmux_input_select(
-        &pinmux, kTopEarlgreyPinmuxPeripheralInGpioGpio1,
-        kTopEarlgreyPinmuxInselIob1));
+    CHECK_DIF_OK(dif_pinmux_mio_select_input(
+        &pinmux, dt_gpio_periph_io(kGpioDt, kDtGpioPeriphIoGpio0), kDtPadIob0));
+    CHECK_DIF_OK(dif_pinmux_mio_select_input(
+        &pinmux, dt_gpio_periph_io(kGpioDt, kDtGpioPeriphIoGpio1), kDtPadIob1));
   }
 
   CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(


### PR DESCRIPTION
This PR is still in progress and is kept to see how many tests still remain to be converted.

Remaining targets to convert:

- [x] `pwrmgr_sleep_power_glitch_test`
- [x] `pwrmgr_lowpower_cancel_test`
- [x] `chip_power_sleep_load_test`
- [x] `sensor_ctrl_wakeup_test`
- [x] `alert_handler_lpg_sleep_mode_alerts`
- [x] `ast_clk_rst_inputs`
- [x] `pwrmgr_sleep_resets_lib`
- [x] `pwrmgr_deep_sleep_power_glitch_test`
- [x] `dif_pwrmgr_unittest`
- [x] `pwrmgr_b2b_sleep_reset_test`
- [x] `pwrmgr_random_sleep_power_glitch_reset_test`
- [x] `sram_ctrl_sleep_sram_ret_contents_impl`