### PR TITLE
[sw,e2e] Detect boot failure in provisioning e2e test

### DIFF
--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -602,6 +602,8 @@ pub fn check_slot_b_boot_up(
     //   //sw/device/silicon_creator/lib/cert/dice_chain.c.
     let rom_ext_failure_msg = r"UDS certificate not valid";
 
+    let error_code_msg = r"BFV:.*\r\n";
+
     let anchor_text = if let Some(owner_anchor) = &owner_fw_success_string {
         let full_owner_anchor = if response.seeds.number != 0 {
             let seed0 = response.seeds.seed[0].as_slice();
@@ -631,9 +633,12 @@ pub fn check_slot_b_boot_up(
             (*owner_anchor).clone()
         };
 
-        format!(r"(?s)({}|{})", rom_ext_failure_msg, full_owner_anchor)
+        format!(
+            r"(?s)({}|{}|{})",
+            rom_ext_failure_msg, error_code_msg, full_owner_anchor
+        )
     } else {
-        rom_ext_failure_msg.to_string()
+        format!(r"(?s)({}|{})", rom_ext_failure_msg, error_code_msg)
     };
 
     let result =
@@ -642,8 +647,10 @@ pub fn check_slot_b_boot_up(
     match result {
         Ok(captures) => {
             if captures[0] == *rom_ext_failure_msg {
-                // Error message found.
                 bail!("Invalid UDS certificate detected!");
+            }
+            if captures[0].starts_with("BFV:") {
+                bail!("Error detected!");
             }
         }
         Err(e) => {


### PR DESCRIPTION
This commit adds the BFV boot failure message to the test regex, which should catch the error reported in PR #26452.

* #26452

### To avoid breaking CI, this PR SHOULD be merged after #26452.