### PR TITLE
[dice,cwt] Update the Issuer/Subject name size

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -39,12 +39,15 @@ enum payload_entry_sizes {
   kProfileNameLength = 10,
   // The Key ID length, which equals to the SHA256 digest size in bytes
   kIssuerSubjectKeyIdLength = kHmacDigestNumBytes,
-  // The size of issuer & subject name, which equals to the ascii size
-  // transformed form Key ID.
-  kIssuerSubjectNameLength = kIssuerSubjectKeyIdLength * 2,
+  // The identifiers are 20 octets (reserve double size for HEX translation) so
+  // they fit in the RFC 5280 serialNumber field constraints and the
+  // X520SerialNumber type when hex encoded.
+  kIssuerSubjectNameLength = 40,
   // 64 byte should be enough for 2 entries
   kConfigDescBuffSize = 64,
 };
+static_assert(kIssuerSubjectNameLength < (1u << kIssuerSubjectKeyIdLength),
+              "Insufficient SubjectNameLength");
 
 enum cwt_cert_expectations {
   // Size of magic bytes to distinguish between CoseKey and CoseSign1 message.
@@ -140,7 +143,7 @@ static void fill_dice_id_string(
     const uint8_t dice_id[kIssuerSubjectKeyIdLength],
     char dice_id_str[kIssuerSubjectNameLength + 1]) {
   size_t idx;
-  for (idx = 0; idx < kIssuerSubjectKeyIdLength; idx++, dice_id_str += 2)
+  for (idx = 0; idx * 2 < kIssuerSubjectNameLength; idx++, dice_id_str += 2)
     util_hexdump_byte(dice_id[idx], (uint8_t *)&dice_id_str[0]);
 }
 

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -200,6 +200,15 @@ rom_error_t dice_uds_tbs_cert_build(
       .pub_key_ec_y = (uint8_t *)uds_pubkey->y,
       .pub_key_ec_y_size = sizeof(uds_pubkey->y),
   };
+  // For DICE CWT implementation, no need to sign UDS_Pub but just a COSE_Key
+  // structure.
+  // Those otp_*measurement parameters exist just for API alignment between
+  // different implementations.
+  OT_DISCARD(otp_creator_sw_cfg_measurement);
+  OT_DISCARD(otp_owner_sw_cfg_measurement);
+  OT_DISCARD(otp_rot_creator_auth_codesign_measurement);
+  OT_DISCARD(otp_rot_creator_auth_state_measurement);
+  OT_DISCARD(key_ids);
   HARDENED_RETURN_IF_ERROR(
       cwt_cose_key_build(&cwt_cose_key_params, tbs_cert, tbs_cert_size));
 


### PR DESCRIPTION
There are a few cases where the DICE needs to generate an identifier for use in certificates. To ensure these identifiers are deterministic and require no additional DICE inputs, the identifiers are derived from the associated public key. The identifiers are 20 octets so they fit in the RFC 5280 serialNumber field constraints and the X520SerialNumber type when hex encoded.

Ref: https://pigweed.googlesource.com/open-dice/+/HEAD/docs/specification.md#deriving-identifiers