### PR TITLE
[hsmtool] Add vendor specific AES_KWP mechanism

### DIFF
--- a/sw/host/hsmtool/src/commands/ecdsa/export.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/export.rs
@@ -17,7 +17,7 @@ use crate::util::attribute::{AttrData, AttributeMap, AttributeType, KeyType, Obj
 use crate::util::helper;
 use crate::util::key::ecdsa::{save_private_key, save_public_key};
 use crate::util::key::KeyEncoding;
-use crate::util::wrap::Wrap;
+use crate::util::wrap::{Wrap, WrapPrivateKey};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Export {
@@ -31,6 +31,9 @@ pub struct Export {
     /// Wrap the exported key a wrapping key.
     #[arg(long)]
     wrap: Option<String>,
+    // Wrapping key mechanism. Required when wrap is specified.
+    #[arg(long, default_value = "aes-key-wrap-pad")]
+    wrap_mechanism: Option<WrapPrivateKey>,
     #[arg(short, long, value_enum, default_value = "pem")]
     format: KeyEncoding,
     filename: PathBuf,
@@ -55,7 +58,10 @@ impl Export {
     }
 
     fn wrap_key(&self, session: &Session, object: ObjectHandle) -> Result<()> {
-        let wrapper = Wrap::AesKeyWrapPad;
+        let wrapper: Wrap = self
+            .wrap_mechanism
+            .ok_or(anyhow!("wrap_mechanism is required when wrap is specified"))?
+            .into();
         let wrapped = wrapper.wrap(session, object, self.wrap.as_deref())?;
         helper::write_file(&self.filename, &wrapped)?;
         Ok(())

--- a/sw/host/hsmtool/src/commands/ecdsa/import.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/import.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
@@ -15,7 +15,7 @@ use crate::module::Module;
 use crate::util::attribute::{AttrData, AttributeMap, AttributeType};
 use crate::util::helper;
 use crate::util::key::ecdsa::{load_private_key, load_public_key};
-use crate::util::wrap::Wrap;
+use crate::util::wrap::{Wrap, WrapPrivateKey};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Import {
@@ -35,6 +35,9 @@ pub struct Import {
     /// Unwrap the imported key with a wrapping key.
     #[arg(long)]
     unwrap: Option<String>,
+    /// Unwrapping key mechanism. Required when unwrap is specified.
+    #[arg(long, default_value = "aes-key-wrap-pad")]
+    unwrap_mechanism: Option<WrapPrivateKey>,
     filename: PathBuf,
 }
 
@@ -57,7 +60,12 @@ impl Import {
 
     fn unwrap_key(&self, session: &Session, template: &AttributeMap) -> Result<()> {
         let key = helper::read_file(&self.filename)?;
-        let wrapper = Wrap::AesKeyWrapPad;
+        let wrapper: Wrap = self
+            .unwrap_mechanism
+            .ok_or(anyhow!(
+                "unwrap_mechanism is required when wrap is specified"
+            ))?
+            .into();
         let _key = wrapper.unwrap(session, key.as_slice(), self.unwrap.as_deref(), template)?;
         Ok(())
     }

--- a/sw/host/hsmtool/src/commands/rsa/export.rs
+++ b/sw/host/hsmtool/src/commands/rsa/export.rs
@@ -17,7 +17,7 @@ use crate::util::attribute::{AttrData, AttributeMap, AttributeType, KeyType, Obj
 use crate::util::helper;
 use crate::util::key::rsa::{save_private_key, save_public_key};
 use crate::util::key::KeyEncoding;
-use crate::util::wrap::Wrap;
+use crate::util::wrap::{Wrap, WrapPrivateKey};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Export {
@@ -31,6 +31,9 @@ pub struct Export {
     /// Wrap the exported key a wrapping key.
     #[arg(long)]
     wrap: Option<String>,
+    // Wrapping key mechanism. Required when wrap is specified.
+    #[arg(long, default_value = "aes-key-wrap-pad")]
+    wrap_mechanism: Option<WrapPrivateKey>,
     #[arg(short, long, value_enum, default_value = "pem")]
     format: KeyEncoding,
     filename: PathBuf,
@@ -55,7 +58,10 @@ impl Export {
     }
 
     fn wrap_key(&self, session: &Session, object: ObjectHandle) -> Result<()> {
-        let wrapper = Wrap::AesKeyWrapPad;
+        let wrapper: Wrap = self
+            .wrap_mechanism
+            .ok_or(anyhow!("wrap_mechanism is required when wrap is specified"))?
+            .into();
         let wrapped = wrapper.wrap(session, object, self.wrap.as_deref())?;
         helper::write_file(&self.filename, &wrapped)?;
         Ok(())

--- a/sw/host/hsmtool/src/commands/rsa/import.rs
+++ b/sw/host/hsmtool/src/commands/rsa/import.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
@@ -15,7 +15,7 @@ use crate::module::Module;
 use crate::util::attribute::{AttrData, AttributeMap, AttributeType};
 use crate::util::helper;
 use crate::util::key::rsa::{load_private_key, load_public_key};
-use crate::util::wrap::Wrap;
+use crate::util::wrap::{Wrap, WrapPrivateKey};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Import {
@@ -35,6 +35,9 @@ pub struct Import {
     /// Unwrap the imported key with a wrapping key.
     #[arg(long)]
     unwrap: Option<String>,
+    /// Unwrapping key mechanism. Required when unwrap is specified.
+    #[arg(long, default_value = "aes-key-wrap-pad")]
+    unwrap_mechanism: Option<WrapPrivateKey>,
     filename: PathBuf,
 }
 
@@ -59,7 +62,12 @@ impl Import {
 
     fn unwrap_key(&self, session: &Session, template: &AttributeMap) -> Result<()> {
         let key = helper::read_file(&self.filename)?;
-        let wrapper = Wrap::AesKeyWrapPad;
+        let wrapper: Wrap = self
+            .unwrap_mechanism
+            .ok_or(anyhow!(
+                "unwrap_mechanism is required when wrap is specified"
+            ))?
+            .into();
         let _key = wrapper.unwrap(session, key.as_slice(), self.unwrap.as_deref(), template)?;
         Ok(())
     }

--- a/sw/host/hsmtool/src/util/wrap.rs
+++ b/sw/host/hsmtool/src/util/wrap.rs
@@ -9,6 +9,7 @@
 use anyhow::{Ok, Result};
 use clap::ValueEnum;
 use cryptoki::mechanism::rsa::{PkcsMgfType, PkcsOaepParams, PkcsOaepSource};
+use cryptoki::mechanism::vendor_defined::{VendorDefinedMechanism, CKM_VENDOR_DEFINED};
 use cryptoki::mechanism::{Mechanism, MechanismType};
 use cryptoki::object::{Attribute, ObjectHandle};
 use cryptoki::session::Session;
@@ -29,9 +30,34 @@ pub enum Wrap {
     AesKeyWrapPad,
     RsaPkcs,
     RsaPkcsOaep,
+    VendorThalesAesKwp,
+}
+
+/// The wrapping mechanism to use for private keys.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Display, EnumString, ValueEnum,
+)]
+#[strum(ascii_case_insensitive)]
+pub enum WrapPrivateKey {
+    AesKeyWrap,
+    AesKeyWrapPad,
+    VendorThalesAesKwp,
+}
+
+impl From<WrapPrivateKey> for Wrap {
+    fn from(wrap: WrapPrivateKey) -> Self {
+        match wrap {
+            WrapPrivateKey::AesKeyWrap => Wrap::AesKeyWrap,
+            WrapPrivateKey::AesKeyWrapPad => Wrap::AesKeyWrapPad,
+            WrapPrivateKey::VendorThalesAesKwp => Wrap::VendorThalesAesKwp,
+        }
+    }
 }
 
 impl Wrap {
+    // Vendor defined mechanism for Thales AES key wrap.
+    const CKM_THALES_AES_KWP: u64 = CKM_VENDOR_DEFINED | 0x00000171;
+
     pub fn mechanism(&self) -> Result<Mechanism> {
         match self {
             Wrap::AesKeyWrap => Ok(Mechanism::AesKeyWrap),
@@ -42,6 +68,12 @@ impl Wrap {
                 PkcsMgfType::MGF1_SHA256,
                 PkcsOaepSource::empty(),
             ))),
+            Wrap::VendorThalesAesKwp => {
+                Ok(Mechanism::VendorDefined(VendorDefinedMechanism::new::<()>(
+                    MechanismType::new_vendor_defined(Wrap::CKM_THALES_AES_KWP)?,
+                    None,
+                )))
+            }
         }
     }
 
@@ -49,7 +81,7 @@ impl Wrap {
         let mut attrs = helper::search_spec(None, label)?;
         attrs.push(Attribute::Wrap(true));
         match self {
-            Wrap::AesKeyWrap | Wrap::AesKeyWrapPad => {
+            Wrap::AesKeyWrap | Wrap::AesKeyWrapPad | Wrap::VendorThalesAesKwp => {
                 attrs.push(Attribute::KeyType(KeyType::Aes.try_into()?));
                 attrs.push(Attribute::Class(ObjectClass::SecretKey.try_into()?));
                 helper::find_one_object(session, &attrs)
@@ -66,7 +98,7 @@ impl Wrap {
         let mut attrs = helper::search_spec(None, label)?;
         attrs.push(Attribute::Unwrap(true));
         match self {
-            Wrap::AesKeyWrap | Wrap::AesKeyWrapPad => {
+            Wrap::AesKeyWrap | Wrap::AesKeyWrapPad | Wrap::VendorThalesAesKwp => {
                 attrs.push(Attribute::KeyType(KeyType::Aes.try_into()?));
                 attrs.push(Attribute::Class(ObjectClass::SecretKey.try_into()?));
                 helper::find_one_object(session, &attrs)
@@ -97,7 +129,7 @@ impl Wrap {
             .try_into()
             .map_err(HsmError::AttributeError)?;
 
-        if *self == Wrap::RsaPkcsOaep {
+        if *self == Wrap::RsaPkcsOaep || *self == Wrap::RsaPkcs {
             let result = match key_type {
                 KeyType::Aes => Ok(()),
                 KeyType::GenericSecret => Ok(()),

--- a/sw/host/provisioning/orchestrator/README.md
+++ b/sw/host/provisioning/orchestrator/README.md
@@ -22,6 +22,7 @@ bazel run \
     --test-exit-token="0x22222222_22222222_22222222_22222222" \
     --fpga=${FPGA_TARGET} \
     --non-interactive \
+    --ast-cfg-version=0 \
     --db-path=$(pwd)/provisioning.sqlite
 ```
 


### PR DESCRIPTION
The HSM used in provisioning infrastructure uses a custom mechanism identifier (`CKM_AES_KWP = (CKM_VENDOR_DEFINED + 0x171)`) even though the implementation follows the RFC 3394 and 5649 specifations.

The `CKM_AES_KWP` implemented by Thales is also equivalent to the KWP algorithm specified by NIST SP 800-38F.

This change adds a custom `Wrap::VendorThalesAesKwp` mechanism to `hsmtool` to be able to wrap/unwrap private keys with `AES_KWP`.