### PR TITLE
Emergency Darjeeling fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,6 +756,7 @@ jobs:
           # Compile some selected targets
           ./bazelisk.sh build                                \
             --build_tests_only=false                         \
+            --//hw/top=darjeeling                            \
             //sw/device/tests:uart_smoketest_sim_dv
 
   qemu_smoketest:

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -53,9 +53,9 @@ _manifest_entry_point = _ottf_start - _ottf_start_address;
  * the flash region.  Otherwise, the value kHardenedBoolTrue (0x739) is
  * selected.
  */
-_manifest_address_translation = (_text_start >= ORIGIN(eflash) &&
-                                 _text_start < (ORIGIN(eflash)
-                                              + LENGTH(eflash))) ? 0x1d4 : 0x739;
+_manifest_address_translation = (_text_start >= ORIGIN(ottf_storage) &&
+                                 _text_start < (ORIGIN(ottf_storage)
+                                              + LENGTH(ottf_storage))) ? 0x1d4 : 0x739;
 
 PHDRS {
   static_critical_segment PT_LOAD;


### PR DESCRIPTION
The LTO PR broke Darjeeling builds due to a linking error. This was not caught in CI due a stupid error in the CI job.