### PR TITLE
Cherrypick #26533 diff to master: [sw,dice] Lockdown the attestation seed page to readonly

### DIFF
--- a/sw/device/silicon_creator/rom_ext/imm_section/imm_section.c
+++ b/sw/device/silicon_creator/rom_ext/imm_section/imm_section.c
@@ -48,6 +48,7 @@ static rom_error_t imm_section_start(void) {
 
   // Lockdown the attestation seed to readonly as soon as possible to prevent
   // key tampering and exfiltration.
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageAttestationKeySeeds);
   flash_ctrl_cert_info_page_owner_restrict(
       &kFlashCtrlInfoPageAttestationKeySeeds);
   flash_ctrl_info_cfg_lock(&kFlashCtrlInfoPageAttestationKeySeeds);

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -72,8 +72,12 @@ fn check_public_key(key: &SubjectPublicKeyInfo, id: &[u8], subject: &Name) -> Re
     let SubjectPublicKeyInfo::EcPublicKey(info) = key;
 
     let mut material = Vec::new();
-    material.extend(&info.public_key.x.get_value().to_bytes_be());
-    material.extend(&info.public_key.y.get_value().to_bytes_be());
+    let x = &info.public_key.x.get_value().to_bytes_be();
+    let y = &info.public_key.y.get_value().to_bytes_be();
+    material.extend(vec![0; 32 - x.len()]);
+    material.extend(x);
+    material.extend(vec![0; 32 - y.len()]);
+    material.extend(y);
     let hash = sha256::sha256(&material).to_be_bytes();
     let keyid = &hash[..20];
     log::info!("computed id = {:?}", hex::encode(keyid));


### PR DESCRIPTION
* #26533

The cherrypick PR #26533 introduces some fixes when cherrypick to earlgrey_1.0.0. This PR ports these differences back to master, including:
* Fix pubkey id hashing in attestation e2e test
* Set attestation seed flash scrambling/ecc before lockdown