### PR TITLE
[testutils] remove flash_ctrl_testutils_backdoor_init

### DIFF
--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -18,8 +18,6 @@
 
 #include "flash_ctrl_regs.h"  // Generated
 
-static const dt_flash_ctrl_t kFlashCtrlDt = kDtFlashCtrl;
-
 #define MODULE_ID MAKE_MODULE_ID('f', 'c', 't')
 
 status_t flash_ctrl_testutils_wait_for_init(
@@ -296,21 +294,6 @@ status_t flash_ctrl_testutils_bank_erase(dif_flash_ctrl_state_t *flash_state,
   TRY(dif_flash_ctrl_set_bank_erase_enablement(flash_state, bank,
                                                bank_erase_enabled));
   return OK_STATUS();
-}
-
-status_t flash_ctrl_testutils_backdoor_init(
-    dif_flash_ctrl_state_t *flash_state) {
-  TRY(dif_flash_ctrl_init_state(flash_state,
-                                mmio_region_from_addr(dt_flash_ctrl_reg_block(
-                                    kFlashCtrlDt, kDtFlashCtrlRegBlockCore))));
-
-  return flash_ctrl_testutils_default_region_access(flash_state,
-                                                    /*rd_en*/ true,
-                                                    /*prog_en*/ true,
-                                                    /*erase_en*/ true,
-                                                    /*scramble_en*/ false,
-                                                    /*ecc_en*/ false,
-                                                    /*he_en*/ false);
 }
 
 static void flash_ctrl_testutils_flush_read_buffers(void) {

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -238,17 +238,6 @@ enum {
 };
 
 /**
- * Init the backdoor API, it should be called before
- * `flash_ctrl_testutils_backdoor_wait_update`.
- *
- * @param flash_state A flash_ctrl handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-status_t flash_ctrl_testutils_backdoor_init(
-    dif_flash_ctrl_state_t *flash_state);
-
-/**
  * This detects changes in a specific byte in flash memory contents with a
  * timeout. In some cases the party updating it uses a backdoor overwrite,
  * so this code flushes the read buffers since the backdoor API has no

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
@@ -22,7 +22,6 @@ static dif_pinmux_t pinmux;
 static dif_sysrst_ctrl_t sysrst_ctrl;
 static dif_pwrmgr_t pwrmgr;
 static dif_rstmgr_t rstmgr;
-static dif_flash_ctrl_state_t flash;
 static dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
 
 const uint32_t kTestPhaseTimeoutUsec = 10000;
@@ -184,8 +183,6 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
-
-  CHECK_STATUS_OK(flash_ctrl_testutils_backdoor_init(&flash));
 
   pinmux_setup();
   rstmgr_reset_info = rstmgr_testutils_reason_get();

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -101,7 +101,6 @@ static scramble_test_frame *reference_frame;
 
 static dif_sram_ctrl_t ret_sram;
 static dif_rstmgr_t rstmgr;
-static dif_flash_ctrl_state_t flash;
 
 /**
  * Test pattern to be written and read from SRAM.
@@ -446,10 +445,6 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_sram_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR),
       &ret_sram));
-
-  if (kDeviceType == kDeviceSimDV) {
-    CHECK_STATUS_OK(flash_ctrl_testutils_backdoor_init(&flash));
-  }
 
   main_sram_addr = OT_ALIGN_MEM(rand_testutils_gen32_range(
       (uintptr_t)_freertos_heap_start,

--- a/sw/device/tests/sysrst_ctrl_outputs_test.c
+++ b/sw/device/tests/sysrst_ctrl_outputs_test.c
@@ -23,7 +23,6 @@ static dif_pinmux_t pinmux;
 static const dt_pinmux_t kPinmuxDt = kDtPinmuxAon;
 static const dt_sysrst_ctrl_t kSysrstCtrlDt = kDtSysrstCtrlAon;
 static dif_sysrst_ctrl_t sysrst_ctrl;
-static dif_flash_ctrl_state_t flash;
 
 enum {
   kTestPhaseTimeoutUsecDV = 100,
@@ -178,9 +177,6 @@ static void set_output_overrides(uint8_t override_value) {
 bool test_main(void) {
   CHECK_DIF_OK(dif_pinmux_init_from_dt(kPinmuxDt, &pinmux));
   CHECK_DIF_OK(dif_sysrst_ctrl_init_from_dt(kSysrstCtrlDt, &sysrst_ctrl));
-  if (kDeviceType == kDeviceSimDV) {
-    CHECK_STATUS_OK(flash_ctrl_testutils_backdoor_init(&flash));
-  }
 
   const volatile uint8_t *kTestPhase =
       kDeviceType == kDeviceSimDV ? &kTestPhaseDV : &kTestPhaseReal;

--- a/sw/device/tests/sysrst_ctrl_ulp_z3_wakeup_test.c
+++ b/sw/device/tests/sysrst_ctrl_ulp_z3_wakeup_test.c
@@ -35,7 +35,6 @@ static dif_pwrmgr_t pwrmgr;
 static dif_rstmgr_t rstmgr;
 static dif_pinmux_t pinmux;
 static dif_sysrst_ctrl_t sysrst_ctrl;
-static dif_flash_ctrl_state_t flash;
 static dif_gpio_t gpio;
 
 enum {
@@ -205,12 +204,9 @@ bool test_main(void) {
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
 
   // In DV, we use flash backdoor writes to store the phase.
-  if (kDeviceType == kDeviceSimDV) {
-    CHECK_STATUS_OK(flash_ctrl_testutils_backdoor_init(&flash));
-  }
   // On real devices, we cannot store it in RAM since the wakeup will erase
   // it so use three pins to read the test phase.
-  else {
+  if (kDeviceType != kDeviceSimDV) {
     CHECK_DIF_OK(dif_pinmux_input_select(
         &pinmux, kTopEarlgreyPinmuxPeripheralInGpioGpio0,
         kTopEarlgreyPinmuxInselIob0));


### PR DESCRIPTION
The backdoor wait mechanism was updated to not rely on flash_ctrl anymore, so the init is no longer needed.