### PR TITLE
[boot_svc] Check the bootsvc message length 

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
@@ -56,7 +56,7 @@ typedef struct boot_svc_min_bl0_sec_ver_res {
   /**
    * Status response from ROM_EXT.
    */
-  rom_error_t status;
+  uint32_t status;
 } boot_svc_min_bl0_sec_ver_res_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_svc_min_bl0_sec_ver_res_t, header, 0);

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h
@@ -59,7 +59,7 @@ typedef struct boot_svc_next_boot_bl0_slot_res {
   /**
    * Response status from the ROM_EXT.
    */
-  rom_error_t status;
+  uint32_t status;
   /**
    * Which slot is primary.
    */

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
@@ -86,7 +86,7 @@ typedef struct boot_svc_ownership_activate_res {
   /**
    * Response status from the ROM_EXT.
    */
-  rom_error_t status;
+  uint32_t status;
 } boot_svc_ownership_activate_res_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_res_t, header, 0);

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
@@ -95,7 +95,7 @@ typedef struct boot_svc_ownership_unlock_res {
   /**
    * Response status from the ROM_EXT.
    */
-  rom_error_t status;
+  uint32_t status;
 } boot_svc_ownership_unlock_res_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_res_t, header, 0);


### PR DESCRIPTION
Check that the boot_svc message length is valid before computing the digest.