### PR TITLE
[sw,e2e] Fix provisioning e2e test CI tags

### DIFF
--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -129,9 +129,9 @@ sh_test(
             "changes_otp",
             "exclusive",
             "manuf",
-        ] + [fpga] + [
+        ] + [fpga] + ([
             "manual",
-        ] if cfg.get("offline", False) else [],
+        ] if cfg.get("offline", False) else []),
         toolchains = ["@rules_python//python:current_py_toolchain"],
     )
     for sku, cfg in EARLGREY_SKUS.items()


### PR DESCRIPTION
The missing parenthesis clears all the tags, which makes the test be skipped regardless of the offline flag. The test should only be skipped if offline.