### PR TITLE
[rom_ext] remove duplicate ROM_EXT target

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/imm_rom_ext/defs.bzl
@@ -10,10 +10,6 @@ DEFAULT_EXEC_ENV = [
     "//hw/top_earlgrey:silicon_creator",
 ]
 
-IMM_ROM_EXT_VARIATIONS = [
-    "main",
-]
-
 # CAUTION: The message below should match the message defined in:
 #   //sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
 IMMUTABLE_HASH_UNENFORCED_MSG = "hash unenforced"

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -13,10 +13,6 @@ load(
     "ROM_EXT_VERSION",
     "SLOTS",
 )
-load(
-    "//sw/device/silicon_creator/imm_rom_ext:defs.bzl",
-    "IMM_ROM_EXT_VARIATIONS",
-)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -285,36 +281,6 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib/ownership/keys/fake",
     ],
 )
-
-[
-    opentitan_binary(
-        name = "rom_ext_with_{}_imm_slot_virtual".format(imm_name),
-        testonly = True,
-        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-        exec_env = [
-            "//hw/top_earlgrey:fpga_cw310",
-            "//hw/top_earlgrey:fpga_cw340",
-            "//hw/top_earlgrey:sim_dv_base",
-            "//hw/top_earlgrey:sim_verilator_base",
-            "//hw/top_earlgrey:silicon_creator",
-        ],
-        extra_bazel_features = [
-            "minsize",
-            "use_lld",
-        ],
-        linker_script = ":ld_slot_virtual",
-        manifest = ":manifest",
-        deps = [
-            ":rom_ext_dice_x509",
-            "//sw/device/lib/crt",
-            "//sw/device/silicon_creator/lib:manifest_def",
-            "//sw/device/silicon_creator/lib/ownership:test_owner",
-            "//sw/device/silicon_creator/lib/ownership/keys/fake",
-            "//sw/device/silicon_creator/imm_rom_ext:{}_section_dice_x509_slot_virtual".format(imm_name),
-        ],
-    )
-    for imm_name in IMM_ROM_EXT_VARIATIONS
-]
 
 manifest(d = {
     "name": "manifest_bad_address_translation",

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -5,13 +5,6 @@
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
 load(
-    "//rules/opentitan:defs.bzl",
-    "DEFAULT_TEST_FAILURE_MSG",
-    "DEFAULT_TEST_SUCCESS_MSG",
-    "fpga_params",
-    "opentitan_test",
-)
-load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_hex",
@@ -20,9 +13,15 @@ load(
     "otp_partition",
 )
 load(
+    "//rules/opentitan:defs.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
+    "DEFAULT_TEST_SUCCESS_MSG",
+    "fpga_params",
+    "opentitan_test",
+)
+load(
     "//sw/device/silicon_creator/imm_rom_ext:defs.bzl",
     "IMMUTABLE_HASH_UNENFORCED_MSG",
-    "IMM_ROM_EXT_VARIATIONS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -32,37 +31,31 @@ filegroup(
     srcs = ["boot_test.c"],
 )
 
-[
-    otp_json_immutable_rom_ext(
-        name = "otp_json_with_{}_imm_romext_enabled".format(name),
-        testonly = True,
-        partitions = [
-            otp_partition(
-                name = "CREATOR_SW_CFG",
-                items = {
-                    "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
-                },
-            ),
-        ],
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_with_{}_imm_slot_virtual".format(name),
-        visibility = ["//visibility:private"],
-    )
-    for name in IMM_ROM_EXT_VARIATIONS
-]
+otp_json_immutable_rom_ext(
+    name = "otp_json_with_imm_romext_enabled",
+    testonly = True,
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
+            },
+        ),
+    ],
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+    visibility = ["//visibility:private"],
+)
 
-[
-    otp_image(
-        name = "otp_img_with_{}_imm_romext_enabled".format(name),
-        testonly = True,
-        src = "//hw/ip/otp_ctrl/data:otp_json_prod",
-        overlays = STD_OTP_OVERLAYS + [
-            "//sw/device/silicon_creator/rom_ext/e2e:otp_json_secret2_locked",
-            ":otp_json_with_{}_imm_romext_enabled".format(name),
-        ],
-        visibility = ["//visibility:private"],
-    )
-    for name in IMM_ROM_EXT_VARIATIONS
-]
+otp_image(
+    name = "otp_img_with_imm_romext_enabled",
+    testonly = True,
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
+    overlays = STD_OTP_OVERLAYS + [
+        "//sw/device/silicon_creator/rom_ext/e2e:otp_json_secret2_locked",
+        ":otp_json_with_imm_romext_enabled",
+    ],
+    visibility = ["//visibility:private"],
+)
 
 _POSITIONS = {
     "owner_slot_a": {
@@ -129,17 +122,15 @@ _POSITIONS = {
         "success": "rom_ext_slot = __BB\r\n",
         "otp_img": None,
     },
-} | {
-    "romext_virtual_a_with_{}_imm_romext_enabled".format(name): {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_with_{}_imm_slot_virtual".format(name),
+    "romext_virtual_a_with_imm_romext_enabled": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",
         "success": "rom_ext_slot = AA__\r\n",
         "failure": IMMUTABLE_HASH_UNENFORCED_MSG,
-        "otp_img": ":otp_img_with_{}_imm_romext_enabled".format(name),
-    }
-    for name in IMM_ROM_EXT_VARIATIONS
+        "otp_img": ":otp_img_with_imm_romext_enabled",
+    },
 }
 
 [


### PR DESCRIPTION
The immutable ROM_EXT section is compiled into every ROM_EXT. The immutability is only enforced by the ROM if an OTP flag is set. This removes a duplicate ROM_EXT build target that is no longer needed.