### PR TITLE
Add support for aarch64

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -24,11 +24,13 @@ readonly release="v1.11.0"
 declare -A hashes=(
     # sha256sums for v1.11.0.  Update this if you update the release.
     [linux-amd64]="231ec5ca8115e94c75a1f4fbada1a062b48822ca04f21f26e4cb1cd8973cd458"
+    [linux-arm64]="f9119deb1eeb6d730ee8b2e1a14d09cb45638f0447df23144229c5b3b3bc2408"
 )
 
 declare -A architectures=(
     # Map `uname -m -o` to bazelisk's precompiled binary target names.
     [x86_64 GNU/Linux]="linux-amd64"
+    [aarch64 GNU/Linux]="linux-arm64"
 )
 
 function os_arch() {

--- a/hw/ip/otbn/dv/uvm/get-toolchain-paths.sh
+++ b/hw/ip/otbn/dv/uvm/get-toolchain-paths.sh
@@ -6,6 +6,8 @@
 set -o errexit
 set -o pipefail
 
+: ${HOST_ARCH:=$(uname -m)}
+
 # If we are on an air-gapped machine, we need to first ensure the toolchain has
 # been unpacked from the repository cache.
 if [[ -n ${BAZEL_CACHE} ]]; then
@@ -13,18 +15,18 @@ if [[ -n ${BAZEL_CACHE} ]]; then
   ${BAZEL_CMD} fetch \
     --distdir="${BAZEL_DISTDIR}" \
     --repository_cache="${BAZEL_CACHE}" \
-    @lowrisc_rv32imcb_files//...
+    @lowrisc_rv32imcb_${HOST_ARCH}_files//...
 else
   BAZEL_CMD="./bazelisk.sh"
-  ${BAZEL_CMD} fetch @lowrisc_rv32imcb_files//...
+  ${BAZEL_CMD} fetch @lowrisc_rv32imcb_${HOST_ARCH}_files//...
 fi
 
 # Set environment variables for the RV32 linker and assembler.
 RV32_TOOL_LD=$(${BAZEL_CMD} query \
-  'deps(@lowrisc_rv32imcb_files//:bin/riscv32-unknown-elf-ld)' \
+  "deps(@lowrisc_rv32imcb_${HOST_ARCH}_files//:bin/riscv32-unknown-elf-ld)" \
   --output location | cut -f1 -d:)
 RV32_TOOL_AS=$(${BAZEL_CMD} query \
-  'deps(@lowrisc_rv32imcb_files//:bin/riscv32-unknown-elf-as)' \
+  "deps(@lowrisc_rv32imcb_${HOST_ARCH}_files//:bin/riscv32-unknown-elf-as)" \
   --output location | cut -f1 -d:)
 export RV32_TOOL_LD
 export RV32_TOOL_AS

--- a/rules/certificates.bzl
+++ b/rules/certificates.bzl
@@ -4,6 +4,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+load("//rules:host_cpu.bzl", "get_host_cpu")
 
 def _certificate_codegen_impl(ctx):
     tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
@@ -70,7 +71,7 @@ certificate_codegen = rule(
     attrs = {
         "template": attr.label(allow_single_file = True, doc = "path to the hjson template file"),
         "clang_format": attr.label(
-            default = "@lowrisc_rv32imcb_files//:bin/clang-format",
+            default = "@lowrisc_rv32imcb_{}_files//:bin/clang-format".format(get_host_cpu()),
             allow_single_file = True,
             cfg = "host",
             executable = True,

--- a/rules/host.bzl
+++ b/rules/host.bzl
@@ -41,3 +41,8 @@ host_tools_transition = transition(
         "//hw/bitstream/universal:env",
     ],
 )
+
+HOST_ARCHS = [
+    "x86_64",
+    "aarch64",
+]

--- a/rules/host_cpu.bzl
+++ b/rules/host_cpu.bzl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+
+def get_host_cpu():
+    cpu_constraint = "@platforms//cpu:"
+    for constraint in HOST_CONSTRAINTS:
+        if constraint.startswith(cpu_constraint):
+            return constraint[len(cpu_constraint):]

--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -9,6 +9,7 @@ load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "C_COMPILE_ACTION_NAME")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("//rules:rv.bzl", "rv_rule")
+load("//rules:host_cpu.bzl", "get_host_cpu")
 
 def _ensure_tag(tags, *tag):
     for t in tag:
@@ -63,7 +64,7 @@ clang_format_attrs = {
         doc = "Command to execute to display diffs",
     ),
     "clang_format": attr.label(
-        default = "@lowrisc_rv32imcb_files//:bin/clang-format",
+        default = "@lowrisc_rv32imcb_{}_files//:bin/clang-format".format(get_host_cpu()),
         allow_single_file = True,
         cfg = "host",
         executable = True,
@@ -191,7 +192,7 @@ def _cc_aspect_impl(target, ctx, action_callback):
 
 # To see which checks clang-tidy knows about, run this command:
 #
-#  ./bazelisk.sh run @lowrisc_rv32imcb_files//:bin/clang-tidy -- --checks='*' --list-checks
+#  ./bazelisk.sh run @lowrisc_rv32imcb_$(uname -m)_files//:bin/clang-tidy -- --checks='*' --list-checks
 _CLANG_TIDY_CHECKS = [
     "clang-analyzer-core.*",
     # Disable advice to replace `memcpy` with `mempcy_s`.
@@ -264,7 +265,7 @@ def _make_clang_tidy_aspect(enable_fix):
                 executable = True,
             ),
             "_clang_tidy": attr.label(
-                default = "@lowrisc_rv32imcb_files//:bin/clang-tidy",
+                default = "@lowrisc_rv32imcb_{}_files//:bin/clang-tidy".format(get_host_cpu()),
                 allow_single_file = True,
                 cfg = "host",
                 executable = True,

--- a/sw/host/opentitanlib/src/util/status.rs
+++ b/sw/host/opentitanlib/src/util/status.rs
@@ -13,7 +13,7 @@ use object::{Object, ObjectSection};
 use num_enum::TryFromPrimitive;
 
 use std::convert::TryFrom;
-use std::ffi::CString;
+use std::ffi::{c_char, CString};
 use std::path::PathBuf;
 
 pub use bindgen::status::absl_status_t as RawStatusCode;
@@ -57,7 +57,7 @@ fn status_create_safe(code: StatusCode, mod_id: u32, file: String, arg: i32) -> 
 
 // Convert an array of i8 to a string. This function will stop at first 0 (or at the
 // end of the array if it contains no zero).
-fn c_string_to_string(array: &[i8]) -> String {
+fn c_string_to_string(array: &[c_char]) -> String {
     let array = array
         .iter()
         .map(|c| *c as u8)
@@ -91,7 +91,7 @@ impl Status {
             //   to the english name of the error code,
             // - a non-null pointer to an integer (argument),
             // - a non-null pointer to a char[3] buffer that is filled with the module ID.
-            status_extract(status, &mut _code_str, &mut arg, &mut mod_id as *mut i8)
+            status_extract(status, &mut _code_str, &mut arg, &mut mod_id as *mut c_char)
         };
         let code = match is_err_status {
             false => StatusCode::Ok,

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.11.tar.gz",
-            strip_prefix = "crt-0.4.11",
-            sha256 = "ee52d825fbaf654d76fe689cac7345a3a652c7f779912b46226adb9aee92b9ab",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.18.tar.gz",
+            strip_prefix = "crt-0.4.18",
+            sha256 = "de2a8b8e7501bafe8ca12498e2dadbb38129497838cf06482c32dcfbf34d65c7",
         )

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -5,6 +5,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_rust//bindgen:bindgen.bzl", "rust_bindgen_toolchain")
 load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_vendor")
+load("//rules:host.bzl", "HOST_ARCHS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -19,23 +20,26 @@ string_flag(
     make_variable = "OPENSSL_PKG_CONFIG_PATH",
 )
 
-rust_bindgen_toolchain(
-    name = "bindgen_toolchain_impl",
+[rust_bindgen_toolchain(
+    name = "bindgen_toolchain_impl_" + host_arch,
     bindgen = "@rules_rust//bindgen/3rdparty:bindgen",
-    clang = "@bindgen_clang_linux//:clang",
-    libclang = "@bindgen_clang_linux//:libclang",
+    clang = "@bindgen_clang_linux_{}//:clang".format(host_arch),
+    libclang = "@bindgen_clang_linux_{}//:libclang".format(host_arch),
     libstdcxx = select({
         ":specify_bindgen_libstdcxx": "@bindgen_libstdcxx_linux//:libstdc++",
         "//conditions:default": None,
     }),
-    system_includes = "@bindgen_clang_linux//:system_includes",
-)
+    system_includes = "@bindgen_clang_linux_{}//:system_includes".format(host_arch),
+) for host_arch in HOST_ARCHS]
 
-toolchain(
-    name = "bindgen_toolchain",
-    toolchain = "bindgen_toolchain_impl",
+[toolchain(
+    name = "bindgen_toolchain_" + host_arch,
+    exec_compatible_with = [
+        "@platforms//cpu:" + host_arch,
+    ],
+    toolchain = "bindgen_toolchain_impl_" + host_arch,
     toolchain_type = "@rules_rust//bindgen:toolchain_type",
-)
+) for host_arch in HOST_ARCHS]
 
 crates_vendor(
     name = "crate_index",

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -5,6 +5,7 @@
 load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_dependencies")
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
 load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
+load("//rules:host.bzl", "HOST_ARCHS")
 
 def rust_deps():
     rules_rust_dependencies()
@@ -20,8 +21,9 @@ def rust_deps():
     )
 
     rust_bindgen_dependencies()
-    native.register_toolchains(
-        "//third_party/rust:bindgen_toolchain",
-    )
+    for host_arch in HOST_ARCHS:
+        native.register_toolchains(
+            "//third_party/rust:bindgen_toolchain_" + host_arch,
+        )
 
     rust_analyzer_dependencies()

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 : "${BAZEL_PYTHON_WHEEL_REPO:=ot_python_wheels}"
 : "${BAZEL_BITSTREAMS_REPO:=bitstreams}"
 
+: ${HOST_ARCH:=$(uname -m)}
+
 LINE_SEP="====================================================================="
 
 ################################################################################
@@ -143,10 +145,10 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     //... \
     @remote_java_tools//... \
     @remote_java_tools_linux//... \
-    @bindgen_clang_linux//... \
+    @bindgen_clang_linux_${HOST_ARCH}//... \
     @rules_rust_bindgen__bindgen-0.65.1//... \
     @go_sdk//... \
-    @lowrisc_rv32imcb_files//... \
+    @lowrisc_rv32imcb_${HOST_ARCH}_files//... \
     @local_config_cc_toolchains//... \
     @local_config_platform//... \
     @local_config_sh//... \


### PR DESCRIPTION
This allows both compiling opentitantool and images for the sival chips on hosts with ARM architecture. Before merging this we should adjust the release paths for crt, lowrisc toolchains and safe ftdi.