### PR TITLE
[crypto] Fix EDN CMD_STS field const

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -510,7 +510,7 @@ static status_t edn_ready_block(uint32_t edn_address) {
     reg = abs_mmio_read32(edn_address + EDN_SW_CMD_STS_REG_OFFSET);
   } while (!bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_RDY_BIT));
 
-  if (bitfield_field32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_FIELD)) {
+  if (bitfield_field32_read(reg, EDN_SW_CMD_STS_CMD_STS_FIELD)) {
     return OTCRYPTO_RECOV_ERR;
   }
   return OTCRYPTO_OK;


### PR DESCRIPTION
This register has the same layout in the EDN and CSRGN, but it does not seem like a good idea to rely on that.