### PR TITLE
[hw,soc_dbg_ctrl,rtl] Use output of shadowed reg of debug category

### DIFF
--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
@@ -200,7 +200,7 @@ module soc_dbg_ctrl
       // In Soc_DbgStProd, the debug policy is driven by the RoT according to the negotiated or
       // authorized policy
       lc_ctrl_state_pkg::SocDbgStProd: begin
-        soc_dbg_policy_d.category = dbg_category_e'(core_reg2hw.debug_policy_category_shadowed.q);
+        soc_dbg_policy_d.category = dbg_category_e'(core_hw2reg.debug_policy_category_shadowed.d);
         soc_dbg_policy_d.valid    =
           prim_mubi_pkg::mubi4_t'(core_reg2hw.debug_policy_valid_shadowed.q);
         soc_dbg_policy_d.relocked = prim_mubi_pkg::mubi4_t'(core_reg2hw.debug_policy_relocked.q);


### PR DESCRIPTION
The .q signal of the reg_top is only active for a single cycle when doing a read from the SW interface. Instead, directly use the output of the shadowed register.