### PR TITLE
[dice,cwt] Update the Issuer/Subject name size

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -38,12 +38,15 @@ enum payload_entry_sizes {
   kProfileNameLength = 10,
   // The Key ID length, which equals to the SHA256 digest size in bytes
   kIssuerSubjectKeyIdLength = kHmacDigestNumBytes,
-  // The size of issuer & subject name, which equals to the ascii size
-  // transformed form Key ID.
-  kIssuerSubjectNameLength = kIssuerSubjectKeyIdLength * 2,
+  // The identifiers are 20 octets (reserve double size for HEX translation) so
+  // they fit in the RFC 5280 serialNumber field constraints and the
+  // X520SerialNumber type when hex encoded.
+  kIssuerSubjectNameLength = 40,
   // 64 byte should be enough for 2 entries
   kConfigDescBuffSize = 64,
 };
+static_assert(kIssuerSubjectNameLength < (1u << kIssuerSubjectKeyIdLength),
+              "Insufficient SubjectNameLength");
 
 // Reusable buffer for generating Configuration Descriptor
 static uint8_t config_desc_buf[kConfigDescBuffSize] = {0};
@@ -77,7 +80,7 @@ static void fill_dice_id_string(
     const uint8_t dice_id[kIssuerSubjectKeyIdLength],
     char dice_id_str[kIssuerSubjectNameLength + 1]) {
   size_t idx;
-  for (idx = 0; idx < kIssuerSubjectKeyIdLength; idx++, dice_id_str += 2)
+  for (idx = 0; idx * 2 < kIssuerSubjectNameLength; idx++, dice_id_str += 2)
     util_hexdump_byte(dice_id[idx], (uint8_t *)&dice_id_str[0]);
 }
 

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -82,7 +82,7 @@ static void fill_dice_id_string(
 }
 
 static rom_error_t configuration_descriptor_build(
-    uint8_t *buf, size_t *buf_size, const size_t sec_version,
+    size_t *buf_size, const size_t sec_version,
     const hmac_digest_t *manifest_measurement) {
   cbor_out_t cbor_out;
   cbor_out_init(&cbor_out, config_desc_buf);
@@ -130,6 +130,11 @@ rom_error_t dice_uds_tbs_cert_build(
   // structure.
   // Those otp_*measurement parameters exist just for API alignment between
   // different implementations.
+  OT_DISCARD(otp_creator_sw_cfg_measurement);
+  OT_DISCARD(otp_owner_sw_cfg_measurement);
+  OT_DISCARD(otp_rot_creator_auth_codesign_measurement);
+  OT_DISCARD(otp_rot_creator_auth_state_measurement);
+  OT_DISCARD(key_ids);
   HARDENED_RETURN_IF_ERROR(
       cwt_cose_key_build(&cwt_cose_key_params, tbs_cert, tbs_cert_size));
 
@@ -164,7 +169,7 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
   // No extension measurement is needed in CDI_0, just pass a NULL to the
   // config_descriptors to bypass encoding.
   HARDENED_RETURN_IF_ERROR(configuration_descriptor_build(
-      config_desc_buf, &config_desc_buf_size, rom_ext_security_version, NULL));
+      &config_desc_buf_size, rom_ext_security_version, NULL));
   hmac_digest_t conf_hash;
   hmac_sha256(config_desc_buf, config_desc_buf_size, &conf_hash);
   util_reverse_bytes(conf_hash.digest, kHmacDigestNumBytes);
@@ -260,7 +265,7 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
 
   size_t config_desc_buf_size = sizeof(config_desc_buf);
   HARDENED_RETURN_IF_ERROR(configuration_descriptor_build(
-      config_desc_buf, &config_desc_buf_size, owner_security_version,
+      &config_desc_buf_size, owner_security_version,
       owner_manifest_measurement));
   hmac_digest_t conf_hash;
   hmac_sha256(config_desc_buf, config_desc_buf_size, &conf_hash);


### PR DESCRIPTION
There are a few cases where the DICE needs to generate an identifier for use in certificates. To ensure these identifiers are deterministic and require no additional DICE inputs, the identifiers are derived from the associated public key. The identifiers are 20 octets so they fit in the RFC 5280 serialNumber field constraints and the X520SerialNumber type when hex encoded.

Ref: https://pigweed.googlesource.com/open-dice/+/HEAD/docs/specification.md#deriving-identifiers
