### PR TITLE
[pattgen,dv] Fix constraint in pattgen_perf_vseq

### DIFF
--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_perf_vseq.sv
@@ -20,8 +20,8 @@ class pattgen_perf_vseq extends pattgen_base_vseq;
     ch_cfg = pattgen_channel_cfg::type_id::create($sformatf("channel_cfg_%0d", channel));
     `DV_CHECK_RANDOMIZE_WITH_FATAL(ch_cfg,
       ch_cfg.prediv dist {0 :/ 1, 1024 :/ 1};
-      ch_cfg.len    dist {0 :/ 1, 1023 :/ 1};
-      ch_cfg.reps   dist {0 :/ 1,   63 :/ 1};
+      ch_cfg.len    dist {0 :/ 1,   63 :/ 1};
+      ch_cfg.reps   dist {0 :/ 1, 1023 :/ 1};
       // dependent constraints
       solve ch_cfg.len before ch_cfg.data;
       ch_cfg.data inside {[0 : (1 << (ch_cfg.len + 1)) - 1]};


### PR DESCRIPTION
This gets rid of a build warning (one field is a 10 bit variable and the other is 6 bits; the original author had just got the two ranges backwards).