### PR TITLE
[sw,ot_certs] Add X509 setter helper for automatic size assertions

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -129,6 +129,7 @@ cc_library(
     hdrs = ["dice.h"],
     deps = [
         ":cert",
+        ":template",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:check",
@@ -203,6 +204,7 @@ cc_library(
     hdrs = ["tpm.h"],
     deps = [
         ":cert",
+        ":template",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",


### PR DESCRIPTION
Previously, variable size assertions were manually implemented, which is prone to errors. This commit introduces a setter helper designed to automatically generate these size assertions, improving readability and reducing potential inconsistencies.