### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@6e466c15

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 591c3812f951a4acc8014eb2d9d727936d11bf99
+    rev: 6e466c1504b61333d1b2ba85c69bff94b65e9284
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/verification.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/verification.rst
@@ -111,7 +111,7 @@ In order to run the co-simulation flow, you'll need:
   + Some custom CSRs
   + Custom NMI behavior
 
-  Ibex verification should work with the Spike version that is tagged as ``ibex-cosim-v0.5``.
+  Ibex verification should work with the Spike version that named ``ibex_cosim``.
 
   Spike must be built with the ``--enable-commitlog`` and ``--enable-misaligned`` options.
   ``--enable-commitlog`` is needed to produce log output to track the instructions that were executed.

--- a/hw/vendor/lowrisc_ibex/dv/cosim/cosim.h
+++ b/hw/vendor/lowrisc_ibex/dv/cosim/cosim.h
@@ -85,7 +85,15 @@ class Cosim {
 
   // Set the value of MIP.
   //
-  // At the next call of `step`, the MIP value will take effect (i.e. if it's a
+  // Two versions of MIP must be supplied the `pre_mip` and the `post_mip`. The
+  // `pre_mip` is the value of MIP that is used to determine if an interrupt is
+  // pending. The `post_mip` is the value of MIP that the next instruction
+  // executed (which will be the first instruction of the interrupt vector when
+  // an interrupt ir triggered) observes. These will be different in the case
+  // where an interrupt is raised triggering an interrupt handler but then
+  // drops before the first instruction of the handler has executed.
+  //
+  // At the next call of `step`, the MIP values will take effect (i.e. if it's a
   // new interrupt that is enabled it will step straight to that handler).
   virtual void set_mip(uint32_t pre_mip, uint32_t post_mip) = 0;
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
@@ -925,88 +925,14 @@ module ibex_controller #(
       RESET, BOOT_SET, WAIT_SLEEP, SLEEP, FIRST_FETCH, DECODE, FLUSH,
       IRQ_TAKEN, DBG_TAKEN_IF, DBG_TAKEN_ID})
 
-  `ifdef INC_ASSERT
-    // If something that causes a jump into an exception handler is seen that jump must occur before
-    // the next instruction executes. The logic tracks whether a jump into an exception handler is
-    // expected. Assertions check the jump occurs.
-
-    logic exception_req, exception_req_pending, exception_req_accepted, exception_req_done;
-    logic exception_pc_set, seen_exception_pc_set, expect_exception_pc_set;
-    logic exception_req_needs_pc_set;
-
-    assign exception_req = (special_req | enter_debug_mode | handle_irq);
-    // Any exception rquest will cause a transition out of DECODE, once the controller transitions
-    // back into DECODE we're done handling the request.
-    assign exception_req_done =
-      exception_req_pending & (ctrl_fsm_cs != DECODE) & (ctrl_fsm_ns == DECODE);
-
-    assign exception_req_needs_pc_set = enter_debug_mode | handle_irq | special_req_pc_change;
-
-    // An exception PC set uses specific PC types
-    assign exception_pc_set =
-      exception_req_pending & (pc_set_o & (pc_mux_o inside {PC_EXC, PC_ERET, PC_DRET}));
-
-    always @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        exception_req_pending   <= 1'b0;
-        exception_req_accepted  <= 1'b0;
-        expect_exception_pc_set <= 1'b0;
-        seen_exception_pc_set   <= 1'b0;
-      end else begin
-        // Keep `exception_req_pending` asserted once an exception_req is seen until it is done
-        exception_req_pending <= (exception_req_pending | exception_req) & ~exception_req_done;
-
-        // The exception req has been accepted once the controller transitions out of decode
-        exception_req_accepted <= (exception_req_accepted & ~exception_req_done) |
-          (exception_req & ctrl_fsm_ns != DECODE);
-
-        // Set `expect_exception_pc_set` if exception req needs one and keep it asserted until
-        // exception req is done
-        expect_exception_pc_set <= (expect_exception_pc_set | exception_req_needs_pc_set) &
-          ~exception_req_done;
-
-        // Keep `seen_exception_pc_set` asserted once an exception PC set is seen until the
-        // exception req is done
-        seen_exception_pc_set <= (seen_exception_pc_set | exception_pc_set) & ~exception_req_done;
-      end
-    end
-
-    // Once an exception request has been accepted it must be handled before controller goes back to
-    // DECODE
-    `ASSERT(IbexNoDoubleExceptionReq, exception_req_accepted |-> ctrl_fsm_cs != DECODE)
-
-    // Only signal ready, allowing a new instruction into ID, if there is no exception request
-    // pending or it is done this cycle.
-    `ASSERT(IbexDontSkipExceptionReq,
-      id_in_ready_o |-> !exception_req_pending || exception_req_done)
-
-    // Once a PC set has been performed for an exception request there must not be any other
-    // excepting those to move into debug mode.
-    `ASSERT(IbexNoDoubleSpecialReqPCSet,
-      seen_exception_pc_set &&
-        !((ctrl_fsm_cs inside {DBG_TAKEN_IF, DBG_TAKEN_ID}) &&
-          (pc_mux_o == PC_EXC) && (exc_pc_mux_o == EXC_PC_DBD))
-      |-> !pc_set_o)
-
-    // When an exception request is done there must have been an appropriate PC set (either this
-    // cycle or a previous one).
-    `ASSERT(IbexSetExceptionPCOnSpecialReqIfExpected,
-      exception_req_pending && expect_exception_pc_set && exception_req_done |->
-      seen_exception_pc_set || exception_pc_set)
-
-    // If there's a pending exception req that doesn't need a PC set we must not see one
-    `ASSERT(IbexNoPCSetOnSpecialReqIfNotExpected,
-      exception_req_pending && !expect_exception_pc_set |-> ~pc_set_o)
-
-    // If entering or exiting debug mode, the pipeline must be flushed. This is because Ibex
-    // currently does not support some of the pipeline stages being in debug mode; either all or
-    // none of the pipeline stages must be in debug mode. As `flush_id_o` only affects the ID/EX
-    // stage but does not prevent a fetched instruction from proceeding to ID/EX the next cycle, the
-    // assertion additionally requires `pc_set_o`, which sets the PC in the IF stage to a new value,
-    // hence preventing a fetched instruction from proceeding to the ID/EX stage in the next cycle.
-    `ASSERT(IbexPipelineFlushOnChangingDebugMode,
-      debug_mode_d != debug_mode_q |-> flush_id_o & pc_set_o)
-  `endif
+  // If entering or exiting debug mode, the pipeline must be flushed. This is because Ibex
+  // currently does not support some of the pipeline stages being in debug mode; either all or
+  // none of the pipeline stages must be in debug mode. As `flush_id_o` only affects the ID/EX
+  // stage but does not prevent a fetched instruction from proceeding to ID/EX the next cycle, the
+  // assertion additionally requires `pc_set_o`, which sets the PC in the IF stage to a new value,
+  // hence preventing a fetched instruction from proceeding to the ID/EX stage in the next cycle.
+  `ASSERT(IbexPipelineFlushOnChangingDebugMode,
+    debug_mode_d != debug_mode_q |-> flush_id_o & pc_set_o)
 
   `ifdef RVFI
     // Workaround for internal verilator error when using hierarchical refers to calcuate this

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -83,6 +83,7 @@ module ibex_decoder #(
   // CSRs
   output logic                 csr_access_o,          // access to CSR
   output ibex_pkg::csr_op_e    csr_op_o,              // operation to perform on CSR
+  output ibex_pkg::csr_num_e   csr_addr_o,            // CSR address
 
   // LSU
   output logic                 data_req_o,            // start transaction to data memory
@@ -137,6 +138,8 @@ module ibex_decoder #(
   assign imm_b_type_o = { {19{instr[31]}}, instr[31], instr[7], instr[30:25], instr[11:8], 1'b0 };
   assign imm_u_type_o = { instr[31:12], 12'b0 };
   assign imm_j_type_o = { {12{instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0 };
+
+  assign csr_addr_o = csr_num_e'(instr[31:20]);
 
   // immediate for CSR manipulation (zero extended)
   assign zimm_rs1_type_o = { 27'b0, instr_rs1 }; // rs1
@@ -1168,9 +1171,10 @@ module ibex_decoder #(
           alu_op_b_mux_sel_o = OP_B_IMM;
         end else begin
           // instruction to read/modify CSR
-          alu_op_b_mux_sel_o = OP_B_IMM;
           imm_a_mux_sel_o    = IMM_A_Z;
-          imm_b_mux_sel_o    = IMM_B_I;  // CSR address is encoded in I imm
+
+          // No need for operand/immediate B mux selection. The CSR address is fed out as csr_addr_o
+          // as the CSR address always comes from the same field in the instruction.
 
           if (instr_alu[14]) begin
             // rs1 field is used as immediate

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -95,6 +95,7 @@ module ibex_id_stage #(
   // CSR
   output logic                      csr_access_o,
   output ibex_pkg::csr_op_e         csr_op_o,
+  output ibex_pkg::csr_num_e        csr_addr_o,
   output logic                      csr_op_en_o,
   output logic                      csr_save_if_o,
   output logic                      csr_save_id_o,
@@ -290,6 +291,7 @@ module ibex_id_stage #(
   logic        data_req_allowed;
 
   // CSR control
+  logic        no_flush_csr_addr;
   logic        csr_pipe_flush;
 
   logic [31:0] alu_operand_a;
@@ -497,6 +499,7 @@ module ibex_id_stage #(
     // CSRs
     .csr_access_o(csr_access_o),
     .csr_op_o    (csr_op_o),
+    .csr_addr_o  (csr_addr_o),
 
     // LSU
     .data_req_o           (lsu_req_dec),
@@ -509,36 +512,20 @@ module ibex_id_stage #(
     .branch_in_dec_o(branch_in_dec)
   );
 
-  /////////////////////////////////
-  // CSR-related pipeline flushes //
-  /////////////////////////////////
-  always_comb begin : csr_pipeline_flushes
-    csr_pipe_flush = 1'b0;
+  // Flush pipe on most CSR modification. Some CSR modifications alter how instructions execute
+  // (e.g. the PMP CSRs) so this ensures all instructions always see the latest architectural state
+  // when entering the fetch stage. This causes some needless flushes but performance impact is
+  // limited. We have a single fetch stage to flush not many stages of a deep pipeline and CSR
+  // instructions are in general rare and not part of performance critical parts of the code.
+  //
+  // No flush is triggered for a small number of specific CSRs. These are ones that have been
+  // specifically identified to be a) likely to be modifed in exception handlers and b) safe to
+  // alter without a flush.
+  assign no_flush_csr_addr = csr_addr_o inside {CSR_MSCRATCH, CSR_MEPC};
 
-    // A pipeline flush is needed to let the controller react after modifying certain CSRs:
-    // - When enabling interrupts, pending IRQs become visible to the controller only during
-    //   the next cycle. If during that cycle the core disables interrupts again, it does not
-    //   see any pending IRQs and consequently does not start to handle interrupts.
-    // - When modifying any PMP CSR, PMP check of the next instruction might get invalidated.
-    //   Hence, a pipeline flush is needed to instantiate another PMP check with the updated CSRs.
-    // - When modifying debug CSRs.
-    if (csr_op_en_o == 1'b1 && (csr_op_o == CSR_OP_WRITE || csr_op_o == CSR_OP_SET)) begin
-      if (csr_num_e'(instr_rdata_i[31:20]) == CSR_MSTATUS ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_MIE     ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_MSECCFG ||
-          // To catch all PMPCFG/PMPADDR registers, get the shared top most 7 bits.
-          instr_rdata_i[31:25] == 7'h1D) begin
-        csr_pipe_flush = 1'b1;
-      end
-    end else if (csr_op_en_o == 1'b1 && csr_op_o != CSR_OP_READ) begin
-      if (csr_num_e'(instr_rdata_i[31:20]) == CSR_DCSR      ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_DPC       ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_DSCRATCH0 ||
-          csr_num_e'(instr_rdata_i[31:20]) == CSR_DSCRATCH1) begin
-        csr_pipe_flush = 1'b1;
-      end
-    end
-  end
+  assign csr_pipe_flush = (csr_op_en_o == 1)                                         &&
+                          (csr_op_o inside {CSR_OP_WRITE, CSR_OP_SET, CSR_OP_CLEAR}) &&
+                          !no_flush_csr_addr;
 
   ////////////////
   // Controller //

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_register_file_fpga.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_register_file_fpga.sv
@@ -150,10 +150,7 @@ module ibex_register_file_fpga #(
     assign rdata_a_o = (raddr_a_i == '0) ? WordZeroVal : mem_o_a;
     assign rdata_b_o = (raddr_b_i == '0) ? WordZeroVal : mem_o_b;
   end else begin : gen_no_rdata_mux_check
-    // async_read a
     assign rdata_a_o = (raddr_a_i == '0) ? WordZeroVal : mem[raddr_a_i];
-
-    // async_read b
     assign rdata_b_o = (raddr_b_i == '0) ? WordZeroVal : mem[raddr_b_i];
 
     assign oh_raddr_a_err = 1'b0;


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
6e466c1504b61333d1b2ba85c69bff94b65e9284

* Verification should be done with ibex_cosim branch (Marno van der Maas)
* [cosim] Update comment on `set_mip` in Cosim interface (Greg Chadwick)
* [rtl] Remove low utility assertions (Greg Chadwick)
* [rtl] Flush pipe on all CSR modifications (Greg Chadwick)
* [rtl] Read csr_addr direct from instruction (Greg Chadwick)
* [ibex_core] Fix assertion when SecureIbex is false (Rupert Swarbrick)
* [ibex_register_file_fpga] Drop two confusing comments (Rupert Swarbrick)