### PR TITLE
[aon_timer,doc] Remove 32-bit wakeup timer reference in the docs

### DIFF
--- a/hw/ip/aon_timer/README.md
+++ b/hw/ip/aon_timer/README.md
@@ -14,7 +14,7 @@ See that document for an overview of how it is integrated into the top level sys
 
 ## Features
 
-- Two 32-bit upcounting timers: one timer functions as a wakeup timer, one as a watchdog timer
+- Two upcounting timers: one 64-bit timer that functions as a wakeup timer, and a 32-bit one that functions as a watchdog timer
 - The watchdog timer has two thresholds: bark (generates an interrupt) and bite (resets core)
 - There is 12 bit pre-scaler for the wakeup timer to enable very long timeouts
 


### PR DESCRIPTION
When the AON timer's wakeup counter was changed from 32 bits to 64 bits, the docs were mostly updated (in the theory of operation / registers / programmer's guide), but the index README page was missed - specifically the list of features. This is the first thing most people will read about the IP, so it should probably be accurate.