### PR TITLE
Final software fixes for Darjeeling DV 

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -252,9 +252,12 @@ def _opentitan_binary(ctx):
             default_info.extend(provides["logs"])
 
         # FIXME: vmem is a special case for ram targets used in ROM e2e test
-        # cases.
+        # cases. Some tops like Darjeeling expect a different word size than
+        # Earlgrey.
         if provides.get("vmem"):
             default_info.append(provides["vmem"])
+        if provides.get("vmem32"):
+            default_info.append(provides["vmem32"])
 
         # FIXME(cfrantz): Special case: The englishbreakfast verilator model
         # requires a non-scrambled ROM image.

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//lib:types.bzl", "types")
-load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "OpenTitanBinaryInfo", "PROVIDER_FIELDS")
+load("@lowrisc_opentitan//rules/opentitan:providers.bzl", "OpenTitanBinaryInfo")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_files")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
@@ -235,6 +235,8 @@ def _do_update(name, file, data_files, param, action_param):
     """Update the files list and param dictionaries."""
     if name in param:
         fail(name, "already exists in the param dictionary")
+    if type(file) != "File":
+        return
     data_files.append(file)
     param[name] = file.short_path
     if action_param != None:
@@ -268,10 +270,8 @@ def update_file_provider(name, provider, data_files, param, action_param = None,
     if not provider:
         # Nothing to do.
         return
-    for field in PROVIDER_FIELDS:
+    for field in dir(provider):
         file = getattr(provider, field, None)
-        if not file:
-            continue
         if field == default:
             _update(name, file, data_files, param, action_param)
         else:

--- a/rules/opentitan/providers.bzl
+++ b/rules/opentitan/providers.bzl
@@ -48,18 +48,6 @@ ALL_BINARY_PROVIDERS = [
     SimQemuBinaryInfo,
 ]
 
-PROVIDER_FIELDS = [
-    "elf",
-    "binary",
-    "default",
-    "rom",
-    "signed_bin",
-    "disassembly",
-    "logs",
-    "mapfile",
-    "vmem",
-]
-
 def get_binary_files(attrs, field = "binary", providers = ALL_BINARY_PROVIDERS):
     """Get the list of binary files associated with a list of labels.
 

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -56,6 +56,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         )
         default = rom
         vmem = rom
+        vmem32 = None
     elif ctx.attr.kind == "ram":
         default = elf
         rom = None
@@ -67,6 +68,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             src = signed_bin if signed_bin else binary,
             word_size = 32,
         )
+        vmem32 = None
     elif ctx.attr.kind == "flash":
         # First convert to VMEM, then scramble according to flash
         # scrambling settings.
@@ -78,6 +80,12 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
             name = name,
             src = signed_bin if signed_bin else binary,
             word_size = 64,
+        )
+        vmem32 = convert_to_vmem(
+            ctx,
+            name = name,
+            src = signed_bin if signed_bin else binary,
+            word_size = 32,
         )
         vmem = scramble_flash(
             ctx,
@@ -112,6 +120,7 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "logs": logs,
         "mapfile": mapfile,
         "vmem": vmem,
+        "vmem32": vmem32,
         "hashfile": hashfile,
     }
 


### PR DESCRIPTION
This is a semi-hack to enable Darjeeling DV: when building the sim_dv firmware image, create both a 32-bit and 64-bit VMEM so that the DV env can pickup whichever it likes. This requires a small change to how files are exposed (see commit).