### PR TITLE
[topgen] Pass through ipgen params to the ipgen config

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -644,7 +644,7 @@
         GpioAsHwStrapsEn: "1"
         GpioAsyncOn: "1"
       }
-      ipgen_param:
+      ipgen_params:
       {
         num_inp_period_counters: 8
       }
@@ -10528,7 +10528,7 @@
           domain: "0"
         }
       }
-      ipgen_param:
+      ipgen_params:
       {
         num_ranges: 32
       }
@@ -10871,9 +10871,9 @@
       type: rv_core_ibex
       template_type: rv_core_ibex
       attr: ipgen
-      ipgen_param:
+      ipgen_params:
       {
-        NumRegions: 32
+        num_regions: 32
       }
       param_decl:
       {

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -311,7 +311,7 @@
         GpioAsHwStrapsEn: "1",
         GpioAsyncOn: "1"
       },
-      ipgen_param: {
+      ipgen_params: {
         num_inp_period_counters: 8
       }
       attr: "ipgen"
@@ -1085,7 +1085,7 @@
       base_addr: {
         soc_mbx: "0x01464000"
       },
-      ipgen_param: {
+      ipgen_params: {
         num_ranges: 32
       }
       attr: "ipgen",
@@ -1095,8 +1095,8 @@
       type: "rv_core_ibex",
       template_type: "rv_core_ibex",
       attr: "ipgen",
-      ipgen_param: {
-        NumRegions: 32
+      ipgen_params: {
+        num_regions: 32
       }
       param_decl: {PMPEnable: "1",
                    PMPGranularity: "0",

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
@@ -6,9 +6,9 @@
   param_values:
   {
     num_ranges: 32
-    module_instance_name: ac_range_check
     nr_role_bits: 4
     nr_ctn_uid_bits: 5
+    module_instance_name: ac_range_check
     topname: darjeeling
     uniquified_modules: {}
   }

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/top_darjeeling_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/top_darjeeling_rv_core_ibex.ipconfig.hjson
@@ -5,11 +5,11 @@
   instance_name: top_darjeeling_rv_core_ibex
   param_values:
   {
-    racl_support: false
     num_regions: 32
     module_instance_name: rv_core_ibex
     topname: darjeeling
     uniquified_modules: {}
+    racl_support: false
   }
   dtgen:
   {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9562,9 +9562,9 @@
       type: rv_core_ibex
       template_type: rv_core_ibex
       attr: ipgen
-      ipgen_param:
+      ipgen_params:
       {
-        NumRegions: 2
+        num_regions: 2
       }
       param_decl:
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1013,8 +1013,8 @@
       type: "rv_core_ibex",
       template_type: "rv_core_ibex",
       attr: "ipgen",
-      ipgen_param: {
-        NumRegions: 2
+      ipgen_params: {
+        num_regions: 2
       }
       param_decl: {PMPEnable: "1",
                    PMPGranularity: "0",

--- a/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
@@ -5,10 +5,10 @@
   instance_name: top_earlgrey_gpio
   param_values:
   {
-    num_inp_period_counters: 0
     module_instance_name: gpio
     topname: earlgrey
     uniquified_modules: {}
+    num_inp_period_counters: 0
   }
   dtgen:
   {

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/top_earlgrey_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/top_earlgrey_rv_core_ibex.ipconfig.hjson
@@ -5,11 +5,11 @@
   instance_name: top_earlgrey_rv_core_ibex
   param_values:
   {
-    racl_support: false
     num_regions: 2
     module_instance_name: rv_core_ibex
     topname: earlgrey
     uniquified_modules: {}
+    racl_support: false
   }
   dtgen:
   {

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4259,9 +4259,9 @@
       type: rv_core_ibex
       template_type: rv_core_ibex
       attr: ipgen
-      ipgen_param:
+      ipgen_params:
       {
-        NumRegions: 2
+        num_regions: 2
       }
       param_decl:
       {

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -581,8 +581,8 @@
       type: "rv_core_ibex",
       template_type: "rv_core_ibex",
       attr: "ipgen",
-      ipgen_param: {
-        NumRegions: 2
+      ipgen_params: {
+        num_regions: 2
       }
       param_decl: {PMPEnable: "0",
                    PMPGranularity: "0",

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
@@ -5,10 +5,10 @@
   instance_name: top_englishbreakfast_gpio
   param_values:
   {
-    num_inp_period_counters: 0
     module_instance_name: gpio
     topname: englishbreakfast
     uniquified_modules: {}
+    num_inp_period_counters: 0
   }
   dtgen:
   {

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/top_englishbreakfast_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/top_englishbreakfast_rv_core_ibex.ipconfig.hjson
@@ -5,11 +5,11 @@
   instance_name: top_englishbreakfast_rv_core_ibex
   param_values:
   {
-    racl_support: false
     num_regions: 2
     module_instance_name: rv_core_ibex
     topname: englishbreakfast
     uniquified_modules: {}
+    racl_support: false
   }
   dtgen:
   {

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -278,7 +278,7 @@ module_optional = {
         'l', 'optional list of paths to incoming alert configurations for the '
         'alert_handler'
     ],
-    'ipgen_param': ['g', 'Optional ipgen parameters for that instance'],
+    'ipgen_params': ['g', 'Optional ipgen parameters for that instance'],
     'template_type': ['s', 'Base template type of ipgen IPs'],
     'racl_group': [
         's', 'Only valid for racl_ctrl IPs. Defines the RACL group this '


### PR DESCRIPTION
This allows the user to arbitrarily set ipgen params on ipgen IPs. These parameters are passed through to the ipgen renderings This allows integrators to easily define custom ipgen parameters and get them used without changes in topgen.