### PR TITLE
[rules,opentitan] Generate non-scrambled ROM images for sim_dv

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -258,6 +258,9 @@ def _opentitan_binary(ctx):
 
         # FIXME(cfrantz): Special case: The englishbreakfast verilator model
         # requires a non-scrambled ROM image.
+        #
+        # DV simulation might also need non-scrambled ROM to reduce simulation
+        # run times.
         if provides.get("rom32"):
             default_info.append(provides["rom32"])
 

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -54,11 +54,21 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             rom_scramble_config = exec_env.rom_scramble_config,
             rom_scramble_tool = ctx.executable.rom_scramble_tool,
         )
+
+        # We may want to run non-scrambled ROM in DV environment, for faster
+        # run times.
+        rom32 = convert_to_vmem(
+            ctx,
+            name = name,
+            src = binary,
+            word_size = 32,
+        )
         default = rom
         vmem = rom
     elif ctx.attr.kind == "ram":
         default = elf
         rom = None
+        rom32 = None
 
         # Generate Un-scrambled RAM VMEM (for testing SRAM injection in DV)
         vmem = convert_to_vmem(
@@ -91,6 +101,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             _tool = exec_env.flash_scramble_tool.files_to_run,
         )
         rom = None
+        rom32 = None
         default = vmem
         vmem = vmem_base
     else:
@@ -107,6 +118,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "binary": binary,
         "default": default,
         "rom": rom,
+        "rom32": rom32,
         "signed_bin": signed_bin,
         "disassembly": disassembly,
         "logs": logs,


### PR DESCRIPTION
Some DV simulation test benches may choose to disable ROM scrambling in order to reduce run times. In this case they would use an un-scrambled ROM image.