### PR TITLE
[sw,dice] Lockdown the attestation seed page to readonly

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -37,6 +37,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:static_critical",
         "//sw/device/silicon_creator/lib/base:static_dice",
         "//sw/device/silicon_creator/lib/cert:dice_chain",
+        "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/ownership:ownership_key",
         "//sw/device/silicon_creator/rom_ext:rom_ext_manifest",

--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -37,6 +37,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:static_critical",
         "//sw/device/silicon_creator/lib/base:static_dice",
         "//sw/device/silicon_creator/lib/cert:dice_chain",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/ownership:ownership_key",

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
@@ -12,6 +12,7 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/epmp_state.h"
@@ -44,6 +45,12 @@ static rom_error_t imm_rom_ext_start(void) {
     //   //sw/device/silicon_creator/imm_rom_ext/defs.bzl
     dbg_puts("info: hash unenforced\r\n");
   }
+
+  // Lockdown the attestation seed to readonly as soon as possible to prevent
+  // key tampering and exfiltration.
+  flash_ctrl_cert_info_page_owner_restrict(
+      &kFlashCtrlInfoPageAttestationKeySeeds);
+  flash_ctrl_info_cfg_lock(&kFlashCtrlInfoPageAttestationKeySeeds);
 
   // Establish our identity.
   const manifest_t *rom_ext = rom_ext_manifest();

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -483,6 +483,7 @@ cc_library(
     deps = [
         ":attestation",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:sec_mmio",

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -485,7 +485,6 @@ rom_error_t dice_chain_init(void) {
   dice_chain_reset_cert_obj();
 
   // Configure DICE certificate flash info page and buffer it into RAM.
-  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageAttestationKeySeeds);
   flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageDiceCerts);
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageFactoryCerts,
                           kCertificateInfoPageCfg);

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -715,6 +715,10 @@ void flash_ctrl_info_cfg_set(const flash_ctrl_info_page_t *info_page,
   sec_mmio_write32(flash_ctrl_core_base() + info_page->cfg_offset, reg);
 }
 
+void flash_ctrl_info_cfg_lock(const flash_ctrl_info_page_t *info_page) {
+  sec_mmio_write32(flash_ctrl_core_base() + info_page->cfg_wen_offset, 0);
+}
+
 void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
   uint32_t reg = 0;
   switch (launder32(enable)) {

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -172,6 +172,7 @@ enum {
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,
   kFlashCtrlSecMmioInfoCfgSet = 1,
+  kFlashCtrlSecMmioInfoCfgLock = 1,
   kFlashCtrlSecMmioInfoPermsSet = 1,
   kFlashCtrlSecMmioBankErasePermsSet = 1,
   kFlashCtrlSecMmioInit = 3,
@@ -567,6 +568,18 @@ void flash_ctrl_data_region_protect(flash_ctrl_region_index_t region,
  */
 void flash_ctrl_info_cfg_set(const flash_ctrl_info_page_t *info_page,
                              flash_ctrl_cfg_t cfg);
+
+/**
+ * Write-locks configuration settings for an info page.
+ *
+ * The caller is responsible for calling
+ * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgLock)` when sec_mmio is
+ * being used to check expectations.
+ *
+ * @param info_page An information page.
+ * @param cfg New configuration settings.
+ */
+void flash_ctrl_info_cfg_lock(const flash_ctrl_info_page_t *info_page);
 
 /**
  * Set bank erase permissions for both flash banks.

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
@@ -94,13 +95,11 @@ static rom_error_t load_attestation_keygen_seed(uint32_t additional_seed_idx,
     flash_ctrl_error_code_get(&flash_ctrl_err_code);
     if (flash_ctrl_err_code.rd_err) {
       // If we encountered a read error, this means the attestation seed page
-      // has not been provisioned yet. In this case, we erase the page and
+      // has not been provisioned yet. In this case, we clear the seed and
       // continue, which will simply result in generating an invalid identity.
       dbg_puts(
-          "Warning: Attestation key seed flash info page not provisioned. "
-          "Erasing page to format.\r\n");
-      HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
-          &kFlashCtrlInfoPageAttestationKeySeeds, kFlashCtrlEraseTypePage));
+          "Warning: Attestation key seed flash info page not provisioned.\r\n");
+      memset(seed, 0, kAttestationSeedBytes);
       return kErrorOk;
     }
     return err;

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -291,8 +291,6 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data,
 
   // Remove write and erase access to the certificate pages before handing over
   // execution to the owner firmware (owner firmware can still read).
-  flash_ctrl_cert_info_page_owner_restrict(
-      &kFlashCtrlInfoPageAttestationKeySeeds);
   flash_ctrl_cert_info_page_owner_restrict(&kFlashCtrlInfoPageDiceCerts);
 
   // Disable access to silicon creator info pages, the OTP creator partition


### PR DESCRIPTION
The attestation seed page contains CSPRNG generated seeds, which will be mixed to the derived seed for generating the keypair. It is crucial that the page should not be tampered by less secure boot stages, which could lead to key leakage.

To prevent seed tampering, we lockdown the page to readonly at the IMM_ROM_EXT stage which owns the first key ladder state (UDS).