### PR TITLE
[tlul,rtl] Add UserInIsZero for tlul_adapter_sram

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -188,7 +188,8 @@ module tlul_adapter_sram
 
   tlul_rsp_intg_gen #(
     .EnableRspIntgGen(EnableRspIntgGen),
-    .EnableDataIntgGen(EnableDataIntgGen)
+    .EnableDataIntgGen(EnableDataIntgGen),
+    .UserInIsZero(1'b1)
   ) u_rsp_gen (
     .tl_i(tl_out),
     .tl_o


### PR DESCRIPTION
- Comes in complement to commit 623663c
- This is linked to code coverage closure for HMAC see https://github.com/lowRISC/opentitan/pull/26473#issuecomment-2697545700 and the next ones.