### PR TITLE
[racl,topgen] Fix _get_racl_params for multiple racl groups

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -725,7 +725,7 @@ def _get_racl_params(top: ConfigT) -> ParamsT:
         policies = list(top["racl"]["policies"].values())[0]
     else:
         # More than one policy, we need to find the matching set of policies
-        racl_group = racl_ctrl["racl_group"]
+        racl_group = racl_ctrl.get("racl_group", "Null")
         policies = top["racl"]["policies"][racl_group]
 
     num_subscribing_ips = defaultdict(int)


### PR DESCRIPTION
Tiny fix in topgen to allow multiple racl groups in the racl config.
Previously, that particular branch in the code has never been triggered before and did not work as expected.