### PR TITLE
[manuf] add ability to log UJSON payloads to console

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -175,6 +175,7 @@ opentitan_test(
             "//sw/device/lib/runtime:ibex",
             "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing:pinmux_testutils",
+            "//sw/device/lib/testing/json:provisioning_data",
             "//sw/device/lib/testing/test_framework:check",
             "//sw/device/lib/testing/test_framework:ottf_console",
             "//sw/device/lib/testing/test_framework:ottf_isrs",

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -17,6 +17,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_console.h"

--- a/sw/host/opentitanlib/src/test_utils/rpc.rs
+++ b/sw/host/opentitanlib/src/test_utils/rpc.rs
@@ -20,8 +20,8 @@ pub trait ConsoleSend<T>
 where
     T: ConsoleDevice + ?Sized,
 {
-    fn send(&self, device: &T) -> Result<()>;
-    fn send_with_crc(&self, device: &T) -> Result<()>;
+    fn send(&self, device: &T) -> Result<String>;
+    fn send_with_crc(&self, device: &T) -> Result<String>;
 }
 
 impl<T, U> ConsoleSend<T> for U
@@ -29,21 +29,22 @@ where
     T: ConsoleDevice + ?Sized,
     U: Serialize,
 {
-    fn send(&self, device: &T) -> Result<()> {
+    fn send(&self, device: &T) -> Result<String> {
         let s = serde_json::to_string(self)?;
         log::info!("Sending: {}", s);
         device.console_write(s.as_bytes())?;
-        Ok(())
+        Ok(s)
     }
 
-    fn send_with_crc(&self, device: &T) -> Result<()> {
+    fn send_with_crc(&self, device: &T) -> Result<String> {
         let s = serde_json::to_string(self)?;
         log::info!("Sending: {}", s);
         device.console_write(s.as_bytes())?;
         let actual_crc = OttfCrc {
             crc: Crc::<u32>::new(&CRC_32_ISO_HDLC).checksum(s.as_bytes()),
         };
-        actual_crc.send(device)
+        let crc_s = actual_crc.send(device)?;
+        Ok(s + &crc_s)
     }
 }
 

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -27,6 +27,7 @@ package(default_visibility = ["//visibility:public"])
             "@crate_index//:elliptic-curve",
             "@crate_index//:hex",
             "@crate_index//:humantime",
+            "@crate_index//:indexmap",
             "@crate_index//:log",
             "@crate_index//:p256",
             "@crate_index//:serde_json",

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -135,6 +135,12 @@ def main(args_in):
         help="Use AST patch in flash info page 0 during FT individualize step.",
     )
     parser.add_argument(
+        "--log-ujson-payloads",
+        action="store_true",
+        default=False,
+        help="Log UJSON host-->device payloads to console for ATE development.",
+    )
+    parser.add_argument(
         "--non-interactive",
         action="store_true",
         default=False,
@@ -200,6 +206,7 @@ def main(args_in):
                 enable_alerts=args.enable_alerts,
                 use_ext_clk=args.use_ext_clk,
                 patch_ast=args.patch_ast,
+                log_ujson_payloads=args.log_ujson_payloads,
                 require_confirmation=not args.non_interactive)
     dut.run_cp()
     if args.cp_only:

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -54,6 +54,7 @@ class OtDut():
     enable_alerts: bool
     use_ext_clk: bool
     patch_ast: bool
+    log_ujson_payloads: bool
     require_confirmation: bool = True
 
     def _make_log_dir(self) -> None:
@@ -286,6 +287,10 @@ class OtDut():
             # individualization if requested.
             if self.patch_ast:
                 cmd += " --use-ast-patch-during-individualize"
+
+            # Enable UJSON message logging.
+            if self.log_ujson_payloads:
+                cmd += " --log-ujson-payloads"
 
             # Get user confirmation before running command.
             logging.info(f"Running command: {cmd}")

--- a/sw/host/provisioning/orchestrator/tests/e2e.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e.sh
@@ -29,4 +29,5 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --fpga=${FPGA} \
   --ast-cfg-version=0 \
   --non-interactive \
+  "$@" \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
@@ -33,5 +33,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --enable-alerts \
   --use-ext-clk \
   --patch-ast \
+  --log-ujson-payloads \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/ujson_lib/BUILD
+++ b/sw/host/provisioning/ujson_lib/BUILD
@@ -25,6 +25,7 @@ rust_library(
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:arrayvec",
+        "@crate_index//:indexmap",
         "@crate_index//:serde",
     ],
 )

--- a/sw/host/provisioning/ujson_lib/src/lib.rs
+++ b/sw/host/provisioning/ujson_lib/src/lib.rs
@@ -2,4 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use indexmap::IndexMap;
+
 pub mod provisioning_data;
+
+pub struct UjsonPayloads {
+    /// HashMap of "Name" --> "UJSON data" sent from the Host to the Device
+    /// during provisioning.
+    pub dut_in: IndexMap<String, String>,
+}

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -68,18 +68,18 @@ fn run_aes_testcase(
         "ecb" => CryptotestAesMode::Ecb.send(spi_console)?,
         "ofb" => CryptotestAesMode::Ofb.send(spi_console)?,
         _ => panic!("Invalid AES mode"),
-    }
+    };
     match test_case.operation.as_str() {
         "encrypt" => CryptotestAesOperation::Encrypt.send(spi_console)?,
         "decrypt" => CryptotestAesOperation::Decrypt.send(spi_console)?,
         _ => panic!("Invalid AES operation"),
-    }
+    };
     match test_case.padding.as_str() {
         "null" => CryptotestAesPadding::Null.send(spi_console)?,
         "pkcs7" => CryptotestAesPadding::Pkcs7.send(spi_console)?,
         "iso9797m2" => CryptotestAesPadding::Iso9797M2.send(spi_console)?,
         _ => panic!("Invalid AES padding scheme"),
-    }
+    };
 
     let mut iv: ArrayVec<u8, AES_BLOCK_BYTES>;
     match &test_case.iv {


### PR DESCRIPTION
To facilitate bringup of manufacturing flows in DV and on ATE, this adds a flag `--log-ujson-payloads` to the E2E FT provisioning flow to print the UJSON payloads (from Host-->Device) as hexstrings to the console. This can be demonstrated by running:

```sh
bazel test --test_output=streamed --test_arg="--log-ujson-payloads" \
  //sw/host/provisioning/orchestrator/tests:e2e_emulation_tpm_hyper310_test
```

CC: @benjbender 