### PR TITLE
Fix race in alert_esc_agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -103,7 +103,7 @@ class alert_monitor extends alert_esc_base_monitor;
                   req.ping_timeout = 1'b1;
                 end
                 begin : wait_ping_handshake
-                  while (cfg.vif.alert_tx_final.alert_p !== 1'b1) @(cfg.vif.monitor_cb)
+                  while (cfg.vif.alert_tx_final.alert_p !== 1'b1) @(cfg.vif.monitor_cb);
                   req.alert_handshake_sta = AlertReceived;
                   wait_ack();
                   req.alert_handshake_sta = AlertAckReceived;


### PR DESCRIPTION
The first commit is just a tidy-up. The second is the more interesting one and has the following commit message:

> [alert,dv] Fix race in alert_esc_agent
> 
> When an alert comes out, alert_monitor::alert_thread sees it and
> creates a sequence item that it sends to the sequencer, which sends it
> to alert_receiver_driver. It then gets consumed by
> alert_receiver_driver::rsp_alert, which is supposed to ack the alert.
> 
> Before this commit, there would always be an alert signal detected
> just after reset (in the alert init phase). That would then sit in
> r_alert_rsp_q until the under_reset flag was cleared.
> 
> Once that happened, the driver would cause a fatal error (that I'd
> added in b1095ff440c last November) because it was seeing an item that
> asked it to respond to an alert, but the alert had disappeared!
> 
> It's a bit fiddly to tell the monitor to ignore the apparent alert
> during the init phase, because the monitor doesn't actually model that
> handshake. But we *know* that there wasn't really an alert to respond
> to.
> 
> After this commit, the driver accepts the alert immediately, but
> responds instantly (with a "yeah, yeah. I've handled it") if we're
> still starting up.

Fixes #26448.