### PR TITLE
[ac_range_check,dv] Sequence and scoreboard for smoke test

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_dut_cfg.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_dut_cfg.sv
@@ -7,7 +7,6 @@
 // be contained in this file, but directly in the files where they are needed as this may lead to
 // some conflicts.
 class ac_range_check_dut_cfg extends uvm_object;
-  rand tl_main_vars_t  tl_main_vars;
   rand bit [TL_DW-1:0] range_base[NUM_RANGES];  // Granularity is 32-bit words, 2-LSBs are ignored
   rand bit [TL_DW-1:0] range_limit[NUM_RANGES]; // Granularity is 32-bit words, 2-LSBs are ignored
   rand range_perm_t    range_perm[NUM_RANGES];
@@ -40,9 +39,6 @@ endfunction : post_randomize
 function void ac_range_check_dut_cfg::do_print(uvm_printer printer);
   `uvm_info(this.get_name(), "do_print function has been called", UVM_DEBUG);
   super.do_print(printer);
-
-  printer.print_generic("tl_main_vars", "tl_main_vars_t", $bits(tl_main_vars),
-                        $sformatf("%p", tl_main_vars));
 
   foreach (range_perm[i]) begin
     printer.print_field($sformatf("range_perm[%0d]", i), "range_perm_t", $bits(range_perm[i]),

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -66,6 +66,11 @@ package ac_range_check_env_pkg;
     DataWrite = 3
   } tl_phase_e;
 
+  typedef enum bit {
+    AccessDenied  = 0,
+    AccessGranted = 1
+  } access_decision_e;
+
   // Functions
   // Retrieve the index of the CSR based on its name
   function automatic int get_csr_idx(string csr_ral_name, string csr_name);

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -20,6 +20,8 @@ package ac_range_check_env_pkg;
 
   // Imports from packages
   import prim_mubi_pkg::mubi4_t;
+  import prim_mubi_pkg::MuBi4True;
+  import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::mubi4_bool_to_mubi;
   import prim_mubi_pkg::mubi4_logic_test_true_strict;
   import prim_mubi_pkg::mubi8_t;
@@ -34,6 +36,13 @@ package ac_range_check_env_pkg;
   typedef enum int {
     DenyCntReached = 0
   } ac_range_check_intr_e;
+
+  typedef enum bit [1:0] {
+    AChanRead  = 0,
+    AChanWrite = 1,
+    DChanRead  = 2,
+    DChanWrite = 3
+  } tl_phase_e;
 
   typedef struct packed {
     bit log_denied_access;
@@ -59,12 +68,10 @@ package ac_range_check_env_pkg;
     bit [DataWidth-1:0] data;
   } tl_main_vars_t;
 
-  typedef enum bit [1:0] {
-    AChanRead  = 0,
-    AChanWrite = 1,
-    DChanRead  = 2,
-    DChanWrite = 3
-  } tl_phase_e;
+  typedef struct {
+    tl_seq_item item;
+    int         cnt;
+  } tl_filt_t;
 
   typedef enum bit {
     AccessDenied  = 0,

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -60,10 +60,10 @@ package ac_range_check_env_pkg;
   } tl_main_vars_t;
 
   typedef enum bit [1:0] {
-    AddrRead  = 0,
-    AddrWrite = 1,
-    DataRead  = 2,
-    DataWrite = 3
+    AChanRead  = 0,
+    AChanWrite = 1,
+    DChanRead  = 2,
+    DChanWrite = 3
   } tl_phase_e;
 
   typedef enum bit {

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -60,6 +60,7 @@ package ac_range_check_env_pkg;
   } racl_policy_t;
 
   typedef struct packed {
+    bit                 instr_type;
     bit                 write;
     bit [AddrWidth-1:0] addr;
     bit [MaskWidth-1:0] mask;

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -26,6 +26,8 @@ package ac_range_check_env_pkg;
   import prim_mubi_pkg::mubi4_logic_test_true_strict;
   import prim_mubi_pkg::mubi8_t;
   import prim_mubi_pkg::MuBi8False;
+  import tl_agent_pkg::InstrTypeLsbPos;
+  import tl_agent_pkg::InstrTypeMsbPos;
 
   // Parameters
   parameter uint   NUM_ALERTS       = 2;

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -60,13 +60,9 @@ package ac_range_check_env_pkg;
   } racl_policy_t;
 
   typedef struct packed {
-    bit                 rand_write;
     bit                 write;
-    bit                 rand_addr;
     bit [AddrWidth-1:0] addr;
-    bit                 rand_mask;
     bit [MaskWidth-1:0] mask;
-    bit                 rand_data;
     bit [DataWidth-1:0] data;
   } tl_main_vars_t;
 

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -416,19 +416,24 @@ endfunction : reset
 function void ac_range_check_scoreboard::check_phase(uvm_phase phase);
   super.check_phase(phase);
 
-  if (matching_cnt == 0) begin
-    `uvm_error(`gfn, {"No matching transaction found, it can be because all TL accesses have been ",
-                      "filtered. Please check your DUT configuration and your sequence."})
-  end
+  // This condition seems useless, but the way the environment builds the scoreboard, it doesn't
+  // care about this configuration field for some reason. We don't need to check the following
+  // things when the ran test is related to the CSR checks in particular.
+  if (cfg.en_scb) begin
+    if (matching_cnt == 0) begin
+      `uvm_error(`gfn, {"No matching transaction found, it can be because all the TL accesses have",
+                        " been filtered. Please check your DUT configuration and your sequence."})
+    end
 
-  if (act_tl_filt_q.size() > 0) begin
-    `uvm_error(`gfn, {"Queue act_tl_filt_q is not empty: not all the received TL transactions have",
-                      " been compared."})
-  end
+    if (act_tl_filt_q.size() > 0) begin
+      `uvm_error(`gfn, {"Queue act_tl_filt_q is not empty: not all the received TL transactions",
+                        " have been compared."})
+    end
 
-  if (exp_tl_filt_q.size() > 0) begin
-    `uvm_error(`gfn, {"Queue exp_tl_filt_q is not empty: not all the received TL transactions have",
-                      " been compared."})
+    if (exp_tl_filt_q.size() > 0) begin
+      `uvm_error(`gfn, {"Queue exp_tl_filt_q is not empty: not all the received TL transactions",
+                        " have been compared."})
+    end
   end
 endfunction : check_phase
 

--- a/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
@@ -111,13 +111,14 @@ task ac_range_check_base_vseq::cfg_range_racl_policy();
 endtask : cfg_range_racl_policy
 
 task ac_range_check_base_vseq::send_single_tl_unfilt_tr();
-  tl_host_single_seq tl_unfilt_host_seq;
+  cip_tl_host_single_seq tl_unfilt_host_seq;
   `uvm_create_on(tl_unfilt_host_seq, p_sequencer.tl_unfilt_sqr)
   `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_unfilt_host_seq,
-                                 write == tl_main_vars.write;
-                                 addr  == tl_main_vars.addr;
-                                 mask  == tl_main_vars.mask;
-                                 data  == tl_main_vars.data;)
+                                 instr_type == mubi4_bool_to_mubi(tl_main_vars.instr_type);
+                                 write      == tl_main_vars.write;
+                                 addr       == tl_main_vars.addr;
+                                 mask       == tl_main_vars.mask;
+                                 data       == tl_main_vars.data;)
 
   csr_utils_pkg::increment_outstanding_access();
   `uvm_info(`gfn, "Starting tl_unfilt_host_seq", UVM_MEDIUM)

--- a/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_common_vseq.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_common_vseq.sv
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This sequence is mainly used to run the CSR tests, there is no need to run multiple transactions
-// in this sequence. Hence, the constraint is set to run only one transaction.
+// This sequence should only be used to run the CSR tests:
+//   - no need to have the scoreboard enabled (as it causes false errors with CSR tests)
+//   - no need to run multiple transactions. Hence, the constraint "num_trans" is set to 1
 class ac_range_check_common_vseq extends ac_range_check_base_vseq;
   `uvm_object_utils(ac_range_check_common_vseq)
 

--- a/hw/ip_templates/ac_range_check/dv/tests/ac_range_check_base_test.sv
+++ b/hw/ip_templates/ac_range_check/dv/tests/ac_range_check_base_test.sv
@@ -18,9 +18,24 @@ class ac_range_check_base_test extends cip_base_test #(
 
   // Standard SV/UVM methods
   extern function new(string name="", uvm_component parent=null);
+  extern function void build_phase(uvm_phase phase);
 endclass : ac_range_check_base_test
 
 
 function ac_range_check_base_test::new(string name="", uvm_component parent=null);
   super.new(name, parent);
 endfunction : new
+
+function void ac_range_check_base_test::build_phase(uvm_phase phase);
+  string test_seq_s;
+
+  super.build_phase(phase);
+
+  // Disable some scoreboard checks for the CSR tests (unfortunately we cannot simply avoid the
+  // scoreboard to be created by setting this config flag, which should be the case)
+  void'($value$plusargs("UVM_TEST_SEQ=%0s", test_seq_s));
+  $display("test_seq_s = %s", test_seq_s);
+  if (test_seq_s == "ac_range_check_common_vseq") begin
+    cfg.en_scb = 0;
+  end
+endfunction : build_phase

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_dut_cfg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_dut_cfg.sv
@@ -7,7 +7,6 @@
 // be contained in this file, but directly in the files where they are needed as this may lead to
 // some conflicts.
 class ac_range_check_dut_cfg extends uvm_object;
-  rand tl_main_vars_t  tl_main_vars;
   rand bit [TL_DW-1:0] range_base[NUM_RANGES];  // Granularity is 32-bit words, 2-LSBs are ignored
   rand bit [TL_DW-1:0] range_limit[NUM_RANGES]; // Granularity is 32-bit words, 2-LSBs are ignored
   rand range_perm_t    range_perm[NUM_RANGES];
@@ -40,9 +39,6 @@ endfunction : post_randomize
 function void ac_range_check_dut_cfg::do_print(uvm_printer printer);
   `uvm_info(this.get_name(), "do_print function has been called", UVM_DEBUG);
   super.do_print(printer);
-
-  printer.print_generic("tl_main_vars", "tl_main_vars_t", $bits(tl_main_vars),
-                        $sformatf("%p", tl_main_vars));
 
   foreach (range_perm[i]) begin
     printer.print_field($sformatf("range_perm[%0d]", i), "range_perm_t", $bits(range_perm[i]),

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -66,6 +66,11 @@ package ac_range_check_env_pkg;
     DataWrite = 3
   } tl_phase_e;
 
+  typedef enum bit {
+    AccessDenied  = 0,
+    AccessGranted = 1
+  } access_decision_e;
+
   // Functions
   // Retrieve the index of the CSR based on its name
   function automatic int get_csr_idx(string csr_ral_name, string csr_name);

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -20,6 +20,8 @@ package ac_range_check_env_pkg;
 
   // Imports from packages
   import prim_mubi_pkg::mubi4_t;
+  import prim_mubi_pkg::MuBi4True;
+  import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::mubi4_bool_to_mubi;
   import prim_mubi_pkg::mubi4_logic_test_true_strict;
   import prim_mubi_pkg::mubi8_t;
@@ -34,6 +36,13 @@ package ac_range_check_env_pkg;
   typedef enum int {
     DenyCntReached = 0
   } ac_range_check_intr_e;
+
+  typedef enum bit [1:0] {
+    AChanRead  = 0,
+    AChanWrite = 1,
+    DChanRead  = 2,
+    DChanWrite = 3
+  } tl_phase_e;
 
   typedef struct packed {
     bit log_denied_access;
@@ -59,12 +68,10 @@ package ac_range_check_env_pkg;
     bit [DataWidth-1:0] data;
   } tl_main_vars_t;
 
-  typedef enum bit [1:0] {
-    AChanRead  = 0,
-    AChanWrite = 1,
-    DChanRead  = 2,
-    DChanWrite = 3
-  } tl_phase_e;
+  typedef struct {
+    tl_seq_item item;
+    int         cnt;
+  } tl_filt_t;
 
   typedef enum bit {
     AccessDenied  = 0,

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -60,10 +60,10 @@ package ac_range_check_env_pkg;
   } tl_main_vars_t;
 
   typedef enum bit [1:0] {
-    AddrRead  = 0,
-    AddrWrite = 1,
-    DataRead  = 2,
-    DataWrite = 3
+    AChanRead  = 0,
+    AChanWrite = 1,
+    DChanRead  = 2,
+    DChanWrite = 3
   } tl_phase_e;
 
   typedef enum bit {

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -60,6 +60,7 @@ package ac_range_check_env_pkg;
   } racl_policy_t;
 
   typedef struct packed {
+    bit                 instr_type;
     bit                 write;
     bit [AddrWidth-1:0] addr;
     bit [MaskWidth-1:0] mask;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -26,6 +26,8 @@ package ac_range_check_env_pkg;
   import prim_mubi_pkg::mubi4_logic_test_true_strict;
   import prim_mubi_pkg::mubi8_t;
   import prim_mubi_pkg::MuBi8False;
+  import tl_agent_pkg::InstrTypeLsbPos;
+  import tl_agent_pkg::InstrTypeMsbPos;
 
   // Parameters
   parameter uint   NUM_ALERTS       = 2;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -60,13 +60,9 @@ package ac_range_check_env_pkg;
   } racl_policy_t;
 
   typedef struct packed {
-    bit                 rand_write;
     bit                 write;
-    bit                 rand_addr;
     bit [AddrWidth-1:0] addr;
-    bit                 rand_mask;
     bit [MaskWidth-1:0] mask;
-    bit                 rand_data;
     bit [DataWidth-1:0] data;
   } tl_main_vars_t;
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -416,19 +416,24 @@ endfunction : reset
 function void ac_range_check_scoreboard::check_phase(uvm_phase phase);
   super.check_phase(phase);
 
-  if (matching_cnt == 0) begin
-    `uvm_error(`gfn, {"No matching transaction found, it can be because all TL accesses have been ",
-                      "filtered. Please check your DUT configuration and your sequence."})
-  end
+  // This condition seems useless, but the way the environment builds the scoreboard, it doesn't
+  // care about this configuration field for some reason. We don't need to check the following
+  // things when the ran test is related to the CSR checks in particular.
+  if (cfg.en_scb) begin
+    if (matching_cnt == 0) begin
+      `uvm_error(`gfn, {"No matching transaction found, it can be because all the TL accesses have",
+                        " been filtered. Please check your DUT configuration and your sequence."})
+    end
 
-  if (act_tl_filt_q.size() > 0) begin
-    `uvm_error(`gfn, {"Queue act_tl_filt_q is not empty: not all the received TL transactions have",
-                      " been compared."})
-  end
+    if (act_tl_filt_q.size() > 0) begin
+      `uvm_error(`gfn, {"Queue act_tl_filt_q is not empty: not all the received TL transactions",
+                        " have been compared."})
+    end
 
-  if (exp_tl_filt_q.size() > 0) begin
-    `uvm_error(`gfn, {"Queue exp_tl_filt_q is not empty: not all the received TL transactions have",
-                      " been compared."})
+    if (exp_tl_filt_q.size() > 0) begin
+      `uvm_error(`gfn, {"Queue exp_tl_filt_q is not empty: not all the received TL transactions",
+                        " have been compared."})
+    end
   end
 endfunction : check_phase
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
@@ -111,13 +111,14 @@ task ac_range_check_base_vseq::cfg_range_racl_policy();
 endtask : cfg_range_racl_policy
 
 task ac_range_check_base_vseq::send_single_tl_unfilt_tr();
-  tl_host_single_seq tl_unfilt_host_seq;
+  cip_tl_host_single_seq tl_unfilt_host_seq;
   `uvm_create_on(tl_unfilt_host_seq, p_sequencer.tl_unfilt_sqr)
   `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_unfilt_host_seq,
-                                 write == tl_main_vars.write;
-                                 addr  == tl_main_vars.addr;
-                                 mask  == tl_main_vars.mask;
-                                 data  == tl_main_vars.data;)
+                                 instr_type == mubi4_bool_to_mubi(tl_main_vars.instr_type);
+                                 write      == tl_main_vars.write;
+                                 addr       == tl_main_vars.addr;
+                                 mask       == tl_main_vars.mask;
+                                 data       == tl_main_vars.data;)
 
   csr_utils_pkg::increment_outstanding_access();
   `uvm_info(`gfn, "Starting tl_unfilt_host_seq", UVM_MEDIUM)

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_common_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_common_vseq.sv
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This sequence is mainly used to run the CSR tests, there is no need to run multiple transactions
-// in this sequence. Hence, the constraint is set to run only one transaction.
+// This sequence should only be used to run the CSR tests:
+//   - no need to have the scoreboard enabled (as it causes false errors with CSR tests)
+//   - no need to run multiple transactions. Hence, the constraint "num_trans" is set to 1
 class ac_range_check_common_vseq extends ac_range_check_base_vseq;
   `uvm_object_utils(ac_range_check_common_vseq)
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/tests/ac_range_check_base_test.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/tests/ac_range_check_base_test.sv
@@ -18,9 +18,24 @@ class ac_range_check_base_test extends cip_base_test #(
 
   // Standard SV/UVM methods
   extern function new(string name="", uvm_component parent=null);
+  extern function void build_phase(uvm_phase phase);
 endclass : ac_range_check_base_test
 
 
 function ac_range_check_base_test::new(string name="", uvm_component parent=null);
   super.new(name, parent);
 endfunction : new
+
+function void ac_range_check_base_test::build_phase(uvm_phase phase);
+  string test_seq_s;
+
+  super.build_phase(phase);
+
+  // Disable some scoreboard checks for the CSR tests (unfortunately we cannot simply avoid the
+  // scoreboard to be created by setting this config flag, which should be the case)
+  void'($value$plusargs("UVM_TEST_SEQ=%0s", test_seq_s));
+  $display("test_seq_s = %s", test_seq_s);
+  if (test_seq_s == "ac_range_check_common_vseq") begin
+    cfg.en_scb = 0;
+  end
+endfunction : build_phase


### PR DESCRIPTION
**Main changes**
- Add prediction and comparison to the scoreboard
- Create constrained random sequences to cover most of the range check registers capabilities

**Still remaining**
According to the smoke test definition from the testplan [ac_range_check_smoke](https://opentitan.org/book/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check_testplan.html#ac_range_check_smoke):
- Now most of the `RANGE_*` registers are configured randomly (with constraints), except the `log_denied_access` field from `RANGE_PERM` reg.
- Another points to mention: 
  - TL transaction `mask` is always set to 4'hF.
  - TLUL errors are not checked.