### PR TITLE
[ottf] introduce OTTF_BACKDOOR_READ macro

### DIFF
--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -296,31 +296,6 @@ status_t flash_ctrl_testutils_bank_erase(dif_flash_ctrl_state_t *flash_state,
   return OK_STATUS();
 }
 
-static void flash_ctrl_testutils_flush_read_buffers(void) {
-  // Cause read buffers to flush since it reads 32 bytes, which is the
-  // size of the read buffers.
-  enum { kBufferBytes = 32 };
-  static volatile const uint8_t kFlashFlusher[kBufferBytes];
-  for (int i = 0; i < sizeof(kFlashFlusher); ++i) {
-    (void)kFlashFlusher[i];
-  }
-}
-
-status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
-                                                   uint8_t prior_data,
-                                                   size_t timeout_usec) {
-  uint8_t new_data = 0;
-  const ibex_timeout_t timeout = ibex_timeout_init(timeout_usec);
-  do {
-    if (ibex_timeout_check(&timeout)) {
-      return DEADLINE_EXCEEDED();
-    }
-    flash_ctrl_testutils_flush_read_buffers();
-    new_data = addr[0];
-  } while (new_data == prior_data);
-  return OK_STATUS();
-}
-
 status_t flash_ctrl_testutils_show_faults(
     const dif_flash_ctrl_state_t *flash_ctrl) {
   dif_flash_ctrl_faults_t faults = {.memory_properties_error = false};

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -238,25 +238,6 @@ enum {
 };
 
 /**
- * This detects changes in a specific byte in flash memory contents with a
- * timeout. In some cases the party updating it uses a backdoor overwrite,
- * so this code flushes the read buffers since the backdoor API has no
- * mechanism to flush.
- *
- * The `flash_ctrl_testutils_backdoor_init` function should be called prior
- * to this.
- *
- * @param addr The volatile address of a uint8_t variable where an update
- * is expected.
- * @param prior_data The prior data value.
- * @param timeout_usec Timeout in microseconds.
- */
-OT_WARN_UNUSED_RESULT
-status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
-                                                   uint8_t prior_data,
-                                                   size_t timeout_usec);
-
-/**
  * Write to log any faults set in the status register.
  *
  * @param flash_state A flash_ctrl state handle.

--- a/sw/device/lib/testing/test_framework/status.c
+++ b/sw/device/lib/testing/test_framework/status.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/testing/test_framework/status.h"
 
+#include <stdatomic.h>
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/runtime/hart.h"
@@ -23,6 +25,13 @@ static void test_status_device_write(test_status_t test_status) {
 }
 
 void test_status_set(test_status_t test_status) {
+  // This function is used to convey info to test harness, which may poke at
+  // backdoor variables. Add a fence to provide corrrect synchronization.
+  //
+  // This technically should be a thread fence, but use a signal fence to avoid
+  // emitting instructions as Ibex doesn't reorder memory accesses itself.
+  atomic_signal_fence(memory_order_release);
+
   switch (test_status) {
     case kTestStatusPassed: {
       LOG_INFO("PASS!");

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6474,7 +6474,6 @@ opentitan_test(
         "//sw/device/lib/dif:sysrst_ctrl",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:sysrst_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ottf_utils",
@@ -6591,7 +6590,6 @@ opentitan_test(
         "//sw/device/lib/dif:sysrst_ctrl",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:sysrst_ctrl_testutils",
@@ -7180,10 +7178,10 @@ opentitan_test(
         "//sw/device/lib/base:stdasm",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing:sram_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
     ],
 )
 

--- a/sw/device/tests/pattgen_ios_test.c
+++ b/sw/device/tests/pattgen_ios_test.c
@@ -44,7 +44,8 @@ enum {
   /* non-DV variable in RAM. */                      \
   OTTF_BACKDOOR_VAR type name##Real = default_val;
 
-#define BACKDOOR_VAR(name) (kDeviceType == kDeviceSimDV ? name##DV : name##Real)
+#define BACKDOOR_VAR(name) \
+  (kDeviceType == kDeviceSimDV ? OTTF_BACKDOOR_READ(name##DV) : name##Real)
 
 // Following volatile const will be overwritten by
 // SV testbench with random values.

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -156,9 +156,9 @@ opentitan_test(
         "//sw/device/lib/dif:sysrst_ctrl",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
     ],
 )
 

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
@@ -9,10 +9,10 @@
 #include "sw/device/lib/dif/dif_sysrst_ctrl.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_utils.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -90,7 +90,7 @@ enum {
 };
 
 // Test phase written by testbench.
-static volatile const uint8_t kTestPhase[1] = {0};
+static volatile const uint8_t kTestPhase = 0;
 
 // Sets up the pinmux to assign input and output pads
 // to the sysrst_ctrl peripheral as required.
@@ -140,16 +140,14 @@ static void configure_combo_reset(void) {
 // Waits for the kTestPhase variable to be changed by a backdoor overwrite
 // from the testbench in `chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv`. This will
 // indicate that the testbench is ready to proceed with the next phase of the
-// test. The function `flash_ctrl_testutils_backdoor_wait_update` is used to
-// deal with possible caching that can prevent the software to read the new
-// value of `kTestPhase`.
+// test.
 static void sync_with_testbench(uint8_t prior_phase) {
   // Set WFI status for testbench synchronization,
   // no actual WFI instruction is issued.
   test_status_set(kTestStatusInWfi);
   test_status_set(kTestStatusInTest);
-  CHECK_STATUS_OK(flash_ctrl_testutils_backdoor_wait_update(
-      &kTestPhase[0], prior_phase, kTestPhaseTimeoutUsec));
+  IBEX_SPIN_FOR(OTTF_BACKDOOR_READ(kTestPhase) != prior_phase,
+                kTestPhaseTimeoutUsec);
 }
 
 // Enables the sysrst_ctrl overrides for the output pins. Allows
@@ -191,7 +189,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_set_enabled(
       &sysrst_ctrl, kDifSysrstCtrlPinEcResetInOut, kDifToggleDisabled));
 
-  uint8_t current_test_phase = kTestPhase[0];
+  uint8_t current_test_phase = kTestPhase;
   while (current_test_phase < kTestPhaseDone) {
     LOG_INFO("Test phase %d", current_test_phase);
     switch (current_test_phase) {
@@ -217,7 +215,7 @@ bool test_main(void) {
         break;
     }
     sync_with_testbench(current_test_phase);
-    current_test_phase = kTestPhase[0];
+    current_test_phase = kTestPhase;
   }
   return true;
 }

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -11,12 +11,12 @@
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/rand_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/sram_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_utils.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rstmgr_regs.h"     // Generated.
@@ -373,8 +373,8 @@ static status_t sync_testbench(uint8_t prior_phase, uint8_t next_phase) {
     test_status_set(kTestStatusInWfi);
     test_status_set(kTestStatusInTest);
 
-    TRY(flash_ctrl_testutils_backdoor_wait_update(&kTestPhase, prior_phase,
-                                                  kTestPhaseTimeoutUsec));
+    IBEX_TRY_SPIN_FOR(OTTF_BACKDOOR_READ(kTestPhase) != prior_phase,
+                      kTestPhaseTimeoutUsec);
 
     TRY_CHECK(kTestPhase == next_phase);
   }


### PR DESCRIPTION
This introduce `OTTF_BACKDOOR_READ` macro which (hopefully) does everything correctly.

I converted all `flash_ctrl_testutils_backdoor_wait_update` users to use this. Marking as draft because there're much more backdoor users...