### PR TITLE
[tl,dv] Fix infinite loop in tl_host_driver

### DIFF
--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -191,7 +191,7 @@ task tl_host_driver::send_a_channel_request(tl_seq_item req);
   `DV_SPINWAIT_EXIT(while (is_source_in_pending_req(req.a_source)) @(cfg.vif.host_cb);,
                     wait(reset_asserted);)
 
-  while (!req_done && !req_abort) begin
+  while (!req_done && !req_abort && !reset_asserted) begin
     if (cfg.use_seq_item_a_valid_delay) begin
       a_valid_delay = req.a_valid_delay;
     end else begin


### PR DESCRIPTION
This was my fault and I triggered the problem with commit [09af19f](https://github.com/lowRISC/opentitan/commit/09af19f7801964fc28262d9075459d6061949135). What I hadn't realised was how the flow worked when reset got asserted. Before my previous change:

  - Suppose we're in the middle of send_a_request_body
  - The reset is asserted and the DV_SPINWAIT_EXIT macro exits.
  - We then go around the loop again, skipping the first wait.
  - Then we set req_abort=1
  - The next wait doesn't do anything (because we're in reset)
  - We get back to the top of the loop, which exits because req_abort is true.

This is a bit mad! It would probably make more sense to drop out on the third bullet above, and that's what this commit does.

The reason my previous change broke things is that it switched the last argument of send_a_request_body to be an output argument. The effect is that we write req_abort=0 on bullet 5, so the loop doesn't exit any more. Oh no!

Making the loop work more explicitly (matching the check for abort or reset on line 237) seems like a good idea, and it also fixes a stupid bug.