### PR TITLE
[RACL] Render policy selectors

### DIFF
--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -2202,9 +2202,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX0_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX0_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX0_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX0_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX0_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX0_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[74:73])
   ) u_mbx0 (
 
@@ -2238,9 +2238,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX1_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX1_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX1_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX1_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX1_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX1_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[76:75])
   ) u_mbx1 (
 
@@ -2274,9 +2274,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX2_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX2_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX2_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX2_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX2_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX2_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[78:77])
   ) u_mbx2 (
 
@@ -2341,9 +2341,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX4_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX4_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX4_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX4_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX4_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX4_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[82:81])
   ) u_mbx4 (
 
@@ -2377,9 +2377,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX5_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX5_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX5_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX5_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX5_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX5_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[84:83])
   ) u_mbx5 (
 
@@ -2444,9 +2444,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX_JTAG_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX_JTAG_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX_JTAG_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX_JTAG_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[88:87])
   ) u_mbx_jtag (
 
@@ -2480,9 +2480,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX_PCIE0_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX_PCIE0_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX_PCIE0_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX_PCIE0_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[90:89])
   ) u_mbx_pcie0 (
 
@@ -2516,9 +2516,9 @@ module top_darjeeling #(
   mbx #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVecSoc(RACL_POLICY_SEL_MBX_PCIE1_SOC),
-    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_WDATA),
-    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_RDATA),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX_PCIE1_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX_PCIE1_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX_PCIE1_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[92:91])
   ) u_mbx_pcie1 (
 
@@ -2602,7 +2602,7 @@ module top_darjeeling #(
   ac_range_check #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-    .RaclPolicySelVec(RACL_POLICY_SEL_AC_RANGE_CHECK),
+    .RaclPolicySelVec(RACL_POLICY_SEL_VEC_AC_RANGE_CHECK),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[98:97])
   ) u_ac_range_check (
 

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_racl_pkg.sv
@@ -15,346 +15,315 @@ package top_darjeeling_racl_pkg;
   import top_racl_pkg::*;
 
   /**
-   * RACL groups:
+   * RACL groups and policies:
    *   Null
-   *     ALL_RD_WR   (Idx 0)
-   *     ROT_PRIVATE (Idx 1)
-   *     SOC_ROT     (Idx 2)
+   *     0: ALL_RD_WR
+   *     1: ROT_PRIVATE
+   *     2: SOC_ROT
    */
 
   /**
    * Policy selection vector for mbx0
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           ALL_RD_WR (Idx 0)
-   *     SOC_STATUS:            ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_ADDR: ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_DATA: ALL_RD_WR (Idx 0)
-   *   Window to policy mapping:
-   *     WDATA: ALL_RD_WR (Idx 0)
-   *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX0_SOC [4] = '{
-    0, 0, 0, 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX0_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX0_SOC_WIN_WDATA = 0;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX0_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX0_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX0_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
    * Policy selection vector for mbx1
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           ALL_RD_WR (Idx 0)
-   *     SOC_STATUS:            ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_ADDR: ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_DATA: ALL_RD_WR (Idx 0)
-   *   Window to policy mapping:
-   *     WDATA: ALL_RD_WR (Idx 0)
-   *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX1_SOC [4] = '{
-    0, 0, 0, 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX1_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX1_SOC_WIN_WDATA = 0;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX1_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX1_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX1_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
    * Policy selection vector for mbx2
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           ALL_RD_WR (Idx 0)
-   *     SOC_STATUS:            ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_ADDR: ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_DATA: ALL_RD_WR (Idx 0)
-   *   Window to policy mapping:
-   *     WDATA: ALL_RD_WR (Idx 0)
-   *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX2_SOC [4] = '{
-    0, 0, 0, 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX2_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX2_SOC_WIN_WDATA = 0;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX2_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX2_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX2_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
    * Policy selection vector for mbx4
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           ALL_RD_WR (Idx 0)
-   *     SOC_STATUS:            ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_ADDR: ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_DATA: ALL_RD_WR (Idx 0)
-   *   Window to policy mapping:
-   *     WDATA: ALL_RD_WR (Idx 0)
-   *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX4_SOC [4] = '{
-    0, 0, 0, 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX4_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX4_SOC_WIN_WDATA = 0;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX4_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX4_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX4_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
    * Policy selection vector for mbx5
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           ALL_RD_WR (Idx 0)
-   *     SOC_STATUS:            ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_ADDR: ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_DATA: ALL_RD_WR (Idx 0)
-   *   Window to policy mapping:
-   *     WDATA: ALL_RD_WR (Idx 0)
-   *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX5_SOC [4] = '{
-    0, 0, 0, 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX5_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX5_SOC_WIN_WDATA = 0;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX5_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX5_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX5_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
    * Policy selection vector for mbx_jtag
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           ALL_RD_WR (Idx 0)
-   *     SOC_STATUS:            ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_ADDR: ALL_RD_WR (Idx 0)
-   *     SOC_DOE_INTR_MSG_DATA: ALL_RD_WR (Idx 0)
-   *   Window to policy mapping:
-   *     WDATA: ALL_RD_WR (Idx 0)
-   *     RDATA: ALL_RD_WR (Idx 0)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_JTAG_SOC [4] = '{
-    0, 0, 0, 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX_JTAG_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_WDATA = 0;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_JTAG_SOC_WIN_RDATA = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX_JTAG_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX_JTAG_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
    * Policy selection vector for mbx_pcie0
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           SOC_ROT (Idx 2)
-   *     SOC_STATUS:            SOC_ROT (Idx 2)
-   *     SOC_DOE_INTR_MSG_ADDR: SOC_ROT (Idx 2)
-   *     SOC_DOE_INTR_MSG_DATA: SOC_ROT (Idx 2)
-   *   Window to policy mapping:
-   *     WDATA: SOC_ROT (Idx 2)
-   *     RDATA: SOC_ROT (Idx 2)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE0_SOC [4] = '{
-    2, 2, 2, 2
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX_PCIE0_SOC [4] = '{
+    RACL_POLICY_SEL_SOC_ROT,     // 0 SOC_CONTROL           : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 1 SOC_STATUS            : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT      // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 2
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_WDATA = 2;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE0_SOC_WIN_RDATA = 2;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX_PCIE0_SOC_WDATA =
+    RACL_POLICY_SEL_SOC_ROT;     // Policy Idx 2
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX_PCIE0_SOC_RDATA =
+    RACL_POLICY_SEL_SOC_ROT;     // Policy Idx 2
 
   /**
    * Policy selection vector for mbx_pcie1
    *   TLUL interface name: soc
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     SOC_CONTROL:           SOC_ROT (Idx 2)
-   *     SOC_STATUS:            SOC_ROT (Idx 2)
-   *     SOC_DOE_INTR_MSG_ADDR: SOC_ROT (Idx 2)
-   *     SOC_DOE_INTR_MSG_DATA: SOC_ROT (Idx 2)
-   *   Window to policy mapping:
-   *     WDATA: SOC_ROT (Idx 2)
-   *     RDATA: SOC_ROT (Idx 2)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE1_SOC [4] = '{
-    2, 2, 2, 2
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX_PCIE1_SOC [4] = '{
+    RACL_POLICY_SEL_SOC_ROT,     // 0 SOC_CONTROL           : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 1 SOC_STATUS            : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT      // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 2
   };
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_WDATA = 2;
-  parameter racl_policy_sel_t RACL_POLICY_SEL_MBX_PCIE1_SOC_WIN_RDATA = 2;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX_PCIE1_SOC_WDATA =
+    RACL_POLICY_SEL_SOC_ROT;     // Policy Idx 2
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX_PCIE1_SOC_RDATA =
+    RACL_POLICY_SEL_SOC_ROT;     // Policy Idx 2
 
   /**
    * Policy selection vector for ac_range_check
    *   TLUL interface name: None
    *   RACL group: Null
-   *   Register to policy mapping:
-   *     INTR_STATE:                    SOC_ROT (Idx 2)
-   *     INTR_ENABLE:                   SOC_ROT (Idx 2)
-   *     INTR_TEST:                     SOC_ROT (Idx 2)
-   *     ALERT_TEST:                    SOC_ROT (Idx 2)
-   *     ALERT_STATUS:                  SOC_ROT (Idx 2)
-   *     LOG_CONFIG:                    SOC_ROT (Idx 2)
-   *     LOG_STATUS:                    SOC_ROT (Idx 2)
-   *     LOG_ADDRESS:                   SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_0:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_1:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_2:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_3:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_4:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_5:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_6:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_7:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_8:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_9:                SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_10:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_11:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_12:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_13:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_14:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_15:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_16:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_17:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_18:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_19:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_20:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_21:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_22:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_23:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_24:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_25:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_26:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_27:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_28:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_29:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_30:               SOC_ROT (Idx 2)
-   *     RANGE_REGWEN_31:               SOC_ROT (Idx 2)
-   *     RANGE_BASE_0:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_1:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_2:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_3:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_4:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_5:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_6:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_7:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_8:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_9:                  SOC_ROT (Idx 2)
-   *     RANGE_BASE_10:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_11:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_12:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_13:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_14:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_15:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_16:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_17:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_18:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_19:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_20:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_21:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_22:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_23:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_24:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_25:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_26:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_27:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_28:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_29:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_30:                 SOC_ROT (Idx 2)
-   *     RANGE_BASE_31:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_0:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_1:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_2:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_3:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_4:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_5:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_6:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_7:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_8:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_9:                 SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_10:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_11:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_12:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_13:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_14:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_15:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_16:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_17:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_18:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_19:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_20:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_21:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_22:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_23:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_24:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_25:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_26:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_27:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_28:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_29:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_30:                SOC_ROT (Idx 2)
-   *     RANGE_LIMIT_31:                SOC_ROT (Idx 2)
-   *     RANGE_PERM_0:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_1:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_2:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_3:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_4:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_5:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_6:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_7:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_8:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_9:                  SOC_ROT (Idx 2)
-   *     RANGE_PERM_10:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_11:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_12:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_13:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_14:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_15:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_16:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_17:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_18:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_19:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_20:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_21:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_22:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_23:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_24:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_25:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_26:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_27:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_28:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_29:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_30:                 SOC_ROT (Idx 2)
-   *     RANGE_PERM_31:                 SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_0:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_1:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_2:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_3:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_4:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_5:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_6:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_7:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_8:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_9:  SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_10: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_11: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_12: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_13: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_14: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_15: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_16: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_17: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_18: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_19: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_20: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_21: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_22: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_23: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_24: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_25: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_26: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_27: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_28: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_29: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_30: SOC_ROT (Idx 2)
-   *     RANGE_RACL_POLICY_SHADOWED_31: SOC_ROT (Idx 2)
    */
-  parameter racl_policy_sel_t RACL_POLICY_SEL_AC_RANGE_CHECK [168] = '{
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_AC_RANGE_CHECK [168] = '{
+    RACL_POLICY_SEL_SOC_ROT,     //   0 INTR_STATE                    : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   1 INTR_ENABLE                   : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   2 INTR_TEST                     : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   3 ALERT_TEST                    : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   4 ALERT_STATUS                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   5 LOG_CONFIG                    : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   6 LOG_STATUS                    : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   7 LOG_ADDRESS                   : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   8 RANGE_REGWEN_0                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //   9 RANGE_REGWEN_1                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  10 RANGE_REGWEN_2                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  11 RANGE_REGWEN_3                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  12 RANGE_REGWEN_4                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  13 RANGE_REGWEN_5                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  14 RANGE_REGWEN_6                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  15 RANGE_REGWEN_7                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  16 RANGE_REGWEN_8                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  17 RANGE_REGWEN_9                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  18 RANGE_REGWEN_10               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  19 RANGE_REGWEN_11               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  20 RANGE_REGWEN_12               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  21 RANGE_REGWEN_13               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  22 RANGE_REGWEN_14               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  23 RANGE_REGWEN_15               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  24 RANGE_REGWEN_16               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  25 RANGE_REGWEN_17               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  26 RANGE_REGWEN_18               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  27 RANGE_REGWEN_19               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  28 RANGE_REGWEN_20               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  29 RANGE_REGWEN_21               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  30 RANGE_REGWEN_22               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  31 RANGE_REGWEN_23               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  32 RANGE_REGWEN_24               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  33 RANGE_REGWEN_25               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  34 RANGE_REGWEN_26               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  35 RANGE_REGWEN_27               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  36 RANGE_REGWEN_28               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  37 RANGE_REGWEN_29               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  38 RANGE_REGWEN_30               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  39 RANGE_REGWEN_31               : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  40 RANGE_BASE_0                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  41 RANGE_BASE_1                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  42 RANGE_BASE_2                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  43 RANGE_BASE_3                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  44 RANGE_BASE_4                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  45 RANGE_BASE_5                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  46 RANGE_BASE_6                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  47 RANGE_BASE_7                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  48 RANGE_BASE_8                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  49 RANGE_BASE_9                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  50 RANGE_BASE_10                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  51 RANGE_BASE_11                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  52 RANGE_BASE_12                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  53 RANGE_BASE_13                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  54 RANGE_BASE_14                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  55 RANGE_BASE_15                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  56 RANGE_BASE_16                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  57 RANGE_BASE_17                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  58 RANGE_BASE_18                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  59 RANGE_BASE_19                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  60 RANGE_BASE_20                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  61 RANGE_BASE_21                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  62 RANGE_BASE_22                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  63 RANGE_BASE_23                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  64 RANGE_BASE_24                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  65 RANGE_BASE_25                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  66 RANGE_BASE_26                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  67 RANGE_BASE_27                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  68 RANGE_BASE_28                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  69 RANGE_BASE_29                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  70 RANGE_BASE_30                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  71 RANGE_BASE_31                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  72 RANGE_LIMIT_0                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  73 RANGE_LIMIT_1                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  74 RANGE_LIMIT_2                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  75 RANGE_LIMIT_3                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  76 RANGE_LIMIT_4                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  77 RANGE_LIMIT_5                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  78 RANGE_LIMIT_6                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  79 RANGE_LIMIT_7                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  80 RANGE_LIMIT_8                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  81 RANGE_LIMIT_9                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  82 RANGE_LIMIT_10                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  83 RANGE_LIMIT_11                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  84 RANGE_LIMIT_12                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  85 RANGE_LIMIT_13                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  86 RANGE_LIMIT_14                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  87 RANGE_LIMIT_15                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  88 RANGE_LIMIT_16                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  89 RANGE_LIMIT_17                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  90 RANGE_LIMIT_18                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  91 RANGE_LIMIT_19                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  92 RANGE_LIMIT_20                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  93 RANGE_LIMIT_21                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  94 RANGE_LIMIT_22                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  95 RANGE_LIMIT_23                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  96 RANGE_LIMIT_24                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  97 RANGE_LIMIT_25                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  98 RANGE_LIMIT_26                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     //  99 RANGE_LIMIT_27                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 100 RANGE_LIMIT_28                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 101 RANGE_LIMIT_29                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 102 RANGE_LIMIT_30                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 103 RANGE_LIMIT_31                : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 104 RANGE_PERM_0                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 105 RANGE_PERM_1                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 106 RANGE_PERM_2                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 107 RANGE_PERM_3                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 108 RANGE_PERM_4                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 109 RANGE_PERM_5                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 110 RANGE_PERM_6                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 111 RANGE_PERM_7                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 112 RANGE_PERM_8                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 113 RANGE_PERM_9                  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 114 RANGE_PERM_10                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 115 RANGE_PERM_11                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 116 RANGE_PERM_12                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 117 RANGE_PERM_13                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 118 RANGE_PERM_14                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 119 RANGE_PERM_15                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 120 RANGE_PERM_16                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 121 RANGE_PERM_17                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 122 RANGE_PERM_18                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 123 RANGE_PERM_19                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 124 RANGE_PERM_20                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 125 RANGE_PERM_21                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 126 RANGE_PERM_22                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 127 RANGE_PERM_23                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 128 RANGE_PERM_24                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 129 RANGE_PERM_25                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 130 RANGE_PERM_26                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 131 RANGE_PERM_27                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 132 RANGE_PERM_28                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 133 RANGE_PERM_29                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 134 RANGE_PERM_30                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 135 RANGE_PERM_31                 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 136 RANGE_RACL_POLICY_SHADOWED_0  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 137 RANGE_RACL_POLICY_SHADOWED_1  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 138 RANGE_RACL_POLICY_SHADOWED_2  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 139 RANGE_RACL_POLICY_SHADOWED_3  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 140 RANGE_RACL_POLICY_SHADOWED_4  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 141 RANGE_RACL_POLICY_SHADOWED_5  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 142 RANGE_RACL_POLICY_SHADOWED_6  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 143 RANGE_RACL_POLICY_SHADOWED_7  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 144 RANGE_RACL_POLICY_SHADOWED_8  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 145 RANGE_RACL_POLICY_SHADOWED_9  : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 146 RANGE_RACL_POLICY_SHADOWED_10 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 147 RANGE_RACL_POLICY_SHADOWED_11 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 148 RANGE_RACL_POLICY_SHADOWED_12 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 149 RANGE_RACL_POLICY_SHADOWED_13 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 150 RANGE_RACL_POLICY_SHADOWED_14 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 151 RANGE_RACL_POLICY_SHADOWED_15 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 152 RANGE_RACL_POLICY_SHADOWED_16 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 153 RANGE_RACL_POLICY_SHADOWED_17 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 154 RANGE_RACL_POLICY_SHADOWED_18 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 155 RANGE_RACL_POLICY_SHADOWED_19 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 156 RANGE_RACL_POLICY_SHADOWED_20 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 157 RANGE_RACL_POLICY_SHADOWED_21 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 158 RANGE_RACL_POLICY_SHADOWED_22 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 159 RANGE_RACL_POLICY_SHADOWED_23 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 160 RANGE_RACL_POLICY_SHADOWED_24 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 161 RANGE_RACL_POLICY_SHADOWED_25 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 162 RANGE_RACL_POLICY_SHADOWED_26 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 163 RANGE_RACL_POLICY_SHADOWED_27 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 164 RANGE_RACL_POLICY_SHADOWED_28 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 165 RANGE_RACL_POLICY_SHADOWED_29 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT,     // 166 RANGE_RACL_POLICY_SHADOWED_30 : Policy Idx 2
+    RACL_POLICY_SEL_SOC_ROT      // 167 RANGE_RACL_POLICY_SHADOWED_31 : Policy Idx 2
   };
 
 endpackage

--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -108,5 +108,12 @@ package top_racl_pkg;
   parameter racl_role_t RACL_ROLE_ROLE1 = 4'h1;
   parameter racl_role_t RACL_ROLE_SOC   = 4'h2;
 
+  /**
+   * RACL Policy Selectors for group Null
+   */
+  parameter racl_policy_sel_t RACL_POLICY_SEL_ALL_RD_WR = 0;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_ROT_PRIVATE = 1;
+  parameter racl_policy_sel_t RACL_POLICY_SEL_SOC_ROT = 2;
+
 
 endpackage

--- a/util/raclgen/lib.py
+++ b/util/raclgen/lib.py
@@ -76,17 +76,6 @@ def _read_hjson(filename: str) -> Dict[str, object]:
         raise SystemExit(sys.exc_info()[1])
 
 
-def format_parameter_name_prefix(
-        module_name: str, racl_group: str = None, if_name: str = None) -> str:
-    group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
-    if_suffix = f"_{if_name.upper()}" if if_name else ""
-    return f"RACL_POLICY_SEL_{module_name.upper()}{group_suffix}{if_suffix}"
-
-
-def format_parameter_range_value(range: Dict) -> str:
-    return f"'{{base:'h{range['base']:x},mask:'h{range['mask']:x},policy:{range['policy']}}}"
-
-
 def parse_racl_config(config_path: str) -> Dict[str, object]:
     racl_config = _read_hjson(config_path)
 

--- a/util/topgen/templates/top_racl_pkg.sv.tpl
+++ b/util/topgen/templates/top_racl_pkg.sv.tpl
@@ -107,5 +107,18 @@ package top_racl_pkg;
   % endfor
 
 % endif
+% if racl_config.get('policies'):
+  % for racl_group, policies in racl_config.get('policies').items():
+  /**
+   * RACL Policy Selectors for group ${racl_group}
+   */
+<% group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else "" %>\
+    % for policy_idx,policy in enumerate(list(policies)):
+<% name = "RACL_POLICY_SEL{}_{}".format(group_suffix,policy['name'].upper()) %>\
+  parameter racl_policy_sel_t ${name} = ${policy_idx};
+    % endfor
+  % endfor
+
+% endif
 
 endpackage

--- a/util/topgen/templates/toplevel_racl.tpl
+++ b/util/topgen/templates/toplevel_racl.tpl
@@ -14,17 +14,17 @@
       group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
       if_suffix = f"_{if_name.upper()}" if if_name else ""
       if_suffix2 = f"{if_name.title()}" if if_name else ""
-      policy_sel_name = f"RACL_POLICY_SEL_{m['name'].upper()}{group_suffix}{if_suffix}"
+      policy_sel_name = f"{m['name'].upper()}{group_suffix}{if_suffix}"
 %>\
     % if len(register_mapping) > 0:
-    .RaclPolicySelVec${if_suffix2}(${policy_sel_name}),
+    .RaclPolicySelVec${if_suffix2}(RACL_POLICY_SEL_VEC_${policy_sel_name}),
     % endif
     % for window_name, policy_idx in window_mapping.items():
-    .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(${policy_sel_name}_WIN_${window_name.upper()}),
+    .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(RACL_POLICY_SEL_WIN_${policy_sel_name}_${window_name.upper()}),
     % endfor
     % if len(range_mapping) > 0:
-    .RaclPolicySelRanges${if_suffix2}Num(${policy_sel_name}_NUM_RANGES),
-    .RaclPolicySelRanges${if_suffix2}(${policy_sel_name}_RANGES),
+    .RaclPolicySelNumRanges${if_suffix2}(RACL_POLICY_SEL_NUM_RANGES_${policy_sel_name}),
+    .RaclPolicySelRanges${if_suffix2}(RACL_POLICY_SEL_RANGES_${policy_sel_name}),
     % endif
   % endfor
 % endif

--- a/util/topgen/templates/toplevel_racl_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg.sv.tpl
@@ -11,7 +11,7 @@ package top_${topcfg["name"]}_racl_pkg;
 <% import math %>\
 % if 'racl' in topcfg:
   /**
-   * RACL groups:
+   * RACL groups and policies:
 % for racl_group in racl_config['policies']:
    *   ${racl_group}
 <%
@@ -20,7 +20,7 @@ package top_${topcfg["name"]}_racl_pkg;
     policy_idx_len = math.ceil(math.log10(max(1,len(policy_names)+1)))
 %>\
   % for policy_idx, policy_name in enumerate(policy_names):
-   *     ${f"{policy_name}".ljust(policy_name_len)} (Idx ${f"{policy_idx}".rjust(policy_idx_len)})
+   *     ${f"{policy_idx}".rjust(policy_idx_len)}: ${policy_name}
   % endfor
 % endfor
    */


### PR DESCRIPTION
This commit:
* Renders the policy selectors (indices) for all policies.
* Uses the rendered policy selectors in the policy selection vectors.
* Moves the relevant information to an inline comment.
* Renames policy selection vectors from `POLICY_SEL_` to `POLICY_SEL_VEC_` to avoid naming conflicts between the policy selectors and the policy selection vectors.

The goal of this PR is to remove magic values in the selection vectors and make debugging easier by providing all the relevant information as an inline comment within the policy selection vectors.
Furthermore, this allows using the rendered policy selectors to index into the policy vector, which may be used by external IPs.