### PR TITLE
[dv,chip] DV fixes for chip_sw_mbx_smoketest

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -151,8 +151,14 @@
   // Add a default software build option to indicates that this is Darjeeling.
   sw_build_opts: ["--//hw/top=darjeeling"]
 
-  // Add a default build option to indicate it is a top-level DV testbench.
-  build_opts: ["+define+TOP_LEVEL_DV"]
+  build_opts: [
+    // Add a default build option to indicate it is a top-level DV testbench.
+    "+define+TOP_LEVEL_DV",
+
+    // Ensure that the RISC-V JTAG agent uses DMI rather than direct TL-UL;
+    // this is required by the JTAG mailbox interface.
+    "+define+USE_DMI_INTERFACE"
+  ]
 
   // Add build modes.
   build_modes: [

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_external_alerts_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_external_alerts_vseq.sv
@@ -64,8 +64,8 @@ class chip_sw_soc_proxy_external_alerts_vseq extends chip_sw_base_vseq;
 
       // Trigger the alert.
       `uvm_info(`gfn, $sformatf("Triggering fatal alert %0d.", i), UVM_LOW)
-      cfg.chip_vif.signal_probe_soc_fatal_alert_req(.kind(dv_utils_pkg::SignalProbeForce),
-                                                    .value(alert_req));
+      void'(cfg.chip_vif.signal_probe_soc_fatal_alert_req(.kind(dv_utils_pkg::SignalProbeForce),
+                                                          .value(alert_req)));
 
       // Ensure that the alert gets acknowledged.
       cfg.chip_vif.cpu_clk_rst_if.wait_clks(2);
@@ -83,7 +83,7 @@ class chip_sw_soc_proxy_external_alerts_vseq extends chip_sw_base_vseq;
       `uvm_info(`gfn, $sformatf("CPU reset asserted."), UVM_MEDIUM)
 
       // Release the alert.
-      cfg.chip_vif.signal_probe_soc_fatal_alert_req(.kind(dv_utils_pkg::SignalProbeRelease));
+      void'(cfg.chip_vif.signal_probe_soc_fatal_alert_req(.kind(dv_utils_pkg::SignalProbeRelease)));
 
       // Wait for reset release.
       `DV_SPINWAIT(cfg.chip_vif.cpu_clk_rst_if.wait_for_reset(.wait_negedge(1'b0),
@@ -107,8 +107,8 @@ class chip_sw_soc_proxy_external_alerts_vseq extends chip_sw_base_vseq;
 
       // Trigger the alert.
       `uvm_info(`gfn, $sformatf("Triggering recoverable alert %0d.", i), UVM_LOW)
-      cfg.chip_vif.signal_probe_soc_recov_alert_req(.kind(dv_utils_pkg::SignalProbeForce),
-                                                    .value(alert_req));
+      void'(cfg.chip_vif.signal_probe_soc_recov_alert_req(.kind(dv_utils_pkg::SignalProbeForce),
+                                                          .value(alert_req)));
 
       // Ensure that the alert gets acknowledged.
       cfg.chip_vif.cpu_clk_rst_if.wait_clks(2);
@@ -130,7 +130,7 @@ class chip_sw_soc_proxy_external_alerts_vseq extends chip_sw_base_vseq;
       join
 
       // Release the alert.
-      cfg.chip_vif.signal_probe_soc_recov_alert_req(.kind(dv_utils_pkg::SignalProbeRelease));
+      void'(cfg.chip_vif.signal_probe_soc_recov_alert_req(.kind(dv_utils_pkg::SignalProbeRelease)));
     end
   endtask
 

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_external_wakeup_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_external_wakeup_vseq.sv
@@ -19,13 +19,13 @@ class chip_sw_soc_proxy_external_wakeup_vseq extends chip_sw_base_vseq;
 
     // Trigger the external wakeup request.
     `uvm_info(`gfn, $sformatf("Triggering external wakeup request"), UVM_LOW)
-    cfg.chip_vif.signal_probe_soc_wkup_async(.kind(dv_utils_pkg::SignalProbeForce),
-                                             .value(1'b1));
+    void'(cfg.chip_vif.signal_probe_soc_wkup_async(.kind(dv_utils_pkg::SignalProbeForce),
+                                                   .value(1'b1)));
 
     // Wait for software to confirm external wakeup request.
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "External wakeup request detected.")
 
     // Release the external wakeup request.
-    cfg.chip_vif.signal_probe_soc_wkup_async(.kind(dv_utils_pkg::SignalProbeRelease));
+    void'(cfg.chip_vif.signal_probe_soc_wkup_async(.kind(dv_utils_pkg::SignalProbeRelease)));
   endtask
 endclass

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_gpio_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_gpio_vseq.sv
@@ -80,8 +80,8 @@ class chip_sw_soc_proxy_gpio_vseq extends chip_sw_base_vseq;
                                 soc_proxy_pkg::NumSocGpio,
                                 gpo),
                 UVM_MEDIUM)
-      cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeForce),
-                                              .value(gpo));
+      void'(cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeForce),
+                                                    .value(gpo)));
 
       // Check that the signal appears at the DIOs.
       `DV_SPINWAIT_EXIT(
@@ -101,7 +101,7 @@ class chip_sw_soc_proxy_gpio_vseq extends chip_sw_base_vseq;
       )
 
       // Release drive.
-      cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeRelease));
+      void'(cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeRelease)));
     end
   endtask
 
@@ -156,8 +156,8 @@ class chip_sw_soc_proxy_gpio_vseq extends chip_sw_base_vseq;
                                 soc_proxy_pkg::NumSocGpio,
                                 gpo),
                 UVM_MEDIUM)
-      cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeForce),
-                                              .value(gpo));
+      void'(cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeForce),
+                                                    .value(gpo)));
 
       // Check that the signal appears at the MIOs.
       `DV_SPINWAIT_EXIT(
@@ -175,15 +175,15 @@ class chip_sw_soc_proxy_gpio_vseq extends chip_sw_base_vseq;
       )
 
       // Release drive.
-      cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeRelease));
+      void'(cfg.chip_vif.signal_probe_soc_gpo_async(.kind(dv_utils_pkg::SignalProbeRelease)));
     end
   endtask
 
   task send_external_irq();
-    cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeForce),
-                                             .value(1'b1));
+    void'(cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeForce),
+                                             .value(1'b1)));
     cfg.chip_vif.cpu_clk_rst_if.wait_clks(100);
-    cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeRelease));
+    void'(cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeRelease)));
   endtask
 
   task await_muxable_soc_gpis_mapped();

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_smoke_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_soc_proxy_smoke_vseq.sv
@@ -31,8 +31,8 @@ class chip_sw_soc_proxy_smoke_vseq extends chip_sw_base_vseq;
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "External resets enabled.")
 
     // Trigger the external reset request.
-    cfg.chip_vif.signal_probe_soc_rst_req_async(.kind(dv_utils_pkg::SignalProbeForce),
-                                                .value(1'b1));
+    void'(cfg.chip_vif.signal_probe_soc_rst_req_async(.kind(dv_utils_pkg::SignalProbeForce),
+                                                      .value(1'b1)));
 
     // Fork background threads to ensure that most reset domains do *not* get reset.
     fork
@@ -62,7 +62,7 @@ class chip_sw_soc_proxy_smoke_vseq extends chip_sw_base_vseq;
     )
 
     // Deactivate external reset request.
-    cfg.chip_vif.signal_probe_soc_rst_req_async(.kind(dv_utils_pkg::SignalProbeRelease));
+    void'(cfg.chip_vif.signal_probe_soc_rst_req_async(.kind(dv_utils_pkg::SignalProbeRelease)));
 
     // Wait until SW confirms reset on external request.
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "Reset on external request.")
@@ -77,7 +77,8 @@ class chip_sw_soc_proxy_smoke_vseq extends chip_sw_base_vseq;
 
       // Trigger external IRQ.
       `uvm_info(`gfn, $sformatf("Triggering %s.", irq_str), UVM_LOW)
-      cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeForce), .value(intr));
+      void'(cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeForce),
+                                                     .value(intr)));
 
       fork
         begin
@@ -93,7 +94,7 @@ class chip_sw_soc_proxy_smoke_vseq extends chip_sw_base_vseq;
 
       // Deactivate external IRQ.
       `uvm_info(`gfn, $sformatf("Releasing %s.", irq_str), UVM_LOW)
-      cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeRelease));
+      void'(cfg.chip_vif.signal_probe_soc_intr_async(.kind(dv_utils_pkg::SignalProbeRelease)));
     end
 
   endtask


### PR DESCRIPTION
This PR provides some simple fixes to the DV side of `chip_sw_mbx_smoketest` allowing it to pass. The creation of orphaned soc_control and soc_status registers led to UVM warnings on the master branch, resulting in a test failure even after the software component had reported successful completion.

Clean up a few build warnings at the same time, in an effort to keep the build log clean so that we can spot any real problems; these are just probe/release calls that do not require the state of the affected signal.