### PR TITLE
[tools,ipgen] Improve VLNV renaming

### DIFF
--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent.core
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
-      - lowrisc:ip_interfaces:flash_ctrl_pkg
+      - lowrisc:virtual_ip:flash_ctrl_pkg
     files:
       - flash_phy_prim_if.sv
       - flash_phy_prim_agent_pkg.sv

--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -18,7 +18,7 @@ filesets:
       - lowrisc:prim:sec_anchor
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
-      - lowrisc:ip_interfaces:flash_ctrl_pkg
+      - lowrisc:virtual_ip:flash_ctrl_pkg
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:kmac_pkg
       - lowrisc:ip:otp_ctrl_pkg

--- a/hw/ip/lc_ctrl/lc_ctrl.core
+++ b/hw/ip/lc_ctrl/lc_ctrl.core
@@ -17,11 +17,11 @@ filesets:
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:tlul
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:virtual_ip:pwrmgr_pkg
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:kmac_pkg
       - lowrisc:ip:rv_dm
-      - lowrisc:ip_interfaces:alert_handler_pkg
+      - lowrisc:virtual_ip:alert_handler_pkg
     files:
       - rtl/lc_ctrl_regs_reg_top.sv
       - rtl/lc_ctrl_dmi_reg_top.sv

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -12,8 +12,8 @@ filesets:
       - lowrisc:prim:ram_1p
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
-      - lowrisc:ip_interfaces:flash_ctrl_pkg
-      - lowrisc:ip_interfaces:flash_ctrl_prim_reg_top
+      - lowrisc:virtual_ip:flash_ctrl_pkg
+      - lowrisc:virtual_ip:flash_ctrl_prim_reg_top
     files:
       - rtl/prim_generic_flash_bank.sv
       - rtl/prim_generic_flash.sv

--- a/hw/ip/soc_dbg_ctrl/soc_dbg_ctrl.core
+++ b/hw/ip/soc_dbg_ctrl/soc_dbg_ctrl.core
@@ -14,7 +14,7 @@ filesets:
       # TODO(PR #23555): This must depend upon the Darjeeling pwrmgr pkg directly
       # for the pwr_boot_status_t structure presently.
       # - lowrisc:ip_interfaces:pwrmgr_pkg
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/soc_dbg_ctrl_reg_pkg.sv

--- a/hw/ip_templates/ac_range_check/data/ac_range_check.tpldesc.hjson
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name:    "uniquified_modules"
+      desc:    "A dictionary mapping template_names to uniquified_names"
+      type:    "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name:    "module_instance_name"
       desc:    "instance name in case there are multiple AC Range Check instances"
       type:    "string"

--- a/hw/ip_templates/alert_handler/alert_handler_pkg.core.tpl
+++ b/hw/ip_templates/alert_handler/alert_handler_pkg.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv(f"lowrisc:ip:{module_instance_name}_pkg:0.1")}
 description: "Alert Handler constants in packages"
 virtual:
-  - "lowrisc:ip_interfaces:${module_instance_name}_pkg"
+  - "lowrisc:virtual_ip:${module_instance_name}_pkg"
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/alert_handler/data/alert_handler.tpldesc.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "n_alerts"
       desc: "Number of alert sources"
       type: "int"

--- a/hw/ip_templates/clkmgr/clkmgr.core.tpl
+++ b/hw/ip_templates/clkmgr/clkmgr.core.tpl
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg", pwrmgr_vlnv_prefix)}
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:buf

--- a/hw/ip_templates/clkmgr/clkmgr_pkg.core.tpl
+++ b/hw/ip_templates/clkmgr/clkmgr_pkg.core.tpl
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: ${instance_vlnv("lowrisc:systems:clkmgr_pkg:0.1")}
+name: ${instance_vlnv("lowrisc:ip:clkmgr_pkg:0.1")}
 description: "Top specific clock manager package"
 virtual:
-  - lowrisc:ip_interfaces:clkmgr_pkg
+  - lowrisc:virtual_ip:clkmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/clkmgr/data/clkmgr.tpldesc.hjson
+++ b/hw/ip_templates/clkmgr/data/clkmgr.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "src_clks"
       desc: "The source clocks"
       type: "object"
@@ -91,12 +97,6 @@
       desc: "Generate outputs for a clkmgr that would connect to an alert handler"
       type: "bool"
       default: "1"
-    }
-    {
-      name: "pwrmgr_vlnv_prefix"
-      desc: "Provides the VLNV prefix (for instance_vlnv) for the pwrmgr_pkg used by this clkmgr"
-      type: "string"
-      default: ""
     }
     {
       name: "top_pkg_vlnv"

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env.core.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env.core.tpl
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg", pwrmgr_vlnv_prefix)}
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - ${instance_vlnv("lowrisc:ip:clkmgr_pkg")}
       - ${top_pkg_vlnv}
     files:

--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "banks"
       desc: "Number of banks"
       type: "int"
@@ -86,12 +92,6 @@
       desc: "The total size in bytes"
       type: "int"
       default: "1048576"
-    }
-    {
-      name: "pwrmgr_vlnv_prefix"
-      desc: "Provides the VLNV prefix (for instance_vlnv) for the pwrmgr_pkg used by this clkmgr"
-      type: "string"
-      default: ""
     }
     {
       name: "top_pkg_vlnv"

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core.tpl
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_prince:0.1
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
-      - ${instance_vlnv("lowrisc:ip_interfaces:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
       - lowrisc:dv:mem_bkdr_util
     files:
       - flash_ctrl_bkdr_util_pkg.sv

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_pkg.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_pkg.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg:0.1")}
 description: "Top specific flash package"
 virtual:
-  - lowrisc:ip_interfaces:flash_ctrl_pkg
+  - lowrisc:virtual_ip:flash_ctrl_pkg
 
 filesets:
   files_rtl:
@@ -13,7 +13,7 @@ filesets:
       - ${top_pkg_vlnv}
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg", pwrmgr_vlnv_prefix)}
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_prim_reg_top.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_prim_reg_top.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:flash_ctrl_prim_reg_top:1.0")}
 description: "Generic register top for the FLASH wrapper"
 virtual:
-  - lowrisc:ip_interfaces:flash_ctrl_prim_reg_top
+  - lowrisc:virtual_ip:flash_ctrl_prim_reg_top
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/gpio/data/gpio.tpldesc.hjson
+++ b/hw/ip_templates/gpio/data/gpio.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple gpio instances"
       type: "string"

--- a/hw/ip_templates/otp_ctrl/data/otp_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/otp_ctrl/data/otp_ctrl.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "otp_mmap"
       desc: "An object containing the memory map and all attributes"
       type: "object"

--- a/hw/ip_templates/otp_ctrl/dv/cov/otp_ctrl_cov.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/cov/otp_ctrl_cov.core.tpl
@@ -4,13 +4,11 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:dv:otp_ctrl_cov")}
 description: "OTP_CTRL functional coverage and bind files"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_cov
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - ${instance_vlnv("lowrisc:ip:otp_ctrl_top_specific_pkg")}
 
   files_dv:

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env.core.tpl
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:dv:otp_ctrl_env:0.1")}
 description: "OTP_CTRL DV UVM environment"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_env
 
 filesets:
   files_dv:

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util.core.tpl
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:dv:otp_ctrl_mem_bkdr_util:0.1")}
 description: "OTP_CTRL mem_bkdr_util support package"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_mem_bkdr_util
 
 filesets:
   files_dv:

--- a/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/otp_ctrl_sim.core.tpl
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:dv:otp_ctrl_sim:0.1")}
 description: "OTP_CTRL DV sim target"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_sim
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/otp_ctrl/dv/sva/otp_ctrl_sva.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/sva/otp_ctrl_sva.core.tpl
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:dv:otp_ctrl_sva:0.1")}
 description: "OTP_CTRL assertion modules and bind file."
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_sva
 
 filesets:
   files_dv:

--- a/hw/ip_templates/otp_ctrl/dv/tests/otp_ctrl_test.core.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/tests/otp_ctrl_test.core.tpl
@@ -4,8 +4,6 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:dv:otp_ctrl_test:0.1")}
 description: "OTP_CTRL DV UVM test"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_test
 
 filesets:
   files_dv:

--- a/hw/ip_templates/otp_ctrl/otp_ctrl.core.tpl
+++ b/hw/ip_templates/otp_ctrl/otp_ctrl.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:otp_ctrl:1.0")}
 description: "OTP Controller"
 virtual:
-  - lowrisc:ip_interfaces:otp_ctrl
+  - lowrisc:virtual_ip:otp_ctrl
 
 filesets:
   files_rtl:
@@ -25,7 +25,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
       - lowrisc:prim:sec_anchor
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
       - "fileset_partner  ? (partner:systems:ast_pkg)"

--- a/hw/ip_templates/otp_ctrl/otp_ctrl_prim_reg_top.core
+++ b/hw/ip_templates/otp_ctrl/otp_ctrl_prim_reg_top.core
@@ -10,7 +10,7 @@ filesets:
       # otp_ctrl_prim_reg_top.sv should depend on generic items for now.
       # This may change and will require reworking the flow to generate
       # the otp prim.
-      - lowrisc:ip_interfaces:otp_ctrl_top_specific_pkg
+      - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
     files:
       - rtl/otp_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/otp_ctrl/otp_ctrl_top_specific_pkg.core.tpl
+++ b/hw/ip_templates/otp_ctrl/otp_ctrl_top_specific_pkg.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:otp_ctrl_top_specific_pkg:1.0")}
 description: "OTP Controller Top Specific Packages"
 virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_top_specific_pkg
+  - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson.tpl
@@ -6,7 +6,7 @@
   name: otp_ctrl
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_${topname}_{name}:0.1
+  fusesoc_core: ${instance_vlnv("lowrisc:ip:{name}:0.1")}
 
   import_cfgs: [// Project wide common GTECH synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]

--- a/hw/ip_templates/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson.tpl
@@ -6,7 +6,7 @@
   name: otp_ctrl
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_${topname}_{name}:0.1
+  fusesoc_core: lowrisc:${topname}_ip:{name}:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]

--- a/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "n_wkup_detect"
       desc: "Number of wakeups"
       type: "int"

--- a/hw/ip_templates/pinmux/pinmux_pkg.core.tpl
+++ b/hw/ip_templates/pinmux/pinmux_pkg.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:pinmux_pkg:0.1")}
 description: "Pinmux package"
 virtual:
-  - lowrisc:ip_interfaces:pinmux_pkg
+  - lowrisc:virtual_ip:pinmux_pkg
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "NumWkups"
       desc: "Number of wakeup requests"
       type: "int"

--- a/hw/ip_templates/pwrmgr/pwrmgr_pkg.core.tpl
+++ b/hw/ip_templates/pwrmgr/pwrmgr_pkg.core.tpl
@@ -5,7 +5,7 @@ CAPI=2:
 name: ${instance_vlnv("lowrisc:ip:pwrmgr_pkg:0.1")}
 description: "Power manager package"
 virtual:
-  - lowrisc:ip_interfaces:pwrmgr_pkg
+  - lowrisc:virtual_ip:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple RACL Ctrl instances"
       type: "string"

--- a/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "clks"
       desc: "List of source clocks, as in 'aon', 'io', 'io_div2'"
       type: "object"
@@ -118,20 +124,14 @@
       default: "1"
     }
     {
-      name: "alert_handler_vlnv_prefix"
-      desc: "Provides the VLNV prefix (for instance_vlnv) for the alert_handler used by this rstmgr"
-      type: "string"
-      default: ""
-    }
-    {
-      name: "pwrmgr_vlnv_prefix"
-      desc: "Provides the VLNV prefix (for instance_vlnv) for the pwrmgr used by this rstmgr"
+      name: "alert_handler_vlnv"
+      desc: "Provides the vlnv for alert_handler_pkt used by this rstmgr"
       type: "string"
       default: ""
     }
     {
       name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this clkmgr"
+      desc: "Provides the VLNV for the top_pkg used by this rstmgr"
       type: "string"
       default: "lowrisc:constants:top_pkg"
     }

--- a/hw/ip_templates/rstmgr/dv/sva/rstmgr_sva_ifs.core.tpl
+++ b/hw/ip_templates/rstmgr/dv/sva/rstmgr_sva_ifs.core.tpl
@@ -8,7 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg", pwrmgr_vlnv_prefix)}
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
       - ${instance_vlnv("lowrisc:ip:rstmgr")}
 

--- a/hw/ip_templates/rstmgr/rstmgr.core.tpl
+++ b/hw/ip_templates/rstmgr/rstmgr.core.tpl
@@ -8,8 +8,8 @@ description: "Reset manager RTL"
 filesets:
   files_rtl:
     depend:
-% if len(alert_handler_vlnv_prefix) > 0:
-      - ${instance_vlnv("lowrisc:ip:alert_handler_pkg", alert_handler_vlnv_prefix)}
+% if alert_handler_vlnv:
+      - ${alert_handler_vlnv}
 % endif
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul

--- a/hw/ip_templates/rstmgr/rstmgr_pkg.core.tpl
+++ b/hw/ip_templates/rstmgr/rstmgr_pkg.core.tpl
@@ -4,13 +4,11 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: ${instance_vlnv("lowrisc:ip:rstmgr_pkg:0.1")}
 description: "Reset manager package"
-virtual:
-  - lowrisc:ip_interfaces:rstmgr_pkg
 
 filesets:
   files_rtl:
     depend:
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg", pwrmgr_vlnv_prefix)}
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
     files:
       - rtl/rstmgr_reg_pkg.sv
       - rtl/rstmgr_pkg.sv

--- a/hw/ip_templates/rv_plic/data/rv_plic.tpldesc.hjson
+++ b/hw/ip_templates/rv_plic/data/rv_plic.tpldesc.hjson
@@ -10,6 +10,12 @@
       default: ""
     }
     {
+      name: "uniquified_modules"
+      desc: "A dictionary mapping template_names to uniquified_names"
+      type: "object"
+      default: {"clkmgr": "clkmgr1"}
+    }
+    {
       name: "src"
       desc: "Number of interrupt sources"
       type: "int"

--- a/hw/top_darjeeling/dv/chip_sim.core
+++ b/hw/top_darjeeling/dv/chip_sim.core
@@ -18,9 +18,9 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:dv:top_darjeeling_chip_test
-      - lowrisc:opentitan:top_darjeeling_clkmgr_sva
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_sva
-      - lowrisc:opentitan:top_darjeeling_rstmgr_sva
+      - lowrisc:darjeeling_dv:clkmgr_sva
+      - lowrisc:darjeeling_dv:pwrmgr_sva
+      - lowrisc:darjeeling_dv:rstmgr_sva
       - lowrisc:dv:top_darjeeling_sva
       - lowrisc:dv:top_darjeeling_xbar_dbg_bind
       - lowrisc:dv:top_darjeeling_xbar_main_bind

--- a/hw/top_darjeeling/dv/env/chip_env.core
+++ b/hw/top_darjeeling/dv/env/chip_env.core
@@ -22,7 +22,7 @@ filesets:
       - lowrisc:dv:jtag_dmi_agent
       - lowrisc:dv:lc_ctrl_dv_utils
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_mem_bkdr_util
+      - lowrisc:darjeeling_dv:otp_ctrl_mem_bkdr_util
       - lowrisc:dv:ralgen
       - lowrisc:dv:spi_agent
       - lowrisc:dv:str_utils
@@ -31,7 +31,7 @@ filesets:
       - lowrisc:dv:uart_agent
       - lowrisc:dv:i2c_agent
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
       - "!fileset_partner ? (lowrisc:systems:top_darjeeling_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_darjeeling_ast_pkg)"

--- a/hw/top_darjeeling/dv/sva/top_darjeeling_sva.core
+++ b/hw/top_darjeeling/dv/sva/top_darjeeling_sva.core
@@ -7,7 +7,7 @@ description: "TOP_DARJEELING assertion modules and bind file."
 filesets:
   files_dv:
     depend:
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:darjeeing_ip:pwrmgr_pkg
       - lowrisc:prim:assert
       - lowrisc:systems:top_darjeeling
     files:

--- a/hw/top_darjeeling/formal/top_darjeeling_fpv_ip_cfgs.hjson
+++ b/hw/top_darjeeling/formal/top_darjeeling_fpv_ip_cfgs.hjson
@@ -51,7 +51,7 @@
              {
                name: rv_plic_fpv
                dut: rv_plic_tb
-               fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic_fpv
+               fusesoc_core: lowrisc:darjeeling_fpv:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip_autogen/rv_plic/{sub_flow}/{tool}"
                cov: true

--- a/hw/top_darjeeling/formal/top_darjeeling_fpv_prim_cfgs.hjson
+++ b/hw/top_darjeeling/formal/top_darjeeling_fpv_prim_cfgs.hjson
@@ -19,7 +19,7 @@
              {
               name: alert_handler_esc_timer_fpv
               dut: alert_handler_esc_timer_tb
-              fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler_esc_timer_fpv
+              fusesoc_core: lowrisc:darjeeling_ip:alert_handler_esc_timer_fpv
               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
               rel_path: "hw/{top_chip}/ip_autogen/alert_handler/alert_handler_esc_timer/{sub_flow}/{tool}"
               cov: true
@@ -27,7 +27,7 @@
              {
               name: alert_handler_ping_timer_fpv
               dut: alert_handler_ping_timer_tb
-              fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler_ping_timer_fpv
+              fusesoc_core: lowrisc:darjeeling_ip:alert_handler_ping_timer_fpv
               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
               rel_path: "hw/{top_chip}/ip_autogen/alert_handler/alert_handler/ping_timer/{sub_flow}/{tool}"
               cov: true

--- a/hw/top_darjeeling/formal/top_darjeeling_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_darjeeling/formal/top_darjeeling_fpv_sec_cm_cfgs.hjson
@@ -44,7 +44,7 @@
              {
                name: alert_handler_sec_cm
                dut: alert_handler
-               fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler_sva
+               fusesoc_core: lowrisc:darjeeling_dv:alert_handler_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip_autogen/alert_handler/{sub_flow}/{tool}"
                stopats: ["*u_state_regs.state_o"]
@@ -220,7 +220,7 @@
               {
                name: rv_plic_sec_cm
                dut: rv_plic
-               fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic_fpv
+               fusesoc_core: lowrisc:darjeeling_fpv:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip/rv_plic/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"

--- a/hw/top_darjeeling/ip/ast/ast.core
+++ b/hw/top_darjeeling/ip/ast/ast.core
@@ -16,7 +16,7 @@ filesets:
       - lowrisc:prim:clock_inv
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lfsr
-      - lowrisc:opentitan:top_darjeeling_pinmux_pkg
+      - lowrisc:darjeeling_ip:pinmux_pkg
       - lowrisc:prim:assert
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi
@@ -24,9 +24,9 @@ filesets:
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:ip:entropy_src_pkg
-      - lowrisc:opentitan:top_darjeeling_alert_handler_pkg
-      - lowrisc:opentitan:top_darjeeling_clkmgr_pkg
-      - lowrisc:opentitan:top_darjeeling_rstmgr_pkg
+      - lowrisc:darjeeling_ip:alert_handler_pkg
+      - lowrisc:darjeeling_ip:clkmgr_pkg
+      - lowrisc:darjeeling_ip:rstmgr_pkg
       - lowrisc:systems:top_darjeeling_ast_pkg
     files:
       - rtl/ast_reg_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/ac_range_check.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/ac_range_check.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_ac_range_check:0.1
+name: lowrisc:darjeeling_ip:ac_range_check:0.1
 description: "AC Range Check RTL"
 
 filesets:

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
@@ -10,5 +10,12 @@
     nr_role_bits: 4
     nr_ctn_uid_bits: 5
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim.core
@@ -2,19 +2,19 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_ac_range_check_sim:0.1
+name: lowrisc:darjeeling_dv:ac_range_check_sim:0.1
 description: "AC_RANGE_CHECK DV sim target"
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_darjeeling_ac_range_check:0.1
+      - lowrisc:darjeeling_ip:ac_range_check:0.1
     file_type: systemVerilogSource
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_ac_range_check_test
-      - lowrisc:opentitan:top_darjeeling_ac_range_check_sva
+      - lowrisc:darjeeling_dv:ac_range_check_test
+      - lowrisc:darjeeling_dv:ac_range_check_sva
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: xcelium
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_ac_range_check_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:ac_range_check_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/ac_range_check_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_ac_range_check_env:0.1
+name: lowrisc:darjeeling_dv:ac_range_check_env:0.1
 description: "AC_RANGE_CHECK DV UVM environment"
 filesets:
   files_dv:

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/sva/ac_range_check_sva.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/sva/ac_range_check_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_ac_range_check_sva:0.1
+name: lowrisc:darjeeling_dv:ac_range_check_sva:0.1
 description: "AC_RANGE_CHECK assertion modules and bind file."
 filesets:
   files_dv:
@@ -15,7 +15,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_darjeeling_ac_range_check
+      - lowrisc:darjeeling_ip:ac_range_check
 
 generate:
   csr_assert_gen:

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/tests/ac_range_check_test.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/tests/ac_range_check_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_ac_range_check_test:0.1
+name: lowrisc:darjeeling_dv:ac_range_check_test:0.1
 description: "AC_RANGE_CHECK DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_ac_range_check_env
+      - lowrisc:darjeeling_dv:ac_range_check_env
     files:
       - ac_range_check_test_pkg.sv
       - ac_range_check_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler:0.1
+name: lowrisc:darjeeling_ip:alert_handler:0.1
 description: "Alert Handler"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler_component:0.1
-      - lowrisc:opentitan:top_darjeeling_alert_handler_reg:0.1
+      - lowrisc:darjeeling_ip:alert_handler_component:0.1
+      - lowrisc:darjeeling_ip:alert_handler_reg:0.1
     file_type: systemVerilogSource
 
 parameters:

--- a/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler_component.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler_component.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_component:0.1
+name: lowrisc:darjeeling_ip:alert_handler_component:0.1
 description: "Alert Handler component without the CSRs"
 
 filesets:
@@ -17,7 +17,7 @@ filesets:
       - lowrisc:prim:buf
       - lowrisc:prim:mubi
       - lowrisc:prim:sparse_fsm
-      - lowrisc:opentitan:top_darjeeling_alert_handler_reg
+      - lowrisc:darjeeling_ip:alert_handler_reg
     files:
       - rtl/alert_handler_reg_wrap.sv
       - rtl/alert_handler_lpg_ctrl.sv

--- a/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_pkg:0.1
+name: lowrisc:darjeeling_ip:alert_handler_pkg:0.1
 description: "Alert Handler constants in packages"
 virtual:
-  - "lowrisc:ip_interfaces:alert_handler_pkg"
+  - "lowrisc:virtual_ip:alert_handler_pkg"
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler_reg.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/alert_handler_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_reg:0.1
+name: lowrisc:darjeeling_ip:alert_handler_reg:0.1
 description: "Auto-generated alert handler register sources"
 
 filesets:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim:subreg
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_darjeeling_alert_handler_pkg
+      - lowrisc:darjeeling_ip:alert_handler_pkg
     files:
       - rtl/alert_handler_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
@@ -225,5 +225,12 @@
     ]
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim.core
@@ -2,20 +2,20 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_sim:0.1
+name: lowrisc:darjeeling_dv:alert_handler_sim:0.1
 description: "ALERT_HANDLER DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler:0.1
+      - lowrisc:darjeeling_ip:alert_handler:0.1
     file_type: systemVerilogSource
 
   files_dv:
     depend:
       - lowrisc:dv:ralgen
-      - lowrisc:opentitan:top_darjeeling_alert_handler_tb:0.1
-      - lowrisc:opentitan:top_darjeeling_alert_handler_cov:0.1
-      - lowrisc:opentitan:top_darjeeling_alert_handler_sva:0.1
+      - lowrisc:darjeeling_dv:alert_handler_tb:0.1
+      - lowrisc:darjeeling_dv:alert_handler_cov:0.1
+      - lowrisc:darjeeling_dv:alert_handler_sva:0.1
     file_type: systemVerilogSource
 
 generate:

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:alert_handler_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/alert_handler_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/cov/alert_handler_cov.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/cov/alert_handler_cov.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_cov:0.1
+name: lowrisc:darjeeling_dv:alert_handler_cov:0.1
 description: "ALERT_HANDLER cov bind files"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler_component:0.1  # import alert_handler_pkg
+      - lowrisc:darjeeling_ip:alert_handler_component:0.1  # import alert_handler_pkg
       - lowrisc:dv:dv_utils
     files:
       - alert_handler_cov_bind.sv

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_env:0.1
+name: lowrisc:darjeeling_dv:alert_handler_env:0.1
 description: "ALERT_HANDLER DV UVM environment"
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_darjeeling_alert_handler_pkg:0.1
+      - lowrisc:darjeeling_ip:alert_handler_pkg:0.1
       - lowrisc:prim:mubi_pkg
       - lowrisc:constants:top_darjeeling_top_pkg
     files:

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/sva/alert_handler_sva.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/sva/alert_handler_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_sva:0.1
+name: lowrisc:darjeeling_dv:alert_handler_sva:0.1
 description: "ALERT_HANDLER assertion modules and bind file."
 filesets:
   files_dv:
@@ -15,7 +15,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler:0.1
+      - lowrisc:darjeeling_ip:alert_handler:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/tb/alert_handler_tb.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/tb/alert_handler_tb.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_tb:0.1
+name: lowrisc:darjeeling_dv:alert_handler_tb:0.1
 description: "ALERT_HANDLER UVM TB environment"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler_test:0.1
+      - lowrisc:darjeeling_dv:alert_handler_test:0.1
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/tests/alert_handler_test.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/tests/alert_handler_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_test:0.1
+name: lowrisc:darjeeling_dv:alert_handler_test:0.1
 description: "ALERT_HANDLER DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler_env
+      - lowrisc:darjeeling_dv:alert_handler_env
     files:
       - alert_handler_test_pkg.sv
       - alert_handler_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/alert_handler/fpv/alert_handler_esc_timer_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/fpv/alert_handler_esc_timer_fpv.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_esc_timer_fpv:0.1
+name: lowrisc:darjeeling_fpv:alert_handler_esc_timer_fpv:0.1
 description: "alert_handler_esc_timer FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_darjeeling_alert_handler
+      - lowrisc:darjeeling_ip:alert_handler
     files:
       - vip/alert_handler_esc_timer_assert_fpv.sv
       - tb/alert_handler_esc_timer_bind_fpv.sv

--- a/hw/top_darjeeling/ip_autogen/alert_handler/fpv/alert_handler_ping_timer_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/fpv/alert_handler_ping_timer_fpv.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_alert_handler_ping_timer_fpv:0.1
+name: lowrisc:darjeeling_fpv:alert_handler_ping_timer_fpv:0.1
 description: "ALERT_HANDLER FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_darjeeling_alert_handler
+      - lowrisc:darjeeling_ip:alert_handler
     files:
       - vip/alert_handler_ping_timer_assert_fpv.sv
       - tb/alert_handler_ping_timer_bind_fpv.sv

--- a/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr:0.1
+name: lowrisc:darjeeling_ip:clkmgr:0.1
 description: "Top specific clock manager "
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:buf
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender
       - lowrisc:prim:measure
-      - lowrisc:opentitan:top_darjeeling_clkmgr_pkg:0.1
-      - lowrisc:opentitan:top_darjeeling_clkmgr_reg:0.1
+      - lowrisc:darjeeling_ip:clkmgr_pkg:0.1
+      - lowrisc:darjeeling_ip:clkmgr_reg:0.1
     files:
       - rtl/clkmgr.sv
       - rtl/clkmgr_byp.sv

--- a/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_pkg:0.1
+name: lowrisc:darjeeling_ip:clkmgr_pkg:0.1
 description: "Top specific clock manager package"
 virtual:
-  - lowrisc:ip_interfaces:clkmgr_pkg
+  - lowrisc:virtual_ip:clkmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr_reg.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_reg:0.1
+name: lowrisc:darjeeling_ip:clkmgr_reg:0.1
 description: "Clock manager registers"
 
 filesets:

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
@@ -244,8 +244,14 @@
     exported_clks: {}
     number_of_clock_groups: 7
     with_alert_handler: true
-    pwrmgr_vlnv_prefix: top_darjeeling_
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_sim:0.1
+name: lowrisc:darjeeling_dv:clkmgr_sim:0.1
 description: "CLKMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_clkmgr
+      - lowrisc:darjeeling_ip:clkmgr
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_clkmgr_test:0.1
-      - lowrisc:opentitan:top_darjeeling_clkmgr_sva:0.1
+      - lowrisc:darjeeling_dv:clkmgr_test:0.1
+      - lowrisc:darjeeling_dv:clkmgr_sva:0.1
     files:
       - tb.sv
       - cov/clkmgr_cov_bind.sv

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_clkmgr_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:clkmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/clkmgr_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_env:0.1
+name: lowrisc:darjeeling_dv:clkmgr_env:0.1
 description: "CLKMGR DV UVM environment"
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
-      - lowrisc:opentitan:top_darjeeling_clkmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
+      - lowrisc:darjeeling_ip:clkmgr_pkg
       - lowrisc:constants:top_darjeeling_top_pkg
     files:
       - clkmgr_csrs_if.sv

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/sva/clkmgr_sva.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/sva/clkmgr_sva.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_sva:0.1
+name: lowrisc:darjeeling_dv:clkmgr_sva:0.1
 description: "CLKMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_darjeeling_clkmgr_sva_ifs:0.1
+      - lowrisc:darjeeling_dv:clkmgr_sva_ifs:0.1
     files:
       - clkmgr_bind.sv
       - clkmgr_sec_cm_checker_assert.sv
@@ -17,7 +17,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_darjeeling_clkmgr
+      - lowrisc:darjeeling_ip:clkmgr
 
 generate:
   csr_assert_gen:

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/sva/clkmgr_sva_ifs.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/sva/clkmgr_sva_ifs.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_sva_ifs:0.1
+name: lowrisc:darjeeling_dv:clkmgr_sva_ifs:0.1
 description: "CLKMGR SVA interfaces."
 filesets:
   files_dv:

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/tests/clkmgr_test.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/tests/clkmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_clkmgr_test:0.1
+name: lowrisc:darjeeling_dv:clkmgr_test:0.1
 description: "CLKMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_clkmgr_env:0.1
+      - lowrisc:darjeeling_dv:clkmgr_env:0.1
     files:
       - clkmgr_test_pkg.sv
       - clkmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
@@ -8,5 +8,12 @@
     num_inp_period_counters: 8
     module_instance_name: gpio
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_gpio_env:0.1
+name: lowrisc:darjeeling_dv:gpio_env:0.1
 description: "GPIO DV UVM environmnt"
 filesets:
   files_dv:

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim.core
@@ -2,18 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_gpio_sim:0.1
+name: lowrisc:darjeeling_dv:gpio_sim:0.1
 description: "GPIO DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_gpio:0.1
+      - lowrisc:darjeeling_ip:gpio:0.1
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_gpio_test
-      - lowrisc:opentitan:top_darjeeling_gpio_sva
-      - lowrisc:opentitan:top_darjeeling_gpio_if
+      - lowrisc:darjeeling_dv:gpio_test
+      - lowrisc:darjeeling_dv:gpio_sva
+      - lowrisc:darjeeling_dv:gpio_if
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_gpio_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:gpio_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/gpio_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/interfaces/gpio_if.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/interfaces/gpio_if.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_gpio_if:0.1
+name: lowrisc:darjeeling_dv:gpio_if:0.1
 description: "GPIO Interfaces"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_gpio:0.1
+      - lowrisc:darjeeling_ip:gpio:0.1
     files:
       - gpio_straps_if.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/sva/gpio_sva.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/sva/gpio_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_gpio_sva:0.1
+name: lowrisc:darjeeling_dv:gpio_sva:0.1
 description: "GPIO assertion modules and bind file."
 filesets:
   files_dv:
@@ -15,7 +15,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_darjeeling_gpio:0.1
+      - lowrisc:darjeeling_ip:gpio:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/tests/gpio_test.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/tests/gpio_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_gpio_test:0.1
+name: lowrisc:darjeeling_dv:gpio_test:0.1
 description: "GPIO DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_gpio_env:0.1
+      - lowrisc:darjeeling_dv:gpio_env:0.1
     files:
       - gpio_test_pkg.sv
       - gpio_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/gpio/gpio.core
+++ b/hw/top_darjeeling/ip_autogen/gpio/gpio.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_gpio:0.1
+name: lowrisc:darjeeling_ip:gpio:0.1
 description: "gpio"
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
@@ -2005,5 +2005,12 @@
       ]
     }
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov.core
@@ -2,16 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_cov
+name: lowrisc:darjeeling_dv:otp_ctrl_cov
 description: "OTP_CTRL functional coverage and bind files"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_cov
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip_interfaces:pwrmgr_pkg
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_top_specific_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
+      - lowrisc:darjeeling_ip:otp_ctrl_top_specific_pkg
 
   files_dv:
     depend:

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_env:0.1
+name: lowrisc:darjeeling_dv:otp_ctrl_env:0.1
 description: "OTP_CTRL DV UVM environment"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_env
 
 filesets:
   files_dv:

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_mem_bkdr_util:0.1
+name: lowrisc:darjeeling_dv:otp_ctrl_mem_bkdr_util:0.1
 description: "OTP_CTRL mem_bkdr_util support package"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_mem_bkdr_util
 
 filesets:
   files_dv:
@@ -13,7 +11,7 @@ filesets:
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:crypto_dpi_present
       - lowrisc:dv:lc_ctrl_dv_utils
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_top_specific_pkg:1.0
+      - lowrisc:darjeeling_ip:otp_ctrl_top_specific_pkg:1.0
     files:
       - otp_scrambler_pkg.sv
       - otp_ctrl_mem_bkdr_util_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim.core
@@ -2,22 +2,20 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_sim:0.1
+name: lowrisc:darjeeling_dv:otp_ctrl_sim:0.1
 description: "OTP_CTRL DV sim target"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_sim
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl
+      - lowrisc:darjeeling_ip:otp_ctrl
 
   files_dv:
     depend:
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_test
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_sva
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_cov
+      - lowrisc:darjeeling_dv:otp_ctrl_test
+      - lowrisc:darjeeling_dv:otp_ctrl_sva
+      - lowrisc:darjeeling_dv:otp_ctrl_cov
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_otp_ctrl_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:otp_ctrl_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/otp_ctrl_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/sva/otp_ctrl_sva.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/sva/otp_ctrl_sva.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_sva:0.1
+name: lowrisc:darjeeling_dv:otp_ctrl_sva:0.1
 description: "OTP_CTRL assertion modules and bind file."
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_sva
 
 filesets:
   files_dv:
@@ -18,7 +16,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl
+      - lowrisc:darjeeling_ip:otp_ctrl
 
 generate:
   csr_assert_gen:

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/tests/otp_ctrl_test.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/tests/otp_ctrl_test.core
@@ -2,15 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_test:0.1
+name: lowrisc:darjeeling_dv:otp_ctrl_test:0.1
 description: "OTP_CTRL DV UVM test"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_test
 
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_env
+      - lowrisc:darjeeling_dv:otp_ctrl_env
     files:
       - otp_ctrl_test_pkg.sv
       - otp_ctrl_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl.core
@@ -2,16 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl:1.0
+name: lowrisc:darjeeling_ip:otp_ctrl:1.0
 description: "OTP Controller"
 virtual:
-  - lowrisc:ip_interfaces:otp_ctrl
+  - lowrisc:virtual_ip:otp_ctrl
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl_top_specific_pkg
+      - lowrisc:darjeeling_ip:otp_ctrl_top_specific_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:ram_1p
@@ -25,7 +25,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
       - lowrisc:prim:sec_anchor
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
       - "fileset_partner  ? (partner:systems:ast_pkg)"

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
@@ -10,7 +10,7 @@ filesets:
       # otp_ctrl_prim_reg_top.sv should depend on generic items for now.
       # This may change and will require reworking the flow to generate
       # the otp prim.
-      - lowrisc:ip_interfaces:otp_ctrl_top_specific_pkg
+      - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
     files:
       - rtl/otp_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl_top_specific_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl_top_specific_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_otp_ctrl_top_specific_pkg:1.0
+name: lowrisc:darjeeling_ip:otp_ctrl_top_specific_pkg:1.0
 description: "OTP Controller Top Specific Packages"
 virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_top_specific_pkg
+  - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: otp_ctrl
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_{name}:0.1
+  fusesoc_core: lowrisc:darjeeling_ip:{name}:0.1
 
   import_cfgs: [// Project wide common GTECH synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: otp_ctrl
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_{name}:0.1
+  fusesoc_core: lowrisc:darjeeling_ip:{name}:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
@@ -18,5 +18,12 @@
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_darjeeling_scan_role_pkg
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pinmux_chip_fpv:0.1
+name: lowrisc:darjeeling_systems:pinmux_chip_fpv:0.1
 description: "pinmux FPV target with chip_earlgrey parameters"
 
 filesets:
@@ -13,9 +13,9 @@ filesets:
       - lowrisc:ip:jtag_pkg
       - lowrisc:prim:mubi_pkg
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_darjeeling_pinmux:0.1
+      - lowrisc:darjeeling_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_darjeeling_pinmux_common_fpv:0.1
+      - lowrisc:darjeeling_fpv:pinmux_common_fpv:0.1
       - lowrisc:constants:top_darjeeling_top_pkg
       - lowrisc:systems:top_darjeeling_scan_role_pkg
     files:

--- a/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_common_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_common_fpv.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pinmux_common_fpv:0.1
+name: lowrisc:darjeeling_fpv:pinmux_common_fpv:0.1
 description: "pinmux common FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_darjeeling_pinmux:0.1
+      - lowrisc:darjeeling_ip:pinmux:0.1
     files:
       - vip/pinmux_assert_fpv.sv
       - tb/pinmux_bind_fpv.sv

--- a/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_fpv.core
@@ -2,16 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pinmux_fpv:0.1
+name: lowrisc:darjeeling_fpv:pinmux_fpv:0.1
 description: "pinmux FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_darjeeling_pinmux:0.1
+      - lowrisc:darjeeling_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_darjeeling_pinmux_common_fpv
+      - lowrisc:darjeeling_fpv:pinmux_common_fpv
     files:
       - tb/pinmux_tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/pinmux.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pinmux:0.1
+name: lowrisc:darjeeling_ip:pinmux:0.1
 description: "Pin Multiplexer"
 
 filesets:
@@ -19,8 +19,8 @@ filesets:
       - lowrisc:prim:pad_wrapper_pkg
       - lowrisc:prim:pad_attr
       - lowrisc:ip:jtag_pkg
-      - lowrisc:opentitan:top_darjeeling_pinmux_reg:0.1
-      - lowrisc:opentitan:top_darjeeling_pinmux_pkg:0.1
+      - lowrisc:darjeeling_ip:pinmux_reg:0.1
+      - lowrisc:darjeeling_ip:pinmux_pkg:0.1
     files:
       - rtl/pinmux_wkup.sv
       - rtl/pinmux_jtag_buf.sv

--- a/hw/top_darjeeling/ip_autogen/pinmux/pinmux_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/pinmux_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pinmux_pkg:0.1
+name: lowrisc:darjeeling_ip:pinmux_pkg:0.1
 description: "Pinmux package"
 virtual:
-  - lowrisc:ip_interfaces:pinmux_pkg
+  - lowrisc:virtual_ip:pinmux_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/pinmux/pinmux_reg.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/pinmux_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pinmux_reg:0.1
+name: lowrisc:darjeeling_ip:pinmux_reg:0.1
 description: "Auto-generated pinmux register sources"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_darjeeling_pinmux_pkg
+      - lowrisc:darjeeling_ip:pinmux_pkg
     files:
       - rtl/pinmux_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/pinmux/syn/pinmux_syn_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/syn/pinmux_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: pinmux
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_pinmux:0.1
+  fusesoc_core: lowrisc:darjeeling_ip:pinmux:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"],

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
@@ -73,5 +73,12 @@
     NumRomInputs: 3
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_env:0.1
+name: lowrisc:darjeeling_dv:pwrmgr_env:0.1
 description: "PWRMGR DV UVM environment"
 filesets:
   files_dv:
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:constants:top_darjeeling_top_pkg
     files:
       - pwrmgr_env_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_sim:0.1
+name: lowrisc:darjeeling_dv:pwrmgr_sim:0.1
 description: "PWRMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_pwrmgr:0.1
+      - lowrisc:darjeeling_ip:pwrmgr:0.1
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_test:0.1
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_sva:0.1
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_unit_only_sva:0.1
+      - lowrisc:darjeeling_dv:pwrmgr_test:0.1
+      - lowrisc:darjeeling_dv:pwrmgr_sva:0.1
+      - lowrisc:darjeeling_dv:pwrmgr_unit_only_sva:0.1
     files:
       - tb.sv
       - cov/pwrmgr_cov_bind.sv

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_pwrmgr_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:pwrmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/pwrmgr_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_sva.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_sva:0.1
+name: lowrisc:darjeeling_dv:pwrmgr_sva:0.1
 description: "PWRMGR assertion modules and bind file."
 filesets:
   files_dv:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:dv:clkmgr_pwrmgr_sva_if
       - lowrisc:dv:pwrmgr_rstmgr_sva_if:0.1
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
     files:
       - pwrmgr_bind.sv
       - pwrmgr_clock_enables_sva_if.sv
@@ -21,7 +21,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_darjeeling_pwrmgr:0.1
+      - lowrisc:darjeeling_ip:pwrmgr:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_unit_only_sva.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/sva/pwrmgr_unit_only_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_unit_only_sva:0.1
+name: lowrisc:darjeeling_dv:pwrmgr_unit_only_sva:0.1
 description: "PWRMGR assertion interfaces not suitable for chip level bind file."
 filesets:
   files_dv:
@@ -10,8 +10,8 @@ filesets:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg:0.1
-      - lowrisc:opentitan:top_darjeeling_pwrmgr:0.1
+      - lowrisc:darjeeling_ip:pwrmgr_pkg:0.1
+      - lowrisc:darjeeling_ip:pwrmgr:0.1
 
     files:
       - pwrmgr_unit_only_bind.sv

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/tests/pwrmgr_test.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/tests/pwrmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_test:0.1
+name: lowrisc:darjeeling_dv:pwrmgr_test:0.1
 description: "PWRMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_env:0.1
+      - lowrisc:darjeeling_dv:pwrmgr_env:0.1
     files:
       - pwrmgr_test_pkg.sv
       - pwrmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr:0.1
+name: lowrisc:darjeeling_ip:pwrmgr:0.1
 description: "Power manager RTL"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:clock_buf
       - lowrisc:prim:measure
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg:0.1
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_reg:0.1
+      - lowrisc:darjeeling_ip:pwrmgr_pkg:0.1
+      - lowrisc:darjeeling_ip:pwrmgr_reg:0.1
     files:
       - rtl/pwrmgr_cdc.sv
       - rtl/pwrmgr_slow_fsm.sv

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_pkg:0.1
+name: lowrisc:darjeeling_ip:pwrmgr_pkg:0.1
 description: "Power manager package"
 virtual:
-  - lowrisc:ip_interfaces:pwrmgr_pkg
+  - lowrisc:virtual_ip:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_reg.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_pwrmgr_reg:0.1
+name: lowrisc:darjeeling_ip:pwrmgr_reg:0.1
 description: "Power manager registers"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
     files:
       - rtl/pwrmgr_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -63,5 +63,12 @@
       }
     ]
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/racl_ctrl.core
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/racl_ctrl.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_racl_ctrl:0.1
+name: lowrisc:darjeeling_ip:racl_ctrl:0.1
 description: "RACL Control permission IP"
 
 filesets:

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -543,10 +543,16 @@
     ]
     rst_ni: lc_io_div4
     export_rsts: {}
-    alert_handler_vlnv_prefix: top_darjeeling_
+    alert_handler_vlnv: lowrisc:darjeeling_ip:alert_handler_pkg
     with_alert_handler: true
-    pwrmgr_vlnv_prefix: top_darjeeling_
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -2,18 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_env:0.1
+name: lowrisc:darjeeling_dv:rstmgr_env:0.1
 description: "RSTMGR DV UVM environment"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_rstmgr
+      - lowrisc:darjeeling_ip:rstmgr
 
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_darjeeling_rstmgr_pkg
+      - lowrisc:darjeeling_ip:rstmgr_pkg
       - lowrisc:constants:top_darjeeling_top_pkg
 
     files:

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_cnsty_chk_sim:0.1
+name: lowrisc:darjeeling_dv:rstmgr_cnsty_chk_sim:0.1
 description: "Rstmgr_cnsty_chk DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_rstmgr_cnsty_chk:0.1
+      - lowrisc:darjeeling_ip:rstmgr_cnsty_chk:0.1
       - lowrisc:dv:sec_cm
     file_type: systemVerilogSource
 

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_rstmgr_cnsty_chk_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:rstmgr_cnsty_chk_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/data/rstmgr_cnsty_chk_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_sim:0.1
+name: lowrisc:darjeeling_dv:rstmgr_sim:0.1
 description: "RSTMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_rstmgr
+      - lowrisc:darjeeling_ip:rstmgr
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_rstmgr_test:0.1
-      - lowrisc:opentitan:top_darjeeling_rstmgr_sva:0.1
+      - lowrisc:darjeeling_dv:rstmgr_test:0.1
+      - lowrisc:darjeeling_dv:rstmgr_sva:0.1
     files:
       - tb.sv
       - cov/rstmgr_cov_bind.sv

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_darjeeling_rstmgr_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:rstmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/rstmgr_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sva.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sva.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_sva:0.1
+name: lowrisc:darjeeling_dv:rstmgr_sva:0.1
 description: "RSTMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:prim:mubi
-      - lowrisc:opentitan:top_darjeeling_rstmgr_pkg:0.1
+      - lowrisc:darjeeling_ip:rstmgr_pkg:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_darjeeling_rstmgr_sva_ifs:0.1
+      - lowrisc:darjeeling_dv:rstmgr_sva_ifs:0.1
 
     files:
       - rstmgr_bind.sv

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sva_ifs.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/sva/rstmgr_sva_ifs.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_sva_ifs:0.1
+name: lowrisc:darjeeling_dv:rstmgr_sva_ifs:0.1
 description: "RSTMGR cascading resets assertion interface."
 filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
-      - lowrisc:opentitan:top_darjeeling_rstmgr
+      - lowrisc:darjeeling_ip:rstmgr
 
     files:
       - rstmgr_attrs_sva_if.sv

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/tests/rstmgr_test.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/tests/rstmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_test:0.1
+name: lowrisc:darjeeling_dv:rstmgr_test:0.1
 description: "RSTMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_darjeeling_rstmgr_env:0.1
+      - lowrisc:darjeeling_dv:rstmgr_env:0.1
     files:
       - rstmgr_test_pkg.sv
       - rstmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr:0.1
+name: lowrisc:darjeeling_ip:rstmgr:0.1
 description: "Reset manager RTL"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_alert_handler_pkg
+      - lowrisc:darjeeling_ip:alert_handler_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:clock_mux2
@@ -17,9 +17,9 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:clock_buf
       - lowrisc:prim:sparse_fsm
-      - lowrisc:opentitan:top_darjeeling_rstmgr_pkg:0.1
-      - lowrisc:opentitan:top_darjeeling_rstmgr_reg:0.1
-      - lowrisc:opentitan:top_darjeeling_rstmgr_cnsty_chk:0.1
+      - lowrisc:darjeeling_ip:rstmgr_pkg:0.1
+      - lowrisc:darjeeling_ip:rstmgr_reg:0.1
+      - lowrisc:darjeeling_ip:rstmgr_cnsty_chk:0.1
     files:
       - rtl/rstmgr_ctrl.sv
       - rtl/rstmgr_por.sv

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_cnsty_chk.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_cnsty_chk.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: lowrisc:opentitan:top_darjeeling_rstmgr_cnsty_chk:0.1
+name: lowrisc:darjeeling_ip:rstmgr_cnsty_chk:0.1
 description: "Rstmgr consistency checker"
 filesets:
   files_rtl:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:rv_core_ibex_pkg
-      - lowrisc:opentitan:top_darjeeling_rstmgr_pkg
+      - lowrisc:darjeeling_ip:rstmgr_pkg
     files:
       - rtl/rstmgr_cnsty_chk.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_pkg.core
@@ -2,15 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_pkg:0.1
+name: lowrisc:darjeeling_ip:rstmgr_pkg:0.1
 description: "Reset manager package"
-virtual:
-  - lowrisc:ip_interfaces:rstmgr_pkg
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
     files:
       - rtl/rstmgr_reg_pkg.sv
       - rtl/rstmgr_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_reg.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rstmgr_reg:0.1
+name: lowrisc:darjeeling_ip:rstmgr_reg:0.1
 description: "Reset manager registers"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_darjeeling_rstmgr_pkg
+      - lowrisc:darjeeling_ip:rstmgr_pkg
     files:
       - rtl/rstmgr_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -10,5 +10,12 @@
     target: 1
     prio: 3
     topname: darjeeling
+    uniquified_modules:
+    {
+      racl_ctrl: racl_ctrl
+      ac_range_check: ac_range_check
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/rv_plic_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/rv_plic_fpv.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rv_plic_fpv:0.1
+name: lowrisc:darjeeling_ip:rv_plic_fpv:0.1
 description: "FPV for RISC-V PLIC"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_darjeeling_rv_plic
+      - lowrisc:darjeeling_ip:rv_plic
       - lowrisc:fpv:csr_assert_gen
     files:
       - tb/rv_plic_bind_fpv.sv
@@ -24,7 +24,7 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../data/rv_plic.hjson
-      depend: lowrisc:opentitan:top_darjeeling_rv_plic
+      depend: lowrisc:darjeeling_ip:rv_plic
 
 targets:
   default: &default_target

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rv_plic.core
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rv_plic.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rv_plic:0.1
+name: lowrisc:darjeeling_ip:rv_plic:0.1
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_rv_plic_component:0.1
+      - lowrisc:darjeeling_ip:rv_plic_component:0.1
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
     files:

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rv_plic_component.core
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rv_plic_component.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_darjeeling_rv_plic_component:0.1
+name: lowrisc:darjeeling_ip:rv_plic_component:0.1
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:

--- a/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
@@ -39,7 +39,7 @@
                   rel_path: "hw/ip/aes/dv/lint/{tool}"
              },
           //    {    name: alert_handler
-          //         fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler_sim
+          //         fusesoc_core: lowrisc:darjeeling_dv:alert_handler_sim
           //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
           //         rel_path: "hw/top_darjeeling/ip_autogen/alert_handler/dv/lint/{tool}"
           //    },
@@ -74,7 +74,7 @@
                   rel_path: "hw/ip/edn/dv/lint/{tool}"
              },
              {    name: gpio
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_gpio_sim
+                  fusesoc_core: lowrisc:darjeeling_dv:gpio_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_darjeeling/ip_autogen/gpio/dv/lint/{tool}"
              },
@@ -111,7 +111,7 @@
                   rel_path: "hw/ip/lc_ctrl/dv/lint/{tool}"
              },
              {    name: otp_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_otp_ctrl_sim
+                  fusesoc_core: lowrisc:darjeeling_dv:otp_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_darjeeling/ip_autogen/otp_ctrl/dv/lint/{tool}"
              },

--- a/hw/top_darjeeling/lint/top_darjeeling_fpv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_fpv_lint_cfgs.hjson
@@ -22,13 +22,13 @@
   use_cfgs: [
             // {
             //   name: alert_handler_esc_timer_fpv
-            //   fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_esc_timer_fpv
+            //   fusesoc_core: lowrisc:earlgrey_fpv:alert_handler_esc_timer_fpv
             //   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
             //   rel_path: "hw/ip/alert_handler/alert_handler_esc_timer_fpv/lint/{tool}"
             //  }
             //  {
             //   name: alert_handler_ping_timer_fpv
-            //   fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_ping_timer_fpv
+            //   fusesoc_core: lowrisc:earlgrey_fpv:alert_handler_ping_timer_fpv
             //   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
             //   rel_path: "hw/ip/alert_handler/alert_handler_ping_timer_fpv/lint/{tool}"
             // }
@@ -148,7 +148,7 @@
              }
             //  {
             //     name: top_darjeeling_rv_plic_fpv
-            //     fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic_fpv
+            //     fusesoc_core: lowrisc:darjeeling_ip:rv_plic_fpv
             //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
             //     rel_path: "hw/top_darjeeling/ip_autogen/rv_plic/fpv/lint/{tool}"
             //  }

--- a/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
@@ -37,7 +37,7 @@
                   rel_path: "hw/ip/aes/lint/{tool}"
              },
              {    name: alert_handler
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler
+                  fusesoc_core: lowrisc:darjeeling_ip:alert_handler
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_darjeeling/ip_autogen/alert_handler/lint/{tool}"
                   overrides: [
@@ -64,7 +64,7 @@
                   ]
              },
              //{    name: clkmgr
-             //     fusesoc_core: lowrisc:opentitan:top_darjeeling_clkmgr
+             //     fusesoc_core: lowrisc:darjeeling_ip:clkmgr
              //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
              //     rel_path: "hw/top_darjeeling/ip_autogen/clkmgr/lint/{tool}",
              //     overrides: [
@@ -126,7 +126,7 @@
                   rel_path: "hw/ip/otbn/lint/{tool}"
              },
              {    name: otp_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_otp_ctrl
+                  fusesoc_core: lowrisc:darjeeling_ip:otp_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_darjeeling/ip_autogen/otp_ctrl/lint/{tool}"
                   overrides: [
@@ -137,7 +137,7 @@
                   ]
              },
              //{    name: pinmux
-             //     fusesoc_core: lowrisc:opentitan:top_darjeeling_pinmux
+             //     fusesoc_core: lowrisc:darjeeling_ip:pinmux
              //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
              //     rel_path: "hw/top_darjeeling/ip_autogen/pinmux/lint/{tool}"
              //     overrides: [
@@ -159,7 +159,7 @@
                   ]
              },
              {    name: pwrmgr
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_pwrmgr
+                  fusesoc_core: lowrisc:darjeeling_ip:pwrmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/top_darjeeling/ip_autogen/pwrmgr/lint/{tool}",
                   overrides: [
@@ -175,7 +175,7 @@
                   rel_path: "hw/ip/rom_ctrl/lint/{tool}"
              },
              {    name: rstmgr
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_rstmgr
+                  fusesoc_core: lowrisc:darjeeling_ip:rstmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/top_darjeeling/ip_autogen/rstmgr/lint/{tool}",
                   overrides: [
@@ -186,7 +186,7 @@
                   ]
              },
              {    name: gpio
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_gpio
+                  fusesoc_core: lowrisc:darjeeling_ip:gpio
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_darjeeling/ip_autogen/gpio/lint/{tool}"
                   overrides: [
@@ -217,7 +217,7 @@
              //     rel_path: "hw/ip/socdbg_ctrl/lint/{tool}"
              //},
              {    name: top_darjeeling_rv_plic
-                  fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic
+                  fusesoc_core: lowrisc:darjeeling_ip:rv_plic
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_darjeeling/ip_autogen/rv_plic/lint/{tool}"
              },

--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -9,8 +9,8 @@ filesets:
     depend:
       # Place the autogen packages first to avoid conflicts
       - lowrisc:systems:top_darjeeling_racl_pkg
-      - lowrisc:opentitan:top_darjeeling_alert_handler_reg
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
+      - lowrisc:darjeeling_ip:alert_handler_reg
+      - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:ip:uart:0.1
       - lowrisc:ip:rv_core_ibex
       - lowrisc:ip:rv_dm
@@ -40,16 +40,16 @@ filesets:
       - lowrisc:top_darjeeling:xbar_main
       - lowrisc:top_darjeeling:xbar_mbx
       - lowrisc:top_darjeeling:xbar_peri
-      - lowrisc:opentitan:top_darjeeling_ac_range_check
-      - lowrisc:opentitan:top_darjeeling_alert_handler
-      - lowrisc:opentitan:top_darjeeling_clkmgr
-      - lowrisc:opentitan:top_darjeeling_otp_ctrl
-      - lowrisc:opentitan:top_darjeeling_pinmux
-      - lowrisc:opentitan:top_darjeeling_pwrmgr
-      - lowrisc:opentitan:top_darjeeling_rstmgr
-      - lowrisc:opentitan:top_darjeeling_rv_plic
-      - lowrisc:opentitan:top_darjeeling_racl_ctrl
-      - lowrisc:opentitan:top_darjeeling_gpio
+      - lowrisc:darjeeling_ip:ac_range_check
+      - lowrisc:darjeeling_ip:alert_handler
+      - lowrisc:darjeeling_ip:clkmgr
+      - lowrisc:darjeeling_ip:otp_ctrl
+      - lowrisc:darjeeling_ip:pinmux
+      - lowrisc:darjeeling_ip:pwrmgr
+      - lowrisc:darjeeling_ip:rstmgr
+      - lowrisc:darjeeling_ip:rv_plic
+      - lowrisc:darjeeling_ip:racl_ctrl
+      - lowrisc:darjeeling_ip:gpio
       - lowrisc:ip:aon_timer
       - lowrisc:ip:adc_ctrl
       - lowrisc:ip:sysrst_ctrl

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -19,13 +19,13 @@ filesets:
   files_dv:
     depend:
       # Place the autogen packages first to avoid conflicts
-      - lowrisc:opentitan:top_earlgrey_alert_handler_reg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:alert_handler_reg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:tlul
       - lowrisc:dv:top_earlgrey_chip_test
-      - lowrisc:opentitan:top_earlgrey_clkmgr_sva
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_sva
-      - lowrisc:opentitan:top_earlgrey_rstmgr_sva
+      - lowrisc:earlgrey_dv:clkmgr_sva
+      - lowrisc:earlgrey_dv:pwrmgr_sva
+      - lowrisc:earlgrey_dv:rstmgr_sva
       - lowrisc:dv:top_earlgrey_sva
       - lowrisc:dv:top_earlgrey_xbar_main_bind
       - lowrisc:dv:top_earlgrey_xbar_peri_bind
@@ -34,7 +34,7 @@ filesets:
       - lowrisc:dv:sim_sram
       - lowrisc:dv:sw_test_status
       - lowrisc:dv:sw_logger_if
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_bkdr_util
+      - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
       - lowrisc:dv:rom_ctrl_bkdr_util
       - lowrisc:dv:sram_ctrl_bkdr_util
       - lowrisc:dv_dpi_c:gpiodpi

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -23,8 +23,8 @@ filesets:
       - lowrisc:dv:jtag_riscv_agent
       - lowrisc:dv:jtag_dmi_agent
       - lowrisc:dv:lc_ctrl_dv_utils
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_bkdr_util
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_mem_bkdr_util
+      - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
+      - lowrisc:earlgrey_dv:otp_ctrl_mem_bkdr_util
       - lowrisc:dv:ralgen
       - lowrisc:dv:spi_agent
       - lowrisc:dv:spi_host_sva
@@ -36,7 +36,7 @@ filesets:
       - lowrisc:dv:i2c_agent
       - lowrisc:dv:pattgen_agent
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:dv:lc_ctrl_dv_utils
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"

--- a/hw/top_earlgrey/dv/sva/top_earlgrey_sva.core
+++ b/hw/top_earlgrey/dv/sva/top_earlgrey_sva.core
@@ -7,7 +7,7 @@ description: "TOP_EARLGREY assertion modules and bind file."
 filesets:
   files_dv:
     depend:
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:prim:assert
       - lowrisc:systems:top_earlgrey
     files:

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
@@ -23,7 +23,7 @@
              {
                name: pinmux_fpv
                dut: pinmux_tb
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_pinmux_fpv
+               fusesoc_core: lowrisc:earlgrey_fpv:pinmux_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
@@ -35,7 +35,7 @@
              {
                name: pinmux_chip_fpv
                dut: pinmux_chip_tb
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_pinmux_chip_fpv
+               fusesoc_core: lowrisc:earlgrey_fpv:pinmux_chip_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pinmux/{sub_flow}/{tool}"
                defines: "FPV_ALERT_NO_SIGINT_ERR"
@@ -46,7 +46,7 @@
              {
                name: rv_plic_fpv
                dut: rv_plic_tb
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_rv_plic_fpv
+               fusesoc_core: lowrisc:earlgrey_ip:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/rv_plic/{sub_flow}/{tool}"
                cov: true

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
@@ -19,7 +19,7 @@
              {
               name: alert_handler_esc_timer_fpv
               dut: alert_handler_esc_timer_tb
-              fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_esc_timer_fpv
+              fusesoc_core: lowrisc:earlgrey_fpv:alert_handler_esc_timer_fpv
               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
               rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_esc_timer/{sub_flow}/{tool}"
               cov: true
@@ -28,7 +28,7 @@
              {
               name: alert_handler_ping_timer_fpv
               dut: alert_handler_ping_timer_tb
-              fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_ping_timer_fpv
+              fusesoc_core: lowrisc:earlgrey_fpv:alert_handler_ping_timer_fpv
               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
               rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/alert_handler/ping_timer/{sub_flow}/{tool}"
               cov: true

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
@@ -44,7 +44,7 @@
              {
                name: alert_handler_sec_cm
                dut: alert_handler
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_sva
+               fusesoc_core: lowrisc:earlgrey_dv:alert_handler_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/{sub_flow}/{tool}"
                stopats: ["*u_state_regs.state_o"]
@@ -53,7 +53,7 @@
              {
                name: clkmgr_sec_cm
                dut: clkmgr
-               fusesoc_core: lowrisc:dv:clkmgr_sva
+               fusesoc_core: lowrisc:earlgrey_dv:clkmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/clkmgr/{sub_flow}/{tool}"
                task: "FpvSecCm"
@@ -88,7 +88,7 @@
              {
                name: flash_ctrl_sec_cm
                dut: flash_ctrl
-               fusesoc_core: lowrisc:dv:flash_ctrl_sva
+               fusesoc_core: lowrisc:earlgrey_dv:flash_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/flash_ctrl/{sub_flow}/{tool}"
                overrides: [
@@ -133,7 +133,7 @@
              {
                name: otp_ctrl_sec_cm
                dut: otp_ctrl
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_otp_ctrl_sva
+               fusesoc_core: earlgrey_dv:otp_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/otp_ctrl/{sub_flow}/{tool}"
                stopats: ["*u_state_regs.state_o"]
@@ -151,7 +151,7 @@
              {
                name: pwrmgr_sec_cm
                dut: pwrmgr
-               fusesoc_core: lowrisc:dv:pwrmgr_sva
+               fusesoc_core: lowrisc:earlgrey_dv:pwrmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pwrmgr/{sub_flow}/{tool}"
                overrides: [
@@ -175,7 +175,7 @@
              {
                name: rstmgr_sec_cm
                dut: rstmgr
-               fusesoc_core: lowrisc:dv:rstmgr_sva
+               fusesoc_core: lowrisc:earlgrey_dv:rstmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/rstmgr/{sub_flow}/{tool}"
                overrides: [
@@ -215,7 +215,7 @@
              {
                name: pinmux_sec_cm
                dut: pinmux
-               fusesoc_core: lowrisc:ip_interfaces:pinmux
+               fusesoc_core: lowrisc:earlgrey_ip:pinmux
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pinmux/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"
@@ -229,7 +229,7 @@
               {
                name: rv_plic_sec_cm
                dut: rv_plic
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_rv_plic_fpv
+               fusesoc_core: lowrisc:earlgrey_ip:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip/rv_plic/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"
@@ -279,7 +279,7 @@
              {
                name: pwrmgr_esc_unstoppable
                dut: pwrmgr
-               fusesoc_core: lowrisc:dv:pwrmgr_sva
+               fusesoc_core: lowrisc:earlgrey_dv:pwrmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pwrmgr/{sub_flow}/{tool}"
                overrides: [

--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -16,16 +16,16 @@ filesets:
       - lowrisc:prim:clock_inv
       - lowrisc:prim:lc_dec
       - lowrisc:prim:lfsr
-      - lowrisc:ip_interfaces:pinmux_pkg
+      - lowrisc:earlgrey_ip:pinmux_pkg
       - lowrisc:prim:assert
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:mubi
       - lowrisc:prim:multibit_sync
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
-      - lowrisc:ip_interfaces:alert_handler_pkg
-      - lowrisc:ip_interfaces:clkmgr_pkg
-      - lowrisc:ip_interfaces:rstmgr_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
+      - lowrisc:earlgrey_ip:clkmgr_pkg
+      - lowrisc:earlgrey_ip:rstmgr_pkg
       - lowrisc:systems:top_earlgrey_ast_pkg
     files:
       - rtl/ast_reg_pkg.sv

--- a/hw/top_earlgrey/ip/ast/top_earlgrey_ast_top.core
+++ b/hw/top_earlgrey/ip/ast/top_earlgrey_ast_top.core
@@ -7,11 +7,11 @@ description: "Pseudo top-level for Earl Grey's ast"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_pkg
-      - lowrisc:opentitan:top_earlgrey_clkmgr_pkg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg
-      - lowrisc:opentitan:top_earlgrey_pinmux_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
+      - lowrisc:earlgrey_ip:clkmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:rstmgr_pkg
+      - lowrisc:earlgrey_ip:pinmux_pkg
       - lowrisc:systems:top_earlgrey_ast
 
 parameters:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler:0.1
+name: lowrisc:earlgrey_ip:alert_handler:0.1
 description: "Alert Handler"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_component:0.1
-      - lowrisc:opentitan:top_earlgrey_alert_handler_reg:0.1
+      - lowrisc:earlgrey_ip:alert_handler_component:0.1
+      - lowrisc:earlgrey_ip:alert_handler_reg:0.1
     file_type: systemVerilogSource
 
 parameters:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_component.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_component.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_component:0.1
+name: lowrisc:earlgrey_ip:alert_handler_component:0.1
 description: "Alert Handler component without the CSRs"
 
 filesets:
@@ -17,7 +17,7 @@ filesets:
       - lowrisc:prim:buf
       - lowrisc:prim:mubi
       - lowrisc:prim:sparse_fsm
-      - lowrisc:opentitan:top_earlgrey_alert_handler_reg
+      - lowrisc:earlgrey_ip:alert_handler_reg
     files:
       - rtl/alert_handler_reg_wrap.sv
       - rtl/alert_handler_lpg_ctrl.sv

--- a/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_pkg:0.1
+name: lowrisc:earlgrey_ip:alert_handler_pkg:0.1
 description: "Alert Handler constants in packages"
 virtual:
-  - "lowrisc:ip_interfaces:alert_handler_pkg"
+  - "lowrisc:virtual_ip:alert_handler_pkg"
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_reg.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_reg:0.1
+name: lowrisc:earlgrey_ip:alert_handler_reg:0.1
 description: "Auto-generated alert handler register sources"
 
 filesets:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim:subreg
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_earlgrey_alert_handler_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
     files:
       - rtl/alert_handler_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
@@ -149,5 +149,10 @@
     ]
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim.core
@@ -2,20 +2,20 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_sim:0.1
+name: lowrisc:earlgrey_dv:alert_handler_sim:0.1
 description: "ALERT_HANDLER DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler:0.1
+      - lowrisc:earlgrey_ip:alert_handler:0.1
     file_type: systemVerilogSource
 
   files_dv:
     depend:
       - lowrisc:dv:ralgen
-      - lowrisc:opentitan:top_earlgrey_alert_handler_tb:0.1
-      - lowrisc:opentitan:top_earlgrey_alert_handler_cov:0.1
-      - lowrisc:opentitan:top_earlgrey_alert_handler_sva:0.1
+      - lowrisc:earlgrey_dv:alert_handler_tb:0.1
+      - lowrisc:earlgrey_dv:alert_handler_cov:0.1
+      - lowrisc:earlgrey_dv:alert_handler_sva:0.1
     file_type: systemVerilogSource
 
 generate:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:alert_handler_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/alert_handler_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cov.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/cov/alert_handler_cov.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_cov:0.1
+name: lowrisc:earlgrey_dv:alert_handler_cov:0.1
 description: "ALERT_HANDLER cov bind files"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_component:0.1  # import alert_handler_pkg
+      - lowrisc:earlgrey_ip:alert_handler_component:0.1  # import alert_handler_pkg
       - lowrisc:dv:dv_utils
     files:
       - alert_handler_cov_bind.sv

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_env:0.1
+name: lowrisc:earlgrey_dv:alert_handler_env:0.1
 description: "ALERT_HANDLER DV UVM environment"
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_earlgrey_alert_handler_pkg:0.1
+      - lowrisc:earlgrey_ip:alert_handler_pkg:0.1
       - lowrisc:prim:mubi_pkg
       - lowrisc:constants:top_earlgrey_top_pkg
     files:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/sva/alert_handler_sva.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/sva/alert_handler_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_sva:0.1
+name: lowrisc:earlgrey_dv:alert_handler_sva:0.1
 description: "ALERT_HANDLER assertion modules and bind file."
 filesets:
   files_dv:
@@ -15,7 +15,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler:0.1
+      - lowrisc:earlgrey_ip:alert_handler:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/tb/alert_handler_tb.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/tb/alert_handler_tb.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_tb:0.1
+name: lowrisc:earlgrey_dv:alert_handler_tb:0.1
 description: "ALERT_HANDLER UVM TB environment"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_test:0.1
+      - lowrisc:earlgrey_dv:alert_handler_test:0.1
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/tests/alert_handler_test.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/tests/alert_handler_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_test:0.1
+name: lowrisc:earlgrey_dv:alert_handler_test:0.1
 description: "ALERT_HANDLER DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_env
+      - lowrisc:earlgrey_dv:alert_handler_env
     files:
       - alert_handler_test_pkg.sv
       - alert_handler_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/alert_handler/fpv/alert_handler_esc_timer_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/fpv/alert_handler_esc_timer_fpv.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_esc_timer_fpv:0.1
+name: lowrisc:earlgrey_fpv:alert_handler_esc_timer_fpv:0.1
 description: "alert_handler_esc_timer FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_earlgrey_alert_handler
+      - lowrisc:earlgrey_ip:alert_handler
     files:
       - vip/alert_handler_esc_timer_assert_fpv.sv
       - tb/alert_handler_esc_timer_bind_fpv.sv

--- a/hw/top_earlgrey/ip_autogen/alert_handler/fpv/alert_handler_ping_timer_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/fpv/alert_handler_ping_timer_fpv.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_alert_handler_ping_timer_fpv:0.1
+name: lowrisc:earlgrey_fpv:alert_handler_ping_timer_fpv:0.1
 description: "ALERT_HANDLER FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_earlgrey_alert_handler
+      - lowrisc:earlgrey_ip:alert_handler
     files:
       - vip/alert_handler_ping_timer_assert_fpv.sv
       - tb/alert_handler_ping_timer_bind_fpv.sv

--- a/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr:0.1
+name: lowrisc:earlgrey_ip:clkmgr:0.1
 description: "Top specific clock manager "
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:buf
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender
       - lowrisc:prim:measure
-      - lowrisc:opentitan:top_earlgrey_clkmgr_pkg:0.1
-      - lowrisc:opentitan:top_earlgrey_clkmgr_reg:0.1
+      - lowrisc:earlgrey_ip:clkmgr_pkg:0.1
+      - lowrisc:earlgrey_ip:clkmgr_reg:0.1
     files:
       - rtl/clkmgr.sv
       - rtl/clkmgr_byp.sv

--- a/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_pkg:0.1
+name: lowrisc:earlgrey_ip:clkmgr_pkg:0.1
 description: "Top specific clock manager package"
 virtual:
-  - lowrisc:ip_interfaces:clkmgr_pkg
+  - lowrisc:virtual_ip:clkmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr_reg.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_reg:0.1
+name: lowrisc:earlgrey_ip:clkmgr_reg:0.1
 description: "Clock manager registers"
 
 filesets:

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
@@ -259,8 +259,12 @@
     exported_clks: {}
     number_of_clock_groups: 7
     with_alert_handler: true
-    pwrmgr_vlnv_prefix: top_earlgrey_
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_sim:0.1
+name: lowrisc:earlgrey_dv:clkmgr_sim:0.1
 description: "CLKMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_clkmgr
+      - lowrisc:earlgrey_ip:clkmgr
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_clkmgr_test:0.1
-      - lowrisc:opentitan:top_earlgrey_clkmgr_sva:0.1
+      - lowrisc:earlgrey_dv:clkmgr_test:0.1
+      - lowrisc:earlgrey_dv:clkmgr_sva:0.1
     files:
       - tb.sv
       - cov/clkmgr_cov_bind.sv

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_clkmgr_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:clkmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/clkmgr_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_env:0.1
+name: lowrisc:earlgrey_dv:clkmgr_env:0.1
 description: "CLKMGR DV UVM environment"
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
-      - lowrisc:opentitan:top_earlgrey_clkmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:clkmgr_pkg
       - lowrisc:constants:top_earlgrey_top_pkg
     files:
       - clkmgr_csrs_if.sv

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/sva/clkmgr_sva.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/sva/clkmgr_sva.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_sva:0.1
+name: lowrisc:earlgrey_dv:clkmgr_sva:0.1
 description: "CLKMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_earlgrey_clkmgr_sva_ifs:0.1
+      - lowrisc:earlgrey_dv:clkmgr_sva_ifs:0.1
     files:
       - clkmgr_bind.sv
       - clkmgr_sec_cm_checker_assert.sv
@@ -17,7 +17,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_earlgrey_clkmgr
+      - lowrisc:earlgrey_ip:clkmgr
 
 generate:
   csr_assert_gen:

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/sva/clkmgr_sva_ifs.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/sva/clkmgr_sva_ifs.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_sva_ifs:0.1
+name: lowrisc:earlgrey_dv:clkmgr_sva_ifs:0.1
 description: "CLKMGR SVA interfaces."
 filesets:
   files_dv:

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/tests/clkmgr_test.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/tests/clkmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_clkmgr_test:0.1
+name: lowrisc:earlgrey_dv:clkmgr_test:0.1
 description: "CLKMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_clkmgr_env:0.1
+      - lowrisc:earlgrey_dv:clkmgr_env:0.1
     files:
       - clkmgr_test_pkg.sv
       - clkmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
@@ -23,8 +23,12 @@
     bytes_per_page: 2048
     bytes_per_bank: 524288
     size: 1048576
-    pwrmgr_vlnv_prefix: top_earlgrey_
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_cov.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_cov.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_cov
+name: lowrisc:earlgrey_dv:flash_ctrl_cov
 description: "FLASH_CTRL functional coverage interface & bind."
 
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_utils
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl
+      - lowrisc:earlgrey_ip:flash_ctrl
     files:
       - flash_ctrl_cov_bind.sv
       - flash_ctrl_phy_cov_if.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_bkdr_util:0.1
+name: lowrisc:earlgrey_dv:flash_ctrl_bkdr_util:0.1
 description: "Backdoor read/write flash memory for DV"
 
 filesets:
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_prince:0.1
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_pkg
       - lowrisc:dv:mem_bkdr_util
     files:
       - flash_ctrl_bkdr_util_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_env:0.1
+name: lowrisc:earlgrey_dv:flash_ctrl_env:0.1
 description: "FLASH_CTRL DV UVM environment"
 filesets:
   files_dv:
@@ -11,10 +11,10 @@ filesets:
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:dv_lib
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_bkdr_util
+      - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_pkg
       - lowrisc:constants:top_earlgrey_top_pkg
     files:
       - flash_ctrl_eflash_ral_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_flash_ctrl_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:flash_ctrl_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/flash_ctrl_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
@@ -2,22 +2,22 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_sim:0.1
+name: lowrisc:earlgrey_dv:flash_ctrl_sim:0.1
 description: "FLASH_CTRL DV sim target"
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:constants:top_earlgrey_top_pkg
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl:0.1
+      - lowrisc:earlgrey_ip:flash_ctrl:0.1
     file_type: systemVerilogSource
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_bkdr_util
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_test
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_sva
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_cov
+      - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
+      - lowrisc:earlgrey_dv:flash_ctrl_test
+      - lowrisc:earlgrey_dv:flash_ctrl_sva
+      - lowrisc:earlgrey_dv:flash_ctrl_cov
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_sva:0.1
+name: lowrisc:earlgrey_dv:flash_ctrl_sva:0.1
 description: "FLASH_CTRL assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_pkg
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
     files:
@@ -17,7 +17,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl
+      - lowrisc:earlgrey_ip:flash_ctrl
 
 generate:
   csr_assert_gen:

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/tests/flash_ctrl_test.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/tests/flash_ctrl_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_test:0.1
+name: lowrisc:earlgrey_dv:flash_ctrl_test:0.1
 description: "FLASH_CTRL DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_env
+      - lowrisc:earlgrey_dv:flash_ctrl_env
     files:
       - flash_ctrl_test_pkg.sv
       - flash_ctrl_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl:0.1
+name: lowrisc:earlgrey_ip:flash_ctrl:0.1
 description: "Flash Controller"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_reg
+      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_reg
       - lowrisc:constants:top_earlgrey_top_pkg
       - lowrisc:ip:jtag_pkg
     files:

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg:0.1
+name: lowrisc:earlgrey_ip:flash_ctrl_pkg:0.1
 description: "Top specific flash package"
 virtual:
-  - lowrisc:ip_interfaces:flash_ctrl_pkg
+  - lowrisc:virtual_ip:flash_ctrl_pkg
 
 filesets:
   files_rtl:
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:constants:top_earlgrey_top_pkg
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_prim_reg_top:1.0
+name: lowrisc:earlgrey_ip:flash_ctrl_prim_reg_top:1.0
 description: "Generic register top for the FLASH wrapper"
 virtual:
-  - lowrisc:ip_interfaces:flash_ctrl_prim_reg_top
+  - lowrisc:virtual_ip:flash_ctrl_prim_reg_top
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_pkg
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_reg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_reg.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_flash_ctrl_reg:0.1
+name: lowrisc:earlgrey_ip:flash_ctrl_reg:0.1
 description: "Flash registers"
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_pkg
     files:
       - rtl/flash_ctrl_core_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
@@ -8,5 +8,10 @@
     num_inp_period_counters: 0
     module_instance_name: gpio
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_gpio_env:0.1
+name: lowrisc:earlgrey_dv:gpio_env:0.1
 description: "GPIO DV UVM environmnt"
 filesets:
   files_dv:

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim.core
@@ -2,18 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_gpio_sim:0.1
+name: lowrisc:earlgrey_dv:gpio_sim:0.1
 description: "GPIO DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_gpio:0.1
+      - lowrisc:earlgrey_ip:gpio:0.1
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_gpio_test
-      - lowrisc:opentitan:top_earlgrey_gpio_sva
-      - lowrisc:opentitan:top_earlgrey_gpio_if
+      - lowrisc:earlgrey_dv:gpio_test
+      - lowrisc:earlgrey_dv:gpio_sva
+      - lowrisc:earlgrey_dv:gpio_if
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_gpio_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:gpio_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/gpio_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/interfaces/gpio_if.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/interfaces/gpio_if.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_gpio_if:0.1
+name: lowrisc:earlgrey_dv:gpio_if:0.1
 description: "GPIO Interfaces"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_gpio:0.1
+      - lowrisc:earlgrey_ip:gpio:0.1
     files:
       - gpio_straps_if.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/sva/gpio_sva.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/sva/gpio_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_gpio_sva:0.1
+name: lowrisc:earlgrey_dv:gpio_sva:0.1
 description: "GPIO assertion modules and bind file."
 filesets:
   files_dv:
@@ -15,7 +15,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_earlgrey_gpio:0.1
+      - lowrisc:earlgrey_ip:gpio:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/tests/gpio_test.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/tests/gpio_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_gpio_test:0.1
+name: lowrisc:earlgrey_dv:gpio_test:0.1
 description: "GPIO DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_gpio_env:0.1
+      - lowrisc:earlgrey_dv:gpio_env:0.1
     files:
       - gpio_test_pkg.sv
       - gpio_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/gpio/gpio.core
+++ b/hw/top_earlgrey/ip_autogen/gpio/gpio.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_gpio:0.1
+name: lowrisc:earlgrey_ip:gpio:0.1
 description: "gpio"
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
@@ -1986,5 +1986,10 @@
       ]
     }
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/cov/otp_ctrl_cov.core
@@ -2,16 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_cov
+name: lowrisc:earlgrey_dv:otp_ctrl_cov
 description: "OTP_CTRL functional coverage and bind files"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_cov
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip_interfaces:pwrmgr_pkg
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_top_specific_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:otp_ctrl_top_specific_pkg
 
   files_dv:
     depend:

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_env:0.1
+name: lowrisc:earlgrey_dv:otp_ctrl_env:0.1
 description: "OTP_CTRL DV UVM environment"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_env
 
 filesets:
   files_dv:

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_mem_bkdr_util:0.1
+name: lowrisc:earlgrey_dv:otp_ctrl_mem_bkdr_util:0.1
 description: "OTP_CTRL mem_bkdr_util support package"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_mem_bkdr_util
 
 filesets:
   files_dv:
@@ -13,7 +11,7 @@ filesets:
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:crypto_dpi_present
       - lowrisc:dv:lc_ctrl_dv_utils
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_top_specific_pkg:1.0
+      - lowrisc:earlgrey_ip:otp_ctrl_top_specific_pkg:1.0
     files:
       - otp_scrambler_pkg.sv
       - otp_ctrl_mem_bkdr_util_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim.core
@@ -2,22 +2,20 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_sim:0.1
+name: lowrisc:earlgrey_dv:otp_ctrl_sim:0.1
 description: "OTP_CTRL DV sim target"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_sim
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl
+      - lowrisc:earlgrey_ip:otp_ctrl
 
   files_dv:
     depend:
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_test
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_sva
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_cov
+      - lowrisc:earlgrey_dv:otp_ctrl_test
+      - lowrisc:earlgrey_dv:otp_ctrl_sva
+      - lowrisc:earlgrey_dv:otp_ctrl_cov
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_otp_ctrl_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:otp_ctrl_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/otp_ctrl_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/sva/otp_ctrl_sva.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/sva/otp_ctrl_sva.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_sva:0.1
+name: lowrisc:earlgrey_dv:otp_ctrl_sva:0.1
 description: "OTP_CTRL assertion modules and bind file."
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_sva
 
 filesets:
   files_dv:
@@ -18,7 +16,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl
+      - lowrisc:earlgrey_ip:otp_ctrl
 
 generate:
   csr_assert_gen:

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/tests/otp_ctrl_test.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/tests/otp_ctrl_test.core
@@ -2,15 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_test:0.1
+name: lowrisc:earlgrey_dv:otp_ctrl_test:0.1
 description: "OTP_CTRL DV UVM test"
-virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_test
 
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_env
+      - lowrisc:earlgrey_dv:otp_ctrl_env
     files:
       - otp_ctrl_test_pkg.sv
       - otp_ctrl_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl.core
@@ -2,16 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl:1.0
+name: lowrisc:earlgrey_ip:otp_ctrl:1.0
 description: "OTP Controller"
 virtual:
-  - lowrisc:ip_interfaces:otp_ctrl
+  - lowrisc:virtual_ip:otp_ctrl
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl_top_specific_pkg
+      - lowrisc:earlgrey_ip:otp_ctrl_top_specific_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:ram_1p
@@ -25,7 +25,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
       - lowrisc:prim:sec_anchor
-      - lowrisc:ip_interfaces:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
       - "fileset_partner  ? (partner:systems:ast_pkg)"

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
@@ -10,7 +10,7 @@ filesets:
       # otp_ctrl_prim_reg_top.sv should depend on generic items for now.
       # This may change and will require reworking the flow to generate
       # the otp prim.
-      - lowrisc:ip_interfaces:otp_ctrl_top_specific_pkg
+      - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
     files:
       - rtl/otp_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl_top_specific_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl_top_specific_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_otp_ctrl_top_specific_pkg:1.0
+name: lowrisc:earlgrey_ip:otp_ctrl_top_specific_pkg:1.0
 description: "OTP Controller Top Specific Packages"
 virtual:
-  - lowrisc:ip_interfaces:otp_ctrl_top_specific_pkg
+  - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: otp_ctrl
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_{name}:0.1
+  fusesoc_core: lowrisc:earlgrey_ip:{name}:0.1
 
   import_cfgs: [// Project wide common GTECH synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: otp_ctrl
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_{name}:0.1
+  fusesoc_core: lowrisc:earlgrey_ip:{name}:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
@@ -18,5 +18,10 @@
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_earlgrey_scan_role_pkg
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pinmux_chip_fpv:0.1
+name: lowrisc:earlgrey_systems:pinmux_chip_fpv:0.1
 description: "pinmux FPV target with chip_earlgrey parameters"
 
 filesets:
@@ -13,9 +13,9 @@ filesets:
       - lowrisc:ip:jtag_pkg
       - lowrisc:prim:mubi_pkg
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_pinmux:0.1
+      - lowrisc:earlgrey_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_earlgrey_pinmux_common_fpv:0.1
+      - lowrisc:earlgrey_fpv:pinmux_common_fpv:0.1
       - lowrisc:constants:top_earlgrey_top_pkg
       - lowrisc:systems:top_earlgrey_scan_role_pkg
     files:

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_common_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_common_fpv.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pinmux_common_fpv:0.1
+name: lowrisc:earlgrey_fpv:pinmux_common_fpv:0.1
 description: "pinmux common FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_earlgrey_pinmux:0.1
+      - lowrisc:earlgrey_ip:pinmux:0.1
     files:
       - vip/pinmux_assert_fpv.sv
       - tb/pinmux_bind_fpv.sv

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_fpv.core
@@ -2,16 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pinmux_fpv:0.1
+name: lowrisc:earlgrey_fpv:pinmux_fpv:0.1
 description: "pinmux FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_earlgrey_pinmux:0.1
+      - lowrisc:earlgrey_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_earlgrey_pinmux_common_fpv
+      - lowrisc:earlgrey_fpv:pinmux_common_fpv
     files:
       - tb/pinmux_tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/pinmux.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pinmux:0.1
+name: lowrisc:earlgrey_ip:pinmux:0.1
 description: "Pin Multiplexer"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:pad_attr
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:usbdev
-      - lowrisc:opentitan:top_earlgrey_pinmux_reg:0.1
-      - lowrisc:opentitan:top_earlgrey_pinmux_pkg:0.1
+      - lowrisc:earlgrey_ip:pinmux_reg:0.1
+      - lowrisc:earlgrey_ip:pinmux_pkg:0.1
     files:
       - rtl/pinmux_wkup.sv
       - rtl/pinmux_jtag_buf.sv

--- a/hw/top_earlgrey/ip_autogen/pinmux/pinmux_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/pinmux_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pinmux_pkg:0.1
+name: lowrisc:earlgrey_ip:pinmux_pkg:0.1
 description: "Pinmux package"
 virtual:
-  - lowrisc:ip_interfaces:pinmux_pkg
+  - lowrisc:virtual_ip:pinmux_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip_autogen/pinmux/pinmux_reg.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/pinmux_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pinmux_reg:0.1
+name: lowrisc:earlgrey_ip:pinmux_reg:0.1
 description: "Auto-generated pinmux register sources"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_earlgrey_pinmux_pkg
+      - lowrisc:earlgrey_ip:pinmux_pkg
     files:
       - rtl/pinmux_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/pinmux/syn/pinmux_syn_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/syn/pinmux_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: pinmux
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_pinmux:0.1
+  fusesoc_core: lowrisc:earlgrey_ip:pinmux:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"],

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -83,5 +83,10 @@
     NumRomInputs: 1
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_env:0.1
+name: lowrisc:earlgrey_dv:pwrmgr_env:0.1
 description: "PWRMGR DV UVM environment"
 filesets:
   files_dv:
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:constants:top_earlgrey_top_pkg
     files:
       - pwrmgr_env_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_sim:0.1
+name: lowrisc:earlgrey_dv:pwrmgr_sim:0.1
 description: "PWRMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_pwrmgr:0.1
+      - lowrisc:earlgrey_ip:pwrmgr:0.1
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_test:0.1
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_sva:0.1
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_unit_only_sva:0.1
+      - lowrisc:earlgrey_dv:pwrmgr_test:0.1
+      - lowrisc:earlgrey_dv:pwrmgr_sva:0.1
+      - lowrisc:earlgrey_dv:pwrmgr_unit_only_sva:0.1
     files:
       - tb.sv
       - cov/pwrmgr_cov_bind.sv

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_pwrmgr_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:pwrmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/pwrmgr_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_sva.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_sva:0.1
+name: lowrisc:earlgrey_dv:pwrmgr_sva:0.1
 description: "PWRMGR assertion modules and bind file."
 filesets:
   files_dv:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:dv:clkmgr_pwrmgr_sva_if
       - lowrisc:dv:pwrmgr_rstmgr_sva_if:0.1
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
     files:
       - pwrmgr_bind.sv
       - pwrmgr_clock_enables_sva_if.sv
@@ -21,7 +21,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_earlgrey_pwrmgr:0.1
+      - lowrisc:earlgrey_ip:pwrmgr:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_unit_only_sva.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/sva/pwrmgr_unit_only_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_unit_only_sva:0.1
+name: lowrisc:earlgrey_dv:pwrmgr_unit_only_sva:0.1
 description: "PWRMGR assertion interfaces not suitable for chip level bind file."
 filesets:
   files_dv:
@@ -10,8 +10,8 @@ filesets:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg:0.1
-      - lowrisc:opentitan:top_earlgrey_pwrmgr:0.1
+      - lowrisc:earlgrey_ip:pwrmgr_pkg:0.1
+      - lowrisc:earlgrey_ip:pwrmgr:0.1
 
     files:
       - pwrmgr_unit_only_bind.sv

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/tests/pwrmgr_test.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/tests/pwrmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_test:0.1
+name: lowrisc:earlgrey_dv:pwrmgr_test:0.1
 description: "PWRMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_env:0.1
+      - lowrisc:earlgrey_dv:pwrmgr_env:0.1
     files:
       - pwrmgr_test_pkg.sv
       - pwrmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr:0.1
+name: lowrisc:earlgrey_ip:pwrmgr:0.1
 description: "Power manager RTL"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:clock_buf
       - lowrisc:prim:measure
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg:0.1
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_reg:0.1
+      - lowrisc:earlgrey_ip:pwrmgr_pkg:0.1
+      - lowrisc:earlgrey_ip:pwrmgr_reg:0.1
     files:
       - rtl/pwrmgr_cdc.sv
       - rtl/pwrmgr_slow_fsm.sv

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_pkg:0.1
+name: lowrisc:earlgrey_ip:pwrmgr_pkg:0.1
 description: "Power manager package"
 virtual:
-  - lowrisc:ip_interfaces:pwrmgr_pkg
+  - lowrisc:virtual_ip:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_reg.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_pwrmgr_reg:0.1
+name: lowrisc:earlgrey_ip:pwrmgr_reg:0.1
 description: "Power manager registers"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
     files:
       - rtl/pwrmgr_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -690,10 +690,14 @@
     ]
     rst_ni: lc_io_div4
     export_rsts: {}
-    alert_handler_vlnv_prefix: top_earlgrey_
+    alert_handler_vlnv: lowrisc:earlgrey_ip:alert_handler_pkg
     with_alert_handler: true
-    pwrmgr_vlnv_prefix: top_earlgrey_
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -2,18 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_env:0.1
+name: lowrisc:earlgrey_dv:rstmgr_env:0.1
 description: "RSTMGR DV UVM environment"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_rstmgr
+      - lowrisc:earlgrey_ip:rstmgr
 
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg
+      - lowrisc:earlgrey_ip:rstmgr_pkg
       - lowrisc:constants:top_earlgrey_top_pkg
 
     files:

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_cnsty_chk_sim:0.1
+name: lowrisc:earlgrey_dv:rstmgr_cnsty_chk_sim:0.1
 description: "Rstmgr_cnsty_chk DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_rstmgr_cnsty_chk:0.1
+      - lowrisc:earlgrey_ip:rstmgr_cnsty_chk:0.1
       - lowrisc:dv:sec_cm
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_rstmgr_cnsty_chk_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:rstmgr_cnsty_chk_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/data/rstmgr_cnsty_chk_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_sim:0.1
+name: lowrisc:earlgrey_dv:rstmgr_sim:0.1
 description: "RSTMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_rstmgr
+      - lowrisc:earlgrey_ip:rstmgr
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_rstmgr_test:0.1
-      - lowrisc:opentitan:top_earlgrey_rstmgr_sva:0.1
+      - lowrisc:earlgrey_dv:rstmgr_test:0.1
+      - lowrisc:earlgrey_dv:rstmgr_sva:0.1
     files:
       - tb.sv
       - cov/rstmgr_cov_bind.sv

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_earlgrey_rstmgr_sim:0.1
+  fusesoc_core: lowrisc:earlgrey_dv:rstmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/rstmgr_testplan.hjson"

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sva.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sva.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_sva:0.1
+name: lowrisc:earlgrey_dv:rstmgr_sva:0.1
 description: "RSTMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:prim:mubi
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg:0.1
+      - lowrisc:earlgrey_ip:rstmgr_pkg:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_earlgrey_rstmgr_sva_ifs:0.1
+      - lowrisc:earlgrey_dv:rstmgr_sva_ifs:0.1
 
     files:
       - rstmgr_bind.sv

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sva_ifs.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/sva/rstmgr_sva_ifs.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_sva_ifs:0.1
+name: lowrisc:earlgrey_dv:rstmgr_sva_ifs:0.1
 description: "RSTMGR cascading resets assertion interface."
 filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
-      - lowrisc:opentitan:top_earlgrey_rstmgr
+      - lowrisc:earlgrey_ip:rstmgr
 
     files:
       - rstmgr_attrs_sva_if.sv

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/tests/rstmgr_test.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/tests/rstmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_test:0.1
+name: lowrisc:earlgrey_dv:rstmgr_test:0.1
 description: "RSTMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_earlgrey_rstmgr_env:0.1
+      - lowrisc:earlgrey_dv:rstmgr_env:0.1
     files:
       - rstmgr_test_pkg.sv
       - rstmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr:0.1
+name: lowrisc:earlgrey_ip:rstmgr:0.1
 description: "Reset manager RTL"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:clock_mux2
@@ -17,9 +17,9 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:clock_buf
       - lowrisc:prim:sparse_fsm
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg:0.1
-      - lowrisc:opentitan:top_earlgrey_rstmgr_reg:0.1
-      - lowrisc:opentitan:top_earlgrey_rstmgr_cnsty_chk:0.1
+      - lowrisc:earlgrey_ip:rstmgr_pkg:0.1
+      - lowrisc:earlgrey_ip:rstmgr_reg:0.1
+      - lowrisc:earlgrey_ip:rstmgr_cnsty_chk:0.1
     files:
       - rtl/rstmgr_ctrl.sv
       - rtl/rstmgr_por.sv

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_cnsty_chk.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_cnsty_chk.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: lowrisc:opentitan:top_earlgrey_rstmgr_cnsty_chk:0.1
+name: lowrisc:earlgrey_ip:rstmgr_cnsty_chk:0.1
 description: "Rstmgr consistency checker"
 filesets:
   files_rtl:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:rv_core_ibex_pkg
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg
+      - lowrisc:earlgrey_ip:rstmgr_pkg
     files:
       - rtl/rstmgr_cnsty_chk.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_pkg.core
@@ -2,15 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_pkg:0.1
+name: lowrisc:earlgrey_ip:rstmgr_pkg:0.1
 description: "Reset manager package"
-virtual:
-  - lowrisc:ip_interfaces:rstmgr_pkg
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
     files:
       - rtl/rstmgr_reg_pkg.sv
       - rtl/rstmgr_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_reg.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rstmgr_reg:0.1
+name: lowrisc:earlgrey_ip:rstmgr_reg:0.1
 description: "Reset manager registers"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg
+      - lowrisc:earlgrey_ip:rstmgr_pkg
     files:
       - rtl/rstmgr_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
@@ -10,5 +10,10 @@
     target: 1
     prio: 3
     topname: earlgrey
+    uniquified_modules:
+    {
+      alert_handler: alert_handler
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/rv_plic_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/rv_plic_fpv.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rv_plic_fpv:0.1
+name: lowrisc:earlgrey_ip:rv_plic_fpv:0.1
 description: "FPV for RISC-V PLIC"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_earlgrey_rv_plic
+      - lowrisc:earlgrey_ip:rv_plic
       - lowrisc:fpv:csr_assert_gen
     files:
       - tb/rv_plic_bind_fpv.sv
@@ -24,7 +24,7 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../data/rv_plic.hjson
-      depend: lowrisc:opentitan:top_earlgrey_rv_plic
+      depend: lowrisc:earlgrey_ip:rv_plic
 
 targets:
   default: &default_target

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rv_plic.core
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rv_plic.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rv_plic:0.1
+name: lowrisc:earlgrey_ip:rv_plic:0.1
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_rv_plic_component:0.1
+      - lowrisc:earlgrey_ip:rv_plic_component:0.1
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
     files:

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rv_plic_component.core
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rv_plic_component.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_earlgrey_rv_plic_component:0.1
+name: lowrisc:earlgrey_ip:rv_plic_component:0.1
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -24,7 +24,7 @@
                   rel_path: "hw/ip/aes/dv/lint/{tool}"
              },
              {    name: alert_handler
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:alert_handler_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/dv/lint/{tool}"
              },
@@ -34,7 +34,7 @@
                   rel_path: "hw/top_earlgrey/ip/aon_timer/dv/lint/{tool}"
              },
              {    name: clkmgr
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_clkmgr_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:clkmgr_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/clkmgr/dv/lint/{tool}"
              },
@@ -59,12 +59,12 @@
                   rel_path: "hw/ip/edn/dv/lint/{tool}"
              },
              {    name: flash_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_flash_ctrl_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:flash_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/flash_ctrl/dv/lint/{tool}"
              },
              {    name: gpio
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_gpio_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:gpio_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/gpio/dv/lint/{tool}"
              },
@@ -96,7 +96,7 @@
                   rel_path: "hw/ip/lc_ctrl/dv/lint/{tool}"
              },
              {    name: otp_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_otp_ctrl_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:otp_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/otp_ctrl/dv/lint/{tool}"
              },
@@ -131,7 +131,7 @@
                   rel_path: "hw/ip/prim/dv/prim_prince/lint/{tool}"
              },
              {    name: pwrmgr
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_pwrmgr_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:pwrmgr_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/pwrmgr/dv/lint/{tool}"
              },
@@ -141,7 +141,7 @@
                   rel_path: "hw/ip/rom_ctrl/dv/lint/{tool}"
              },
              {    name: rstmgr
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_rstmgr_sim
+                  fusesoc_core: lowrisc:earlgrey_dv:rstmgr_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/rstmgr/dv/lint/{tool}"
              },

--- a/hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson
@@ -19,13 +19,13 @@
 
   use_cfgs: [{
               name: alert_handler_esc_timer_fpv
-              fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_esc_timer_fpv
+              fusesoc_core: lowrisc:earlgrey_fpv:alert_handler_esc_timer_fpv
               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
               rel_path: "hw/ip/alert_handler/alert_handler_esc_timer_fpv/lint/{tool}"
              }
              {
               name: alert_handler_ping_timer_fpv
-              fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_ping_timer_fpv
+              fusesoc_core: lowrisc:earlgrey_fpv:alert_handler_ping_timer_fpv
               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
               rel_path: "hw/ip/alert_handler/alert_handler_ping_timer_fpv/lint/{tool}"
              }
@@ -133,13 +133,13 @@
              }
              {
                name: pinmux_fpv
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_pinmux_fpv
+               fusesoc_core: lowrisc:earlgrey_fpv:pinmux_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pinmux/fpv/lint/{tool}"
              }
              {
                name: top_earlgrey_rv_plic_fpv
-               fusesoc_core: lowrisc:opentitan:top_earlgrey_rv_plic_fpv
+               fusesoc_core: lowrisc:earlgrey_ip:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/rv_plic/fpv/lint/{tool}"
              }

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -27,7 +27,7 @@
                   rel_path: "hw/ip/aes/lint/{tool}"
              },
              {    name: alert_handler
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler
+                  fusesoc_core: lowrisc:earlgrey_ip:alert_handler
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/lint/{tool}"
                   overrides: [
@@ -64,7 +64,7 @@
                   rel_path: "hw/ip/entropy_src/lint/{tool}"
              },
              {    name: clkmgr
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_clkmgr
+                  fusesoc_core: lowrisc:earlgrey_ip:clkmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/top_earlgrey/ip_autogen/clkmgr/lint/{tool}",
                   overrides: [
@@ -90,7 +90,7 @@
                   rel_path: "hw/ip/edn/lint/{tool}"
              },
              {    name: flash_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_flash_ctrl
+                  fusesoc_core: lowrisc:earlgrey_ip:flash_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/flash_ctrl/lint/{tool}"
                   overrides: [
@@ -101,7 +101,7 @@
                   ]
              },
              {    name: gpio
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_gpio
+                  fusesoc_core: lowrisc:earlgrey_ip:gpio
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/gpio/lint/{tool}"
                   overrides: [
@@ -153,7 +153,7 @@
                   rel_path: "hw/ip/otbn/lint/{tool}"
              },
              {    name: otp_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_otp_ctrl
+                  fusesoc_core: lowrisc:earlgrey_ip:otp_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/otp_ctrl/lint/{tool}"
                   overrides: [
@@ -164,7 +164,7 @@
                   ]
              },
              {    name: pinmux
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_pinmux
+                  fusesoc_core: lowrisc:earlgrey_ip:pinmux
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/pinmux/lint/{tool}"
                   overrides: [
@@ -186,7 +186,7 @@
                   ]
              },
              {    name: pwrmgr
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_pwrmgr
+                  fusesoc_core: lowrisc:earlgrey_ip:pwrmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/top_earlgrey/ip_autogen/pwrmgr/lint/{tool}",
                   overrides: [
@@ -202,7 +202,7 @@
                   rel_path: "hw/ip/rom_ctrl/lint/{tool}"
              },
              {    name: rstmgr
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_rstmgr
+                  fusesoc_core: lowrisc:earlgrey_ip:rstmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/top_earlgrey/ip_autogen/rstmgr/lint/{tool}",
                   overrides: [
@@ -223,7 +223,7 @@
                   rel_path: "hw/ip/rv_dm/lint/{tool}"
              },
              {    name: top_earlgrey_rv_plic
-                  fusesoc_core: lowrisc:opentitan:top_earlgrey_rv_plic
+                  fusesoc_core: lowrisc:earlgrey_ip:rv_plic
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_earlgrey/ip_autogen/rv_plic/lint/{tool}"
              },

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -9,8 +9,8 @@ filesets:
     depend:
       # Place the autogen packages first to avoid conflicts
       - lowrisc:systems:top_earlgrey_racl_pkg
-      - lowrisc:opentitan:top_earlgrey_alert_handler_reg
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
+      - lowrisc:earlgrey_ip:alert_handler_reg
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:uart:0.1
       - lowrisc:ip:rv_core_ibex
       - lowrisc:ip:rv_dm
@@ -39,15 +39,15 @@ filesets:
       - lowrisc:ip:usbdev
       - lowrisc:top_earlgrey:xbar_main
       - lowrisc:top_earlgrey:xbar_peri
-      - lowrisc:opentitan:top_earlgrey_alert_handler
-      - lowrisc:opentitan:top_earlgrey_clkmgr
-      - lowrisc:opentitan:top_earlgrey_flash_ctrl
-      - lowrisc:opentitan:top_earlgrey_otp_ctrl
-      - lowrisc:opentitan:top_earlgrey_pinmux
-      - lowrisc:opentitan:top_earlgrey_pwrmgr
-      - lowrisc:opentitan:top_earlgrey_rstmgr
-      - lowrisc:opentitan:top_earlgrey_rv_plic
-      - lowrisc:opentitan:top_earlgrey_gpio
+      - lowrisc:earlgrey_ip:alert_handler
+      - lowrisc:earlgrey_ip:clkmgr
+      - lowrisc:earlgrey_ip:flash_ctrl
+      - lowrisc:earlgrey_ip:gpio
+      - lowrisc:earlgrey_ip:otp_ctrl
+      - lowrisc:earlgrey_ip:pinmux
+      - lowrisc:earlgrey_ip:pwrmgr
+      - lowrisc:earlgrey_ip:rstmgr
+      - lowrisc:earlgrey_ip:rv_plic
       - lowrisc:ip:aon_timer
       - lowrisc:ip:adc_ctrl
       - lowrisc:ip:sysrst_ctrl

--- a/hw/top_englishbreakfast/BUILD
+++ b/hw/top_englishbreakfast/BUILD
@@ -10,13 +10,7 @@ filegroup(
     srcs = glob(
         ["**"],
     ) + [
-        "//hw/top_englishbreakfast/ip_autogen/clkmgr:rtl_files",
-        "//hw/top_englishbreakfast/ip_autogen/flash_ctrl:rtl_files",
-        "//hw/top_englishbreakfast/ip_autogen/gpio:rtl_files",
-        "//hw/top_englishbreakfast/ip_autogen/pinmux:rtl_files",
-        "//hw/top_englishbreakfast/ip_autogen/pwrmgr:rtl_files",
-        "//hw/top_englishbreakfast/ip_autogen/rstmgr:rtl_files",
-        "//hw/top_englishbreakfast/ip_autogen/rv_plic:rtl_files",
+        "//hw/top_englishbreakfast/ip:rtl_files",
     ],
     visibility = ["//visibility:public"],
 )

--- a/hw/top_englishbreakfast/bitstream/BUILD
+++ b/hw/top_englishbreakfast/bitstream/BUILD
@@ -19,7 +19,7 @@ fusesoc_build(
         "mmi": ["synth-vivado/memories.mmi"],
         "logs": ["synth-vivado/lowrisc_systems_chip_englishbreakfast_cw305_0.1.runs/"],
     },
-    systems = ["lowrisc:systems:chip_englishbreakfast_cw305"],
+    systems = ["lowrisc:systems:chip_englishbreakfast_cw305:0.1"],
     tags = ["manual"],
     target = "synth",
 )

--- a/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim_xilinx:prim_xilinx_default_pkg
       - lowrisc:systems:top_englishbreakfast:0.1
       - lowrisc:systems:top_englishbreakfast_pkg
-      - lowrisc:systems:top_earlgrey_ast
+      - lowrisc:systems:top_englishbreakfast_ast
       - lowrisc:systems:top_earlgrey_padring
       - lowrisc:systems:top_earlgrey_scan_role_pkg
     files:

--- a/hw/top_englishbreakfast/ip/BUILD
+++ b/hw/top_englishbreakfast/ip/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "rtl_files",
+    srcs = glob(["**"]) + [
+        "//hw/top_englishbreakfast/ip/ast:rtl_files",
+        "//hw/top_englishbreakfast/ip/sensor_ctrl:rtl_files",
+        "//hw/top_englishbreakfast/ip/xbar_main:rtl_files",
+        "//hw/top_englishbreakfast/ip/xbar_peri:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/clkmgr:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/flash_ctrl:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/gpio:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/pinmux:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/pwrmgr:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/rstmgr:rtl_files",
+        "//hw/top_englishbreakfast/ip_autogen/rv_plic:rtl_files",
+    ],
+)

--- a/hw/top_englishbreakfast/ip/ast/ast.core
+++ b/hw/top_englishbreakfast/ip/ast/ast.core
@@ -1,0 +1,130 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:systems:top_englishbreakfast_ast:0.1"
+description: "Analog Sensor Top generic views"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:tlul
+      - lowrisc:prim:all
+      - lowrisc:prim:clock_buf
+      - lowrisc:prim:clock_div
+      - lowrisc:prim:clock_gating
+      - lowrisc:prim:clock_inv
+      - lowrisc:prim:lc_dec
+      - lowrisc:prim:lfsr
+      - lowrisc:englishbreakfast_ip:pinmux_pkg
+      - lowrisc:prim:assert
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:mubi
+      - lowrisc:prim:multibit_sync
+      - lowrisc:ip:lc_ctrl_pkg
+      - lowrisc:ip:edn_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
+      - lowrisc:englishbreakfast_ip:clkmgr_pkg
+      - lowrisc:englishbreakfast_ip:rstmgr_pkg
+      - lowrisc:systems:top_englishbreakfast_ast_pkg
+    files:
+      - rtl/ast_reg_pkg.sv
+      - rtl/ast_bhv_pkg.sv
+      - rtl/ast.sv
+      - rtl/ast_reg_top.sv
+      - rtl/adc.sv
+      - rtl/adc_ana.sv
+      - rtl/vcc_pgd.sv
+      - rtl/vio_pgd.sv
+      - rtl/vcaon_pgd.sv
+      - rtl/vcmain_pgd.sv
+      - rtl/ast_alert.sv
+      - rtl/aon_clk.sv
+      - rtl/aon_osc.sv
+      - rtl/io_clk.sv
+      - rtl/io_osc.sv
+      - rtl/sys_clk.sv
+      - rtl/sys_osc.sv
+      - rtl/usb_clk.sv
+      - rtl/usb_osc.sv
+      - rtl/gfr_clk_mux2.sv
+      - rtl/ast_clks_byp.sv
+      - rtl/rglts_pdm_3p3v.sv
+      - rtl/ast_pulse_sync.sv
+      - rtl/ast_entropy.sv
+      - rtl/dev_entropy.sv
+      - rtl/rng.sv
+      - rtl/ast_dft.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/ast.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/ast.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/ast.vbl
+    file_type: veribleLintWaiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+  AST_BYPASS_CLK:
+    datatype: bool
+    paramtype: vlogdefine
+  ANALOGSIM:
+    datatype: bool
+    paramtype: vlogdefine
+
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+    toplevel: ast
+    parameters:
+     - SYNTHESIS
+     - AST_BYPASS_CLK
+     - ANALOGSIM
+
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+  sim:
+    <<: *default_target
+    default_tool: vcs
+    filesets:
+      - files_rtl
+    tools:
+      vcs:
+        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++11 -timescale=1ns/1ps -l vcs.log]
+    toplevel: ast

--- a/hw/top_englishbreakfast/ip/ast/ast_pkg.core
+++ b/hw/top_englishbreakfast/ip/ast/ast_pkg.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:systems:top_englishbreakfast_ast_pkg"
+description: "Analog sensor top (AST) wrapper package"
+virtual:
+  - lowrisc:systems:ast_pkg
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:ip:lc_ctrl_pkg
+    files:
+      - rtl/ast_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/top_englishbreakfast/ip/ast/rtl/adc.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/adc.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/adc.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/adc_ana.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/adc_ana.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/adc_ana.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/aon_clk.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/aon_clk.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/aon_clk.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/aon_osc.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/aon_osc.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_alert.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_alert.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_alert.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_bhv_pkg.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_bhv_pkg.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_bhv_pkg.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_clks_byp.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_clks_byp.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_dft.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_dft.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_dft.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_entropy.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_entropy.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_entropy.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_pkg.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_pkg.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_pulse_sync.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_pulse_sync.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/ast_pulse_sync.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/dev_entropy.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/dev_entropy.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/dev_entropy.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/gfr_clk_mux2.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/gfr_clk_mux2.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/gfr_clk_mux2.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/io_clk.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/io_clk.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/io_clk.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/io_osc.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/io_osc.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/io_osc.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/rglts_pdm_3p3v.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/rglts_pdm_3p3v.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/rglts_pdm_3p3v.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/rng.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/rng.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/rng.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/sys_clk.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/sys_clk.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/sys_clk.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/sys_osc.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/sys_osc.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/sys_osc.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/usb_clk.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/usb_clk.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/usb_clk.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/usb_osc.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/usb_osc.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/vcaon_pgd.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/vcaon_pgd.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/vcaon_pgd.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/vcc_pgd.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/vcc_pgd.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/vcc_pgd.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/vcmain_pgd.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/vcmain_pgd.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/vcmain_pgd.sv

--- a/hw/top_englishbreakfast/ip/ast/rtl/vio_pgd.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/vio_pgd.sv
@@ -1,0 +1,1 @@
+../../../../top_earlgrey/ip/ast/rtl/vio_pgd.sv

--- a/hw/top_englishbreakfast/ip/sensor_ctrl/BUILD
+++ b/hw/top_englishbreakfast/ip/sensor_ctrl/BUILD
@@ -14,6 +14,6 @@ filegroup(
             "README.md",
         ],
     ) + [
-        "//hw/top_englishbreakfast/ip/ast/data:all_files",
+        "//hw/top_englishbreakfast/ip/sensor_ctrl/data:all_files",
     ],
 )

--- a/hw/top_englishbreakfast/ip/xbar_main/BUILD
+++ b/hw/top_englishbreakfast/ip/xbar_main/BUILD
@@ -14,6 +14,6 @@ filegroup(
             "README.md",
         ],
     ) + [
-        "//hw/top_englishbreakfast/ip/ast/data:all_files",
+        "//hw/top_englishbreakfast/ip/xbar_main/data:all_files",
     ],
 )

--- a/hw/top_englishbreakfast/ip/xbar_main/data/BUILD
+++ b/hw/top_englishbreakfast/ip/xbar_main/data/BUILD
@@ -5,15 +5,6 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "rtl_files",
-    srcs = glob(
-        ["**"],
-        exclude = [
-            "dv/**",
-            "doc/**",
-            "README.md",
-        ],
-    ) + [
-        "//hw/top_englishbreakfast/ip/ast/data:all_files",
-    ],
+    name = "all_files",
+    srcs = glob(["**"]),
 )

--- a/hw/top_englishbreakfast/ip/xbar_peri/BUILD
+++ b/hw/top_englishbreakfast/ip/xbar_peri/BUILD
@@ -14,6 +14,6 @@ filegroup(
             "README.md",
         ],
     ) + [
-        "//hw/top_englishbreakfast/ip/ast/data:all_files",
+        "//hw/top_englishbreakfast/ip/xbar_peri/data:all_files",
     ],
 )

--- a/hw/top_englishbreakfast/ip/xbar_peri/data/BUILD
+++ b/hw/top_englishbreakfast/ip/xbar_peri/data/BUILD
@@ -5,15 +5,6 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "rtl_files",
-    srcs = glob(
-        ["**"],
-        exclude = [
-            "dv/**",
-            "doc/**",
-            "README.md",
-        ],
-    ) + [
-        "//hw/top_englishbreakfast/ip/ast/data:all_files",
-    ],
+    name = "all_files",
+    srcs = glob(["**"]),
 )

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/clkmgr.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/clkmgr.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr:0.1
+name: lowrisc:englishbreakfast_ip:clkmgr:0.1
 description: "Top specific clock manager "
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:buf
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender
       - lowrisc:prim:measure
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_pkg:0.1
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_reg:0.1
+      - lowrisc:englishbreakfast_ip:clkmgr_pkg:0.1
+      - lowrisc:englishbreakfast_ip:clkmgr_reg:0.1
     files:
       - rtl/clkmgr.sv
       - rtl/clkmgr_byp.sv

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/clkmgr_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/clkmgr_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_pkg:0.1
+name: lowrisc:englishbreakfast_ip:clkmgr_pkg:0.1
 description: "Top specific clock manager package"
 virtual:
-  - lowrisc:ip_interfaces:clkmgr_pkg
+  - lowrisc:virtual_ip:clkmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/clkmgr_reg.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/clkmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_reg:0.1
+name: lowrisc:englishbreakfast_ip:clkmgr_reg:0.1
 description: "Clock manager registers"
 
 filesets:

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
@@ -236,8 +236,11 @@
     exported_clks: {}
     number_of_clock_groups: 8
     with_alert_handler: false
-    pwrmgr_vlnv_prefix: top_englishbreakfast_
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_sim:0.1
+name: lowrisc:englishbreakfast_dv:clkmgr_sim:0.1
 description: "CLKMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr
+      - lowrisc:englishbreakfast_ip:clkmgr
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_test:0.1
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_sva:0.1
+      - lowrisc:englishbreakfast_dv:clkmgr_test:0.1
+      - lowrisc:englishbreakfast_dv:clkmgr_sva:0.1
     files:
       - tb.sv
       - cov/clkmgr_cov_bind.sv

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_clkmgr_sim:0.1
+  fusesoc_core: lowrisc:englishbreakfast_dv:clkmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/clkmgr_testplan.hjson"

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_env:0.1
+name: lowrisc:englishbreakfast_dv:clkmgr_env:0.1
 description: "CLKMGR DV UVM environment"
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:clkmgr_pkg
       - lowrisc:constants:top_englishbreakfast_top_pkg
     files:
       - clkmgr_csrs_if.sv

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/sva/clkmgr_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/sva/clkmgr_sva.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_sva:0.1
+name: lowrisc:englishbreakfast_dv:clkmgr_sva:0.1
 description: "CLKMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_sva_ifs:0.1
+      - lowrisc:englishbreakfast_dv:clkmgr_sva_ifs:0.1
     files:
       - clkmgr_bind.sv
       - clkmgr_sec_cm_checker_assert.sv
@@ -17,7 +17,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr
+      - lowrisc:englishbreakfast_ip:clkmgr
 
 generate:
   csr_assert_gen:

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/sva/clkmgr_sva_ifs.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/sva/clkmgr_sva_ifs.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_sva_ifs:0.1
+name: lowrisc:englishbreakfast_dv:clkmgr_sva_ifs:0.1
 description: "CLKMGR SVA interfaces."
 filesets:
   files_dv:

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/tests/clkmgr_test.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/tests/clkmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_clkmgr_test:0.1
+name: lowrisc:englishbreakfast_dv:clkmgr_test:0.1
 description: "CLKMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr_env:0.1
+      - lowrisc:englishbreakfast_dv:clkmgr_env:0.1
     files:
       - clkmgr_test_pkg.sv
       - clkmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
@@ -23,8 +23,11 @@
     bytes_per_page: 2048
     bytes_per_bank: 32768
     size: 65536
-    pwrmgr_vlnv_prefix: top_englishbreakfast_
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_cov.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_cov.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_cov
+name: lowrisc:englishbreakfast_dv:flash_ctrl_cov
 description: "FLASH_CTRL functional coverage interface & bind."
 
 filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_utils
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl
+      - lowrisc:englishbreakfast_ip:flash_ctrl
     files:
       - flash_ctrl_cov_bind.sv
       - flash_ctrl_phy_cov_if.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_bkdr_util:0.1
+name: lowrisc:englishbreakfast_dv:flash_ctrl_bkdr_util:0.1
 description: "Backdoor read/write flash memory for DV"
 
 filesets:
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_prince:0.1
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
       - lowrisc:dv:mem_bkdr_util
     files:
       - flash_ctrl_bkdr_util_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_env:0.1
+name: lowrisc:englishbreakfast_dv:flash_ctrl_env:0.1
 description: "FLASH_CTRL DV UVM environment"
 filesets:
   files_dv:
@@ -11,10 +11,10 @@ filesets:
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:dv_lib
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_bkdr_util
+      - lowrisc:englishbreakfast_dv:flash_ctrl_bkdr_util
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
       - lowrisc:constants:top_englishbreakfast_top_pkg
     files:
       - flash_ctrl_eflash_ral_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_sim:0.1
+  fusesoc_core: lowrisc:englishbreakfast_dv:flash_ctrl_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/flash_ctrl_testplan.hjson"

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
@@ -2,22 +2,22 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_sim:0.1
+name: lowrisc:englishbreakfast_dv:flash_ctrl_sim:0.1
 description: "FLASH_CTRL DV sim target"
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:constants:top_englishbreakfast_top_pkg
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl:0.1
+      - lowrisc:englishbreakfast_ip:flash_ctrl:0.1
     file_type: systemVerilogSource
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_bkdr_util
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_test
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_sva
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_cov
+      - lowrisc:englishbreakfast_dv:flash_ctrl_bkdr_util
+      - lowrisc:englishbreakfast_dv:flash_ctrl_test
+      - lowrisc:englishbreakfast_dv:flash_ctrl_sva
+      - lowrisc:englishbreakfast_dv:flash_ctrl_cov
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_sva:0.1
+name: lowrisc:englishbreakfast_dv:flash_ctrl_sva:0.1
 description: "FLASH_CTRL assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
     files:
@@ -17,7 +17,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl
+      - lowrisc:englishbreakfast_ip:flash_ctrl
 
 generate:
   csr_assert_gen:

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/tests/flash_ctrl_test.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/tests/flash_ctrl_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_test:0.1
+name: lowrisc:englishbreakfast_dv:flash_ctrl_test:0.1
 description: "FLASH_CTRL DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_env
+      - lowrisc:englishbreakfast_dv:flash_ctrl_env
     files:
       - flash_ctrl_test_pkg.sv
       - flash_ctrl_base_test.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl:0.1
+name: lowrisc:englishbreakfast_ip:flash_ctrl:0.1
 description: "Flash Controller"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_reg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_reg
       - lowrisc:constants:top_englishbreakfast_top_pkg
       - lowrisc:ip:jtag_pkg
     files:

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg:0.1
+name: lowrisc:englishbreakfast_ip:flash_ctrl_pkg:0.1
 description: "Top specific flash package"
 virtual:
-  - lowrisc:ip_interfaces:flash_ctrl_pkg
+  - lowrisc:virtual_ip:flash_ctrl_pkg
 
 filesets:
   files_rtl:
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:constants:top_englishbreakfast_top_pkg
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_prim_reg_top:1.0
+name: lowrisc:englishbreakfast_ip:flash_ctrl_prim_reg_top:1.0
 description: "Generic register top for the FLASH wrapper"
 virtual:
-  - lowrisc:ip_interfaces:flash_ctrl_prim_reg_top
+  - lowrisc:virtual_ip:flash_ctrl_prim_reg_top
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_reg.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_reg.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_flash_ctrl_reg:0.1
+name: lowrisc:englishbreakfast_ip:flash_ctrl_reg:0.1
 description: "Flash registers"
 
 filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
     files:
       - rtl/flash_ctrl_core_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
@@ -8,5 +8,9 @@
     num_inp_period_counters: 0
     module_instance_name: gpio
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_gpio_env:0.1
+name: lowrisc:englishbreakfast_dv:gpio_env:0.1
 description: "GPIO DV UVM environmnt"
 filesets:
   files_dv:

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim.core
@@ -2,18 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_gpio_sim:0.1
+name: lowrisc:englishbreakfast_dv:gpio_sim:0.1
 description: "GPIO DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_gpio:0.1
+      - lowrisc:englishbreakfast_ip:gpio:0.1
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_gpio_test
-      - lowrisc:opentitan:top_englishbreakfast_gpio_sva
-      - lowrisc:opentitan:top_englishbreakfast_gpio_if
+      - lowrisc:englishbreakfast_dv:gpio_test
+      - lowrisc:englishbreakfast_dv:gpio_sva
+      - lowrisc:englishbreakfast_dv:gpio_if
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/gpio_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_gpio_sim:0.1
+  fusesoc_core: lowrisc:englishbreakfast_dv:gpio_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/gpio_testplan.hjson"

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/interfaces/gpio_if.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/interfaces/gpio_if.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_gpio_if:0.1
+name: lowrisc:englishbreakfast_dv:gpio_if:0.1
 description: "GPIO Interfaces"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_gpio:0.1
+      - lowrisc:englishbreakfast_ip:gpio:0.1
     files:
       - gpio_straps_if.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/sva/gpio_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/sva/gpio_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_gpio_sva:0.1
+name: lowrisc:englishbreakfast_dv:gpio_sva:0.1
 description: "GPIO assertion modules and bind file."
 filesets:
   files_dv:
@@ -15,7 +15,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_gpio:0.1
+      - lowrisc:englishbreakfast_ip:gpio:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/tests/gpio_test.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/tests/gpio_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_gpio_test:0.1
+name: lowrisc:englishbreakfast_dv:gpio_test:0.1
 description: "GPIO DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_gpio_env:0.1
+      - lowrisc:englishbreakfast_dv:gpio_env:0.1
     files:
       - gpio_test_pkg.sv
       - gpio_base_test.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/gpio/gpio.core
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/gpio.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_gpio:0.1
+name: lowrisc:englishbreakfast_ip:gpio:0.1
 description: "gpio"
 filesets:
   files_rtl:

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
@@ -18,5 +18,9 @@
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_englishbreakfast_scan_role_pkg
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pinmux_chip_fpv:0.1
+name: lowrisc:englishbreakfast_systems:pinmux_chip_fpv:0.1
 description: "pinmux FPV target with chip_earlgrey parameters"
 
 filesets:
@@ -13,9 +13,9 @@ filesets:
       - lowrisc:ip:jtag_pkg
       - lowrisc:prim:mubi_pkg
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_pinmux:0.1
+      - lowrisc:englishbreakfast_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_englishbreakfast_pinmux_common_fpv:0.1
+      - lowrisc:englishbreakfast_fpv:pinmux_common_fpv:0.1
       - lowrisc:constants:top_englishbreakfast_top_pkg
       - lowrisc:systems:top_englishbreakfast_scan_role_pkg
     files:

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_common_fpv.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_common_fpv.core
@@ -2,14 +2,14 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pinmux_common_fpv:0.1
+name: lowrisc:englishbreakfast_fpv:pinmux_common_fpv:0.1
 description: "pinmux common FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_englishbreakfast_pinmux:0.1
+      - lowrisc:englishbreakfast_ip:pinmux:0.1
     files:
       - vip/pinmux_assert_fpv.sv
       - tb/pinmux_bind_fpv.sv

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_fpv.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_fpv.core
@@ -2,16 +2,16 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pinmux_fpv:0.1
+name: lowrisc:englishbreakfast_fpv:pinmux_fpv:0.1
 description: "pinmux FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:opentitan:top_englishbreakfast_pinmux:0.1
+      - lowrisc:englishbreakfast_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_englishbreakfast_pinmux_common_fpv
+      - lowrisc:englishbreakfast_fpv:pinmux_common_fpv
     files:
       - tb/pinmux_tb.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pinmux:0.1
+name: lowrisc:englishbreakfast_ip:pinmux:0.1
 description: "Pin Multiplexer"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:pad_attr
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:usbdev
-      - lowrisc:opentitan:top_englishbreakfast_pinmux_reg:0.1
-      - lowrisc:opentitan:top_englishbreakfast_pinmux_pkg:0.1
+      - lowrisc:englishbreakfast_ip:pinmux_reg:0.1
+      - lowrisc:englishbreakfast_ip:pinmux_pkg:0.1
     files:
       - rtl/pinmux_wkup.sv
       - rtl/pinmux_jtag_buf.sv

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pinmux_pkg:0.1
+name: lowrisc:englishbreakfast_ip:pinmux_pkg:0.1
 description: "Pinmux package"
 virtual:
-  - lowrisc:ip_interfaces:pinmux_pkg
+  - lowrisc:virtual_ip:pinmux_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux_reg.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/pinmux_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pinmux_reg:0.1
+name: lowrisc:englishbreakfast_ip:pinmux_reg:0.1
 description: "Auto-generated pinmux register sources"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_englishbreakfast_pinmux_pkg
+      - lowrisc:englishbreakfast_ip:pinmux_pkg
     files:
       - rtl/pinmux_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/syn/pinmux_syn_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/syn/pinmux_syn_cfg.hjson
@@ -6,7 +6,7 @@
   name: pinmux
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_pinmux:0.1
+  fusesoc_core: lowrisc:englishbreakfast_ip:pinmux:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"],

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
@@ -62,5 +62,9 @@
     NumRomInputs: 1
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_env:0.1
+name: lowrisc:englishbreakfast_dv:pwrmgr_env:0.1
 description: "PWRMGR DV UVM environment"
 filesets:
   files_dv:
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
       - lowrisc:constants:top_englishbreakfast_top_pkg
     files:
       - pwrmgr_env_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_sim:0.1
+name: lowrisc:englishbreakfast_dv:pwrmgr_sim:0.1
 description: "PWRMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr:0.1
+      - lowrisc:englishbreakfast_ip:pwrmgr:0.1
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_test:0.1
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_sva:0.1
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_unit_only_sva:0.1
+      - lowrisc:englishbreakfast_dv:pwrmgr_test:0.1
+      - lowrisc:englishbreakfast_dv:pwrmgr_sva:0.1
+      - lowrisc:englishbreakfast_dv:pwrmgr_unit_only_sva:0.1
     files:
       - tb.sv
       - cov/pwrmgr_cov_bind.sv

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_pwrmgr_sim:0.1
+  fusesoc_core: lowrisc:englishbreakfast_dv:pwrmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/pwrmgr_testplan.hjson"

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_sva:0.1
+name: lowrisc:englishbreakfast_dv:pwrmgr_sva:0.1
 description: "PWRMGR assertion modules and bind file."
 filesets:
   files_dv:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:dv:clkmgr_pwrmgr_sva_if
       - lowrisc:dv:pwrmgr_rstmgr_sva_if:0.1
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
     files:
       - pwrmgr_bind.sv
       - pwrmgr_clock_enables_sva_if.sv
@@ -21,7 +21,7 @@ filesets:
 
   files_formal:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr:0.1
+      - lowrisc:englishbreakfast_ip:pwrmgr:0.1
 
 generate:
   csr_assert_gen:

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_unit_only_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/sva/pwrmgr_unit_only_sva.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_unit_only_sva:0.1
+name: lowrisc:englishbreakfast_dv:pwrmgr_unit_only_sva:0.1
 description: "PWRMGR assertion interfaces not suitable for chip level bind file."
 filesets:
   files_dv:
@@ -10,8 +10,8 @@ filesets:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg:0.1
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr:0.1
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg:0.1
+      - lowrisc:englishbreakfast_ip:pwrmgr:0.1
 
     files:
       - pwrmgr_unit_only_bind.sv

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/tests/pwrmgr_test.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/tests/pwrmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_test:0.1
+name: lowrisc:englishbreakfast_dv:pwrmgr_test:0.1
 description: "PWRMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_env:0.1
+      - lowrisc:englishbreakfast_dv:pwrmgr_env:0.1
     files:
       - pwrmgr_test_pkg.sv
       - pwrmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr:0.1
+name: lowrisc:englishbreakfast_ip:pwrmgr:0.1
 description: "Power manager RTL"
 
 filesets:
@@ -20,8 +20,8 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:clock_buf
       - lowrisc:prim:measure
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg:0.1
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_reg:0.1
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg:0.1
+      - lowrisc:englishbreakfast_ip:pwrmgr_reg:0.1
     files:
       - rtl/pwrmgr_cdc.sv
       - rtl/pwrmgr_slow_fsm.sv

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg:0.1
+name: lowrisc:englishbreakfast_ip:pwrmgr_pkg:0.1
 description: "Power manager package"
 virtual:
-  - lowrisc:ip_interfaces:pwrmgr_pkg
+  - lowrisc:virtual_ip:pwrmgr_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr_reg.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/pwrmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_pwrmgr_reg:0.1
+name: lowrisc:englishbreakfast_ip:pwrmgr_reg:0.1
 description: "Power manager registers"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
     files:
       - rtl/pwrmgr_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -450,10 +450,13 @@
     ]
     rst_ni: lc_io_div4
     export_rsts: {}
-    alert_handler_vlnv_prefix: top_earlgrey_
+    alert_handler_vlnv: lowrisc:earlgrey_ip:alert_handler_pkg
     with_alert_handler: false
-    pwrmgr_vlnv_prefix: top_englishbreakfast_
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -2,18 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_env:0.1
+name: lowrisc:englishbreakfast_dv:rstmgr_env:0.1
 description: "RSTMGR DV UVM environment"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr
+      - lowrisc:englishbreakfast_ip:rstmgr
 
   files_dv:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_pkg
+      - lowrisc:englishbreakfast_ip:rstmgr_pkg
       - lowrisc:constants:top_englishbreakfast_top_pkg
 
     files:

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_cnsty_chk_sim:0.1
+name: lowrisc:englishbreakfast_dv:rstmgr_cnsty_chk_sim:0.1
 description: "Rstmgr_cnsty_chk DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_cnsty_chk:0.1
+      - lowrisc:englishbreakfast_ip:rstmgr_cnsty_chk:0.1
       - lowrisc:dv:sec_cm
     file_type: systemVerilogSource
 

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_rstmgr_cnsty_chk_sim:0.1
+  fusesoc_core: lowrisc:englishbreakfast_dv:rstmgr_cnsty_chk_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/data/rstmgr_cnsty_chk_testplan.hjson"

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim.core
@@ -2,17 +2,17 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_sim:0.1
+name: lowrisc:englishbreakfast_dv:rstmgr_sim:0.1
 description: "RSTMGR DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr
+      - lowrisc:englishbreakfast_ip:rstmgr
 
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_test:0.1
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_sva:0.1
+      - lowrisc:englishbreakfast_dv:rstmgr_test:0.1
+      - lowrisc:englishbreakfast_dv:rstmgr_sva:0.1
     files:
       - tb.sv
       - cov/rstmgr_cov_bind.sv

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_rstmgr_sim:0.1
+  fusesoc_core: lowrisc:englishbreakfast_dv:rstmgr_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/rstmgr_testplan.hjson"

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sva.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_sva:0.1
+name: lowrisc:englishbreakfast_dv:rstmgr_sva:0.1
 description: "RSTMGR assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:prim:mubi
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_pkg:0.1
+      - lowrisc:englishbreakfast_ip:rstmgr_pkg:0.1
       - lowrisc:fpv:csr_assert_gen
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_sva_ifs:0.1
+      - lowrisc:englishbreakfast_dv:rstmgr_sva_ifs:0.1
 
     files:
       - rstmgr_bind.sv

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sva_ifs.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/sva/rstmgr_sva_ifs.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_sva_ifs:0.1
+name: lowrisc:englishbreakfast_dv:rstmgr_sva_ifs:0.1
 description: "RSTMGR cascading resets assertion interface."
 filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
       - lowrisc:dv:pwrmgr_rstmgr_sva_if
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr
+      - lowrisc:englishbreakfast_ip:rstmgr
 
     files:
       - rstmgr_attrs_sva_if.sv

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/tests/rstmgr_test.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/tests/rstmgr_test.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_test:0.1
+name: lowrisc:englishbreakfast_dv:rstmgr_test:0.1
 description: "RSTMGR DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_env:0.1
+      - lowrisc:englishbreakfast_dv:rstmgr_env:0.1
     files:
       - rstmgr_test_pkg.sv
       - rstmgr_base_test.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr:0.1
+name: lowrisc:englishbreakfast_ip:rstmgr:0.1
 description: "Reset manager RTL"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_earlgrey_alert_handler_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:clock_mux2
@@ -17,9 +17,9 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:prim:clock_buf
       - lowrisc:prim:sparse_fsm
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_pkg:0.1
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_reg:0.1
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_cnsty_chk:0.1
+      - lowrisc:englishbreakfast_ip:rstmgr_pkg:0.1
+      - lowrisc:englishbreakfast_ip:rstmgr_reg:0.1
+      - lowrisc:englishbreakfast_ip:rstmgr_cnsty_chk:0.1
     files:
       - rtl/rstmgr_ctrl.sv
       - rtl/rstmgr_por.sv

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr_cnsty_chk.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr_cnsty_chk.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_cnsty_chk:0.1
+name: lowrisc:englishbreakfast_ip:rstmgr_cnsty_chk:0.1
 description: "Rstmgr consistency checker"
 filesets:
   files_rtl:
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:rv_core_ibex_pkg
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_pkg
+      - lowrisc:englishbreakfast_ip:rstmgr_pkg
     files:
       - rtl/rstmgr_cnsty_chk.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr_pkg.core
@@ -2,15 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_pkg:0.1
+name: lowrisc:englishbreakfast_ip:rstmgr_pkg:0.1
 description: "Reset manager package"
-virtual:
-  - lowrisc:ip_interfaces:rstmgr_pkg
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
     files:
       - rtl/rstmgr_reg_pkg.sv
       - rtl/rstmgr_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr_reg.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rstmgr_reg:0.1
+name: lowrisc:englishbreakfast_ip:rstmgr_reg:0.1
 description: "Reset manager registers"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:prim:subreg
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr_pkg
+      - lowrisc:englishbreakfast_ip:rstmgr_pkg
     files:
       - rtl/rstmgr_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
@@ -10,5 +10,9 @@
     target: 1
     prio: 3
     topname: englishbreakfast
+    uniquified_modules:
+    {
+      rv_plic: rv_plic
+    }
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/rv_plic_fpv.core
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/rv_plic_fpv.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rv_plic_fpv:0.1
+name: lowrisc:englishbreakfast_ip:rv_plic_fpv:0.1
 description: "FPV for RISC-V PLIC"
 
 filesets:
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
-      - lowrisc:opentitan:top_englishbreakfast_rv_plic
+      - lowrisc:englishbreakfast_ip:rv_plic
       - lowrisc:fpv:csr_assert_gen
     files:
       - tb/rv_plic_bind_fpv.sv
@@ -24,7 +24,7 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../data/rv_plic.hjson
-      depend: lowrisc:opentitan:top_englishbreakfast_rv_plic
+      depend: lowrisc:englishbreakfast_ip:rv_plic
 
 targets:
   default: &default_target

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rv_plic.core
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rv_plic.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rv_plic:0.1
+name: lowrisc:englishbreakfast_ip:rv_plic:0.1
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_rv_plic_component:0.1
+      - lowrisc:englishbreakfast_ip:rv_plic_component:0.1
       - lowrisc:ip:tlul
       - lowrisc:prim:subreg
     files:

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rv_plic_component.core
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rv_plic_component.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:opentitan:top_englishbreakfast_rv_plic_component:0.1
+name: lowrisc:englishbreakfast_ip:rv_plic_component:0.1
 description: "RISC-V Platform Interrupt Controller (PLIC)"
 
 filesets:

--- a/hw/top_englishbreakfast/lint/top_englishbreakfast_lint_cfgs.hjson
+++ b/hw/top_englishbreakfast/lint/top_englishbreakfast_lint_cfgs.hjson
@@ -19,7 +19,7 @@
   rel_path: "hw/top_englishbreakfast/lint/{tool}"
 
   use_cfgs: [{    name: flash_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_flash_ctrl
+                  fusesoc_core: lowrisc:englishbreakfast_ip:flash_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/flash_ctrl/lint/{tool}"
                   overrides: [
@@ -30,7 +30,7 @@
                   ]
              },
              {    name: otp_ctrl
-                  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_otp_ctrl
+                  fusesoc_core: lowrisc:englishbreakfast_ip:otp_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/otp_ctrl/lint/{tool}"
                   overrides: [
@@ -41,7 +41,7 @@
                   ]
              },
              {    name: pwrmgr
-                  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_pwrmgr
+                  fusesoc_core: lowrisc:englishbreakfast_ip:pwrmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/ip/pwrmgr/lint/{tool}",
                   overrides: [
@@ -52,7 +52,7 @@
                   ]
              },
              {    name: rstmgr
-                  fusesoc_core: lowrisc:opentitan:top_englishbreakfast_rstmgr
+                  fusesoc_core: lowrisc:englishbreakfast_ip:rstmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/ip/rstmgr/lint/{tool}",
                   overrides: [

--- a/hw/top_englishbreakfast/top_englishbreakfast.core
+++ b/hw/top_englishbreakfast/top_englishbreakfast.core
@@ -7,8 +7,8 @@ description: "Technology-independent English Breakfast toplevel"
 filesets:
   files_rtl_generic:
     depend:
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr_pkg
-      - lowrisc:opentitan:top_earlgrey_alert_handler_pkg
+      - lowrisc:englishbreakfast_ip:pwrmgr_pkg
+      - lowrisc:earlgrey_ip:alert_handler_pkg
       # Manually instantiated
       - lowrisc:ip:rv_core_ibex
       - lowrisc:ip:rv_dm
@@ -32,13 +32,13 @@ filesets:
       - lowrisc:ip:usbdev
       - lowrisc:top_englishbreakfast:xbar_main
       - lowrisc:top_englishbreakfast:xbar_peri
-      - lowrisc:opentitan:top_englishbreakfast_clkmgr
-      - lowrisc:opentitan:top_englishbreakfast_flash_ctrl
-      - lowrisc:opentitan:top_englishbreakfast_pinmux
-      - lowrisc:opentitan:top_englishbreakfast_pwrmgr
-      - lowrisc:opentitan:top_englishbreakfast_rstmgr
-      - lowrisc:opentitan:top_englishbreakfast_rv_plic
-      - lowrisc:opentitan:top_englishbreakfast_gpio
+      - lowrisc:englishbreakfast_ip:clkmgr
+      - lowrisc:englishbreakfast_ip:flash_ctrl
+      - lowrisc:englishbreakfast_ip:pinmux
+      - lowrisc:englishbreakfast_ip:pwrmgr
+      - lowrisc:englishbreakfast_ip:rstmgr
+      - lowrisc:englishbreakfast_ip:rv_plic
+      - lowrisc:englishbreakfast_ip:gpio
       - lowrisc:ip:rom_ctrl
       - lowrisc:ip:aon_timer
       - lowrisc:tlul:headers

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -22,8 +22,8 @@ from design.lib.OtpMemMap import OtpMemMap
 from ipgen import (IpBlockRenderer, IpConfig, IpDescriptionOnlyRenderer,
                    IpTemplate, TemplateRenderError)
 from mako import exceptions
-from mako.template import Template
 from mako.lookup import TemplateLookup
+from mako.template import Template
 from raclgen.lib import DEFAULT_RACL_CONFIG
 from reggen import access, gen_rtl, gen_sec_cm_testplan, window
 from reggen.countermeasure import CounterMeasure
@@ -67,6 +67,24 @@ IP_RAW_PATH = SRCTREE_TOP / "hw" / "ip"
 IP_TEMPLATES_PATH = SRCTREE_TOP / "hw" / "ip_templates"
 
 
+class UniquifiedModules(object):
+    """This holds the uniquified name for all uniquified modules."""
+
+    def __init__(self):
+        self.modules: Dict[str, str] = {}
+
+    def add_module(self, name: str, uniquified_name: str):
+        if (name in self.modules and uniquified_name != self.modules[name]):
+            raise SystemExit(f"Multiple renames for module {name}")
+        self.modules[name] = uniquified_name
+
+    def get_uniq_name(self, name: str) -> Optional[str]:
+        return self.modules.get(name)
+
+
+uniquified_modules = UniquifiedModules()
+
+
 class IpAttrs(NamedTuple):
     """Hold IP block, and path to hjson."""
     ip_block: IpBlock
@@ -81,10 +99,12 @@ def _ipgen_render_prelude(template_name: str, topname: str,
                    if params else template_name)
     top_name = f"top_{topname}"
     instance_name = f"{top_name}_{module_name}"
-
     ip_template = IpTemplate.from_template_path(IP_TEMPLATES_PATH /
                                                 template_name)
-    params.update({"topname": topname})
+    params.update({
+        "topname": topname,
+        "uniquified_modules": uniquified_modules.modules
+    })
 
     try:
         ip_config = IpConfig(ip_template.params, instance_name, params)
@@ -231,10 +251,18 @@ def generate_xbars(top: ConfigT, out_path: Path) -> None:
 def generate_ipgen(top: ConfigT, module: ConfigT, params: ParamsT,
                    out_path: Path) -> None:
     topname = top["name"]
+    template_name = module["template_type"]
     module_name = module["type"]
     module_instance_name = params.get("module_instance_name")
-
-    assert not module_instance_name or module_instance_name == module_name
+    if module_instance_name and module_instance_name != module_name:
+        raise ValueError(
+            f"Unexpected module_instance_name: expected {module_name}, got "
+            f"{module_instance_name}")
+    uniq_name = uniquified_modules.get_uniq_name(template_name)
+    if uniq_name and uniq_name != module_instance_name:
+        raise ValueError(
+            f"Unexpected uniquified name: expected {module_instance_name}, "
+            f"got {uniq_name}")
     ipgen_render(module["template_type"], topname, params, out_path)
 
 
@@ -292,6 +320,7 @@ def _get_alert_handler_params(top: ConfigT) -> ParamsT:
                                               int(alert["lpg_idx"])))
             lpg_prev_offset += max(alert['lpg_idx'] for alert in alerts) + 1
     module = lib.find_module(top["module"], "alert_handler")
+    uniquified_modules.add_module(module["template_type"], module["type"])
 
     return {
         "module_instance_name": module["type"],
@@ -346,6 +375,7 @@ def _get_rv_plic_params(top: ConfigT) -> ParamsT:
     num_srcs = sum(
         [int(x["width"]) if "width" in x else 1 for x in top["interrupt"]]) + 1
     num_cores = int(top["num_cores"], 0) if "num_cores" in top else 1
+    uniquified_modules.add_module(module["template_type"], module["type"])
     return {
         "module_instance_name": module["type"],
         "src": num_srcs,
@@ -487,10 +517,9 @@ def _get_clkmgr_params(top: ConfigT) -> ParamsT:
         OrderedDict({name: vars(obj)
                      for name, obj in clocks.srcs.items()}),
         "derived_clks":
-        OrderedDict({
-            name: vars(obj)
-            for name, obj in clocks.derived_srcs.items()
-        }),
+        OrderedDict(
+            {name: vars(obj)
+             for name, obj in clocks.derived_srcs.items()}),
         "typed_clocks":
         OrderedDict({ty: d
                      for ty, d in typed_clks.items() if d}),
@@ -504,9 +533,6 @@ def _get_clkmgr_params(top: ConfigT) -> ParamsT:
         len(clocks.groups),
         "with_alert_handler":
         with_alert_handler,
-        # TODO: Register VLNVs and look this up instead of hard-coding.
-        "pwrmgr_vlnv_prefix":
-        f"top_{topname}_",
         "top_pkg_vlnv":
         f"lowrisc:constants:top_{topname}_top_pkg",
     }
@@ -603,13 +629,13 @@ def _get_rstmgr_params(top: ConfigT) -> ParamsT:
     with_alert_handler = lib.find_module(top['module'],
                                          'alert_handler') is not None
     if with_alert_handler:
-        alert_handler_vlnv_prefix = f"top_{topname}_"
+        alert_handler_vlnv = f"lowrisc:{topname}_ip:alert_handler_pkg"
     elif topname == "englishbreakfast":
         # TODO: Clean templates to not require alert_handler. English Breakfast
         # does not have one, so it uses types and constants from Earl Grey.
-        alert_handler_vlnv_prefix = "top_earlgrey_"
+        alert_handler_vlnv = "lowrisc:earlgrey_ip:alert_handler_pkg"
     else:
-        alert_handler_vlnv_prefix = ""
+        alert_handler_vlnv = ""
 
     return {
         "clks": clks,
@@ -621,9 +647,8 @@ def _get_rstmgr_params(top: ConfigT) -> ParamsT:
         "leaf_rsts": leaf_rsts,
         "rst_ni": rst_ni['rst_ni']['name'],
         "export_rsts": top["exported_rsts"],
-        "alert_handler_vlnv_prefix": alert_handler_vlnv_prefix,
+        "alert_handler_vlnv": alert_handler_vlnv,
         "with_alert_handler": with_alert_handler,
-        "pwrmgr_vlnv_prefix": f"top_{topname}_",
         "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
     }
 
@@ -654,8 +679,6 @@ def _get_flash_ctrl_params(top: ConfigT) -> ParamsT:
         "metadata_width": 12,
         "info_types": 3,
         "infos_per_bank": [10, 1, 2],
-        # TODO: Register VLNVs and look this up instead of hard-coding.
-        "pwrmgr_vlnv_prefix": f"top_{topname}_",
         "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
     })
 
@@ -700,10 +723,11 @@ def _get_ac_range_check_params(top: ConfigT) -> ParamsT:
         }
 
     # Get the AC Range Check instance
-    ac_ranges = lib.find_module(top['module'], 'ac_range_check')
+    module = lib.find_module(top['module'], 'ac_range_check')
+    uniquified_modules.add_module(module["template_type"], module["type"])
     params = {
-        "num_ranges": ac_ranges["ipgen_param"]["num_ranges"],
-        "module_instance_name": ac_ranges["type"]
+        "num_ranges": module["ipgen_param"]["num_ranges"],
+        "module_instance_name": module["type"]
     }
     params.update(racl_params)
     return params
@@ -719,13 +743,13 @@ def generate_ac_range_check(top: ConfigT, module: ConfigT,
 
 def _get_racl_params(top: ConfigT) -> ParamsT:
     """Extracts parameters for racl_ctrl ipgen."""
-    racl_ctrl = lib.find_module(top["module"], "racl_ctrl")
+    module = lib.find_module(top["module"], "racl_ctrl")
     if len(top["racl"]["policies"]) == 1:
         # If there is only one set of policies, take the first one
         policies = list(top["racl"]["policies"].values())[0]
     else:
         # More than one policy, we need to find the matching set of policies
-        racl_group = racl_ctrl.get("racl_group", "Null")
+        racl_group = module.get("racl_group", "Null")
         policies = top["racl"]["policies"][racl_group]
 
     num_subscribing_ips = defaultdict(int)
@@ -735,8 +759,10 @@ def _get_racl_params(top: ConfigT) -> ParamsT:
             racl_group = racl_mappings[if_name]["racl_group"]
             num_subscribing_ips[racl_group] += 1
 
+    uniquified_modules.add_module(module["template_type"], module["type"])
+
     return {
-        "module_instance_name": racl_ctrl["type"],
+        "module_instance_name": module["type"],
         "nr_role_bits": top["racl"]["nr_role_bits"],
         "nr_ctn_uid_bits": top["racl"]["nr_ctn_uid_bits"],
         "nr_policies": top["racl"]["nr_policies"],
@@ -1099,8 +1125,7 @@ def create_ipgen_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
         insert_ip_attrs(instance, _get_flash_ctrl_params(topcfg))
     if "otp_ctrl" in ipgen_instances:
         instance = ipgen_instances["otp_ctrl"][0]
-        insert_ip_attrs(instance,
-                        _get_otp_ctrl_params(topcfg, cfg_path))
+        insert_ip_attrs(instance, _get_otp_ctrl_params(topcfg, cfg_path))
     if "ac_range_check" in ipgen_instances:
         instance = ipgen_instances["ac_range_check"][0]
         insert_ip_attrs(instance, _get_ac_range_check_params(topcfg))
@@ -1675,7 +1700,8 @@ def main():
                         topcfg=completecfg,
                         racl_config=racl_config)
         render_template(TOPGEN_TEMPLATE_PATH / 'toplevel_racl_pkg.sv.tpl',
-                        out_path / 'rtl' / 'autogen' / f'top_{topname}_racl_pkg.sv',
+                        out_path / 'rtl' / 'autogen' /
+                        f'top_{topname}_racl_pkg.sv',
                         gencmd=gencmd_sv,
                         topcfg=completecfg,
                         racl_config=racl_config)


### PR DESCRIPTION
This has two commits:
- Add missing ip/ast artifacts to englishbreakfast so it can be used instead of the earlgrey ast
- Change IpTemplateRendererBase._tplfunc_instance_vlnv per the new
  VLNV scheme. This only needs the template name and the info in "self".
  - Remove the extra "prefix" parameter.
  - Remove some unnecessary vlnv related ipgen parameters.
  - Change top core files to use the new naming.

Fixes #26540