### PR TITLE
[perso] setup keymgr OwnerKey stage with PROD binding

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -374,7 +374,7 @@ static void compute_keymgr_owner_binding(void) {
   // We expect the owner to use a Application Key binding  of
   // {`prod`, 0, ... }.
   memset(sealing_binding_value.data, 0, kDiceMeasurementSizeInBytes);
-  sealing_binding_value.data[0] = kOwnerAppDomainTest;
+  sealing_binding_value.data[0] = kOwnerAppDomainProd;
 }
 
 /**
@@ -567,7 +567,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
                                      &curr_pubkey));
-  TRY(dice_cdi_1_cert_build(&kZeroDigest, &kZeroDigest, 0, kOwnerAppDomainTest,
+  TRY(dice_cdi_1_cert_build(&kZeroDigest, &kZeroDigest, 0, kOwnerAppDomainProd,
                             &cdi_1_key_ids, &curr_pubkey, all_certs,
                             &curr_cert_size));
   cdi_1_offset = perso_blob_to_host.next_free;


### PR DESCRIPTION
Some SKUs build factory installed certs based on PROD diversifier. Since ROM_EXT and Owner FW cannot update these keys/certs on the next boot, perso must set them to PROD.