### PR TITLE
[ot_certs] use IndexMap instead of HashMap when generating CWT code

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -191,6 +191,7 @@ cc_library(
         ":cwt_template",
         ":dice_api",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+        "//sw/device/lib/base:macros",
         "//sw/device/lib/base:status",
         "//sw/device/silicon_creator/lib:attestation",
         "//sw/device/silicon_creator/lib:otbn_boot_services",

--- a/sw/host/ot_certs/src/cwt.rs
+++ b/sw/host/ot_certs/src/cwt.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::fs;
 use std::iter;
 use std::path::PathBuf;
@@ -107,7 +106,7 @@ struct CodegenVar {
     value: CodegenVarValue,
 }
 
-type CodegenVarTable = HashMap<String, CodegenVar>;
+type CodegenVarTable = IndexMap<String, CodegenVar>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 enum CodegenVarValue {
@@ -233,7 +232,7 @@ impl CodegenStructure<'_> {
         vars: &'a CodegenVarTable,
     ) -> Result<Vec<CodegenStructure<'a>>> {
         let mut nodes = Vec::<CodegenStructure>::new();
-        let mut id_mapping = HashMap::<String, usize>::new();
+        let mut id_mapping = IndexMap::<String, usize>::new();
         Self::build_codegen_structure(&template.structure, vars, &mut nodes, &mut id_mapping)
             .context("build_codegen_structure failed")?;
         Ok(nodes)
@@ -246,7 +245,7 @@ impl CodegenStructure<'_> {
         cur: &TemplateStructure,
         vars: &'a CodegenVarTable,
         nodes: &mut Vec<CodegenStructure<'a>>,
-        var_ids: &mut HashMap<String, usize>,
+        var_ids: &mut IndexMap<String, usize>,
     ) -> Result<usize> {
         let node = match cur {
             TemplateStructure::Item(name) => {
@@ -541,7 +540,7 @@ fn derive_size_expressions<'a>(
 }
 
 fn collect_codegenvar(template: &CwtTemplate) -> Result<CodegenVarTable> {
-    let mut vars = HashMap::<String, CodegenVar>::new();
+    let mut vars = IndexMap::<String, CodegenVar>::new();
 
     for (name, var) in &template.variables {
         let ret = vars.insert(name.clone(), CodegenVar::from_template_variable(name, var)?);


### PR DESCRIPTION
CWT templating libs are generating by the ot_certs lib component of opentitantool. Using ordered containers like HashMap causes the code generated to be non-reproducible across builds which impacts:

1. build reproducibility across offline signed binaries
2. inability to use the immutable ROM_EXT with CWT DICE cert format.

This fixes the CWT codegen ot_certs library to produce reproducible code.