### PR TITLE
[ownership] remove call to ownership_seal_init in ownership_init

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -199,7 +199,6 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   // turn on read/write/earse permissions until we need them.
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageOwnerSecret, cfg);
 
-  ownership_seal_init();
   // We don't want to abort ownership setup if we fail to
   // read the INFO pages, so we discard the error result.
   if (flash_ctrl_info_read(&kFlashCtrlInfoPageOwnerSlot0, 0,


### PR DESCRIPTION
After cherry-picking the immutable ROM_EXT changes to the earlgrey_1.0.0 branch, the call to ownership_seal is now performed in the immutable ROM_EXT.