### PR TITLE
[hw,aon_timer,rtl] Add RACL support to AON timer

### DIFF
--- a/hw/ip/aon_timer/aon_timer.core
+++ b/hw/ip/aon_timer/aon_timer.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:edge_detector
       - lowrisc:prim:lc_sync
       - lowrisc:ip:tlul
+      - lowrisc:systems:top_racl_pkg
     files:
       - rtl/aon_timer_reg_pkg.sv
       - rtl/aon_timer_reg_top.sv

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -29,7 +29,7 @@
     {clock: "clk_aon_i", reset: "rst_aon_ni"}
   ]
   bus_interfaces: [
-    { protocol: "tlul", direction: "device"}
+    { protocol: "tlul", direction: "device", racl_support: true }
   ],
   interrupt_list: [
     { name: "wkup_timer_expired",
@@ -93,6 +93,26 @@
       package: "",
       struct:  "logic",
       width:   "1"
+    },
+    { struct:  "racl_policy_vec",
+      type:    "uni",
+      name:    "racl_policies",
+      act:     "rcv",
+      package: "top_racl_pkg",
+      desc:    '''
+        Incoming RACL policy vector from a racl_ctrl instance.
+        The policy selection vector (parameter) selects the policy for each register.
+      '''
+    }
+    { struct:  "racl_error_log",
+      type:    "uni",
+      name:    "racl_error",
+      act:     "req",
+      width:   "1"
+      package: "top_racl_pkg",
+      desc:    '''
+        RACL error log information of this module.
+      '''
     }
   ],
   features: [

--- a/hw/ip/aon_timer/doc/interfaces.md
+++ b/hw/ip/aon_timer/doc/interfaces.md
@@ -10,14 +10,16 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name           | Package::Struct    | Type    | Act   |   Width | Description   |
-|:--------------------|:-------------------|:--------|:------|--------:|:--------------|
-| nmi_wdog_timer_bark | logic              | uni     | req   |       1 |               |
-| wkup_req            | logic              | uni     | req   |       1 |               |
-| aon_timer_rst_req   | logic              | uni     | req   |       1 |               |
-| lc_escalate_en      | lc_ctrl_pkg::lc_tx | uni     | rcv   |       1 |               |
-| sleep_mode          | logic              | uni     | rcv   |       1 |               |
-| tl                  | tlul_pkg::tl       | req_rsp | rsp   |       1 |               |
+| Port Name           | Package::Struct               | Type    | Act   |   Width | Description                                                                                                                          |
+|:--------------------|:------------------------------|:--------|:------|--------:|:-------------------------------------------------------------------------------------------------------------------------------------|
+| nmi_wdog_timer_bark | logic                         | uni     | req   |       1 |                                                                                                                                      |
+| wkup_req            | logic                         | uni     | req   |       1 |                                                                                                                                      |
+| aon_timer_rst_req   | logic                         | uni     | req   |       1 |                                                                                                                                      |
+| lc_escalate_en      | lc_ctrl_pkg::lc_tx            | uni     | rcv   |       1 |                                                                                                                                      |
+| sleep_mode          | logic                         | uni     | rcv   |       1 |                                                                                                                                      |
+| racl_policies       | top_racl_pkg::racl_policy_vec | uni     | rcv   |       1 | Incoming RACL policy vector from a racl_ctrl instance. The policy selection vector (parameter) selects the policy for each register. |
+| racl_error          | top_racl_pkg::racl_error_log  | uni     | req   |       1 | RACL error log information of this module.                                                                                           |
+| tl                  | tlul_pkg::tl                  | req_rsp | rsp   |       1 |                                                                                                                                      |
 
 ## Interrupts
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -3643,6 +3643,32 @@
           index: -1
         }
         {
+          name: racl_policies
+          desc:
+            '''
+            Incoming RACL policy vector from a racl_ctrl instance.
+            The policy selection vector (parameter) selects the policy for each register.
+            '''
+          struct: racl_policy_vec
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: aon_timer_aon
+          index: -1
+        }
+        {
+          name: racl_error
+          desc: RACL error log information of this module.
+          struct: racl_error_log
+          package: top_racl_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: aon_timer_aon
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -22010,6 +22036,32 @@
         default: ""
         package: ""
         top_signame: pwrmgr_aon_low_power
+        index: -1
+      }
+      {
+        name: racl_policies
+        desc:
+          '''
+          Incoming RACL policy vector from a racl_ctrl instance.
+          The policy selection vector (parameter) selects the policy for each register.
+          '''
+        struct: racl_policy_vec
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: aon_timer_aon
+        index: -1
+      }
+      {
+        name: racl_error
+        desc: RACL error log information of this module.
+        struct: racl_error_log
+        package: top_racl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: aon_timer_aon
         index: -1
       }
       {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1582,6 +1582,8 @@ module top_darjeeling #(
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs[0]),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .sleep_mode_i(pwrmgr_aon_low_power),
+      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
+      .racl_error_o(),
       .tl_i(aon_timer_aon_tl_req),
       .tl_o(aon_timer_aon_tl_rsp),
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5279,6 +5279,32 @@
           index: -1
         }
         {
+          name: racl_policies
+          desc:
+            '''
+            Incoming RACL policy vector from a racl_ctrl instance.
+            The policy selection vector (parameter) selects the policy for each register.
+            '''
+          struct: racl_policy_vec
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: aon_timer_aon
+          index: -1
+        }
+        {
+          name: racl_error
+          desc: RACL error log information of this module.
+          struct: racl_error_log
+          package: top_racl_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: aon_timer_aon
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -21106,6 +21132,32 @@
         default: ""
         package: ""
         top_signame: pwrmgr_aon_low_power
+        index: -1
+      }
+      {
+        name: racl_policies
+        desc:
+          '''
+          Incoming RACL policy vector from a racl_ctrl instance.
+          The policy selection vector (parameter) selects the policy for each register.
+          '''
+        struct: racl_policy_vec
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: aon_timer_aon
+        index: -1
+      }
+      {
+        name: racl_error
+        desc: RACL error log information of this module.
+        struct: racl_error_log
+        package: top_racl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: aon_timer_aon
         index: -1
       }
       {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2108,6 +2108,8 @@ module top_earlgrey #(
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs[1]),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .sleep_mode_i(pwrmgr_aon_low_power),
+      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
+      .racl_error_o(),
       .tl_i(aon_timer_aon_tl_req),
       .tl_o(aon_timer_aon_tl_rsp),
 

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -2834,6 +2834,32 @@
           index: -1
         }
         {
+          name: racl_policies
+          desc:
+            '''
+            Incoming RACL policy vector from a racl_ctrl instance.
+            The policy selection vector (parameter) selects the policy for each register.
+            '''
+          struct: racl_policy_vec
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: aon_timer_aon
+          index: -1
+        }
+        {
+          name: racl_error
+          desc: RACL error log information of this module.
+          struct: racl_error_log
+          package: top_racl_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: aon_timer_aon
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -10561,6 +10587,32 @@
         default: ""
         package: ""
         top_signame: pwrmgr_aon_low_power
+        index: -1
+      }
+      {
+        name: racl_policies
+        desc:
+          '''
+          Incoming RACL policy vector from a racl_ctrl instance.
+          The policy selection vector (parameter) selects the policy for each register.
+          '''
+        struct: racl_policy_vec
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: aon_timer_aon
+        index: -1
+      }
+      {
+        name: racl_error
+        desc: RACL error log information of this module.
+        struct: racl_error_log
+        package: top_racl_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: aon_timer_aon
         index: -1
       }
       {

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -1040,6 +1040,8 @@ module top_englishbreakfast #(
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs),
       .lc_escalate_en_i(lc_ctrl_pkg::Off),
       .sleep_mode_i(pwrmgr_aon_low_power),
+      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
+      .racl_error_o(),
       .tl_i(tlul_pkg::TL_H2D_DEFAULT),
       .tl_o(),
 


### PR DESCRIPTION
This PR adds RACL support to the AON timer. RACL is disabled for this IP in both Darjeeling, Earlgrey, and Englishbreaksfast.