### PR TITLE
[rtl,tl] Add a parameter to avoid some unused code in prim_subreg

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -1356,7 +1356,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1384,7 +1385,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1453,7 +1455,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_en_ctl_adc_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1480,7 +1483,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_en_ctl_oneshot_mode (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1509,7 +1513,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_pd_ctl_lp_mode (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1536,7 +1541,8 @@ module adc_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_pd_ctl_pwrup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1563,7 +1569,8 @@ module adc_ctrl_reg_top (
     .DW      (24),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (24'h640),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_pd_ctl_wakeup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1591,7 +1598,8 @@ module adc_ctrl_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h4),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_lp_sample_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1619,7 +1627,8 @@ module adc_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h9b),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_sample_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1647,7 +1656,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_fsm_rst (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1677,7 +1687,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_0_min_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1704,7 +1715,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_0_cond_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1731,7 +1743,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_0_max_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1758,7 +1771,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_0_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1788,7 +1802,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_1_min_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1815,7 +1830,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_1_cond_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1842,7 +1858,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_1_max_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1869,7 +1886,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_1_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1899,7 +1917,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_2_min_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1926,7 +1945,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_2_cond_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1953,7 +1973,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_2_max_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1980,7 +2001,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_2_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2010,7 +2032,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_3_min_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2037,7 +2060,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_3_cond_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2064,7 +2088,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_3_max_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2091,7 +2116,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_3_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2121,7 +2147,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_4_min_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2148,7 +2175,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_4_cond_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2175,7 +2203,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_4_max_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2202,7 +2231,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_4_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2232,7 +2262,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_5_min_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2259,7 +2290,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_5_cond_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2286,7 +2318,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_5_max_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2313,7 +2346,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_5_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2343,7 +2377,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_6_min_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2370,7 +2405,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_6_cond_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2397,7 +2433,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_6_max_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2424,7 +2461,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_6_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2454,7 +2492,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_7_min_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2481,7 +2520,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_7_cond_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2508,7 +2548,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_7_max_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2535,7 +2576,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn0_filter_ctl_7_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2565,7 +2607,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_0_min_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2592,7 +2635,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_0_cond_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2619,7 +2663,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_0_max_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2646,7 +2691,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_0_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2676,7 +2722,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_1_min_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2703,7 +2750,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_1_cond_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2730,7 +2778,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_1_max_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2757,7 +2806,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_1_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2787,7 +2837,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_2_min_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2814,7 +2865,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_2_cond_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2841,7 +2893,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_2_max_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2868,7 +2921,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_2_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2898,7 +2952,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_3_min_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2925,7 +2980,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_3_cond_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2952,7 +3008,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_3_max_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2979,7 +3036,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_3_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3009,7 +3067,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_4_min_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3036,7 +3095,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_4_cond_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3063,7 +3123,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_4_max_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3090,7 +3151,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_4_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3120,7 +3182,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_5_min_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3147,7 +3210,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_5_cond_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3174,7 +3238,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_5_max_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3201,7 +3266,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_5_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3231,7 +3297,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_6_min_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3258,7 +3325,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_6_cond_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3285,7 +3353,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_6_max_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3312,7 +3381,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_6_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3342,7 +3412,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_7_min_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3369,7 +3440,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_7_cond_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3396,7 +3468,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_7_max_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3423,7 +3496,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn1_filter_ctl_7_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3455,7 +3529,8 @@ module adc_ctrl_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_0_adc_chn_value_ext_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3482,7 +3557,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_0_adc_chn_value_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3509,7 +3585,8 @@ module adc_ctrl_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_0_adc_chn_value_intr_ext_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3536,7 +3613,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_0_adc_chn_value_intr_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3568,7 +3646,8 @@ module adc_ctrl_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_1_adc_chn_value_ext_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3595,7 +3674,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_1_adc_chn_value_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3622,7 +3702,8 @@ module adc_ctrl_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_1_adc_chn_value_intr_ext_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3649,7 +3730,8 @@ module adc_ctrl_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_chn_val_1_adc_chn_value_intr_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3678,7 +3760,8 @@ module adc_ctrl_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_wakeup_ctl_match_en (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3705,7 +3788,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_wakeup_ctl_trans_en (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3736,7 +3820,8 @@ module adc_ctrl_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_filter_status_match (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3763,7 +3848,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_filter_status_trans (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3792,7 +3878,8 @@ module adc_ctrl_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_intr_ctl_match_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3819,7 +3906,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_intr_ctl_trans_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3846,7 +3934,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_intr_ctl_oneshot_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3875,7 +3964,8 @@ module adc_ctrl_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_intr_status_match (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3902,7 +3992,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_intr_status_trans (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3929,7 +4020,8 @@ module adc_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_adc_intr_status_oneshot (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -1357,7 +1357,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1386,7 +1386,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1456,7 +1456,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_en_ctl_adc_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1484,7 +1484,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_en_ctl_oneshot_mode (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1514,7 +1514,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_pd_ctl_lp_mode (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1542,7 +1542,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_pd_ctl_pwrup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1570,7 +1570,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (24'h640),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_pd_ctl_wakeup_time (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1599,7 +1599,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h4),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_lp_sample_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1628,7 +1628,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h9b),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_sample_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1657,7 +1657,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_fsm_rst (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1688,7 +1688,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_0_min_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1716,7 +1716,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_0_cond_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1744,7 +1744,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_0_max_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1772,7 +1772,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_0_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1803,7 +1803,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_1_min_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1831,7 +1831,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_1_cond_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1859,7 +1859,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_1_max_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1887,7 +1887,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_1_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1918,7 +1918,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_2_min_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1946,7 +1946,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_2_cond_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1974,7 +1974,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_2_max_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2002,7 +2002,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_2_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2033,7 +2033,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_3_min_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2061,7 +2061,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_3_cond_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2089,7 +2089,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_3_max_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2117,7 +2117,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_3_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2148,7 +2148,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_4_min_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2176,7 +2176,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_4_cond_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2204,7 +2204,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_4_max_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2232,7 +2232,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_4_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2263,7 +2263,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_5_min_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2291,7 +2291,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_5_cond_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2319,7 +2319,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_5_max_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2347,7 +2347,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_5_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2378,7 +2378,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_6_min_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2406,7 +2406,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_6_cond_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2434,7 +2434,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_6_max_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2462,7 +2462,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_6_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2493,7 +2493,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_7_min_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2521,7 +2521,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_7_cond_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2549,7 +2549,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_7_max_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2577,7 +2577,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn0_filter_ctl_7_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2608,7 +2608,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_0_min_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2636,7 +2636,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_0_cond_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2664,7 +2664,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_0_max_v_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2692,7 +2692,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_0_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2723,7 +2723,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_1_min_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2751,7 +2751,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_1_cond_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2779,7 +2779,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_1_max_v_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2807,7 +2807,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_1_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2838,7 +2838,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_2_min_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2866,7 +2866,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_2_cond_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2894,7 +2894,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_2_max_v_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2922,7 +2922,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_2_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2953,7 +2953,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_3_min_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2981,7 +2981,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_3_cond_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3009,7 +3009,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_3_max_v_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3037,7 +3037,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_3_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3068,7 +3068,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_4_min_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3096,7 +3096,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_4_cond_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3124,7 +3124,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_4_max_v_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3152,7 +3152,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_4_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3183,7 +3183,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_5_min_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3211,7 +3211,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_5_cond_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3239,7 +3239,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_5_max_v_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3267,7 +3267,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_5_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3298,7 +3298,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_6_min_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3326,7 +3326,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_6_cond_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3354,7 +3354,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_6_max_v_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3382,7 +3382,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_6_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3413,7 +3413,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_7_min_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3441,7 +3441,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_7_cond_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3469,7 +3469,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_7_max_v_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3497,7 +3497,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_chn1_filter_ctl_7_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3761,7 +3761,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_wakeup_ctl_match_en (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3789,7 +3789,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_wakeup_ctl_trans_en (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3879,7 +3879,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_intr_ctl_match_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3907,7 +3907,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_intr_ctl_trans_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3935,7 +3935,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_intr_ctl_oneshot_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3965,7 +3965,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_intr_status_match (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3993,7 +3993,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_intr_status_trans (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4021,7 +4021,7 @@ module adc_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_adc_intr_status_oneshot (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -707,7 +707,8 @@ module aes_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -748,7 +749,8 @@ module aes_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -789,7 +791,8 @@ module aes_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -830,7 +833,8 @@ module aes_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1032,7 +1036,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_aux_shadowed_key_touch_forces_reseed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1068,7 +1073,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_aux_shadowed_force_masks (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1111,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_aux_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1134,7 +1141,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_trigger_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1169,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_trigger_key_iv_data_in_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1188,7 +1197,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_trigger_data_out_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1215,7 +1225,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_trigger_prng_reseed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1244,7 +1255,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_idle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1271,7 +1283,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_stall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1298,7 +1311,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_output_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1325,7 +1339,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_output_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1352,7 +1367,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_input_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1379,7 +1395,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_alert_recov_ctrl_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1406,7 +1423,8 @@ module aes_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_alert_fatal_fault (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -708,7 +708,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -750,7 +750,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -792,7 +792,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -834,7 +834,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1037,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_aux_shadowed_key_touch_forces_reseed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1074,7 +1074,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_aux_shadowed_force_masks (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1112,7 +1112,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_aux_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1142,7 +1142,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_trigger_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1170,7 +1170,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_trigger_key_iv_data_in_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1198,7 +1198,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_trigger_data_out_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1226,7 +1226,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_trigger_prng_reseed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1256,7 +1256,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_idle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1284,7 +1284,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_stall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1312,7 +1312,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_output_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1340,7 +1340,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_output_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1368,7 +1368,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_input_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1396,7 +1396,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_alert_recov_ctrl_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1424,7 +1424,7 @@ module aes_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_alert_fatal_fault (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -615,7 +615,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_ctrl_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -643,7 +643,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_ctrl_prescaler (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -673,7 +673,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_thold_hi (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -702,7 +702,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_thold_lo (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -793,7 +793,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wdog_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -826,7 +826,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wdog_ctrl_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -854,7 +854,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wdog_ctrl_pause_in_sleep (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -886,7 +886,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wdog_bark_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -918,7 +918,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wdog_bite_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -979,7 +979,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_wkup_timer_expired (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1007,7 +1007,7 @@ module aon_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_wdog_timer_bark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -614,7 +614,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_ctrl_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -641,7 +642,8 @@ module aon_timer_reg_top (
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_ctrl_prescaler (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -670,7 +672,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_thold_hi (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -698,7 +701,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_thold_lo (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -728,7 +732,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_count_hi (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -758,7 +763,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_count_lo (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -786,7 +792,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdog_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -818,7 +825,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdog_ctrl_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -845,7 +853,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdog_ctrl_pause_in_sleep (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -876,7 +885,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdog_bark_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -907,7 +917,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdog_bite_thold (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -937,7 +948,8 @@ module aon_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdog_count (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -966,7 +978,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_wkup_timer_expired (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -993,7 +1006,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_wdog_timer_bark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1060,7 +1074,8 @@ module aon_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -252,7 +252,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_cs_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -279,7 +280,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_cs_entropy_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -306,7 +308,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_cs_hw_inst_exc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -333,7 +336,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_cs_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -362,7 +366,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_cs_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -389,7 +394,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_cs_entropy_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -416,7 +422,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_cs_hw_inst_exc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -443,7 +450,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_cs_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -577,7 +585,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -609,7 +618,8 @@ module csrng_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -636,7 +646,8 @@ module csrng_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_sw_app_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -663,7 +674,8 @@ module csrng_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_read_int_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -690,7 +702,8 @@ module csrng_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_fips_force_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -729,7 +742,8 @@ module csrng_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -769,7 +783,8 @@ module csrng_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hffffffff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reseed_interval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -850,7 +865,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -877,7 +893,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -904,7 +921,8 @@ module csrng_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -984,7 +1002,8 @@ module csrng_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_int_state_read_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1012,7 +1031,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_int_state_read_enable_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1051,7 +1071,8 @@ module csrng_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_int_state_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1099,7 +1120,8 @@ module csrng_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fips_force (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1127,7 +1149,8 @@ module csrng_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_exc_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1156,7 +1179,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1183,7 +1207,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_sw_app_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1210,7 +1235,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_read_int_state_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1237,7 +1263,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_fips_force_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1264,7 +1291,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_acmd_flag0_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1291,7 +1319,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_cs_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1318,7 +1347,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_cmd_stage_invalid_acmd_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1345,7 +1375,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_cmd_stage_invalid_cmd_seq_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1372,7 +1403,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_cmd_stage_reseed_cnt_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1401,7 +1433,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_cmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1428,7 +1461,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_genbits_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1455,7 +1489,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_cmdreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1482,7 +1517,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_rcstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1509,7 +1545,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_keyvrc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1536,7 +1573,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_updreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1563,7 +1601,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_bencreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1590,7 +1629,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_bencack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1617,7 +1657,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_pdata_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1644,7 +1685,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_final_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1671,7 +1713,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_gbencack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1698,7 +1741,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_grcstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1725,7 +1769,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_ggenreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1752,7 +1797,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_gadstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1779,7 +1825,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_ggenbits_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1806,7 +1853,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_blkenc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1833,7 +1881,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_cmd_stage_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1860,7 +1909,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1887,7 +1937,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_drbg_gen_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1914,7 +1965,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_drbg_updbe_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1941,7 +1993,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_drbg_updob_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1968,7 +2021,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_aes_cipher_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1995,7 +2049,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_cmd_gen_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2022,7 +2077,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2049,7 +2105,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2076,7 +2133,8 @@ module csrng_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2118,7 +2176,8 @@ module csrng_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2147,7 +2206,8 @@ module csrng_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h4e),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -253,7 +253,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_cs_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -281,7 +281,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_cs_entropy_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +309,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_cs_hw_inst_exc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +337,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_cs_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -367,7 +367,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_cs_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -395,7 +395,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_cs_entropy_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -423,7 +423,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_cs_hw_inst_exc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -451,7 +451,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_cs_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -586,7 +586,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +619,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -647,7 +647,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_sw_app_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -675,7 +675,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_read_int_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -703,7 +703,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_fips_force_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -743,7 +743,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -784,7 +784,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hffffffff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reseed_interval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -866,7 +866,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -894,7 +894,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -922,7 +922,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1003,7 +1003,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_int_state_read_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1032,7 +1032,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_int_state_read_enable_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1072,7 +1072,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_int_state_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1121,7 +1121,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fips_force (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1150,7 +1150,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_exc_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1180,7 +1180,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1208,7 +1208,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_sw_app_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1236,7 +1236,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_read_int_state_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1264,7 +1264,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_fips_force_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1292,7 +1292,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_acmd_flag0_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1320,7 +1320,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_cs_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1348,7 +1348,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_cmd_stage_invalid_acmd_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1376,7 +1376,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_cmd_stage_invalid_cmd_seq_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1404,7 +1404,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_cmd_stage_reseed_cnt_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1434,7 +1434,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_cmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1462,7 +1462,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_genbits_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1490,7 +1490,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_cmdreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1518,7 +1518,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_rcstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1546,7 +1546,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_keyvrc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1574,7 +1574,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_updreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1602,7 +1602,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_bencreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1630,7 +1630,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_bencack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1658,7 +1658,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_pdata_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1686,7 +1686,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_final_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1714,7 +1714,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_gbencack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1742,7 +1742,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_grcstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1770,7 +1770,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_ggenreq_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1798,7 +1798,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_gadstage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1826,7 +1826,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_ggenbits_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1854,7 +1854,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_blkenc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1882,7 +1882,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_cmd_stage_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1910,7 +1910,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1938,7 +1938,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_drbg_gen_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1966,7 +1966,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_drbg_updbe_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1994,7 +1994,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_drbg_updob_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2022,7 +2022,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_aes_cipher_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2050,7 +2050,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_cmd_gen_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2078,7 +2078,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2106,7 +2106,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2134,7 +2134,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2177,7 +2177,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2207,7 +2207,7 @@ module csrng_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h4e),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -317,7 +317,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_dma_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -344,7 +345,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_dma_chunk_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -371,7 +373,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_dma_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -400,7 +403,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_dma_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -427,7 +431,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_dma_chunk_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -454,7 +459,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_dma_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -560,7 +566,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_src_addr_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +600,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_src_addr_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -626,7 +634,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dst_addr_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -659,7 +668,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dst_addr_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -693,7 +703,8 @@ module dma_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_addr_space_id_src_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -720,7 +731,8 @@ module dma_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_addr_space_id_dst_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -764,7 +776,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_enabled_memory_range_base (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -809,7 +822,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_enabled_memory_range_limit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +857,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -871,7 +886,8 @@ module dma_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -920,7 +936,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_total_data_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -953,7 +970,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_chunk_data_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -986,7 +1004,8 @@ module dma_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_transfer_width (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1026,7 +1045,8 @@ module dma_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1053,7 +1073,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_hardware_handshake_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1080,7 +1101,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_digest_swap (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1107,7 +1129,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_initial_transfer (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1134,7 +1157,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1185,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_go (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1196,7 +1221,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_src_config_increment (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1223,7 +1249,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_src_config_wrap (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1257,7 +1284,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dst_config_increment (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1284,7 +1312,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dst_config_wrap (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1324,7 +1353,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_busy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1351,7 +1381,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1378,7 +1409,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_aborted (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1405,7 +1437,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1433,7 +1466,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_sha2_digest_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1461,7 +1495,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_chunk_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1490,7 +1525,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_src_addr_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1517,7 +1553,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_dst_addr_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1544,7 +1581,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_opcode_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1571,7 +1609,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_size_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1598,7 +1637,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_bus_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1625,7 +1665,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_base_limit_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1652,7 +1693,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_range_valid_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1679,7 +1721,8 @@ module dma_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_code_asid_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1708,7 +1751,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1737,7 +1781,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1766,7 +1811,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1795,7 +1841,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1824,7 +1871,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1853,7 +1901,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1882,7 +1931,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1911,7 +1961,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1940,7 +1991,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1969,7 +2021,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1998,7 +2051,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2027,7 +2081,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2056,7 +2111,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2085,7 +2141,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2114,7 +2171,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2143,7 +2201,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sha2_digest_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2176,7 +2235,8 @@ module dma_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h7ff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_handshake_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2209,7 +2269,8 @@ module dma_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clear_intr_src (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2242,7 +2303,8 @@ module dma_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clear_intr_bus (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2276,7 +2338,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2310,7 +2373,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2344,7 +2408,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2378,7 +2443,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2412,7 +2478,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2446,7 +2513,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2480,7 +2548,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2514,7 +2583,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2548,7 +2618,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2582,7 +2653,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2616,7 +2688,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_addr_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2650,7 +2723,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2684,7 +2758,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2718,7 +2793,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2752,7 +2828,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2786,7 +2863,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2820,7 +2898,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2854,7 +2933,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2888,7 +2968,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2922,7 +3003,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +3038,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2990,7 +3073,8 @@ module dma_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_src_wr_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -318,7 +318,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_dma_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -346,7 +346,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_dma_chunk_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -374,7 +374,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_dma_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -404,7 +404,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_dma_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -432,7 +432,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_dma_chunk_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -460,7 +460,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_dma_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -567,7 +567,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_src_addr_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -601,7 +601,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_src_addr_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -635,7 +635,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dst_addr_lo (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -669,7 +669,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dst_addr_hi (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -704,7 +704,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_addr_space_id_src_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -732,7 +732,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_addr_space_id_dst_asid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -777,7 +777,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_enabled_memory_range_base (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -823,7 +823,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_enabled_memory_range_limit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -858,7 +858,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -887,7 +887,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -937,7 +937,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_total_data_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -971,7 +971,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_chunk_data_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1005,7 +1005,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_transfer_width (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1046,7 +1046,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1074,7 +1074,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_hardware_handshake_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1102,7 +1102,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_digest_swap (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1130,7 +1130,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_initial_transfer (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1158,7 +1158,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1186,7 +1186,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_go (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1222,7 +1222,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_src_config_increment (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1250,7 +1250,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_src_config_wrap (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1285,7 +1285,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dst_config_increment (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1313,7 +1313,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dst_config_wrap (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1354,7 +1354,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_busy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1382,7 +1382,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1410,7 +1410,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_aborted (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1438,7 +1438,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1467,7 +1467,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_sha2_digest_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1496,7 +1496,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_chunk_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1526,7 +1526,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_src_addr_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1554,7 +1554,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_dst_addr_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1582,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_opcode_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1610,7 +1610,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_size_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1638,7 +1638,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_bus_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1666,7 +1666,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_base_limit_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1694,7 +1694,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_range_valid_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1722,7 +1722,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_code_asid_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1752,7 +1752,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1782,7 +1782,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1812,7 +1812,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1842,7 +1842,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1872,7 +1872,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1902,7 +1902,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1932,7 +1932,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1962,7 +1962,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1992,7 +1992,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2022,7 +2022,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2052,7 +2052,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2082,7 +2082,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2112,7 +2112,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2142,7 +2142,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2172,7 +2172,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2202,7 +2202,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sha2_digest_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2236,7 +2236,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h7ff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_handshake_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2270,7 +2270,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clear_intr_src (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2304,7 +2304,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clear_intr_bus (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2339,7 +2339,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2374,7 +2374,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2409,7 +2409,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2444,7 +2444,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2479,7 +2479,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2514,7 +2514,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2549,7 +2549,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2584,7 +2584,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2619,7 +2619,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2654,7 +2654,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2689,7 +2689,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_addr_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2724,7 +2724,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2759,7 +2759,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2794,7 +2794,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2829,7 +2829,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2864,7 +2864,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2899,7 +2899,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2934,7 +2934,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2969,7 +2969,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3004,7 +3004,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3039,7 +3039,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3074,7 +3074,7 @@ module dma_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_src_wr_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -206,7 +206,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_edn_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -233,7 +234,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_edn_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -262,7 +264,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_edn_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -289,7 +292,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_edn_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -391,7 +395,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -423,7 +428,8 @@ module edn_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_edn_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -450,7 +456,8 @@ module edn_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_boot_req_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -477,7 +484,8 @@ module edn_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_auto_req_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -504,7 +512,8 @@ module edn_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_ctrl_cmd_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -532,7 +541,8 @@ module edn_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h901),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_boot_ins_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -560,7 +570,8 @@ module edn_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hfff003),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_boot_gen_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -609,7 +620,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_reg_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -636,7 +648,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -663,7 +676,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -690,7 +704,8 @@ module edn_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -719,7 +734,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_cmd_sts_boot_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -746,7 +762,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_cmd_sts_auto_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -773,7 +790,8 @@ module edn_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_cmd_sts_cmd_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -800,7 +818,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_cmd_sts_cmd_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -827,7 +846,8 @@ module edn_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -906,7 +926,8 @@ module edn_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_num_reqs_between_reseeds (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -936,7 +957,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_edn_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -963,7 +985,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_boot_req_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -990,7 +1013,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_auto_req_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1017,7 +1041,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_cmd_fifo_rst_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1044,7 +1069,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_edn_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1071,7 +1097,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_csrng_ack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1100,7 +1127,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_rescmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1127,7 +1155,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_gencmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1154,7 +1183,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_edn_ack_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1181,7 +1211,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_edn_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1208,7 +1239,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_edn_cntr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1235,7 +1267,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1262,7 +1295,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1289,7 +1323,8 @@ module edn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1328,7 +1363,8 @@ module edn_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1357,7 +1393,8 @@ module edn_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'hc1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -207,7 +207,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_edn_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -235,7 +235,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_edn_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -265,7 +265,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_edn_cmd_req_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -293,7 +293,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_edn_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -396,7 +396,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -429,7 +429,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_edn_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -457,7 +457,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_boot_req_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -485,7 +485,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_auto_req_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +513,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_cmd_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +542,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h901),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_boot_ins_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -571,7 +571,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hfff003),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_boot_gen_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -621,7 +621,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_reg_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +649,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +677,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -705,7 +705,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -735,7 +735,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_cmd_sts_boot_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +763,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_cmd_sts_auto_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -791,7 +791,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_cmd_sts_cmd_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -819,7 +819,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_cmd_sts_cmd_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -847,7 +847,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -927,7 +927,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_num_reqs_between_reseeds (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -958,7 +958,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_edn_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -986,7 +986,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_boot_req_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1014,7 +1014,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_auto_req_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1042,7 +1042,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_cmd_fifo_rst_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1070,7 +1070,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_edn_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1098,7 +1098,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_csrng_ack_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1128,7 +1128,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_rescmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1156,7 +1156,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_gencmd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1184,7 +1184,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_edn_ack_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1212,7 +1212,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_edn_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1240,7 +1240,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_edn_cntr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1268,7 +1268,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1296,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1324,7 +1324,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1364,7 +1364,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1394,7 +1394,7 @@ module edn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'hc1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -395,7 +395,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_es_entropy_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -423,7 +423,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_es_health_test_failed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -451,7 +451,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_es_observe_fifo_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -479,7 +479,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_es_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -509,7 +509,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_es_entropy_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -537,7 +537,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_es_health_test_failed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -565,7 +565,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_es_observe_fifo_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +593,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_es_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -728,7 +728,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_me_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -757,7 +757,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_regupd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -786,7 +786,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -832,7 +832,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_module_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -865,7 +865,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_fips_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -893,7 +893,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_fips_flag (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -921,7 +921,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_rng_fips (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -949,7 +949,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_rng_bit_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -977,7 +977,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_rng_bit_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1005,7 +1005,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_threshold_scope (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1033,7 +1033,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_conf_entropy_data_reg_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1066,7 +1066,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_entropy_control_es_route (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1094,7 +1094,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_entropy_control_es_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1143,7 +1143,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h200),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_health_test_windows_fips_window (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1171,7 +1171,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h60),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_health_test_windows_bypass_window (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1996,7 +1996,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_threshold_alert_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2024,7 +2024,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'hfffd),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_threshold_alert_threshold_inv (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2212,7 +2212,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fw_ov_control_fw_ov_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2240,7 +2240,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fw_ov_control_fw_ov_entropy_insert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2269,7 +2269,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fw_ov_sha3_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2314,7 +2314,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fw_ov_rd_fifo_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2382,7 +2382,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h10),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_observe_fifo_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2550,7 +2550,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_fips_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2578,7 +2578,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_entropy_data_reg_en_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2606,7 +2606,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_module_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2634,7 +2634,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_threshold_scope_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2662,7 +2662,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_rng_bit_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2690,7 +2690,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_fw_ov_sha3_start_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2718,7 +2718,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_fw_ov_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2746,7 +2746,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_fw_ov_entropy_insert_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2774,7 +2774,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_route_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2802,7 +2802,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_type_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2830,7 +2830,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_main_sm_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2858,7 +2858,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2886,7 +2886,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_thresh_cfg_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2914,7 +2914,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_fw_ov_wr_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2942,7 +2942,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_es_fw_ov_disable_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2970,7 +2970,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_fips_flag_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2998,7 +2998,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_rng_fips_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3026,7 +3026,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_sts_postht_entropy_drop_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3056,7 +3056,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_esrng_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3084,7 +3084,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_distr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3112,7 +3112,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_observe_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3140,7 +3140,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sfifo_esfinal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3168,7 +3168,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_es_ack_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3196,7 +3196,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_es_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3224,7 +3224,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_es_cntr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3252,7 +3252,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sha3_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3280,7 +3280,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_sha3_rst_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3308,7 +3308,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3336,7 +3336,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3364,7 +3364,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3404,7 +3404,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3434,7 +3434,7 @@ module entropy_src_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'hf5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -394,7 +394,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_es_entropy_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +422,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_es_health_test_failed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -448,7 +450,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_es_observe_fifo_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -475,7 +478,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_es_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -504,7 +508,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_es_entropy_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -531,7 +536,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_es_health_test_failed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +564,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_es_observe_fifo_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -585,7 +592,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_es_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -719,7 +727,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_me_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +756,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_regupd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -775,7 +785,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -820,7 +831,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_module_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -852,7 +864,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_conf_fips_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -879,7 +892,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_conf_fips_flag (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -906,7 +920,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_conf_rng_fips (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -933,7 +948,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_conf_rng_bit_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -960,7 +976,8 @@ module entropy_src_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_conf_rng_bit_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -987,7 +1004,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_conf_threshold_scope (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1014,7 +1032,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_conf_entropy_data_reg_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1046,7 +1065,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_entropy_control_es_route (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1073,7 +1093,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_entropy_control_es_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1121,7 +1142,8 @@ module entropy_src_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h200),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_health_test_windows_fips_window (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1148,7 +1170,8 @@ module entropy_src_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h60),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_health_test_windows_bypass_window (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1972,7 +1995,8 @@ module entropy_src_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_threshold_alert_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1999,7 +2023,8 @@ module entropy_src_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'hfffd),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_threshold_alert_threshold_inv (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2186,7 +2211,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_fw_ov_control_fw_ov_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2213,7 +2239,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_fw_ov_control_fw_ov_entropy_insert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2241,7 +2268,8 @@ module entropy_src_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_fw_ov_sha3_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2285,7 +2313,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fw_ov_rd_fifo_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2352,7 +2381,8 @@ module entropy_src_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h10),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_observe_fifo_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2519,7 +2549,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_fips_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2546,7 +2577,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_entropy_data_reg_en_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2573,7 +2605,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_module_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2600,7 +2633,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_threshold_scope_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2627,7 +2661,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_rng_bit_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2654,7 +2689,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_fw_ov_sha3_start_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2681,7 +2717,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_fw_ov_mode_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2708,7 +2745,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_fw_ov_entropy_insert_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2735,7 +2773,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_route_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2762,7 +2801,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_type_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2789,7 +2829,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_main_sm_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2816,7 +2857,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_bus_cmp_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2843,7 +2885,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_thresh_cfg_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2870,7 +2913,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_fw_ov_wr_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2897,7 +2941,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_es_fw_ov_disable_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2924,7 +2969,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_fips_flag_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2951,7 +2997,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_rng_fips_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2978,7 +3025,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_sts_postht_entropy_drop_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3007,7 +3055,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_esrng_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3034,7 +3083,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_distr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3061,7 +3111,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_observe_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3088,7 +3139,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sfifo_esfinal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3115,7 +3167,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_es_ack_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3142,7 +3195,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_es_main_sm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3169,7 +3223,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_es_cntr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3196,7 +3251,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sha3_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3223,7 +3279,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_sha3_rst_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3250,7 +3307,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_write_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3277,7 +3335,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_read_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3363,8 @@ module entropy_src_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fifo_state_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3343,7 +3403,8 @@ module entropy_src_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_test (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3372,7 +3433,8 @@ module entropy_src_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'hf5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -363,7 +363,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_hmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -391,7 +391,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -419,7 +419,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_hmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +449,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_hmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -477,7 +477,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -505,7 +505,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_hmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -855,7 +855,7 @@ module hmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -362,7 +362,8 @@ module hmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_hmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -389,7 +390,8 @@ module hmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -416,7 +418,8 @@ module hmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_hmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -445,7 +448,8 @@ module hmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_hmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -472,7 +476,8 @@ module hmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -499,7 +504,8 @@ module hmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_hmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -848,7 +854,8 @@ module hmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -366,7 +366,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_fmt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -394,7 +394,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -422,7 +422,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_acq_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -450,7 +450,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -478,7 +478,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_controller_halt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -506,7 +506,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_scl_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -534,7 +534,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_sda_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -562,7 +562,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_stretch_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -590,7 +590,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_sda_unstable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -618,7 +618,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_cmd_complete (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -646,7 +646,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tx_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -674,7 +674,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -702,7 +702,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_acq_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -730,7 +730,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_unexp_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -758,7 +758,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_host_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -788,7 +788,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_fmt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -816,7 +816,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -844,7 +844,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_acq_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -872,7 +872,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -900,7 +900,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_controller_halt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -928,7 +928,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_scl_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -956,7 +956,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_sda_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -984,7 +984,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_stretch_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1012,7 +1012,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_sda_unstable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1040,7 +1040,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_cmd_complete (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1068,7 +1068,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tx_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1096,7 +1096,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1124,7 +1124,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_acq_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1152,7 +1152,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_unexp_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1180,7 +1180,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_host_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1475,7 +1475,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_enablehost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1503,7 +1503,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_enabletarget (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1531,7 +1531,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_llpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1559,7 +1559,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_nack_addr_after_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1587,7 +1587,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_ack_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1615,7 +1615,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_multi_controller_monitor_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1643,7 +1643,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_tx_stretch_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1867,7 +1867,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fdata_fbyte (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1896,7 +1896,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fdata_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1925,7 +1925,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fdata_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1954,7 +1954,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fdata_readb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1983,7 +1983,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fdata_rcont (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2012,7 +2012,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fdata_nakok (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2054,7 +2054,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2083,7 +2083,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_fmtrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2112,7 +2112,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_acqrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2141,7 +2141,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2183,7 +2183,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_host_fifo_config_rx_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2212,7 +2212,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_host_fifo_config_fmt_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2254,7 +2254,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_fifo_config_tx_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2283,7 +2283,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_fifo_config_acq_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2378,7 +2378,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ovrd_txovrden (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2406,7 +2406,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ovrd_sclval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2434,7 +2434,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ovrd_sdaval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2496,7 +2496,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing0_thigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2524,7 +2524,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing0_tlow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2554,7 +2554,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing1_t_r (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2582,7 +2582,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing1_t_f (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2612,7 +2612,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing2_tsu_sta (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2640,7 +2640,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing2_thd_sta (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2670,7 +2670,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing3_tsu_dat (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2698,7 +2698,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing3_thd_dat (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2728,7 +2728,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing4_tsu_sto (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2756,7 +2756,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timing4_t_buf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2786,7 +2786,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2814,7 +2814,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timeout_ctrl_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2842,7 +2842,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2872,7 +2872,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_id_address0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2900,7 +2900,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_id_mask0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2928,7 +2928,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_id_address1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +2956,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_id_mask1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3028,7 +3028,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_txdata (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3058,7 +3058,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_host_timeout_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3088,7 +3088,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (31'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3116,7 +3116,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3145,7 +3145,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_nack_count (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3228,7 +3228,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (31'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_host_nack_handler_timeout_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3256,7 +3256,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_host_nack_handler_timeout_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3286,7 +3286,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_controller_events_nack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3314,7 +3314,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_controller_events_unhandled_nack_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3342,7 +3342,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_controller_events_bus_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3370,7 +3370,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_controller_events_arbitration_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3400,7 +3400,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_events_tx_pending (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3428,7 +3428,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_events_bus_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3456,7 +3456,7 @@ module i2c_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_target_events_arbitration_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -365,7 +365,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_fmt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -392,7 +393,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -419,7 +421,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_acq_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -446,7 +449,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -473,7 +477,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_controller_halt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -500,7 +505,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_scl_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -527,7 +533,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_sda_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -554,7 +561,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_stretch_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -581,7 +589,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_sda_unstable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -608,7 +617,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_cmd_complete (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -635,7 +645,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tx_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -662,7 +673,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -689,7 +701,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_acq_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -716,7 +729,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_unexp_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -743,7 +757,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_host_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -772,7 +787,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_fmt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -799,7 +815,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -826,7 +843,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_acq_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -853,7 +871,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -880,7 +899,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_controller_halt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -907,7 +927,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_scl_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -934,7 +955,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_sda_interference (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -961,7 +983,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_stretch_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -988,7 +1011,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_sda_unstable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1015,7 +1039,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_cmd_complete (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1042,7 +1067,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tx_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1069,7 +1095,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tx_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1096,7 +1123,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_acq_stretch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1123,7 +1151,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_unexp_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1150,7 +1179,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_host_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1444,7 +1474,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_enablehost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1471,7 +1502,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_enabletarget (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1498,7 +1530,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_llpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1525,7 +1558,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_nack_addr_after_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1552,7 +1586,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_ack_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1579,7 +1614,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_multi_controller_monitor_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1606,7 +1642,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_tx_stretch_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1829,7 +1866,8 @@ module i2c_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fdata_fbyte (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1857,7 +1895,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fdata_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1885,7 +1924,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fdata_stop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1913,7 +1953,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fdata_readb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1941,7 +1982,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fdata_rcont (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1969,7 +2011,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fdata_nakok (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2010,7 +2053,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2038,7 +2082,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_fmtrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2066,7 +2111,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_acqrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2094,7 +2140,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2135,7 +2182,8 @@ module i2c_reg_top
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_host_fifo_config_rx_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2163,7 +2211,8 @@ module i2c_reg_top
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_host_fifo_config_fmt_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2204,7 +2253,8 @@ module i2c_reg_top
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_fifo_config_tx_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2232,7 +2282,8 @@ module i2c_reg_top
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_fifo_config_acq_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2326,7 +2377,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ovrd_txovrden (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2353,7 +2405,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ovrd_sclval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2380,7 +2433,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ovrd_sdaval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2441,7 +2495,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing0_thigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2468,7 +2523,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing0_tlow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2497,7 +2553,8 @@ module i2c_reg_top
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing1_t_r (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2524,7 +2581,8 @@ module i2c_reg_top
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing1_t_f (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2553,7 +2611,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing2_tsu_sta (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2580,7 +2639,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing2_thd_sta (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2609,7 +2669,8 @@ module i2c_reg_top
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing3_tsu_dat (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2636,7 +2697,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing3_thd_dat (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2665,7 +2727,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing4_tsu_sto (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2692,7 +2755,8 @@ module i2c_reg_top
     .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (13'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timing4_t_buf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2721,7 +2785,8 @@ module i2c_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2748,7 +2813,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timeout_ctrl_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2775,7 +2841,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2804,7 +2871,8 @@ module i2c_reg_top
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_id_address0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2831,7 +2899,8 @@ module i2c_reg_top
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_id_mask0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2858,7 +2927,8 @@ module i2c_reg_top
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_id_address1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2885,7 +2955,8 @@ module i2c_reg_top
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_id_mask1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +3027,8 @@ module i2c_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_txdata (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +3057,8 @@ module i2c_reg_top
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_host_timeout_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3014,7 +3087,8 @@ module i2c_reg_top
     .DW      (31),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (31'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3041,7 +3115,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3069,7 +3144,8 @@ module i2c_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_nack_count (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3151,7 +3227,8 @@ module i2c_reg_top
     .DW      (31),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (31'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_host_nack_handler_timeout_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3178,7 +3255,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_host_nack_handler_timeout_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3207,7 +3285,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_controller_events_nack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3234,7 +3313,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_controller_events_unhandled_nack_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3261,7 +3341,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_controller_events_bus_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3288,7 +3369,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_controller_events_arbitration_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3317,7 +3399,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_events_tx_pending (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3344,7 +3427,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_events_bus_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3371,7 +3455,8 @@ module i2c_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_target_events_arbitration_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -368,7 +368,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -396,7 +397,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -500,7 +502,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -532,7 +535,8 @@ module keymgr_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_operation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -568,7 +572,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_cdi_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -604,7 +609,8 @@ module keymgr_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_dest_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -644,7 +650,8 @@ module keymgr_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sideload_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -672,7 +679,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reseed_interval_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -704,7 +712,8 @@ module keymgr_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reseed_interval_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -765,7 +774,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -797,7 +807,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -829,7 +840,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -861,7 +873,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -893,7 +906,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -925,7 +939,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -957,7 +972,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -989,7 +1005,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sealing_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1021,7 +1038,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1053,7 +1071,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1085,7 +1104,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1117,7 +1137,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1149,7 +1170,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1181,7 +1203,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1213,7 +1236,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1245,7 +1269,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_attest_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1277,7 +1302,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1309,7 +1335,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1341,7 +1368,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1373,7 +1401,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1405,7 +1434,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1437,7 +1467,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1469,7 +1500,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1501,7 +1533,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1533,7 +1566,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1561,7 +1595,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_creator_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1593,7 +1628,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_creator_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1630,7 +1666,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_owner_int_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1662,7 +1699,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_owner_int_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1699,7 +1737,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_owner_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1731,7 +1770,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_owner_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1769,7 +1809,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1798,7 +1839,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1827,7 +1869,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1856,7 +1899,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1885,7 +1929,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1914,7 +1959,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1943,7 +1989,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1972,7 +2019,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2001,7 +2049,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2030,7 +2079,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2059,7 +2109,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2088,7 +2139,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2117,7 +2169,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2146,7 +2199,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2175,7 +2229,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2204,7 +2259,8 @@ module keymgr_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2232,7 +2288,8 @@ module keymgr_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_working_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2260,7 +2317,8 @@ module keymgr_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_op_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2289,7 +2347,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_invalid_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2316,7 +2375,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_invalid_kmac_input (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2343,7 +2403,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_invalid_shadow_update (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2372,7 +2433,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2399,7 +2461,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2426,7 +2489,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2453,7 +2517,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2480,7 +2545,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_out (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2507,7 +2573,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_regfile_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2534,7 +2601,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_shadow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2561,7 +2629,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_ctrl_fsm_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2588,7 +2657,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_ctrl_fsm_chk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2615,7 +2685,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_ctrl_fsm_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2642,7 +2713,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_reseed_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2669,7 +2741,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_side_ctrl_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2696,7 +2769,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_side_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2723,7 +2797,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_key_ecc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2752,7 +2827,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_creator_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2779,7 +2855,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_owner_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2806,7 +2883,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_dev_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2833,7 +2911,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_health_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2860,7 +2939,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2887,7 +2967,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2914,7 +2995,8 @@ module keymgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_digest (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -369,7 +369,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -398,7 +398,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -503,7 +503,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -536,7 +536,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_operation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -573,7 +573,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_cdi_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -610,7 +610,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_dest_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -651,7 +651,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sideload_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -680,7 +680,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reseed_interval_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -713,7 +713,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reseed_interval_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -775,7 +775,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -808,7 +808,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -841,7 +841,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -874,7 +874,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -907,7 +907,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -940,7 +940,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +973,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1006,7 +1006,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sealing_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1039,7 +1039,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1072,7 +1072,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1105,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1138,7 +1138,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1171,7 +1171,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1204,7 +1204,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1237,7 +1237,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1270,7 +1270,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_attest_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1303,7 +1303,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1336,7 +1336,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1369,7 +1369,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1402,7 +1402,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1435,7 +1435,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1468,7 +1468,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1501,7 +1501,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1534,7 +1534,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1567,7 +1567,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1596,7 +1596,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_creator_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1629,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_creator_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1667,7 +1667,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_owner_int_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1700,7 +1700,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_owner_int_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1738,7 +1738,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_owner_key_ver_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1771,7 +1771,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_owner_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1810,7 +1810,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1840,7 +1840,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1870,7 +1870,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1900,7 +1900,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1930,7 +1930,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1960,7 +1960,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1990,7 +1990,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2020,7 +2020,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2050,7 +2050,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2080,7 +2080,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2110,7 +2110,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2140,7 +2140,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2170,7 +2170,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2200,7 +2200,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2230,7 +2230,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2260,7 +2260,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2289,7 +2289,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_working_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2318,7 +2318,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_op_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2348,7 +2348,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_invalid_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2376,7 +2376,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_invalid_kmac_input (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2404,7 +2404,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_invalid_shadow_update (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2434,7 +2434,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2462,7 +2462,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2490,7 +2490,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2518,7 +2518,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2546,7 +2546,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_out (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2574,7 +2574,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_regfile_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2602,7 +2602,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_shadow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2630,7 +2630,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_ctrl_fsm_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2658,7 +2658,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_ctrl_fsm_chk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2686,7 +2686,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_ctrl_fsm_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2714,7 +2714,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_reseed_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2742,7 +2742,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_side_ctrl_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2770,7 +2770,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_side_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2798,7 +2798,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_key_ecc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2828,7 +2828,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_creator_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2856,7 +2856,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_owner_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2884,7 +2884,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_dev_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2912,7 +2912,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_health_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2940,7 +2940,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2968,7 +2968,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2996,7 +2996,7 @@ module keymgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_digest (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
@@ -347,7 +347,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -376,7 +376,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -481,7 +481,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -514,7 +514,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_operation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -551,7 +551,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_dest_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -588,7 +588,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_slot_src_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -625,7 +625,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_shadowed_slot_dst_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -666,7 +666,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sideload_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -695,7 +695,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reseed_interval_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -728,7 +728,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reseed_interval_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -790,7 +790,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_slot_policy_allow_child (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -818,7 +818,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_slot_policy_exportable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -846,7 +846,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_slot_policy_retain_parent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -899,7 +899,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -932,7 +932,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +965,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -998,7 +998,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1031,7 +1031,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1064,7 +1064,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1097,7 +1097,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1130,7 +1130,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1163,7 +1163,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1196,7 +1196,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1229,7 +1229,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1262,7 +1262,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1295,7 +1295,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1328,7 +1328,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1361,7 +1361,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1394,7 +1394,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_salt_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1427,7 +1427,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1479,7 +1479,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_max_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1518,7 +1518,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1548,7 +1548,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1578,7 +1578,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1608,7 +1608,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1638,7 +1638,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1668,7 +1668,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1698,7 +1698,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1728,7 +1728,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share0_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1758,7 +1758,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1788,7 +1788,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1818,7 +1818,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1848,7 +1848,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1878,7 +1878,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1908,7 +1908,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1938,7 +1938,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1968,7 +1968,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_share1_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1997,7 +1997,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_working_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2026,7 +2026,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_op_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2056,7 +2056,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_invalid_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2084,7 +2084,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_invalid_kmac_input (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2112,7 +2112,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_invalid_shadow_update (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2142,7 +2142,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2170,7 +2170,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2198,7 +2198,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2226,7 +2226,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2254,7 +2254,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_kmac_out (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2282,7 +2282,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_regfile_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2310,7 +2310,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_shadow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2338,7 +2338,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_ctrl_fsm_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2366,7 +2366,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_ctrl_fsm_chk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2394,7 +2394,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_ctrl_fsm_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2422,7 +2422,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_reseed_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2450,7 +2450,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_side_ctrl_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2478,7 +2478,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_side_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2506,7 +2506,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_key_ecc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2536,7 +2536,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_creator_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2564,7 +2564,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_owner_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2592,7 +2592,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_dev_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2620,7 +2620,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_health_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2648,7 +2648,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2676,7 +2676,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2704,7 +2704,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_digest (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2732,7 +2732,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_invalid_root_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2760,7 +2760,7 @@ module keymgr_dpe_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_debug_inactive_lc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
@@ -346,7 +346,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -374,7 +375,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -478,7 +480,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -510,7 +513,8 @@ module keymgr_dpe_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_operation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -546,7 +550,8 @@ module keymgr_dpe_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_dest_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -582,7 +587,8 @@ module keymgr_dpe_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_slot_src_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -618,7 +624,8 @@ module keymgr_dpe_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_shadowed_slot_dst_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +665,8 @@ module keymgr_dpe_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sideload_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -686,7 +694,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reseed_interval_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +727,8 @@ module keymgr_dpe_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reseed_interval_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -779,7 +789,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_slot_policy_allow_child (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -806,7 +817,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_slot_policy_exportable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -833,7 +845,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_slot_policy_retain_parent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -885,7 +898,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -917,7 +931,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -949,7 +964,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -981,7 +997,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1013,7 +1030,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1045,7 +1063,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1077,7 +1096,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1109,7 +1129,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_binding_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1141,7 +1162,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1173,7 +1195,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1205,7 +1228,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1237,7 +1261,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1294,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1301,7 +1327,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1333,7 +1360,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1365,7 +1393,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_salt_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1397,7 +1426,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1448,7 +1478,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_max_key_ver_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1486,7 +1517,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1515,7 +1547,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1544,7 +1577,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1573,7 +1607,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1602,7 +1637,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1631,7 +1667,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1660,7 +1697,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1689,7 +1727,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share0_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1718,7 +1757,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1747,7 +1787,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1776,7 +1817,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1805,7 +1847,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1834,7 +1877,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1863,7 +1907,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1892,7 +1937,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1921,7 +1967,8 @@ module keymgr_dpe_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_share1_output_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1949,7 +1996,8 @@ module keymgr_dpe_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_working_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1977,7 +2025,8 @@ module keymgr_dpe_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_op_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2006,7 +2055,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_invalid_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2033,7 +2083,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_invalid_kmac_input (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2060,7 +2111,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_invalid_shadow_update (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2089,7 +2141,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_cmd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2116,7 +2169,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2143,7 +2197,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2170,7 +2225,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2197,7 +2253,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_kmac_out (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2224,7 +2281,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_regfile_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2251,7 +2309,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_shadow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2278,7 +2337,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_ctrl_fsm_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2305,7 +2365,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_ctrl_fsm_chk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2332,7 +2393,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_ctrl_fsm_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2359,7 +2421,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_reseed_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2386,7 +2449,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_side_ctrl_fsm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2413,7 +2477,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_side_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2440,7 +2505,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_key_ecc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2469,7 +2535,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_creator_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2496,7 +2563,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_owner_seed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2523,7 +2591,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_dev_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2550,7 +2619,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_health_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2577,7 +2647,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_key_version (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2604,7 +2675,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2631,7 +2703,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_digest (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2658,7 +2731,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_invalid_root_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2685,7 +2759,8 @@ module keymgr_dpe_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_debug_inactive_lc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -381,7 +381,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -408,7 +409,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -435,7 +437,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_kmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -464,7 +467,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -491,7 +495,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -518,7 +523,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_kmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -667,7 +673,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_kmac_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -704,7 +711,8 @@ module kmac_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_kstrength (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -741,7 +749,8 @@ module kmac_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -778,7 +787,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_msg_endianness (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -815,7 +825,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_state_endianness (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -852,7 +863,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_sideload (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -889,7 +901,8 @@ module kmac_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_entropy_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -926,7 +939,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_entropy_fast_process (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -963,7 +977,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_msg_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1000,7 +1015,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_entropy_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1053,8 @@ module kmac_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_shadowed_en_unsupported_modestrength (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1270,7 +1287,8 @@ module kmac_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_entropy_period_prescaler (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1297,7 +1315,8 @@ module kmac_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_entropy_period_wait_timer (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1325,7 +1344,8 @@ module kmac_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_entropy_refresh_hash_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1357,7 +1377,8 @@ module kmac_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_entropy_refresh_threshold_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2185,7 +2206,8 @@ module kmac_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_len (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2217,7 +2239,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2249,7 +2272,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2281,7 +2305,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2313,7 +2338,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2345,7 +2371,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2377,7 +2404,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2409,7 +2437,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2441,7 +2470,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2473,7 +2503,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2505,7 +2536,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2537,7 +2569,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prefix_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2565,7 +2598,8 @@ module kmac_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -382,7 +382,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -410,7 +410,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +438,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_kmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -468,7 +468,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_kmac_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -496,7 +496,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_fifo_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -524,7 +524,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_kmac_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -674,7 +674,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_kmac_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -712,7 +712,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_kstrength (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -750,7 +750,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -788,7 +788,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_msg_endianness (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -826,7 +826,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_state_endianness (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -864,7 +864,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_sideload (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -902,7 +902,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_entropy_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -940,7 +940,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_entropy_fast_process (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -978,7 +978,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_msg_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1016,7 +1016,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_entropy_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1054,7 +1054,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_shadowed_en_unsupported_modestrength (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1288,7 +1288,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_entropy_period_prescaler (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1316,7 +1316,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_entropy_period_wait_timer (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1345,7 +1345,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_entropy_refresh_hash_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1378,7 +1378,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_entropy_refresh_threshold_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2207,7 +2207,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_len (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2240,7 +2240,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2273,7 +2273,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2306,7 +2306,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2339,7 +2339,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2372,7 +2372,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2405,7 +2405,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2438,7 +2438,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2471,7 +2471,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2504,7 +2504,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2537,7 +2537,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2570,7 +2570,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prefix_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2599,7 +2599,7 @@ module kmac_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
@@ -468,7 +468,7 @@ module lc_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_claim_transition_if_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
@@ -467,7 +467,8 @@ module lc_ctrl_regs_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_claim_transition_if_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/mbx/rtl/mbx_core_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_core_reg_top.sv
@@ -191,7 +191,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_mbx_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -218,7 +219,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_mbx_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -245,7 +247,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_mbx_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -274,7 +277,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_mbx_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -301,7 +305,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_mbx_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -328,7 +333,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_mbx_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -561,7 +567,8 @@ module mbx_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_address_range_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -600,7 +607,8 @@ module mbx_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_address_range_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -634,7 +642,8 @@ module mbx_core_reg_top (
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inbound_base_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -667,7 +676,8 @@ module mbx_core_reg_top (
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inbound_limit_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -716,7 +726,8 @@ module mbx_core_reg_top (
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_outbound_base_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -749,7 +760,8 @@ module mbx_core_reg_top (
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_outbound_limit_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -804,7 +816,8 @@ module mbx_core_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_outbound_object_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/mbx/rtl/mbx_core_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_core_reg_top.sv
@@ -192,7 +192,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_mbx_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -220,7 +220,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_mbx_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -248,7 +248,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_mbx_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -278,7 +278,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_mbx_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -306,7 +306,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_mbx_abort (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -334,7 +334,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_mbx_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -568,7 +568,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_address_range_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -608,7 +608,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_address_range_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -643,7 +643,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inbound_base_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +677,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inbound_limit_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -727,7 +727,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_outbound_base_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -761,7 +761,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_outbound_limit_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -817,7 +817,7 @@ module mbx_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_outbound_object_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -282,7 +282,8 @@ module mbx_soc_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_status_busy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +310,8 @@ module mbx_soc_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_status_doe_intr_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -336,7 +338,8 @@ module mbx_soc_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_status_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -363,7 +366,8 @@ module mbx_soc_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_status_doe_async_msg_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -390,7 +394,8 @@ module mbx_soc_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_status_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -418,7 +423,8 @@ module mbx_soc_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_doe_intr_msg_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -446,7 +452,8 @@ module mbx_soc_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_soc_doe_intr_msg_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -283,7 +283,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_status_busy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -311,7 +311,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_status_doe_intr_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -339,7 +339,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_status_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -367,7 +367,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_status_doe_async_msg_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -395,7 +395,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_status_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -424,7 +424,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_doe_intr_msg_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -453,7 +453,7 @@ module mbx_soc_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_soc_doe_intr_msg_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -249,7 +249,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -278,7 +278,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -404,7 +404,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h4),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -695,7 +695,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_imem_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -723,7 +723,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_dmem_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -751,7 +751,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_reg_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -779,7 +779,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_bus_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -807,7 +807,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_bad_internal_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -835,7 +835,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_illegal_bus_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -863,7 +863,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_lifecycle_escalation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -891,7 +891,7 @@ module otbn_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_fatal_software (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -248,7 +248,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -276,7 +277,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -401,7 +403,8 @@ module otbn_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h4),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +694,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_imem_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +722,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_dmem_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -745,7 +750,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_reg_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -772,7 +778,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_bus_intg_violation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -799,7 +806,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_bad_internal_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -826,7 +834,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_illegal_bus_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -853,7 +862,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_lifecycle_escalation (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -880,7 +890,8 @@ module otbn_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_fatal_software (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -189,7 +189,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_done_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -217,7 +217,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_done_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -247,7 +247,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_done_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -275,7 +275,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_done_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -362,7 +362,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_enable_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -390,7 +390,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_enable_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -418,7 +418,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_polarity_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -446,7 +446,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_polarity_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -474,7 +474,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_inactive_level_pcl_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -502,7 +502,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_inactive_level_pda_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -530,7 +530,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_inactive_level_pcl_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +558,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_inactive_level_pda_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -587,7 +587,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prediv_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -616,7 +616,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prediv_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -646,7 +646,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_ch0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -676,7 +676,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_ch0_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -706,7 +706,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_ch1_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -736,7 +736,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_ch1_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -766,7 +766,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_size_len_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -794,7 +794,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_size_reps_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -822,7 +822,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_size_len_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -850,7 +850,7 @@ module pattgen_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_size_reps_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -188,7 +188,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_done_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -215,7 +216,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_done_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -244,7 +246,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_done_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -271,7 +274,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_done_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -357,7 +361,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_enable_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -384,7 +389,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_enable_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -411,7 +417,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_polarity_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +445,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_polarity_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -465,7 +473,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_inactive_level_pcl_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -492,7 +501,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_inactive_level_pda_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -519,7 +529,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_inactive_level_pcl_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -546,7 +557,8 @@ module pattgen_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_inactive_level_pda_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -574,7 +586,8 @@ module pattgen_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prediv_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -602,7 +615,8 @@ module pattgen_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prediv_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +645,8 @@ module pattgen_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_ch0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +675,8 @@ module pattgen_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_ch0_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -689,7 +705,8 @@ module pattgen_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_ch1_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +735,8 @@ module pattgen_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_ch1_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +765,8 @@ module pattgen_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_size_len_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -774,7 +793,8 @@ module pattgen_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_size_reps_ch0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -801,7 +821,8 @@ module pattgen_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_size_len_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -828,7 +849,8 @@ module pattgen_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_size_reps_ch1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/prim/rtl/prim_subreg.sv
+++ b/hw/ip/prim/rtl/prim_subreg.sv
@@ -10,7 +10,8 @@ module prim_subreg
   parameter int            DW       = 32,
   parameter sw_access_e    SwAccess = SwAccessRW,
   parameter logic [DW-1:0] RESVAL   = '0 ,   // reset value
-  parameter bit            Mubi     = 1'b0
+  parameter bit            Mubi     = 1'b0,
+  parameter bit            UsesDs   = 1'b1
 ) (
   input clk_i,
   input rst_ni,
@@ -60,8 +61,13 @@ module prim_subreg
     end
   end
 
-  // feed back out for consolidation
-  assign ds = wr_en ? wr_data : qs;
+  // feed back out for consolidation. Note that this isn't driven at all if UsesDs is false (the
+  // place this is instantiated claims that it doesn't read the value, so it's probably sensible to
+  // leave it as 'x to aid debugging).
+  if (UsesDs) begin
+    assign ds = wr_en ? wr_data : qs;
+  end
+
   assign qe = wr_en;
 
   if (SwAccess == SwAccessRC) begin : gen_rc

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -12,7 +12,8 @@ module prim_subreg_shadow
   parameter int            DW       = 32,
   parameter sw_access_e    SwAccess = SwAccessRW,
   parameter logic [DW-1:0] RESVAL   = '0,    // reset value
-  parameter bit            Mubi     = 1'b0
+  parameter bit            Mubi     = 1'b0,
+  parameter bit            UsesDs   = 1'b1
 ) (
   input clk_i,
   input rst_ni,
@@ -117,7 +118,8 @@ module prim_subreg_shadow
     .DW       ( DW             ),
     .SwAccess ( StagedSwAccess ),
     .RESVAL   ( ~RESVAL        ),
-    .Mubi     ( Mubi           )
+    .Mubi     ( Mubi           ),
+    .UsesDs   ( 1'b0           )
   ) staged_reg (
     .clk_i    ( clk_i     ),
     .rst_ni   ( rst_ni    ),
@@ -143,7 +145,8 @@ module prim_subreg_shadow
     .DW       ( DW               ),
     .SwAccess ( InvertedSwAccess ),
     .RESVAL   ( ~RESVAL          ),
-    .Mubi     ( Mubi             )
+    .Mubi     ( Mubi             ),
+    .UsesDs   ( 1'b0             )
   ) shadow_reg (
     .clk_i    ( clk_i           ),
     .rst_ni   ( rst_shadowed_ni ),
@@ -166,7 +169,8 @@ module prim_subreg_shadow
     .DW       ( DW       ),
     .SwAccess ( SwAccess ),
     .RESVAL   ( RESVAL   ),
-    .Mubi     ( Mubi     )
+    .Mubi     ( Mubi     ),
+    .UsesDs   ( UsesDs   )
   ) committed_reg (
     .clk_i    ( clk_i        ),
     .rst_ni   ( rst_ni       ),

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -1121,7 +1121,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1164,7 +1165,8 @@ module pwm_reg_top
     .DW      (27),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (27'h8000),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_clk_div (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1192,7 +1194,8 @@ module pwm_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_dc_resn (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1220,7 +1223,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_cntr_en (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1265,7 +1269,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_en_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1293,7 +1298,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_en_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1321,7 +1327,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_en_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1349,7 +1356,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_en_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1377,7 +1385,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_en_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1405,7 +1414,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_en_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1450,7 +1460,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_invert_invert_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1478,7 +1489,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_invert_invert_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1506,7 +1518,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_invert_invert_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1534,7 +1547,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_invert_invert_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1562,7 +1576,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_invert_invert_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1590,7 +1605,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_invert_invert_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1635,7 +1651,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_0_phase_delay_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1663,7 +1680,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_0_htbt_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1691,7 +1709,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_0_blink_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1736,7 +1755,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_1_phase_delay_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1764,7 +1784,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_1_htbt_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1792,7 +1813,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_1_blink_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1837,7 +1859,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_2_phase_delay_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1865,7 +1888,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_2_htbt_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1893,7 +1917,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_2_blink_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1938,7 +1963,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_3_phase_delay_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1966,7 +1992,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_3_htbt_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1994,7 +2021,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_3_blink_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2039,7 +2067,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_4_phase_delay_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2067,7 +2096,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_4_htbt_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2095,7 +2125,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_4_blink_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2140,7 +2171,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_5_phase_delay_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2168,7 +2200,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_5_htbt_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2196,7 +2229,8 @@ module pwm_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pwm_param_5_blink_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2241,7 +2275,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_0_a_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2269,7 +2304,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_0_b_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2314,7 +2350,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_1_a_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2342,7 +2379,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_1_b_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2387,7 +2425,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_2_a_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2415,7 +2454,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_2_b_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2460,7 +2500,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_3_a_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2488,7 +2529,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_3_b_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2533,7 +2575,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_4_a_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2561,7 +2604,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_4_b_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2606,7 +2650,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_5_a_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2634,7 +2679,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_duty_cycle_5_b_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2679,7 +2725,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_0_x_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2707,7 +2754,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_0_y_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2752,7 +2800,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_1_x_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2780,7 +2829,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_1_y_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2825,7 +2875,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_2_x_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2853,7 +2904,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_2_y_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2898,7 +2950,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_3_x_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2926,7 +2979,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_3_y_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2971,7 +3025,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_4_x_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2999,7 +3054,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_4_y_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3044,7 +3100,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_5_x_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3072,7 +3129,8 @@ module pwm_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_blink_param_5_y_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -1122,7 +1122,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1166,7 +1166,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (27'h8000),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_clk_div (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1195,7 +1195,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_dc_resn (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1224,7 +1224,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_cntr_en (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1270,7 +1270,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_en_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1299,7 +1299,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_en_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1328,7 +1328,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_en_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1357,7 +1357,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_en_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1386,7 +1386,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_en_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1415,7 +1415,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_en_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1461,7 +1461,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_invert_invert_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1490,7 +1490,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_invert_invert_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1519,7 +1519,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_invert_invert_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1548,7 +1548,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_invert_invert_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1577,7 +1577,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_invert_invert_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1606,7 +1606,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_invert_invert_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1652,7 +1652,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_0_phase_delay_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1681,7 +1681,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_0_htbt_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1710,7 +1710,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_0_blink_en_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1756,7 +1756,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_1_phase_delay_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1785,7 +1785,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_1_htbt_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1814,7 +1814,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_1_blink_en_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1860,7 +1860,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_2_phase_delay_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1889,7 +1889,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_2_htbt_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1918,7 +1918,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_2_blink_en_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1964,7 +1964,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_3_phase_delay_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -1993,7 +1993,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_3_htbt_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2022,7 +2022,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_3_blink_en_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2068,7 +2068,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_4_phase_delay_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2097,7 +2097,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_4_htbt_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2126,7 +2126,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_4_blink_en_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2172,7 +2172,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_5_phase_delay_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2201,7 +2201,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_5_htbt_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2230,7 +2230,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pwm_param_5_blink_en_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2276,7 +2276,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_0_a_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2305,7 +2305,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_0_b_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2351,7 +2351,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_1_a_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2380,7 +2380,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_1_b_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2426,7 +2426,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_2_a_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2455,7 +2455,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_2_b_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2501,7 +2501,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_3_a_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2530,7 +2530,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_3_b_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2576,7 +2576,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_4_a_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2605,7 +2605,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_4_b_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2651,7 +2651,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_5_a_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2680,7 +2680,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7fff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_duty_cycle_5_b_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2726,7 +2726,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_0_x_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2755,7 +2755,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_0_y_0 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2801,7 +2801,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_1_x_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2830,7 +2830,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_1_y_1 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2876,7 +2876,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_2_x_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2905,7 +2905,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_2_y_2 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2951,7 +2951,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_3_x_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -2980,7 +2980,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_3_y_3 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3026,7 +3026,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_4_x_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3055,7 +3055,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_4_y_4 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3101,7 +3101,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_5_x_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),
@@ -3130,7 +3130,7 @@ module pwm_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_blink_param_5_y_5 (
     .clk_i   (clk_core_i),
     .rst_ni  (rst_core_ni),

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -169,7 +169,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_checker_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -196,7 +197,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_cause_integrity_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -225,7 +227,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -254,7 +257,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -283,7 +287,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -312,7 +317,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -341,7 +347,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -370,7 +377,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -399,7 +407,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -428,7 +437,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -457,7 +467,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -486,7 +497,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -515,7 +527,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -544,7 +557,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -573,7 +587,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -602,7 +617,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +647,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +677,8 @@ module rom_ctrl_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exp_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -170,7 +170,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_checker_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -198,7 +198,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_cause_integrity_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -228,7 +228,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -258,7 +258,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -288,7 +288,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -318,7 +318,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -348,7 +348,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -378,7 +378,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -408,7 +408,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +438,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -468,7 +468,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -498,7 +498,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -528,7 +528,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +558,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -588,7 +588,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -618,7 +618,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -648,7 +648,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -678,7 +678,7 @@ module rom_ctrl_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exp_digest_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -332,7 +332,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_recov_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -361,7 +361,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -391,7 +391,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +421,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -454,7 +454,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_addr_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -487,7 +487,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_addr_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -520,7 +520,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_addr_matching_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -553,7 +553,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_addr_matching_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -586,7 +586,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_remap_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +619,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ibus_remap_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +649,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -679,7 +679,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -712,7 +712,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_addr_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -745,7 +745,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_addr_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -778,7 +778,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_addr_matching_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -811,7 +811,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_addr_matching_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -844,7 +844,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_remap_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -877,7 +877,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dbus_remap_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -907,7 +907,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_nmi_enable_alert_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -935,7 +935,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_nmi_enable_wdog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +965,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_nmi_state_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -993,7 +993,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_nmi_state_wdog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1023,7 +1023,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1051,7 +1051,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_status_fatal_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1079,7 +1079,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_status_fatal_core_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1107,7 +1107,7 @@ module rv_core_ibex_cfg_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_status_recov_core_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -331,7 +331,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_sw_recov_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -359,7 +360,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_sw_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -388,7 +390,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -417,7 +420,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +453,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_addr_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -481,7 +486,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_addr_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +519,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_addr_matching_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -545,7 +552,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_addr_matching_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -577,7 +585,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_remap_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -609,7 +618,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ibus_remap_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -638,7 +648,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -667,7 +678,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -699,7 +711,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_addr_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -731,7 +744,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_addr_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +777,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_addr_matching_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -795,7 +810,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_addr_matching_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -827,7 +843,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_remap_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -859,7 +876,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dbus_remap_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -888,7 +906,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_nmi_enable_alert_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -915,7 +934,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_nmi_enable_wdog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -944,7 +964,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_nmi_state_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -971,7 +992,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_nmi_state_wdog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1000,7 +1022,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1027,7 +1050,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_status_fatal_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1054,7 +1078,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_status_fatal_core_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1081,7 +1106,8 @@ module rv_core_ibex_cfg_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_status_recov_core_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
@@ -467,7 +467,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_halted (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -496,7 +496,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_going (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -525,7 +525,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_resuming (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -554,7 +554,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exception (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -583,7 +583,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_whereto (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -613,7 +613,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -643,7 +643,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -673,7 +673,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -703,7 +703,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -733,7 +733,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +763,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -793,7 +793,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -823,7 +823,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -853,7 +853,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -883,7 +883,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_abstractcmd_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +913,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -943,7 +943,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +973,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1003,7 +1003,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1033,7 +1033,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1063,7 +1063,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1093,7 +1093,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1123,7 +1123,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_program_buffer_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1153,7 +1153,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dataaddr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1183,7 +1183,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dataaddr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1213,7 +1213,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1243,7 +1243,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1273,7 +1273,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1303,7 +1303,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1333,7 +1333,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1363,7 +1363,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1393,7 +1393,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1423,7 +1423,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1453,7 +1453,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1483,7 +1483,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1513,7 +1513,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1543,7 +1543,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1573,7 +1573,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1603,7 +1603,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1633,7 +1633,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1663,7 +1663,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1693,7 +1693,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1723,7 +1723,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1753,7 +1753,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1783,7 +1783,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1813,7 +1813,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1843,7 +1843,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1873,7 +1873,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1903,7 +1903,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1933,7 +1933,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1963,7 +1963,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1993,7 +1993,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2023,7 +2023,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2053,7 +2053,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2083,7 +2083,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2113,7 +2113,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2143,7 +2143,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2173,7 +2173,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2203,7 +2203,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2233,7 +2233,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2263,7 +2263,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2293,7 +2293,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2323,7 +2323,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2353,7 +2353,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2383,7 +2383,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2413,7 +2413,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2443,7 +2443,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2473,7 +2473,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2503,7 +2503,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2533,7 +2533,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2563,7 +2563,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2593,7 +2593,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2623,7 +2623,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2653,7 +2653,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2683,7 +2683,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2713,7 +2713,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2743,7 +2743,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2773,7 +2773,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2803,7 +2803,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2833,7 +2833,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2863,7 +2863,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2893,7 +2893,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2923,7 +2923,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2953,7 +2953,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2983,7 +2983,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3013,7 +3013,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3043,7 +3043,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3073,7 +3073,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3103,7 +3103,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3133,7 +3133,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3163,7 +3163,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3193,7 +3193,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3223,7 +3223,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3253,7 +3253,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3283,7 +3283,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3313,7 +3313,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3343,7 +3343,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3373,7 +3373,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3403,7 +3403,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3433,7 +3433,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3463,7 +3463,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3493,7 +3493,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3523,7 +3523,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3553,7 +3553,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3583,7 +3583,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3613,7 +3613,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3643,7 +3643,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3673,7 +3673,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3703,7 +3703,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3733,7 +3733,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3763,7 +3763,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3793,7 +3793,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3823,7 +3823,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3853,7 +3853,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3883,7 +3883,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3913,7 +3913,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3943,7 +3943,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3973,7 +3973,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4003,7 +4003,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4033,7 +4033,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4063,7 +4063,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4093,7 +4093,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4123,7 +4123,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4153,7 +4153,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4183,7 +4183,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4213,7 +4213,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4243,7 +4243,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4273,7 +4273,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4303,7 +4303,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4333,7 +4333,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4363,7 +4363,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4393,7 +4393,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4423,7 +4423,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4453,7 +4453,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4483,7 +4483,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4513,7 +4513,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4543,7 +4543,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4573,7 +4573,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4603,7 +4603,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4633,7 +4633,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4663,7 +4663,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4693,7 +4693,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4723,7 +4723,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4753,7 +4753,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4783,7 +4783,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4813,7 +4813,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4843,7 +4843,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4873,7 +4873,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4903,7 +4903,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4933,7 +4933,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4963,7 +4963,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4993,7 +4993,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5023,7 +5023,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5053,7 +5053,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5083,7 +5083,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5113,7 +5113,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5143,7 +5143,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5173,7 +5173,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5203,7 +5203,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5233,7 +5233,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5263,7 +5263,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5293,7 +5293,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5323,7 +5323,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5353,7 +5353,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5383,7 +5383,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5413,7 +5413,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5443,7 +5443,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5473,7 +5473,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5503,7 +5503,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5533,7 +5533,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5563,7 +5563,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5593,7 +5593,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5623,7 +5623,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5653,7 +5653,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5683,7 +5683,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5713,7 +5713,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5743,7 +5743,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5773,7 +5773,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5803,7 +5803,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5833,7 +5833,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5863,7 +5863,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5893,7 +5893,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5923,7 +5923,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5953,7 +5953,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5983,7 +5983,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6013,7 +6013,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6043,7 +6043,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6073,7 +6073,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6103,7 +6103,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6133,7 +6133,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6163,7 +6163,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6193,7 +6193,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6223,7 +6223,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6253,7 +6253,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6283,7 +6283,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6313,7 +6313,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6343,7 +6343,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6373,7 +6373,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6403,7 +6403,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6433,7 +6433,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6463,7 +6463,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6493,7 +6493,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6523,7 +6523,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6553,7 +6553,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6583,7 +6583,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6613,7 +6613,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6643,7 +6643,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6673,7 +6673,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6703,7 +6703,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6733,7 +6733,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6763,7 +6763,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6793,7 +6793,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_186 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6823,7 +6823,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_187 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6853,7 +6853,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_188 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6883,7 +6883,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_189 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6913,7 +6913,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_190 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6943,7 +6943,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_191 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6973,7 +6973,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_192 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7003,7 +7003,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_193 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7033,7 +7033,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_194 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7063,7 +7063,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_195 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7093,7 +7093,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_196 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7123,7 +7123,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_197 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7153,7 +7153,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_198 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7183,7 +7183,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_199 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7213,7 +7213,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_200 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7243,7 +7243,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_201 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7273,7 +7273,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_202 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7303,7 +7303,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_203 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7333,7 +7333,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_204 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7363,7 +7363,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_205 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7393,7 +7393,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_206 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7423,7 +7423,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_207 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7453,7 +7453,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_208 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7483,7 +7483,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_209 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7513,7 +7513,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_210 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7543,7 +7543,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_211 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7573,7 +7573,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_212 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7603,7 +7603,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_213 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7633,7 +7633,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_214 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7663,7 +7663,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_215 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7693,7 +7693,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_216 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7723,7 +7723,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_217 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7753,7 +7753,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_218 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7783,7 +7783,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_219 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7813,7 +7813,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_220 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7843,7 +7843,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_221 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7873,7 +7873,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_222 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7903,7 +7903,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_223 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7933,7 +7933,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_224 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7963,7 +7963,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_225 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7993,7 +7993,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_226 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8023,7 +8023,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_227 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8053,7 +8053,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_228 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8083,7 +8083,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_229 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8113,7 +8113,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_230 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8143,7 +8143,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_231 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8173,7 +8173,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_232 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8203,7 +8203,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_233 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8233,7 +8233,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_234 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8263,7 +8263,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_235 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8293,7 +8293,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_236 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8323,7 +8323,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_237 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8353,7 +8353,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_238 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8383,7 +8383,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_239 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8413,7 +8413,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_240 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8443,7 +8443,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_241 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8473,7 +8473,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_242 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8503,7 +8503,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_243 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8533,7 +8533,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_244 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8563,7 +8563,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_245 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8593,7 +8593,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_246 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8623,7 +8623,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_247 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8653,7 +8653,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_248 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8683,7 +8683,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_249 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8713,7 +8713,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_250 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8743,7 +8743,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_251 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8773,7 +8773,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_252 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8803,7 +8803,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_253 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8833,7 +8833,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_254 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8863,7 +8863,7 @@ module rv_dm_mem_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_flags_255 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
@@ -466,7 +466,8 @@ module rv_dm_mem_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_halted (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -494,7 +495,8 @@ module rv_dm_mem_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_going (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -522,7 +524,8 @@ module rv_dm_mem_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_resuming (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -550,7 +553,8 @@ module rv_dm_mem_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exception (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -578,7 +582,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_whereto (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -607,7 +612,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -636,7 +642,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -665,7 +672,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -694,7 +702,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -723,7 +732,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -752,7 +762,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -781,7 +792,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -810,7 +822,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -839,7 +852,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -868,7 +882,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_abstractcmd_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -897,7 +912,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -926,7 +942,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -955,7 +972,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -984,7 +1002,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1013,7 +1032,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1042,7 +1062,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1071,7 +1092,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1100,7 +1122,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_program_buffer_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1129,7 +1152,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dataaddr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1158,7 +1182,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dataaddr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1187,7 +1212,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1216,7 +1242,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1245,7 +1272,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1274,7 +1302,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1303,7 +1332,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1332,7 +1362,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1361,7 +1392,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1390,7 +1422,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1419,7 +1452,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1448,7 +1482,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1477,7 +1512,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1506,7 +1542,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1535,7 +1572,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1564,7 +1602,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1593,7 +1632,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1622,7 +1662,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1651,7 +1692,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1680,7 +1722,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1709,7 +1752,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1738,7 +1782,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1767,7 +1812,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1796,7 +1842,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1825,7 +1872,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1854,7 +1902,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1883,7 +1932,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1912,7 +1962,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1941,7 +1992,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1970,7 +2022,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1999,7 +2052,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2028,7 +2082,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2057,7 +2112,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2086,7 +2142,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2115,7 +2172,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2144,7 +2202,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2173,7 +2232,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2202,7 +2262,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2231,7 +2292,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2260,7 +2322,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2289,7 +2352,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2318,7 +2382,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2347,7 +2412,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2376,7 +2442,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2405,7 +2472,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2434,7 +2502,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2463,7 +2532,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2492,7 +2562,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2521,7 +2592,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2550,7 +2622,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2579,7 +2652,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2608,7 +2682,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2637,7 +2712,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2666,7 +2742,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2695,7 +2772,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2724,7 +2802,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2753,7 +2832,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2782,7 +2862,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2811,7 +2892,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2840,7 +2922,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2869,7 +2952,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2898,7 +2982,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2927,7 +3012,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +3042,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +3072,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3014,7 +3102,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3043,7 +3132,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3072,7 +3162,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3101,7 +3192,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3130,7 +3222,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3159,7 +3252,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3188,7 +3282,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3217,7 +3312,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3246,7 +3342,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3275,7 +3372,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3402,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3333,7 +3432,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3362,7 +3462,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3391,7 +3492,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3420,7 +3522,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3449,7 +3552,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3478,7 +3582,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3507,7 +3612,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3536,7 +3642,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3565,7 +3672,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3594,7 +3702,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3623,7 +3732,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3652,7 +3762,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3681,7 +3792,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3710,7 +3822,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3739,7 +3852,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3768,7 +3882,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3797,7 +3912,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3826,7 +3942,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3855,7 +3972,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3884,7 +4002,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3913,7 +4032,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3942,7 +4062,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3971,7 +4092,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4000,7 +4122,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4029,7 +4152,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4058,7 +4182,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4087,7 +4212,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4116,7 +4242,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4145,7 +4272,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4302,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4203,7 +4332,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4232,7 +4362,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4261,7 +4392,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4290,7 +4422,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4319,7 +4452,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4348,7 +4482,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4377,7 +4512,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4406,7 +4542,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4435,7 +4572,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4464,7 +4602,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4493,7 +4632,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4522,7 +4662,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4551,7 +4692,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4580,7 +4722,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4609,7 +4752,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4638,7 +4782,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4667,7 +4812,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4696,7 +4842,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4725,7 +4872,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4754,7 +4902,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4783,7 +4932,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4812,7 +4962,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4841,7 +4992,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4870,7 +5022,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4899,7 +5052,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4928,7 +5082,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4957,7 +5112,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4986,7 +5142,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5015,7 +5172,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5044,7 +5202,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5073,7 +5232,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5102,7 +5262,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5131,7 +5292,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5160,7 +5322,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5189,7 +5352,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5218,7 +5382,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5247,7 +5412,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5276,7 +5442,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5305,7 +5472,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5334,7 +5502,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5363,7 +5532,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5562,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5421,7 +5592,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5450,7 +5622,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5479,7 +5652,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5508,7 +5682,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5537,7 +5712,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5566,7 +5742,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5595,7 +5772,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5624,7 +5802,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5653,7 +5832,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5682,7 +5862,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5711,7 +5892,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5740,7 +5922,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5769,7 +5952,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5798,7 +5982,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5827,7 +6012,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5856,7 +6042,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5885,7 +6072,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5914,7 +6102,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5943,7 +6132,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5972,7 +6162,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6001,7 +6192,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6030,7 +6222,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6059,7 +6252,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6088,7 +6282,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6117,7 +6312,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6146,7 +6342,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6175,7 +6372,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6204,7 +6402,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6233,7 +6432,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6262,7 +6462,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6291,7 +6492,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6320,7 +6522,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6349,7 +6552,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6378,7 +6582,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6407,7 +6612,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6436,7 +6642,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6465,7 +6672,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6494,7 +6702,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6523,7 +6732,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6552,7 +6762,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6581,7 +6792,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_186 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6610,7 +6822,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_187 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6639,7 +6852,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_188 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6668,7 +6882,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_189 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6697,7 +6912,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_190 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6726,7 +6942,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_191 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6755,7 +6972,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_192 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6784,7 +7002,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_193 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6813,7 +7032,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_194 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6842,7 +7062,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_195 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6871,7 +7092,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_196 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6900,7 +7122,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_197 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6929,7 +7152,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_198 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6958,7 +7182,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_199 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6987,7 +7212,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_200 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7016,7 +7242,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_201 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7045,7 +7272,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_202 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7074,7 +7302,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_203 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7103,7 +7332,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_204 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7132,7 +7362,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_205 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7161,7 +7392,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_206 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7190,7 +7422,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_207 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7219,7 +7452,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_208 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7248,7 +7482,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_209 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7277,7 +7512,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_210 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7306,7 +7542,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_211 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7335,7 +7572,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_212 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7364,7 +7602,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_213 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7393,7 +7632,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_214 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7422,7 +7662,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_215 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7451,7 +7692,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_216 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7480,7 +7722,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_217 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7509,7 +7752,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_218 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7538,7 +7782,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_219 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7567,7 +7812,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_220 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7596,7 +7842,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_221 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7625,7 +7872,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_222 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7654,7 +7902,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_223 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7683,7 +7932,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_224 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7712,7 +7962,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_225 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7741,7 +7992,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_226 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7770,7 +8022,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_227 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7799,7 +8052,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_228 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7828,7 +8082,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_229 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7857,7 +8112,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_230 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7886,7 +8142,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_231 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7915,7 +8172,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_232 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7944,7 +8202,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_233 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7973,7 +8232,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_234 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8002,7 +8262,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_235 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8031,7 +8292,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_236 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8060,7 +8322,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_237 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8089,7 +8352,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_238 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8118,7 +8382,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_239 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8147,7 +8412,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_240 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8176,7 +8442,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_241 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8205,7 +8472,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_242 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8234,7 +8502,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_243 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8263,7 +8532,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_244 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8292,7 +8562,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_245 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8321,7 +8592,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_246 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8350,7 +8622,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_247 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8379,7 +8652,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_248 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8408,7 +8682,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_249 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8437,7 +8712,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_250 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8466,7 +8742,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_251 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8495,7 +8772,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_252 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8524,7 +8802,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_253 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8553,7 +8832,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_254 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8582,7 +8862,8 @@ module rv_dm_mem_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_flags_255 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -156,7 +156,7 @@ module rv_dm_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_late_debug_enable_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -188,7 +188,7 @@ module rv_dm_regs_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h69696969),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_late_debug_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -155,7 +155,8 @@ module rv_dm_regs_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_late_debug_enable_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -186,7 +187,8 @@ module rv_dm_regs_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h69696969),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_late_debug_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -179,7 +179,8 @@ module rv_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -208,7 +209,8 @@ module rv_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -237,7 +239,8 @@ module rv_timer_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -287,7 +290,8 @@ module rv_timer_reg_top (
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg0_prescale (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -314,7 +318,8 @@ module rv_timer_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg0_step (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -342,7 +347,8 @@ module rv_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timer_v_lower0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -370,7 +376,8 @@ module rv_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timer_v_upper0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -409,7 +416,8 @@ module rv_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hffffffff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_compare_lower0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +457,8 @@ module rv_timer_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hffffffff),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_compare_upper0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -180,7 +180,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -210,7 +210,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -240,7 +240,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -291,7 +291,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg0_prescale (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -319,7 +319,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg0_step (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -348,7 +348,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timer_v_lower0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -377,7 +377,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timer_v_upper0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -417,7 +417,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hffffffff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_compare_lower0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -458,7 +458,7 @@ module rv_timer_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hffffffff),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_compare_upper0_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1568,7 +1568,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_upload_cmdfifo_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1596,7 +1596,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_upload_payload_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1624,7 +1624,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_upload_payload_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1652,7 +1652,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_readbuf_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1680,7 +1680,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_readbuf_flip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1708,7 +1708,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tpm_header_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1736,7 +1736,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tpm_rdfifo_cmd_end (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1764,7 +1764,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tpm_rdfifo_drop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1794,7 +1794,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_upload_cmdfifo_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1822,7 +1822,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_upload_payload_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1850,7 +1850,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_upload_payload_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1878,7 +1878,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_readbuf_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1906,7 +1906,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_readbuf_flip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1934,7 +1934,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tpm_header_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1962,7 +1962,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tpm_rdfifo_cmd_end (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1990,7 +1990,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tpm_rdfifo_drop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2173,7 +2173,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_flash_status_fifo_clr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2201,7 +2201,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_flash_read_buffer_clr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2229,7 +2229,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2259,7 +2259,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_tx_order (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2287,7 +2287,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_rx_order (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2315,7 +2315,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_mailbox_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2377,7 +2377,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intercept_en_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2405,7 +2405,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intercept_en_jedec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2433,7 +2433,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intercept_en_sfdp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2461,7 +2461,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intercept_en_mbx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2599,7 +2599,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h7f),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jedec_cc_cc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2627,7 +2627,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jedec_cc_num_cc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2657,7 +2657,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jedec_id_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2685,7 +2685,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jedec_id_mf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2714,7 +2714,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_read_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2743,7 +2743,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mailbox_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2773,7 +2773,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_upload_status_cmdfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2801,7 +2801,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_upload_status_cmdfifo_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2829,7 +2829,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_upload_status_addrfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2857,7 +2857,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_upload_status_addrfifo_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2887,7 +2887,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_upload_status2_payload_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2915,7 +2915,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_upload_status2_payload_start_idx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3024,7 +3024,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3052,7 +3052,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3080,7 +3080,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3108,7 +3108,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3136,7 +3136,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3164,7 +3164,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3192,7 +3192,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3220,7 +3220,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3248,7 +3248,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3276,7 +3276,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3304,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3332,7 +3332,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3360,7 +3360,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3388,7 +3388,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3416,7 +3416,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3444,7 +3444,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3472,7 +3472,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3500,7 +3500,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3528,7 +3528,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3556,7 +3556,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3584,7 +3584,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3612,7 +3612,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3640,7 +3640,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3668,7 +3668,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3696,7 +3696,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3724,7 +3724,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3752,7 +3752,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3780,7 +3780,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3808,7 +3808,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3836,7 +3836,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3864,7 +3864,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3892,7 +3892,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_0_filter_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3923,7 +3923,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3951,7 +3951,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3979,7 +3979,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4007,7 +4007,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4035,7 +4035,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4063,7 +4063,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4091,7 +4091,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4119,7 +4119,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4147,7 +4147,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4175,7 +4175,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4203,7 +4203,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4231,7 +4231,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4259,7 +4259,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4287,7 +4287,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4315,7 +4315,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4343,7 +4343,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4371,7 +4371,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4399,7 +4399,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4427,7 +4427,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4455,7 +4455,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4483,7 +4483,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4511,7 +4511,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4539,7 +4539,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4567,7 +4567,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4595,7 +4595,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4623,7 +4623,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4651,7 +4651,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4679,7 +4679,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4707,7 +4707,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4735,7 +4735,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4763,7 +4763,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4791,7 +4791,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_1_filter_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4822,7 +4822,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4850,7 +4850,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4878,7 +4878,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4906,7 +4906,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4934,7 +4934,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4962,7 +4962,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4990,7 +4990,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5018,7 +5018,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5046,7 +5046,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5074,7 +5074,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5102,7 +5102,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5130,7 +5130,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5158,7 +5158,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5186,7 +5186,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5214,7 +5214,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5242,7 +5242,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5270,7 +5270,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5298,7 +5298,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5326,7 +5326,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5354,7 +5354,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5382,7 +5382,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5410,7 +5410,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5438,7 +5438,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5466,7 +5466,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5494,7 +5494,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5522,7 +5522,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5550,7 +5550,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5578,7 +5578,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5606,7 +5606,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5634,7 +5634,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5662,7 +5662,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5690,7 +5690,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_2_filter_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5721,7 +5721,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5749,7 +5749,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5777,7 +5777,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5805,7 +5805,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5833,7 +5833,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5861,7 +5861,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5889,7 +5889,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5917,7 +5917,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5945,7 +5945,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5973,7 +5973,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6001,7 +6001,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6029,7 +6029,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6057,7 +6057,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6085,7 +6085,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6113,7 +6113,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6141,7 +6141,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6169,7 +6169,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6197,7 +6197,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6225,7 +6225,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6253,7 +6253,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6281,7 +6281,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6309,7 +6309,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6337,7 +6337,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6365,7 +6365,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6393,7 +6393,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6421,7 +6421,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6449,7 +6449,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6477,7 +6477,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6505,7 +6505,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6533,7 +6533,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6561,7 +6561,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6589,7 +6589,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_3_filter_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6620,7 +6620,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6648,7 +6648,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6676,7 +6676,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6704,7 +6704,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6732,7 +6732,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6760,7 +6760,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6788,7 +6788,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6816,7 +6816,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6844,7 +6844,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6872,7 +6872,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6900,7 +6900,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6928,7 +6928,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6956,7 +6956,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6984,7 +6984,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7012,7 +7012,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7040,7 +7040,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7068,7 +7068,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7096,7 +7096,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7124,7 +7124,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7152,7 +7152,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7180,7 +7180,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7208,7 +7208,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7236,7 +7236,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7264,7 +7264,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7292,7 +7292,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7320,7 +7320,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7348,7 +7348,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7376,7 +7376,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7404,7 +7404,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7432,7 +7432,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7460,7 +7460,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7488,7 +7488,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_4_filter_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7519,7 +7519,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7547,7 +7547,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7575,7 +7575,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7603,7 +7603,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7631,7 +7631,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7659,7 +7659,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7687,7 +7687,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7715,7 +7715,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7743,7 +7743,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7771,7 +7771,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7799,7 +7799,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7827,7 +7827,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7855,7 +7855,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7883,7 +7883,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7911,7 +7911,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7939,7 +7939,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7967,7 +7967,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7995,7 +7995,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8023,7 +8023,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8051,7 +8051,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8079,7 +8079,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8107,7 +8107,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8135,7 +8135,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8163,7 +8163,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8191,7 +8191,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8219,7 +8219,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8247,7 +8247,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_186 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8275,7 +8275,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_187 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8303,7 +8303,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_188 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8331,7 +8331,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_189 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8359,7 +8359,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_190 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8387,7 +8387,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_5_filter_191 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8418,7 +8418,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_192 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8446,7 +8446,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_193 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8474,7 +8474,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_194 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8502,7 +8502,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_195 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8530,7 +8530,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_196 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8558,7 +8558,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_197 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8586,7 +8586,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_198 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8614,7 +8614,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_199 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8642,7 +8642,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_200 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8670,7 +8670,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_201 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8698,7 +8698,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_202 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8726,7 +8726,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_203 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8754,7 +8754,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_204 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8782,7 +8782,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_205 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8810,7 +8810,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_206 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8838,7 +8838,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_207 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8866,7 +8866,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_208 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8894,7 +8894,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_209 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8922,7 +8922,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_210 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8950,7 +8950,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_211 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8978,7 +8978,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_212 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9006,7 +9006,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_213 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9034,7 +9034,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_214 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9062,7 +9062,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_215 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9090,7 +9090,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_216 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9118,7 +9118,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_217 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9146,7 +9146,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_218 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9174,7 +9174,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_219 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9202,7 +9202,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_220 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9230,7 +9230,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_221 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9258,7 +9258,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_222 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9286,7 +9286,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_6_filter_223 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9317,7 +9317,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_224 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9345,7 +9345,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_225 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9373,7 +9373,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_226 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9401,7 +9401,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_227 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9429,7 +9429,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_228 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9457,7 +9457,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_229 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9485,7 +9485,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_230 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9513,7 +9513,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_231 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9541,7 +9541,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_232 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9569,7 +9569,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_233 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9597,7 +9597,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_234 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9625,7 +9625,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_235 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9653,7 +9653,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_236 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9681,7 +9681,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_237 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9709,7 +9709,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_238 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9737,7 +9737,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_239 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9765,7 +9765,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_240 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9793,7 +9793,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_241 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9821,7 +9821,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_242 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9849,7 +9849,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_243 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9877,7 +9877,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_244 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9905,7 +9905,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_245 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9933,7 +9933,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_246 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9961,7 +9961,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_247 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9989,7 +9989,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_248 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10017,7 +10017,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_249 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10045,7 +10045,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_250 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10073,7 +10073,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_251 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10101,7 +10101,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_252 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10129,7 +10129,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_253 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10157,7 +10157,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_254 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10185,7 +10185,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_filter_7_filter_255 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10214,7 +10214,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_addr_swap_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10243,7 +10243,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_addr_swap_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10272,7 +10272,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_payload_swap_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10301,7 +10301,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_payload_swap_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10332,7 +10332,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_opcode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10360,7 +10360,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_addr_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10388,7 +10388,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_addr_swap_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10416,7 +10416,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_mbyte_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10444,7 +10444,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_dummy_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10472,7 +10472,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_dummy_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10500,7 +10500,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_payload_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10528,7 +10528,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_payload_dir_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10556,7 +10556,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_payload_swap_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10584,7 +10584,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_read_pipeline_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10612,7 +10612,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_upload_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10640,7 +10640,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_busy_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10668,7 +10668,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_0_valid_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10699,7 +10699,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_opcode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10727,7 +10727,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_addr_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10755,7 +10755,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_addr_swap_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10783,7 +10783,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_mbyte_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10811,7 +10811,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_dummy_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10839,7 +10839,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_dummy_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10867,7 +10867,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_payload_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10895,7 +10895,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_payload_dir_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10923,7 +10923,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_payload_swap_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10951,7 +10951,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_read_pipeline_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10979,7 +10979,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_upload_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11007,7 +11007,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_busy_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11035,7 +11035,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_1_valid_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11066,7 +11066,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_opcode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11094,7 +11094,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_addr_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11122,7 +11122,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_addr_swap_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11150,7 +11150,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_mbyte_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11178,7 +11178,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_dummy_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11206,7 +11206,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_dummy_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11234,7 +11234,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_payload_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11262,7 +11262,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_payload_dir_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11290,7 +11290,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_payload_swap_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11318,7 +11318,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_read_pipeline_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11346,7 +11346,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_upload_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11374,7 +11374,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_busy_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11402,7 +11402,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_2_valid_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11433,7 +11433,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_opcode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11461,7 +11461,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_addr_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11489,7 +11489,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_addr_swap_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11517,7 +11517,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_mbyte_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11545,7 +11545,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_dummy_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11573,7 +11573,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_dummy_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11601,7 +11601,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_payload_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11629,7 +11629,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_payload_dir_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11657,7 +11657,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_payload_swap_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11685,7 +11685,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_read_pipeline_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11713,7 +11713,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_upload_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11741,7 +11741,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_busy_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11769,7 +11769,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_3_valid_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11800,7 +11800,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_opcode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11828,7 +11828,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_addr_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11856,7 +11856,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_addr_swap_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11884,7 +11884,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_mbyte_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11912,7 +11912,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_dummy_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11940,7 +11940,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_dummy_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11968,7 +11968,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_payload_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11996,7 +11996,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_payload_dir_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12024,7 +12024,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_payload_swap_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12052,7 +12052,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_read_pipeline_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12080,7 +12080,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_upload_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12108,7 +12108,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_busy_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12136,7 +12136,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_4_valid_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12167,7 +12167,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_opcode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12195,7 +12195,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_addr_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12223,7 +12223,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_addr_swap_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12251,7 +12251,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_mbyte_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12279,7 +12279,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_dummy_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12307,7 +12307,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_dummy_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12335,7 +12335,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_payload_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12363,7 +12363,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_payload_dir_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12391,7 +12391,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_payload_swap_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12419,7 +12419,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_read_pipeline_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12447,7 +12447,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_upload_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12475,7 +12475,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_busy_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12503,7 +12503,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_5_valid_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12534,7 +12534,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_opcode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12562,7 +12562,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_addr_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12590,7 +12590,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_addr_swap_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12618,7 +12618,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_mbyte_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12646,7 +12646,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_dummy_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12674,7 +12674,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_dummy_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12702,7 +12702,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_payload_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12730,7 +12730,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_payload_dir_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12758,7 +12758,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_payload_swap_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12786,7 +12786,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_read_pipeline_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12814,7 +12814,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_upload_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12842,7 +12842,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_busy_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12870,7 +12870,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_6_valid_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12901,7 +12901,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_opcode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12929,7 +12929,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_addr_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12957,7 +12957,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_addr_swap_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12985,7 +12985,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_mbyte_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13013,7 +13013,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_dummy_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13041,7 +13041,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_dummy_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13069,7 +13069,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_payload_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13097,7 +13097,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_payload_dir_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13125,7 +13125,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_payload_swap_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13153,7 +13153,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_read_pipeline_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13181,7 +13181,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_upload_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13209,7 +13209,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_busy_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13237,7 +13237,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_7_valid_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13268,7 +13268,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_opcode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13296,7 +13296,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_addr_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13324,7 +13324,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_addr_swap_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13352,7 +13352,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_mbyte_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13380,7 +13380,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_dummy_size_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13408,7 +13408,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_dummy_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13436,7 +13436,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_payload_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13464,7 +13464,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_payload_dir_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13492,7 +13492,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_payload_swap_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13520,7 +13520,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_read_pipeline_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13548,7 +13548,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_upload_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13576,7 +13576,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_busy_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13604,7 +13604,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_8_valid_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13635,7 +13635,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_opcode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13663,7 +13663,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_addr_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13691,7 +13691,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_addr_swap_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13719,7 +13719,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_mbyte_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13747,7 +13747,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_dummy_size_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13775,7 +13775,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_dummy_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13803,7 +13803,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_payload_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13831,7 +13831,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_payload_dir_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13859,7 +13859,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_payload_swap_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13887,7 +13887,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_read_pipeline_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13915,7 +13915,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_upload_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13943,7 +13943,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_busy_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13971,7 +13971,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_9_valid_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14002,7 +14002,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_opcode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14030,7 +14030,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_addr_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14058,7 +14058,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_addr_swap_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14086,7 +14086,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_mbyte_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14114,7 +14114,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_dummy_size_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14142,7 +14142,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_dummy_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14170,7 +14170,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_payload_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14198,7 +14198,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_payload_dir_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14226,7 +14226,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_payload_swap_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14254,7 +14254,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_read_pipeline_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14282,7 +14282,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_upload_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14310,7 +14310,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_busy_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14338,7 +14338,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_10_valid_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14369,7 +14369,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_opcode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14397,7 +14397,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_addr_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14425,7 +14425,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_addr_swap_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14453,7 +14453,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_mbyte_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14481,7 +14481,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_dummy_size_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14509,7 +14509,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_dummy_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14537,7 +14537,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_payload_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14565,7 +14565,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_payload_dir_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14593,7 +14593,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_payload_swap_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14621,7 +14621,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_read_pipeline_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14649,7 +14649,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_upload_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14677,7 +14677,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_busy_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14705,7 +14705,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_11_valid_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14736,7 +14736,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_opcode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14764,7 +14764,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_addr_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14792,7 +14792,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_addr_swap_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14820,7 +14820,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_mbyte_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14848,7 +14848,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_dummy_size_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14876,7 +14876,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_dummy_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14904,7 +14904,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_payload_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14932,7 +14932,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_payload_dir_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14960,7 +14960,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_payload_swap_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14988,7 +14988,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_read_pipeline_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15016,7 +15016,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_upload_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15044,7 +15044,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_busy_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15072,7 +15072,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_12_valid_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15103,7 +15103,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_opcode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15131,7 +15131,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_addr_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15159,7 +15159,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_addr_swap_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15187,7 +15187,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_mbyte_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15215,7 +15215,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_dummy_size_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15243,7 +15243,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_dummy_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15271,7 +15271,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_payload_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15299,7 +15299,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_payload_dir_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15327,7 +15327,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_payload_swap_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15355,7 +15355,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_read_pipeline_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15383,7 +15383,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_upload_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15411,7 +15411,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_busy_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15439,7 +15439,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_13_valid_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15470,7 +15470,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_opcode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15498,7 +15498,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_addr_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15526,7 +15526,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_addr_swap_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15554,7 +15554,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_mbyte_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15582,7 +15582,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_dummy_size_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15610,7 +15610,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_dummy_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15638,7 +15638,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_payload_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15666,7 +15666,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_payload_dir_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15694,7 +15694,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_payload_swap_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15722,7 +15722,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_read_pipeline_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15750,7 +15750,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_upload_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15778,7 +15778,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_busy_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15806,7 +15806,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_14_valid_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15837,7 +15837,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_opcode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15865,7 +15865,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_addr_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15893,7 +15893,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_addr_swap_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15921,7 +15921,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_mbyte_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15949,7 +15949,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_dummy_size_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15977,7 +15977,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_dummy_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16005,7 +16005,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_payload_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16033,7 +16033,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_payload_dir_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16061,7 +16061,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_payload_swap_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16089,7 +16089,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_read_pipeline_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16117,7 +16117,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_upload_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16145,7 +16145,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_busy_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16173,7 +16173,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_15_valid_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16204,7 +16204,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_opcode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16232,7 +16232,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_addr_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16260,7 +16260,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_addr_swap_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16288,7 +16288,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_mbyte_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16316,7 +16316,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_dummy_size_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16344,7 +16344,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_dummy_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16372,7 +16372,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_payload_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16400,7 +16400,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_payload_dir_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16428,7 +16428,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_payload_swap_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16456,7 +16456,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_read_pipeline_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16484,7 +16484,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_upload_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16512,7 +16512,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_busy_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16540,7 +16540,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_16_valid_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16571,7 +16571,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_opcode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16599,7 +16599,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_addr_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16627,7 +16627,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_addr_swap_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16655,7 +16655,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_mbyte_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16683,7 +16683,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_dummy_size_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16711,7 +16711,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_dummy_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16739,7 +16739,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_payload_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16767,7 +16767,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_payload_dir_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16795,7 +16795,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_payload_swap_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16823,7 +16823,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_read_pipeline_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16851,7 +16851,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_upload_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16879,7 +16879,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_busy_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16907,7 +16907,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_17_valid_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16938,7 +16938,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_opcode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16966,7 +16966,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_addr_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16994,7 +16994,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_addr_swap_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17022,7 +17022,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_mbyte_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17050,7 +17050,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_dummy_size_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17078,7 +17078,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_dummy_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17106,7 +17106,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_payload_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17134,7 +17134,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_payload_dir_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17162,7 +17162,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_payload_swap_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17190,7 +17190,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_read_pipeline_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17218,7 +17218,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_upload_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17246,7 +17246,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_busy_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17274,7 +17274,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_18_valid_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17305,7 +17305,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_opcode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17333,7 +17333,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_addr_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17361,7 +17361,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_addr_swap_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17389,7 +17389,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_mbyte_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17417,7 +17417,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_dummy_size_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17445,7 +17445,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_dummy_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17473,7 +17473,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_payload_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17501,7 +17501,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_payload_dir_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17529,7 +17529,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_payload_swap_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17557,7 +17557,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_read_pipeline_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17585,7 +17585,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_upload_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17613,7 +17613,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_busy_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17641,7 +17641,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_19_valid_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17672,7 +17672,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_opcode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17700,7 +17700,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_addr_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17728,7 +17728,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_addr_swap_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17756,7 +17756,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_mbyte_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17784,7 +17784,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_dummy_size_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17812,7 +17812,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_dummy_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17840,7 +17840,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_payload_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17868,7 +17868,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_payload_dir_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17896,7 +17896,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_payload_swap_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17924,7 +17924,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_read_pipeline_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17952,7 +17952,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_upload_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17980,7 +17980,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_busy_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18008,7 +18008,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_20_valid_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18039,7 +18039,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_opcode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18067,7 +18067,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_addr_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18095,7 +18095,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_addr_swap_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18123,7 +18123,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_mbyte_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18151,7 +18151,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_dummy_size_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18179,7 +18179,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_dummy_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18207,7 +18207,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_payload_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18235,7 +18235,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_payload_dir_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18263,7 +18263,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_payload_swap_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18291,7 +18291,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_read_pipeline_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18319,7 +18319,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_upload_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18347,7 +18347,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_busy_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18375,7 +18375,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_21_valid_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18406,7 +18406,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_opcode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18434,7 +18434,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_addr_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18462,7 +18462,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_addr_swap_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18490,7 +18490,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_mbyte_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18518,7 +18518,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_dummy_size_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18546,7 +18546,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_dummy_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18574,7 +18574,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_payload_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18602,7 +18602,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_payload_dir_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18630,7 +18630,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_payload_swap_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18658,7 +18658,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_read_pipeline_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18686,7 +18686,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_upload_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18714,7 +18714,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_busy_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18742,7 +18742,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_22_valid_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18773,7 +18773,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_opcode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18801,7 +18801,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_addr_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18829,7 +18829,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_addr_swap_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18857,7 +18857,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_mbyte_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18885,7 +18885,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_dummy_size_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18913,7 +18913,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_dummy_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18941,7 +18941,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_payload_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18969,7 +18969,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_payload_dir_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18997,7 +18997,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_payload_swap_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19025,7 +19025,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_read_pipeline_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19053,7 +19053,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_upload_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19081,7 +19081,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_busy_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19109,7 +19109,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_23_valid_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19139,7 +19139,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_en4b_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19167,7 +19167,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_en4b_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19197,7 +19197,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_ex4b_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19225,7 +19225,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_ex4b_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19255,7 +19255,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_wren_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19283,7 +19283,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_wren_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19313,7 +19313,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_wrdi_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19341,7 +19341,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cmd_info_wrdi_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19371,7 +19371,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cap_rev (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19399,7 +19399,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cap_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19427,7 +19427,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cap_max_wr_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19455,7 +19455,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cap_max_rd_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19485,7 +19485,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cfg_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19513,7 +19513,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cfg_tpm_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19541,7 +19541,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cfg_hw_reg_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19569,7 +19569,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cfg_tpm_reg_chk_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19597,7 +19597,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_cfg_invalid_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19682,7 +19682,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_access_0_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19710,7 +19710,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_access_0_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19738,7 +19738,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_access_0_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19766,7 +19766,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_access_0_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19796,7 +19796,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19825,7 +19825,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19854,7 +19854,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_intf_capability (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19883,7 +19883,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_int_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19912,7 +19912,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_int_vector (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19941,7 +19941,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_int_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19971,7 +19971,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_did_vid_vid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19999,7 +19999,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_did_vid_did (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20028,7 +20028,7 @@ module spi_device_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_tpm_rid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1567,7 +1567,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_upload_cmdfifo_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1594,7 +1595,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_upload_payload_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1621,7 +1623,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_upload_payload_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1648,7 +1651,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_readbuf_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1675,7 +1679,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_readbuf_flip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1702,7 +1707,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tpm_header_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1729,7 +1735,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tpm_rdfifo_cmd_end (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1756,7 +1763,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tpm_rdfifo_drop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1785,7 +1793,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_upload_cmdfifo_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1812,7 +1821,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_upload_payload_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1839,7 +1849,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_upload_payload_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1866,7 +1877,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_readbuf_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1893,7 +1905,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_readbuf_flip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1920,7 +1933,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tpm_header_not_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1947,7 +1961,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tpm_rdfifo_cmd_end (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1974,7 +1989,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tpm_rdfifo_drop (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2156,7 +2172,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_flash_status_fifo_clr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2183,7 +2200,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_flash_read_buffer_clr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2210,7 +2228,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2239,7 +2258,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_tx_order (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2266,7 +2286,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_rx_order (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2293,7 +2314,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_mailbox_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2354,7 +2376,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intercept_en_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2381,7 +2404,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intercept_en_jedec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2408,7 +2432,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intercept_en_sfdp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2435,7 +2460,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intercept_en_mbx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2572,7 +2598,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h7f),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jedec_cc_cc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2599,7 +2626,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jedec_cc_num_cc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2628,7 +2656,8 @@ module spi_device_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jedec_id_id (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2655,7 +2684,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jedec_id_mf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2683,7 +2713,8 @@ module spi_device_reg_top
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_read_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2711,7 +2742,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mailbox_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2740,7 +2772,8 @@ module spi_device_reg_top
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_upload_status_cmdfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2767,7 +2800,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_upload_status_cmdfifo_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2794,7 +2828,8 @@ module spi_device_reg_top
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_upload_status_addrfifo_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2821,7 +2856,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_upload_status_addrfifo_notempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2850,7 +2886,8 @@ module spi_device_reg_top
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_upload_status2_payload_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2877,7 +2914,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_upload_status2_payload_start_idx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +3023,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3012,7 +3051,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3039,7 +3079,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3066,7 +3107,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3093,7 +3135,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3120,7 +3163,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3147,7 +3191,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3174,7 +3219,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3201,7 +3247,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3228,7 +3275,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3255,7 +3303,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3282,7 +3331,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3309,7 +3359,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3336,7 +3387,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3363,7 +3415,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3390,7 +3443,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3417,7 +3471,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3444,7 +3499,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3471,7 +3527,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3498,7 +3555,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3525,7 +3583,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3552,7 +3611,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3579,7 +3639,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3606,7 +3667,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3633,7 +3695,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3660,7 +3723,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3687,7 +3751,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3714,7 +3779,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3741,7 +3807,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3768,7 +3835,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3795,7 +3863,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3822,7 +3891,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_0_filter_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3852,7 +3922,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3879,7 +3950,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3906,7 +3978,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3933,7 +4006,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3960,7 +4034,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3987,7 +4062,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4014,7 +4090,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4041,7 +4118,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4068,7 +4146,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4095,7 +4174,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4122,7 +4202,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4149,7 +4230,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4176,7 +4258,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4203,7 +4286,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4230,7 +4314,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4257,7 +4342,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4284,7 +4370,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4311,7 +4398,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4338,7 +4426,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4365,7 +4454,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4392,7 +4482,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4419,7 +4510,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4446,7 +4538,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4566,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4500,7 +4594,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4527,7 +4622,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4554,7 +4650,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4581,7 +4678,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4608,7 +4706,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4635,7 +4734,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4662,7 +4762,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4689,7 +4790,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_1_filter_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4719,7 +4821,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4746,7 +4849,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4773,7 +4877,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4800,7 +4905,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4827,7 +4933,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4854,7 +4961,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4881,7 +4989,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4908,7 +5017,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4935,7 +5045,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4962,7 +5073,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4989,7 +5101,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5016,7 +5129,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5043,7 +5157,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5070,7 +5185,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5097,7 +5213,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5124,7 +5241,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5151,7 +5269,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5178,7 +5297,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5205,7 +5325,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5232,7 +5353,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5259,7 +5381,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5286,7 +5409,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5313,7 +5437,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5340,7 +5465,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5367,7 +5493,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5394,7 +5521,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5421,7 +5549,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5448,7 +5577,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5475,7 +5605,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5502,7 +5633,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5529,7 +5661,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5556,7 +5689,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_2_filter_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5586,7 +5720,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5613,7 +5748,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5640,7 +5776,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5667,7 +5804,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5694,7 +5832,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5721,7 +5860,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5748,7 +5888,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5775,7 +5916,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5802,7 +5944,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5829,7 +5972,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5856,7 +6000,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5883,7 +6028,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5910,7 +6056,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5937,7 +6084,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5964,7 +6112,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5991,7 +6140,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6018,7 +6168,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6045,7 +6196,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6072,7 +6224,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6099,7 +6252,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6126,7 +6280,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6153,7 +6308,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6180,7 +6336,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6207,7 +6364,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6234,7 +6392,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6261,7 +6420,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6288,7 +6448,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6315,7 +6476,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6342,7 +6504,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6369,7 +6532,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6396,7 +6560,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6423,7 +6588,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_3_filter_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6453,7 +6619,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6480,7 +6647,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6507,7 +6675,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6534,7 +6703,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6561,7 +6731,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6588,7 +6759,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6615,7 +6787,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6642,7 +6815,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6669,7 +6843,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6696,7 +6871,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6723,7 +6899,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6750,7 +6927,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6777,7 +6955,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6804,7 +6983,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6831,7 +7011,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6858,7 +7039,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6885,7 +7067,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6912,7 +7095,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6939,7 +7123,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6966,7 +7151,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6993,7 +7179,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7020,7 +7207,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7047,7 +7235,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7074,7 +7263,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7101,7 +7291,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7128,7 +7319,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7155,7 +7347,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7182,7 +7375,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7209,7 +7403,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7236,7 +7431,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7263,7 +7459,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7290,7 +7487,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_4_filter_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7320,7 +7518,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7347,7 +7546,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7374,7 +7574,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7401,7 +7602,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7428,7 +7630,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7455,7 +7658,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7482,7 +7686,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7509,7 +7714,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7536,7 +7742,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7563,7 +7770,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7590,7 +7798,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7617,7 +7826,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7644,7 +7854,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7671,7 +7882,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7698,7 +7910,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7725,7 +7938,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7752,7 +7966,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7779,7 +7994,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7806,7 +8022,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7833,7 +8050,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7860,7 +8078,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7887,7 +8106,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7914,7 +8134,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7941,7 +8162,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7968,7 +8190,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7995,7 +8218,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8022,7 +8246,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_186 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8049,7 +8274,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_187 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8076,7 +8302,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_188 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8103,7 +8330,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_189 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8130,7 +8358,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_190 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8157,7 +8386,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_5_filter_191 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8187,7 +8417,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_192 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8214,7 +8445,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_193 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8241,7 +8473,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_194 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8268,7 +8501,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_195 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8295,7 +8529,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_196 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8322,7 +8557,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_197 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8349,7 +8585,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_198 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8376,7 +8613,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_199 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8403,7 +8641,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_200 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8430,7 +8669,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_201 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8457,7 +8697,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_202 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8484,7 +8725,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_203 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8511,7 +8753,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_204 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8538,7 +8781,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_205 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8565,7 +8809,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_206 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8592,7 +8837,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_207 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8619,7 +8865,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_208 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8646,7 +8893,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_209 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8673,7 +8921,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_210 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8700,7 +8949,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_211 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8727,7 +8977,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_212 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8754,7 +9005,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_213 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8781,7 +9033,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_214 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8808,7 +9061,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_215 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8835,7 +9089,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_216 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8862,7 +9117,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_217 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8889,7 +9145,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_218 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8916,7 +9173,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_219 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8943,7 +9201,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_220 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8970,7 +9229,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_221 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8997,7 +9257,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_222 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9024,7 +9285,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_6_filter_223 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9054,7 +9316,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_224 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9081,7 +9344,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_225 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9108,7 +9372,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_226 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9135,7 +9400,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_227 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9162,7 +9428,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_228 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9189,7 +9456,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_229 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9216,7 +9484,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_230 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9243,7 +9512,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_231 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9270,7 +9540,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_232 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9297,7 +9568,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_233 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9324,7 +9596,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_234 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9351,7 +9624,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_235 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9378,7 +9652,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_236 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9405,7 +9680,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_237 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9432,7 +9708,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_238 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9459,7 +9736,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_239 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9486,7 +9764,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_240 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9513,7 +9792,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_241 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9540,7 +9820,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_242 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9567,7 +9848,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_243 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9594,7 +9876,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_244 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9621,7 +9904,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_245 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9648,7 +9932,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_246 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9675,7 +9960,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_247 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9702,7 +9988,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_248 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9729,7 +10016,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_249 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9756,7 +10044,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_250 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9783,7 +10072,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_251 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9810,7 +10100,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_252 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9837,7 +10128,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_253 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9864,7 +10156,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_254 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9891,7 +10184,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_filter_7_filter_255 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9919,7 +10213,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_addr_swap_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9947,7 +10242,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_addr_swap_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9975,7 +10271,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_payload_swap_mask (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10003,7 +10300,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_payload_swap_data (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10033,7 +10331,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_opcode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10060,7 +10359,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_addr_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10087,7 +10387,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_addr_swap_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10114,7 +10415,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_mbyte_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10141,7 +10443,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_dummy_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10168,7 +10471,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_dummy_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10195,7 +10499,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_payload_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10222,7 +10527,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_payload_dir_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10249,7 +10555,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_payload_swap_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10276,7 +10583,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_read_pipeline_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10303,7 +10611,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_upload_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10330,7 +10639,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_busy_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10357,7 +10667,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_0_valid_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10387,7 +10698,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_opcode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10414,7 +10726,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_addr_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10441,7 +10754,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_addr_swap_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10468,7 +10782,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_mbyte_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10495,7 +10810,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_dummy_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10522,7 +10838,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_dummy_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10549,7 +10866,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_payload_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10576,7 +10894,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_payload_dir_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10603,7 +10922,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_payload_swap_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10630,7 +10950,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_read_pipeline_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10657,7 +10978,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_upload_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10684,7 +11006,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_busy_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10711,7 +11034,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_1_valid_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10741,7 +11065,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_opcode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10768,7 +11093,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_addr_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10795,7 +11121,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_addr_swap_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10822,7 +11149,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_mbyte_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10849,7 +11177,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_dummy_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10876,7 +11205,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_dummy_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10903,7 +11233,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_payload_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10930,7 +11261,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_payload_dir_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10957,7 +11289,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_payload_swap_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10984,7 +11317,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_read_pipeline_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11011,7 +11345,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_upload_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11038,7 +11373,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_busy_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11065,7 +11401,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_2_valid_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11095,7 +11432,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_opcode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11122,7 +11460,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_addr_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11149,7 +11488,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_addr_swap_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11176,7 +11516,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_mbyte_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11203,7 +11544,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_dummy_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11230,7 +11572,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_dummy_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11257,7 +11600,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_payload_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11284,7 +11628,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_payload_dir_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11311,7 +11656,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_payload_swap_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11338,7 +11684,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_read_pipeline_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11365,7 +11712,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_upload_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11392,7 +11740,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_busy_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11419,7 +11768,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_3_valid_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11449,7 +11799,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_opcode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11476,7 +11827,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_addr_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11503,7 +11855,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_addr_swap_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11530,7 +11883,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_mbyte_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11557,7 +11911,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_dummy_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11584,7 +11939,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_dummy_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11611,7 +11967,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_payload_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11638,7 +11995,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_payload_dir_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11665,7 +12023,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_payload_swap_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11692,7 +12051,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_read_pipeline_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11719,7 +12079,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_upload_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11746,7 +12107,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_busy_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11773,7 +12135,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_4_valid_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11803,7 +12166,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_opcode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11830,7 +12194,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_addr_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11857,7 +12222,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_addr_swap_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11884,7 +12250,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_mbyte_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11911,7 +12278,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_dummy_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11938,7 +12306,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_dummy_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11965,7 +12334,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_payload_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11992,7 +12362,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_payload_dir_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12019,7 +12390,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_payload_swap_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12046,7 +12418,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_read_pipeline_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12073,7 +12446,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_upload_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12100,7 +12474,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_busy_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12127,7 +12502,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_5_valid_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12157,7 +12533,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_opcode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12184,7 +12561,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_addr_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12211,7 +12589,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_addr_swap_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12238,7 +12617,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_mbyte_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12265,7 +12645,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_dummy_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12292,7 +12673,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_dummy_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12319,7 +12701,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_payload_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12346,7 +12729,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_payload_dir_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12373,7 +12757,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_payload_swap_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12400,7 +12785,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_read_pipeline_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12427,7 +12813,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_upload_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12454,7 +12841,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_busy_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12481,7 +12869,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_6_valid_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12511,7 +12900,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_opcode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12538,7 +12928,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_addr_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12565,7 +12956,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_addr_swap_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12592,7 +12984,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_mbyte_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12619,7 +13012,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_dummy_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12646,7 +13040,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_dummy_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12673,7 +13068,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_payload_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12700,7 +13096,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_payload_dir_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12727,7 +13124,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_payload_swap_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12754,7 +13152,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_read_pipeline_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12781,7 +13180,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_upload_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12808,7 +13208,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_busy_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12835,7 +13236,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_7_valid_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12865,7 +13267,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_opcode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12892,7 +13295,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_addr_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12919,7 +13323,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_addr_swap_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12946,7 +13351,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_mbyte_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12973,7 +13379,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_dummy_size_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13000,7 +13407,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_dummy_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13027,7 +13435,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_payload_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13054,7 +13463,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_payload_dir_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13081,7 +13491,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_payload_swap_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13108,7 +13519,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_read_pipeline_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13135,7 +13547,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_upload_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13162,7 +13575,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_busy_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13189,7 +13603,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_8_valid_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13219,7 +13634,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_opcode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13246,7 +13662,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_addr_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13273,7 +13690,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_addr_swap_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13300,7 +13718,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_mbyte_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13327,7 +13746,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_dummy_size_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13354,7 +13774,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_dummy_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13381,7 +13802,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_payload_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13408,7 +13830,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_payload_dir_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13435,7 +13858,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_payload_swap_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13462,7 +13886,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_read_pipeline_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13489,7 +13914,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_upload_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13516,7 +13942,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_busy_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13543,7 +13970,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_9_valid_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13573,7 +14001,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_opcode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13600,7 +14029,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_addr_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13627,7 +14057,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_addr_swap_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13654,7 +14085,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_mbyte_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13681,7 +14113,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_dummy_size_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13708,7 +14141,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_dummy_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13735,7 +14169,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_payload_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13762,7 +14197,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_payload_dir_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13789,7 +14225,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_payload_swap_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13816,7 +14253,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_read_pipeline_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13843,7 +14281,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_upload_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13870,7 +14309,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_busy_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13897,7 +14337,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_10_valid_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13927,7 +14368,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_opcode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13954,7 +14396,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_addr_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13981,7 +14424,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_addr_swap_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14008,7 +14452,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_mbyte_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14035,7 +14480,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_dummy_size_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14062,7 +14508,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_dummy_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14089,7 +14536,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_payload_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14116,7 +14564,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_payload_dir_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14143,7 +14592,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_payload_swap_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14170,7 +14620,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_read_pipeline_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14197,7 +14648,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_upload_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14224,7 +14676,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_busy_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14251,7 +14704,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_11_valid_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14281,7 +14735,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_opcode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14308,7 +14763,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_addr_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14335,7 +14791,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_addr_swap_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14362,7 +14819,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_mbyte_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14389,7 +14847,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_dummy_size_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14416,7 +14875,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_dummy_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14443,7 +14903,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_payload_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14470,7 +14931,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_payload_dir_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14497,7 +14959,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_payload_swap_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14524,7 +14987,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_read_pipeline_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14551,7 +15015,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_upload_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14578,7 +15043,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_busy_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14605,7 +15071,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_12_valid_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14635,7 +15102,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_opcode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14662,7 +15130,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_addr_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14689,7 +15158,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_addr_swap_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14716,7 +15186,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_mbyte_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14743,7 +15214,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_dummy_size_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14770,7 +15242,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_dummy_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14797,7 +15270,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_payload_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14824,7 +15298,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_payload_dir_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14851,7 +15326,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_payload_swap_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14878,7 +15354,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_read_pipeline_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14905,7 +15382,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_upload_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14932,7 +15410,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_busy_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14959,7 +15438,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_13_valid_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14989,7 +15469,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_opcode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15016,7 +15497,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_addr_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15043,7 +15525,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_addr_swap_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15070,7 +15553,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_mbyte_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15097,7 +15581,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_dummy_size_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15124,7 +15609,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_dummy_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15151,7 +15637,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_payload_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15178,7 +15665,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_payload_dir_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15205,7 +15693,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_payload_swap_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15232,7 +15721,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_read_pipeline_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15259,7 +15749,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_upload_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15286,7 +15777,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_busy_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15313,7 +15805,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_14_valid_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15343,7 +15836,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_opcode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15370,7 +15864,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_addr_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15397,7 +15892,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_addr_swap_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15424,7 +15920,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_mbyte_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15451,7 +15948,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_dummy_size_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15478,7 +15976,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_dummy_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15505,7 +16004,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_payload_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15532,7 +16032,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_payload_dir_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15559,7 +16060,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_payload_swap_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15586,7 +16088,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_read_pipeline_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15613,7 +16116,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_upload_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15640,7 +16144,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_busy_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15667,7 +16172,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_15_valid_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15697,7 +16203,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_opcode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15724,7 +16231,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_addr_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15751,7 +16259,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_addr_swap_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15778,7 +16287,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_mbyte_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15805,7 +16315,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_dummy_size_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15832,7 +16343,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_dummy_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15859,7 +16371,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_payload_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15886,7 +16399,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_payload_dir_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15913,7 +16427,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_payload_swap_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15940,7 +16455,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_read_pipeline_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15967,7 +16483,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_upload_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15994,7 +16511,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_busy_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16021,7 +16539,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_16_valid_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16051,7 +16570,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_opcode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16078,7 +16598,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_addr_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16105,7 +16626,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_addr_swap_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16132,7 +16654,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_mbyte_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16159,7 +16682,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_dummy_size_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16186,7 +16710,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_dummy_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16213,7 +16738,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_payload_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16240,7 +16766,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_payload_dir_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16267,7 +16794,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_payload_swap_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16294,7 +16822,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_read_pipeline_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16321,7 +16850,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_upload_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16348,7 +16878,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_busy_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16375,7 +16906,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_17_valid_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16405,7 +16937,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_opcode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16432,7 +16965,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_addr_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16459,7 +16993,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_addr_swap_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16486,7 +17021,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_mbyte_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16513,7 +17049,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_dummy_size_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16540,7 +17077,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_dummy_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16567,7 +17105,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_payload_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16594,7 +17133,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_payload_dir_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16621,7 +17161,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_payload_swap_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16648,7 +17189,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_read_pipeline_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16675,7 +17217,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_upload_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16702,7 +17245,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_busy_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16729,7 +17273,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_18_valid_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16759,7 +17304,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_opcode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16786,7 +17332,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_addr_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16813,7 +17360,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_addr_swap_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16840,7 +17388,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_mbyte_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16867,7 +17416,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_dummy_size_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16894,7 +17444,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_dummy_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16921,7 +17472,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_payload_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16948,7 +17500,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_payload_dir_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16975,7 +17528,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_payload_swap_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17002,7 +17556,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_read_pipeline_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17029,7 +17584,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_upload_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17056,7 +17612,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_busy_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17083,7 +17640,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_19_valid_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17113,7 +17671,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_opcode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17140,7 +17699,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_addr_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17167,7 +17727,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_addr_swap_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17194,7 +17755,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_mbyte_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17221,7 +17783,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_dummy_size_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17248,7 +17811,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_dummy_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17275,7 +17839,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_payload_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17302,7 +17867,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_payload_dir_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17329,7 +17895,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_payload_swap_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17356,7 +17923,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_read_pipeline_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17383,7 +17951,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_upload_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17410,7 +17979,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_busy_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17437,7 +18007,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_20_valid_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17467,7 +18038,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_opcode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17494,7 +18066,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_addr_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17521,7 +18094,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_addr_swap_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17548,7 +18122,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_mbyte_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17575,7 +18150,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_dummy_size_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17602,7 +18178,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_dummy_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17629,7 +18206,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_payload_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17656,7 +18234,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_payload_dir_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17683,7 +18262,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_payload_swap_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17710,7 +18290,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_read_pipeline_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17737,7 +18318,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_upload_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17764,7 +18346,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_busy_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17791,7 +18374,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_21_valid_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17821,7 +18405,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_opcode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17848,7 +18433,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_addr_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17875,7 +18461,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_addr_swap_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17902,7 +18489,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_mbyte_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17929,7 +18517,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_dummy_size_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17956,7 +18545,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_dummy_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17983,7 +18573,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_payload_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18010,7 +18601,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_payload_dir_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18037,7 +18629,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_payload_swap_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18064,7 +18657,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_read_pipeline_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18091,7 +18685,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_upload_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18118,7 +18713,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_busy_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18145,7 +18741,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_22_valid_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18175,7 +18772,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_opcode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18202,7 +18800,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_addr_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18229,7 +18828,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_addr_swap_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18256,7 +18856,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_mbyte_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18283,7 +18884,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_dummy_size_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18310,7 +18912,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_dummy_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18337,7 +18940,8 @@ module spi_device_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_payload_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18364,7 +18968,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_payload_dir_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18391,7 +18996,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_payload_swap_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18418,7 +19024,8 @@ module spi_device_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_read_pipeline_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18445,7 +19052,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_upload_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18472,7 +19080,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_busy_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18499,7 +19108,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_23_valid_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18528,7 +19138,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_en4b_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18555,7 +19166,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_en4b_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18584,7 +19196,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_ex4b_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18611,7 +19224,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_ex4b_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18640,7 +19254,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_wren_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18667,7 +19282,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_wren_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18696,7 +19312,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_wrdi_opcode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18723,7 +19340,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cmd_info_wrdi_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18752,7 +19370,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cap_rev (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18779,7 +19398,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cap_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18806,7 +19426,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cap_max_wr_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18833,7 +19454,8 @@ module spi_device_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cap_max_rd_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18862,7 +19484,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cfg_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18889,7 +19512,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cfg_tpm_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18916,7 +19540,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cfg_hw_reg_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18943,7 +19568,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cfg_tpm_reg_chk_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18970,7 +19596,8 @@ module spi_device_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_cfg_invalid_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19054,7 +19681,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_access_0_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19081,7 +19709,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_access_0_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19108,7 +19737,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_access_0_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19135,7 +19765,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_access_0_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19164,7 +19795,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19192,7 +19824,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19220,7 +19853,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_intf_capability (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19248,7 +19882,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_int_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19276,7 +19911,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_int_vector (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19304,7 +19940,8 @@ module spi_device_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_int_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19333,7 +19970,8 @@ module spi_device_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_did_vid_vid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19360,7 +19998,8 @@ module spi_device_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_did_vid_did (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19388,7 +20027,8 @@ module spi_device_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_tpm_rid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -292,7 +292,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -320,7 +320,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_spi_event (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -350,7 +350,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -378,7 +378,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_spi_event (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -465,7 +465,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h7f),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +493,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -521,7 +521,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_output_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -549,7 +549,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_sw_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -577,7 +577,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_spien (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -607,7 +607,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_txqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -635,7 +635,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rxqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -663,7 +663,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_cmdqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +691,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rxwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -719,7 +719,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_byteorder (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +747,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rxstall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -775,7 +775,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rxempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -803,7 +803,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rxfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -831,7 +831,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_txwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -859,7 +859,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_txstall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -887,7 +887,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_txempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -915,7 +915,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_txfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -943,7 +943,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -971,7 +971,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1001,7 +1001,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_clkdiv (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1029,7 +1029,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_csnidle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1057,7 +1057,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_csntrail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1085,7 +1085,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_csnlead (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1113,7 +1113,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_fullcyc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1141,7 +1141,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_cpha (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1169,7 +1169,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configopts_cpol (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1198,7 +1198,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1297,7 +1297,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_enable_cmdbusy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1325,7 +1325,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_enable_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1353,7 +1353,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_enable_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1381,7 +1381,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_enable_cmdinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1409,7 +1409,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_enable_csidinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1439,7 +1439,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_status_cmdbusy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1467,7 +1467,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_status_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1495,7 +1495,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_status_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1523,7 +1523,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_status_cmdinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1551,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_status_csidinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1579,7 +1579,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_status_accessinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1609,7 +1609,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_event_enable_rxfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1637,7 +1637,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_event_enable_txempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1665,7 +1665,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_event_enable_rxwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1693,7 +1693,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_event_enable_txwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1721,7 +1721,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_event_enable_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1749,7 +1749,7 @@ module spi_host_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_event_enable_idle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -291,7 +291,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -318,7 +319,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_spi_event (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -347,7 +349,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -374,7 +377,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_spi_event (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -460,7 +464,8 @@ module spi_host_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h7f),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -487,7 +492,8 @@ module spi_host_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -514,7 +520,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_output_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -541,7 +548,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_sw_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -568,7 +576,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_spien (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -597,7 +606,8 @@ module spi_host_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_txqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -624,7 +634,8 @@ module spi_host_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rxqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -651,7 +662,8 @@ module spi_host_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_cmdqd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -678,7 +690,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rxwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -705,7 +718,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_byteorder (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -732,7 +746,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rxstall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -759,7 +774,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rxempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -786,7 +802,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rxfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -813,7 +830,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_txwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -840,7 +858,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_txstall (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -867,7 +886,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_txempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -894,7 +914,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_txfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -921,7 +942,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -948,7 +970,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -977,7 +1000,8 @@ module spi_host_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_clkdiv (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1004,7 +1028,8 @@ module spi_host_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_csnidle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1031,7 +1056,8 @@ module spi_host_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_csntrail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1058,7 +1084,8 @@ module spi_host_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_csnlead (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1085,7 +1112,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_fullcyc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1112,7 +1140,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_cpha (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1139,7 +1168,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configopts_cpol (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1167,7 +1197,8 @@ module spi_host_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1265,7 +1296,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_enable_cmdbusy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1292,7 +1324,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_enable_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1319,7 +1352,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_enable_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1346,7 +1380,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_enable_cmdinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1373,7 +1408,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_enable_csidinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1402,7 +1438,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_status_cmdbusy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1429,7 +1466,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_status_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1456,7 +1494,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_status_underflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1483,7 +1522,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_status_cmdinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1510,7 +1550,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_status_csidinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1537,7 +1578,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_status_accessinval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1566,7 +1608,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_event_enable_rxfull (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1593,7 +1636,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_event_enable_txempty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1620,7 +1664,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_event_enable_rxwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1647,7 +1692,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_event_enable_txwm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1674,7 +1720,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_event_enable_ready (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1701,7 +1748,8 @@ module spi_host_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_event_enable_idle (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -191,7 +191,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_bus_integ_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -218,7 +219,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_init_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -245,7 +247,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_escalated (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -272,7 +275,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_scr_key_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -299,7 +303,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_scr_key_seed_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -326,7 +331,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_init_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -353,7 +359,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_readback_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -380,7 +387,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_sram_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -408,7 +416,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exec_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -439,7 +448,8 @@ module sram_ctrl_regs_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -467,7 +477,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -510,7 +521,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_renew_scr_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -538,7 +550,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -567,7 +580,8 @@ module sram_ctrl_regs_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_scr_key_rotated (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -595,7 +609,8 @@ module sram_ctrl_regs_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_readback_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -626,7 +641,8 @@ module sram_ctrl_regs_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_readback (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -192,7 +192,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_bus_integ_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -220,7 +220,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_init_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -248,7 +248,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_escalated (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -276,7 +276,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_scr_key_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -304,7 +304,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_scr_key_seed_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -332,7 +332,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_init_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -360,7 +360,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_readback_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -388,7 +388,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_sram_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -417,7 +417,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exec_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +449,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -478,7 +478,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -522,7 +522,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_renew_scr_key (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -551,7 +551,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -581,7 +581,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_scr_key_rotated (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -610,7 +610,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_readback_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -642,7 +642,7 @@ module sram_ctrl_regs_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_readback (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -1828,7 +1828,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1857,7 +1857,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1926,7 +1926,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1958,7 +1958,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ec_rst_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1991,7 +1991,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ulp_ac_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2024,7 +2024,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ulp_lid_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2057,7 +2057,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ulp_pwrb_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2086,7 +2086,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ulp_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2115,7 +2115,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ulp_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2179,7 +2179,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_key0_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2207,7 +2207,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2235,7 +2235,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_key1_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2263,7 +2263,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2291,7 +2291,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_key2_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2319,7 +2319,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2347,7 +2347,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_pwrb_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2375,7 +2375,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2403,7 +2403,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_ac_present (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2431,7 +2431,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2459,7 +2459,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_lid_open (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2487,7 +2487,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_invert_ctl_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2520,7 +2520,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_bat_disable_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2548,7 +2548,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_ec_rst_l_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2576,7 +2576,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_pwrb_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2604,7 +2604,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_key0_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2632,7 +2632,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_key1_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2660,7 +2660,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_key2_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2688,7 +2688,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_z3_wakeup_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2716,7 +2716,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_flash_wp_l_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2744,7 +2744,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_bat_disable_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2772,7 +2772,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_ec_rst_l_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2800,7 +2800,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_pwrb_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2828,7 +2828,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_key0_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2856,7 +2856,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_key1_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2884,7 +2884,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_key2_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2912,7 +2912,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_z3_wakeup_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2940,7 +2940,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_allowed_ctl_flash_wp_l_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2970,7 +2970,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2998,7 +2998,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_ec_rst_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3026,7 +3026,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3054,7 +3054,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3082,7 +3082,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3110,7 +3110,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3138,7 +3138,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3166,7 +3166,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_ctl_flash_wp_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3196,7 +3196,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3224,7 +3224,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_ec_rst_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3252,7 +3252,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3280,7 +3280,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3308,7 +3308,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3336,7 +3336,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3364,7 +3364,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3392,7 +3392,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_out_value_flash_wp_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3422,7 +3422,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_pwrb_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3450,7 +3450,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_key0_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3478,7 +3478,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_key1_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3506,7 +3506,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_key2_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3534,7 +3534,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_lid_open (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3562,7 +3562,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_ac_present (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3590,7 +3590,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_ec_rst_l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3618,7 +3618,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_pin_in_value_flash_wp_l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3651,7 +3651,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_pwrb_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3679,7 +3679,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_key0_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3707,7 +3707,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_key1_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3735,7 +3735,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_key2_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3763,7 +3763,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_ac_present_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3791,7 +3791,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_ec_rst_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3819,7 +3819,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_flash_wp_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3847,7 +3847,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_pwrb_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3875,7 +3875,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_key0_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3903,7 +3903,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_key1_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3931,7 +3931,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_key2_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3959,7 +3959,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_ac_present_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3987,7 +3987,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_ec_rst_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4015,7 +4015,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_ctl_flash_wp_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4048,7 +4048,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4082,7 +4082,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_debounce_ctl_debounce_timer (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4110,7 +4110,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_debounce_ctl_auto_block_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4144,7 +4144,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_out_ctl_key0_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4172,7 +4172,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_out_ctl_key1_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4200,7 +4200,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_out_ctl_key2_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4228,7 +4228,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_out_ctl_key0_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4256,7 +4256,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_out_ctl_key1_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4284,7 +4284,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_auto_block_out_ctl_key2_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4318,7 +4318,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_0_key0_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4346,7 +4346,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_0_key1_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4374,7 +4374,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_0_key2_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4402,7 +4402,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_0_pwrb_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4430,7 +4430,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_0_ac_present_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4464,7 +4464,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_1_key0_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4492,7 +4492,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_1_key1_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4520,7 +4520,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_1_key2_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4548,7 +4548,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_1_pwrb_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4576,7 +4576,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_1_ac_present_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4610,7 +4610,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_2_key0_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4638,7 +4638,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_2_key1_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4666,7 +4666,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_2_key2_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4694,7 +4694,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_2_pwrb_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4722,7 +4722,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_2_ac_present_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4756,7 +4756,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_3_key0_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4784,7 +4784,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_3_key1_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4812,7 +4812,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_3_key2_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4840,7 +4840,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_3_pwrb_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4868,7 +4868,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_sel_ctl_3_ac_present_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4901,7 +4901,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_det_ctl_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4934,7 +4934,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_det_ctl_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4967,7 +4967,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_det_ctl_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5000,7 +5000,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_pre_det_ctl_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5034,7 +5034,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_0_key0_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5062,7 +5062,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_0_key1_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5090,7 +5090,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_0_key2_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5118,7 +5118,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_0_pwrb_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5146,7 +5146,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_0_ac_present_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5180,7 +5180,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_1_key0_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5208,7 +5208,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_1_key1_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5236,7 +5236,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_1_key2_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5264,7 +5264,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_1_pwrb_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5292,7 +5292,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_1_ac_present_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5326,7 +5326,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_2_key0_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5354,7 +5354,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_2_key1_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5382,7 +5382,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_2_key2_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5410,7 +5410,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_2_pwrb_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5438,7 +5438,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_2_ac_present_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5472,7 +5472,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_3_key0_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5500,7 +5500,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_3_key1_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5528,7 +5528,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_3_key2_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5556,7 +5556,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_3_pwrb_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5584,7 +5584,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_sel_ctl_3_ac_present_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5617,7 +5617,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_det_ctl_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5650,7 +5650,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_det_ctl_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5683,7 +5683,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_det_ctl_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5716,7 +5716,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_det_ctl_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5750,7 +5750,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_0_bat_disable_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5778,7 +5778,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_0_interrupt_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5806,7 +5806,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_0_ec_rst_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5834,7 +5834,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_0_rst_req_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5868,7 +5868,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_1_bat_disable_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5896,7 +5896,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_1_interrupt_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5924,7 +5924,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_1_ec_rst_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5952,7 +5952,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_1_rst_req_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5986,7 +5986,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_2_bat_disable_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6014,7 +6014,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_2_interrupt_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6042,7 +6042,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_2_ec_rst_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6070,7 +6070,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_2_rst_req_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6104,7 +6104,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_3_bat_disable_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6132,7 +6132,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_3_interrupt_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6160,7 +6160,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_3_ec_rst_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6188,7 +6188,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_com_out_ctl_3_rst_req_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6218,7 +6218,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_combo_intr_status_combo0_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6246,7 +6246,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_combo_intr_status_combo1_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6274,7 +6274,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_combo_intr_status_combo2_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6302,7 +6302,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_combo_intr_status_combo3_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6332,7 +6332,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_pwrb_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6360,7 +6360,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_key0_in_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6388,7 +6388,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_key1_in_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6416,7 +6416,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_key2_in_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6444,7 +6444,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_ac_present_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6472,7 +6472,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_ec_rst_l_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6500,7 +6500,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_flash_wp_l_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6528,7 +6528,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_pwrb_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6556,7 +6556,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_key0_in_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6584,7 +6584,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_key1_in_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6612,7 +6612,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_key2_in_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6640,7 +6640,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_ac_present_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6668,7 +6668,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_ec_rst_l_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6696,7 +6696,7 @@ module sysrst_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_key_intr_status_flash_wp_l_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -1827,7 +1827,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1855,7 +1856,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1923,7 +1925,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1954,7 +1957,8 @@ module sysrst_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ec_rst_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -1986,7 +1990,8 @@ module sysrst_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ulp_ac_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2018,7 +2023,8 @@ module sysrst_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ulp_lid_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2050,7 +2056,8 @@ module sysrst_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ulp_pwrb_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2078,7 +2085,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ulp_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2106,7 +2114,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ulp_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2136,7 +2145,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_status (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2168,7 +2178,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_key0_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2195,7 +2206,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2222,7 +2234,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_key1_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2249,7 +2262,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2276,7 +2290,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_key2_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2303,7 +2318,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2330,7 +2346,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_pwrb_in (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2357,7 +2374,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2384,7 +2402,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_ac_present (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2411,7 +2430,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2438,7 +2458,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_lid_open (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2465,7 +2486,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_invert_ctl_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2497,7 +2519,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_bat_disable_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2524,7 +2547,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_ec_rst_l_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2551,7 +2575,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_pwrb_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2578,7 +2603,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_key0_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2605,7 +2631,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_key1_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2632,7 +2659,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_key2_out_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2659,7 +2687,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_z3_wakeup_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2686,7 +2715,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_flash_wp_l_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2713,7 +2743,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_bat_disable_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2740,7 +2771,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_ec_rst_l_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2767,7 +2799,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_pwrb_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2794,7 +2827,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_key0_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2821,7 +2855,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_key1_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2848,7 +2883,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_key2_out_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2875,7 +2911,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_z3_wakeup_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2902,7 +2939,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_allowed_ctl_flash_wp_l_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2931,7 +2969,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2958,7 +2997,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_ec_rst_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -2985,7 +3025,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3012,7 +3053,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3039,7 +3081,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3066,7 +3109,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3093,7 +3137,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3120,7 +3165,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_ctl_flash_wp_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3149,7 +3195,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_bat_disable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3176,7 +3223,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_ec_rst_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3203,7 +3251,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_pwrb_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3230,7 +3279,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_key0_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3257,7 +3307,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_key1_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3284,7 +3335,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_key2_out (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3311,7 +3363,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_z3_wakeup (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3338,7 +3391,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_out_value_flash_wp_l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3367,7 +3421,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_pwrb_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3394,7 +3449,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_key0_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3421,7 +3477,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_key1_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3448,7 +3505,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_key2_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3475,7 +3533,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_lid_open (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3502,7 +3561,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_ac_present (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3529,7 +3589,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_ec_rst_l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3556,7 +3617,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_pin_in_value_flash_wp_l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3588,7 +3650,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_pwrb_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3615,7 +3678,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_key0_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3642,7 +3706,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_key1_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3669,7 +3734,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_key2_in_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3696,7 +3762,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_ac_present_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3723,7 +3790,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_ec_rst_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3750,7 +3818,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_flash_wp_l_h2l (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3777,7 +3846,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_pwrb_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3804,7 +3874,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_key0_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3831,7 +3902,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_key1_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3858,7 +3930,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_key2_in_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3885,7 +3958,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_ac_present_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3912,7 +3986,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_ec_rst_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3939,7 +4014,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_ctl_flash_wp_l_l2h (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3971,7 +4047,8 @@ module sysrst_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4004,7 +4081,8 @@ module sysrst_ctrl_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_debounce_ctl_debounce_timer (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4031,7 +4109,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_debounce_ctl_auto_block_enable (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4064,7 +4143,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_out_ctl_key0_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4091,7 +4171,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_out_ctl_key1_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4118,7 +4199,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_out_ctl_key2_out_sel (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4145,7 +4227,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_out_ctl_key0_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4172,7 +4255,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_out_ctl_key1_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4199,7 +4283,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_auto_block_out_ctl_key2_out_value (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4232,7 +4317,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_0_key0_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4259,7 +4345,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_0_key1_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4286,7 +4373,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_0_key2_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4313,7 +4401,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_0_pwrb_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4340,7 +4429,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_0_ac_present_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4373,7 +4463,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_1_key0_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4400,7 +4491,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_1_key1_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4427,7 +4519,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_1_key2_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4454,7 +4547,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_1_pwrb_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4481,7 +4575,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_1_ac_present_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4514,7 +4609,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_2_key0_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4541,7 +4637,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_2_key1_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4568,7 +4665,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_2_key2_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4595,7 +4693,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_2_pwrb_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4622,7 +4721,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_2_ac_present_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4655,7 +4755,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_3_key0_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4682,7 +4783,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_3_key1_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4709,7 +4811,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_3_key2_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4736,7 +4839,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_3_pwrb_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4763,7 +4867,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_sel_ctl_3_ac_present_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4795,7 +4900,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_det_ctl_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4827,7 +4933,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_det_ctl_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4859,7 +4966,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_det_ctl_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4891,7 +4999,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_pre_det_ctl_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4924,7 +5033,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_0_key0_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4951,7 +5061,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_0_key1_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -4978,7 +5089,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_0_key2_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5005,7 +5117,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_0_pwrb_in_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5032,7 +5145,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_0_ac_present_sel_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5065,7 +5179,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_1_key0_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5092,7 +5207,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_1_key1_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5119,7 +5235,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_1_key2_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5146,7 +5263,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_1_pwrb_in_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5173,7 +5291,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_1_ac_present_sel_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5206,7 +5325,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_2_key0_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5233,7 +5353,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_2_key1_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5260,7 +5381,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_2_key2_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5287,7 +5409,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_2_pwrb_in_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5314,7 +5437,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_2_ac_present_sel_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5347,7 +5471,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_3_key0_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5374,7 +5499,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_3_key1_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5401,7 +5527,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_3_key2_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5428,7 +5555,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_3_pwrb_in_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5455,7 +5583,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_sel_ctl_3_ac_present_sel_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5487,7 +5616,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_det_ctl_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5519,7 +5649,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_det_ctl_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5551,7 +5682,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_det_ctl_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5583,7 +5715,8 @@ module sysrst_ctrl_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_det_ctl_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5616,7 +5749,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_0_bat_disable_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5643,7 +5777,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_0_interrupt_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5670,7 +5805,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_0_ec_rst_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5697,7 +5833,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_0_rst_req_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5730,7 +5867,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_1_bat_disable_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5757,7 +5895,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_1_interrupt_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5784,7 +5923,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_1_ec_rst_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5811,7 +5951,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_1_rst_req_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5844,7 +5985,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_2_bat_disable_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5871,7 +6013,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_2_interrupt_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5898,7 +6041,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_2_ec_rst_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5925,7 +6069,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_2_rst_req_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5958,7 +6103,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_3_bat_disable_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -5985,7 +6131,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_3_interrupt_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6012,7 +6159,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_3_ec_rst_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6039,7 +6187,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_com_out_ctl_3_rst_req_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -6068,7 +6217,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_combo_intr_status_combo0_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6095,7 +6245,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_combo_intr_status_combo1_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6122,7 +6273,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_combo_intr_status_combo2_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6149,7 +6301,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_combo_intr_status_combo3_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6178,7 +6331,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_pwrb_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6205,7 +6359,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_key0_in_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6232,7 +6387,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_key1_in_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6259,7 +6415,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_key2_in_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6286,7 +6443,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_ac_present_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6313,7 +6471,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_ec_rst_l_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6340,7 +6499,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_flash_wp_l_h2l (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6367,7 +6527,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_pwrb_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6394,7 +6555,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_key0_in_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6421,7 +6583,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_key1_in_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6448,7 +6611,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_key2_in_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6475,7 +6639,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_ac_present_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6502,7 +6667,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_ec_rst_l_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6529,7 +6695,8 @@ module sysrst_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_key_intr_status_flash_wp_l_l2h (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -207,7 +207,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hbc614e),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -236,7 +237,8 @@ module trial1_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -263,7 +265,8 @@ module trial1_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -290,7 +293,8 @@ module trial1_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -317,7 +321,8 @@ module trial1_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h64),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype1_field15_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -345,7 +350,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4000400),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -374,7 +380,8 @@ module trial1_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'hcc55),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -401,7 +408,8 @@ module trial1_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'hee66),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -430,7 +438,8 @@ module trial1_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h4000),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -457,7 +466,8 @@ module trial1_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h8000),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -485,7 +495,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h11111111),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rotype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +524,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'hbbccddee),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_w1ctype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +554,8 @@ module trial1_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (16'heeee),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_w1ctype1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -569,7 +582,8 @@ module trial1_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (16'h7777),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_w1ctype1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -597,7 +611,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'haa775566),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_w1ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -625,7 +640,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (32'h11224488),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_w1stype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -653,7 +669,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (32'hfec8137f),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_w0ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -681,7 +698,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'haa775566),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_r0w1ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -709,7 +727,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h77443399),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rctype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -737,7 +756,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h11223344),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wotype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -766,7 +786,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -793,7 +814,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -820,7 +842,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -847,7 +870,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h4),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -874,7 +898,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (4'h5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -901,7 +926,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -928,7 +954,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -955,7 +982,8 @@ module trial1_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (4'h8),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mixtype0_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -994,7 +1022,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hbabababa),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1073,7 +1102,8 @@ module trial1_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf6f6f6f6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rwtype7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -208,7 +208,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hbc614e),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -238,7 +238,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -266,7 +266,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -294,7 +294,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -322,7 +322,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h64),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype1_field15_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -351,7 +351,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4000400),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -381,7 +381,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'hcc55),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -409,7 +409,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'hee66),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -439,7 +439,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h4000),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -467,7 +467,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h8000),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -496,7 +496,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h11111111),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rotype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -525,7 +525,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'hbbccddee),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_w1ctype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -555,7 +555,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (16'heeee),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_w1ctype1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -583,7 +583,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (16'h7777),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_w1ctype1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -612,7 +612,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'haa775566),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_w1ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -641,7 +641,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (32'h11224488),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_w1stype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -670,7 +670,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (32'hfec8137f),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_w0ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -699,7 +699,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'haa775566),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_r0w1ctype2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -728,7 +728,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h77443399),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rctype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -757,7 +757,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (32'h11223344),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wotype0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -787,7 +787,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -815,7 +815,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +843,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -871,7 +871,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h4),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -899,7 +899,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (4'h5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -927,7 +927,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -955,7 +955,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -983,7 +983,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (4'h8),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mixtype0_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1023,7 +1023,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hbabababa),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1103,7 +1103,7 @@ module trial1_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf6f6f6f6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rwtype7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -240,7 +240,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -268,7 +268,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -296,7 +296,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tx_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -324,7 +324,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -352,7 +352,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_frame_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -380,7 +380,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_break_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -408,7 +408,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -436,7 +436,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_parity_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -464,7 +464,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_tx_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -494,7 +494,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -522,7 +522,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -550,7 +550,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tx_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -578,7 +578,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -606,7 +606,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_frame_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -634,7 +634,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_break_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -662,7 +662,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -690,7 +690,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_parity_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +718,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_tx_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -917,7 +917,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_tx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -945,7 +945,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_rx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +973,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_nf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1001,7 +1001,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_slpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1029,7 +1029,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_llpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1057,7 +1057,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_parity_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1085,7 +1085,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_parity_odd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1113,7 +1113,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_rxblvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1141,7 +1141,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_nco (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1289,7 +1289,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wdata (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1331,7 +1331,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1360,7 +1360,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1389,7 +1389,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_rxilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1418,7 +1418,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_txilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1481,7 +1481,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ovrd_txen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1509,7 +1509,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ovrd_txval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1555,7 +1555,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (24'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1583,7 +1583,7 @@ module uart_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -239,7 +239,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -266,7 +267,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -293,7 +295,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tx_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -320,7 +323,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -347,7 +351,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_frame_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -374,7 +379,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_break_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -401,7 +407,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -428,7 +435,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_parity_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -455,7 +463,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_tx_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -484,7 +493,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -511,7 +521,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -538,7 +549,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tx_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -565,7 +577,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -592,7 +605,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_frame_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +633,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_break_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -646,7 +661,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -673,7 +689,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_parity_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -700,7 +717,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_tx_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -898,7 +916,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_tx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -925,7 +944,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_rx (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -952,7 +972,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_nf (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -979,7 +1000,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_slpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1006,7 +1028,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_llpbk (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1033,7 +1056,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_parity_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1060,7 +1084,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_parity_odd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1087,7 +1112,8 @@ module uart_reg_top
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_rxblvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1114,7 +1140,8 @@ module uart_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_nco (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1288,8 @@ module uart_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wdata (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1302,7 +1330,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_rxrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1330,7 +1359,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_txrst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1358,7 +1388,8 @@ module uart_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_rxilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1386,7 +1417,8 @@ module uart_reg_top
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_txilvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1448,7 +1480,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ovrd_txen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1475,7 +1508,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ovrd_txval (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1520,7 +1554,8 @@ module uart_reg_top
     .DW      (24),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (24'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timeout_ctrl_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1547,7 +1582,8 @@ module uart_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_timeout_ctrl_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -874,7 +874,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_pkt_received (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -902,7 +902,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_pkt_sent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -930,7 +930,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_disconnected (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -958,7 +958,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_host_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -986,7 +986,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_link_reset (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1014,7 +1014,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_link_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1042,7 +1042,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_link_resume (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1070,7 +1070,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_av_out_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1098,7 +1098,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1126,7 +1126,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_av_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1154,7 +1154,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_link_in_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1182,7 +1182,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_crc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1210,7 +1210,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_pid_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1238,7 +1238,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rx_bitstuff_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1266,7 +1266,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_frame (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1294,7 +1294,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_powered (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1322,7 +1322,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_link_out_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1350,7 +1350,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_av_setup_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1380,7 +1380,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_pkt_received (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1408,7 +1408,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_pkt_sent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1436,7 +1436,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_disconnected (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1464,7 +1464,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_host_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1492,7 +1492,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_link_reset (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1520,7 +1520,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_link_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1548,7 +1548,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_link_resume (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1576,7 +1576,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_av_out_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1604,7 +1604,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1632,7 +1632,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_av_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1660,7 +1660,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_link_in_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1688,7 +1688,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_crc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1716,7 +1716,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_pid_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1744,7 +1744,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rx_bitstuff_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1772,7 +1772,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_frame (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1800,7 +1800,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_powered (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1828,7 +1828,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_link_out_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1856,7 +1856,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_av_setup_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2210,7 +2210,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usbctrl_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2238,7 +2238,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usbctrl_resume_link_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2267,7 +2267,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usbctrl_device_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2298,7 +2298,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2326,7 +2326,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2354,7 +2354,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2382,7 +2382,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2410,7 +2410,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2438,7 +2438,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2466,7 +2466,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2494,7 +2494,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2522,7 +2522,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2550,7 +2550,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2578,7 +2578,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2606,7 +2606,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_out_enable_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2637,7 +2637,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2665,7 +2665,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2693,7 +2693,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2721,7 +2721,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2749,7 +2749,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2777,7 +2777,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2805,7 +2805,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2833,7 +2833,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2861,7 +2861,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2889,7 +2889,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2917,7 +2917,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2945,7 +2945,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ep_in_enable_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3230,7 +3230,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3258,7 +3258,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3286,7 +3286,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3314,7 +3314,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3342,7 +3342,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3370,7 +3370,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3398,7 +3398,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3426,7 +3426,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3454,7 +3454,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3482,7 +3482,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3510,7 +3510,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3538,7 +3538,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_setup_setup_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3569,7 +3569,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3597,7 +3597,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3625,7 +3625,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3653,7 +3653,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3681,7 +3681,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3709,7 +3709,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3737,7 +3737,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3765,7 +3765,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3793,7 +3793,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3821,7 +3821,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3849,7 +3849,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3877,7 +3877,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rxenable_out_out_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3908,7 +3908,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3936,7 +3936,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3964,7 +3964,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3992,7 +3992,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4020,7 +4020,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4048,7 +4048,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4076,7 +4076,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4104,7 +4104,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4132,7 +4132,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4160,7 +4160,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4188,7 +4188,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4216,7 +4216,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_set_nak_out_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4247,7 +4247,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4275,7 +4275,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4303,7 +4303,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4331,7 +4331,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4359,7 +4359,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4387,7 +4387,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4415,7 +4415,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4443,7 +4443,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4471,7 +4471,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4499,7 +4499,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4527,7 +4527,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4555,7 +4555,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_sent_sent_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4586,7 +4586,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4614,7 +4614,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4642,7 +4642,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4670,7 +4670,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4698,7 +4698,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4726,7 +4726,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4754,7 +4754,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4782,7 +4782,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4810,7 +4810,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4838,7 +4838,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4866,7 +4866,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4894,7 +4894,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4925,7 +4925,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4953,7 +4953,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4981,7 +4981,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5009,7 +5009,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5037,7 +5037,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5065,7 +5065,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5093,7 +5093,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5121,7 +5121,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5149,7 +5149,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5177,7 +5177,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5205,7 +5205,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5233,7 +5233,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5264,7 +5264,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_0_buffer_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5292,7 +5292,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5320,7 +5320,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_0_sending_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5348,7 +5348,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_0_pend_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5376,7 +5376,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_0_rdy_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5407,7 +5407,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_1_buffer_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5435,7 +5435,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5463,7 +5463,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_1_sending_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5491,7 +5491,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_1_pend_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5519,7 +5519,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_1_rdy_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5550,7 +5550,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_2_buffer_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5578,7 +5578,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5606,7 +5606,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_2_sending_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5634,7 +5634,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_2_pend_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5662,7 +5662,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_2_rdy_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5693,7 +5693,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_3_buffer_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5721,7 +5721,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5749,7 +5749,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_3_sending_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5777,7 +5777,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_3_pend_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5805,7 +5805,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_3_rdy_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5836,7 +5836,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_4_buffer_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5864,7 +5864,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5892,7 +5892,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_4_sending_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5920,7 +5920,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_4_pend_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5948,7 +5948,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_4_rdy_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5979,7 +5979,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_5_buffer_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6007,7 +6007,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6035,7 +6035,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_5_sending_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6063,7 +6063,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_5_pend_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6091,7 +6091,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_5_rdy_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6122,7 +6122,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_6_buffer_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6150,7 +6150,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6178,7 +6178,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_6_sending_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6206,7 +6206,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_6_pend_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6234,7 +6234,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_6_rdy_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6265,7 +6265,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_7_buffer_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6293,7 +6293,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6321,7 +6321,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_7_sending_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6349,7 +6349,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_7_pend_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6377,7 +6377,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_7_rdy_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6408,7 +6408,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_8_buffer_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6436,7 +6436,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_8_size_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6464,7 +6464,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_8_sending_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6492,7 +6492,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_8_pend_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6520,7 +6520,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_8_rdy_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6551,7 +6551,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_9_buffer_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6579,7 +6579,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_9_size_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6607,7 +6607,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_9_sending_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6635,7 +6635,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_9_pend_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6663,7 +6663,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_9_rdy_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6694,7 +6694,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_10_buffer_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6722,7 +6722,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_10_size_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6750,7 +6750,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_10_sending_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6778,7 +6778,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_10_pend_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6806,7 +6806,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_10_rdy_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6837,7 +6837,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_11_buffer_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6865,7 +6865,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_11_size_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6893,7 +6893,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_11_sending_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6921,7 +6921,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_11_pend_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6949,7 +6949,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_configin_11_rdy_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6980,7 +6980,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7008,7 +7008,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7036,7 +7036,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7064,7 +7064,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7092,7 +7092,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7120,7 +7120,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7148,7 +7148,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7176,7 +7176,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7204,7 +7204,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7232,7 +7232,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7260,7 +7260,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7288,7 +7288,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_out_iso_iso_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7319,7 +7319,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7347,7 +7347,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7375,7 +7375,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7403,7 +7403,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7431,7 +7431,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7459,7 +7459,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7487,7 +7487,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7515,7 +7515,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7543,7 +7543,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7571,7 +7571,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7599,7 +7599,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7627,7 +7627,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_in_iso_iso_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7868,7 +7868,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_dp_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7896,7 +7896,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_dn_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7924,7 +7924,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_d_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7952,7 +7952,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_se0_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7980,7 +7980,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_oe_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8008,7 +8008,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_rx_enable_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8036,7 +8036,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_dp_pullup_en_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8064,7 +8064,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_dn_pullup_en_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8092,7 +8092,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_pins_drive_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8122,7 +8122,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_config_use_diff_rcvr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8150,7 +8150,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_config_tx_use_d_se0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8178,7 +8178,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_config_eop_single_bit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8206,7 +8206,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_config_pinflip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8234,7 +8234,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_config_usb_ref_disable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8262,7 +8262,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_config_tx_osc_test_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8456,7 +8456,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_avout_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8485,7 +8485,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_avsetup_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8514,7 +8514,7 @@ module usbdev_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_ctrl_rx_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -873,7 +873,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_pkt_received (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -900,7 +901,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_pkt_sent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -927,7 +929,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_disconnected (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -954,7 +957,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_host_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -981,7 +985,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_link_reset (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1008,7 +1013,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_link_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1035,7 +1041,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_link_resume (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1062,7 +1069,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_av_out_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1089,7 +1097,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1116,7 +1125,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_av_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1143,7 +1153,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_link_in_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1170,7 +1181,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_crc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1197,7 +1209,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_pid_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1224,7 +1237,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rx_bitstuff_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1251,7 +1265,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_frame (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1278,7 +1293,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_powered (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1305,7 +1321,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_link_out_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1332,7 +1349,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_av_setup_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1361,7 +1379,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_pkt_received (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1388,7 +1407,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_pkt_sent (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1415,7 +1435,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_disconnected (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1442,7 +1463,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_host_lost (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1469,7 +1491,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_link_reset (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1496,7 +1519,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_link_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1523,7 +1547,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_link_resume (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1550,7 +1575,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_av_out_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1577,7 +1603,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1604,7 +1631,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_av_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1631,7 +1659,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_link_in_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1658,7 +1687,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_crc_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1685,7 +1715,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_pid_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1712,7 +1743,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rx_bitstuff_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1739,7 +1771,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_frame (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1766,7 +1799,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_powered (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1793,7 +1827,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_link_out_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1820,7 +1855,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_av_setup_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2173,7 +2209,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usbctrl_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2200,7 +2237,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usbctrl_resume_link_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2228,7 +2266,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usbctrl_device_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2258,7 +2297,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2285,7 +2325,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2312,7 +2353,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2339,7 +2381,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2366,7 +2409,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2393,7 +2437,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2420,7 +2465,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2447,7 +2493,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2474,7 +2521,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2501,7 +2549,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2528,7 +2577,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2555,7 +2605,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_out_enable_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2585,7 +2636,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2612,7 +2664,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2639,7 +2692,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2666,7 +2720,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2693,7 +2748,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2720,7 +2776,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2747,7 +2804,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2774,7 +2832,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2801,7 +2860,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2828,7 +2888,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2855,7 +2916,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2882,7 +2944,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ep_in_enable_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3166,7 +3229,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3193,7 +3257,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3220,7 +3285,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3247,7 +3313,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3274,7 +3341,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3301,7 +3369,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3328,7 +3397,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3355,7 +3425,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3382,7 +3453,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3409,7 +3481,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3436,7 +3509,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3463,7 +3537,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_setup_setup_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3493,7 +3568,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3520,7 +3596,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3547,7 +3624,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3574,7 +3652,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3601,7 +3680,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3628,7 +3708,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3655,7 +3736,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3682,7 +3764,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3709,7 +3792,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3736,7 +3820,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3763,7 +3848,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3790,7 +3876,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rxenable_out_out_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3820,7 +3907,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3847,7 +3935,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3874,7 +3963,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3901,7 +3991,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3928,7 +4019,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3955,7 +4047,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3982,7 +4075,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4009,7 +4103,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4036,7 +4131,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4063,7 +4159,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4090,7 +4187,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4117,7 +4215,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_set_nak_out_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4147,7 +4246,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4274,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4201,7 +4302,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4228,7 +4330,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4255,7 +4358,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4282,7 +4386,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4309,7 +4414,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4336,7 +4442,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4363,7 +4470,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4390,7 +4498,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4417,7 +4526,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4444,7 +4554,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_sent_sent_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4474,7 +4585,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4501,7 +4613,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4528,7 +4641,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4555,7 +4669,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4582,7 +4697,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4609,7 +4725,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4636,7 +4753,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4663,7 +4781,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4690,7 +4809,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4717,7 +4837,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4744,7 +4865,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4771,7 +4893,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4801,7 +4924,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4828,7 +4952,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4855,7 +4980,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4882,7 +5008,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4909,7 +5036,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4936,7 +5064,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4963,7 +5092,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4990,7 +5120,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5017,7 +5148,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5044,7 +5176,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5071,7 +5204,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5098,7 +5232,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5128,7 +5263,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_0_buffer_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5155,7 +5291,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5182,7 +5319,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_0_sending_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5209,7 +5347,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_0_pend_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5236,7 +5375,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_0_rdy_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5266,7 +5406,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_1_buffer_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5293,7 +5434,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5320,7 +5462,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_1_sending_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5347,7 +5490,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_1_pend_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5374,7 +5518,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_1_rdy_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5404,7 +5549,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_2_buffer_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5431,7 +5577,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5458,7 +5605,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_2_sending_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5485,7 +5633,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_2_pend_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5512,7 +5661,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_2_rdy_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5542,7 +5692,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_3_buffer_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5569,7 +5720,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5596,7 +5748,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_3_sending_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5623,7 +5776,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_3_pend_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5650,7 +5804,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_3_rdy_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5680,7 +5835,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_4_buffer_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5707,7 +5863,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5734,7 +5891,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_4_sending_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5761,7 +5919,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_4_pend_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5788,7 +5947,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_4_rdy_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5818,7 +5978,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_5_buffer_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5845,7 +6006,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5872,7 +6034,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_5_sending_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5899,7 +6062,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_5_pend_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5926,7 +6090,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_5_rdy_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5956,7 +6121,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_6_buffer_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5983,7 +6149,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6010,7 +6177,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_6_sending_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6037,7 +6205,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_6_pend_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6064,7 +6233,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_6_rdy_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6094,7 +6264,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_7_buffer_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6121,7 +6292,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6148,7 +6320,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_7_sending_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6175,7 +6348,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_7_pend_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6202,7 +6376,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_7_rdy_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6232,7 +6407,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_8_buffer_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6259,7 +6435,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_8_size_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6286,7 +6463,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_8_sending_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6313,7 +6491,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_8_pend_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6340,7 +6519,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_8_rdy_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6370,7 +6550,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_9_buffer_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6397,7 +6578,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_9_size_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6424,7 +6606,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_9_sending_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6451,7 +6634,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_9_pend_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6478,7 +6662,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_9_rdy_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6508,7 +6693,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_10_buffer_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6535,7 +6721,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_10_size_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6562,7 +6749,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_10_sending_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6589,7 +6777,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_10_pend_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6616,7 +6805,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_10_rdy_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6646,7 +6836,8 @@ module usbdev_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_11_buffer_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6673,7 +6864,8 @@ module usbdev_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_11_size_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6700,7 +6892,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_11_sending_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6727,7 +6920,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_11_pend_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6754,7 +6948,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_configin_11_rdy_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6784,7 +6979,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6811,7 +7007,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6838,7 +7035,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6865,7 +7063,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6892,7 +7091,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6919,7 +7119,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6946,7 +7147,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6973,7 +7175,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7000,7 +7203,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7027,7 +7231,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7054,7 +7259,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7081,7 +7287,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_out_iso_iso_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7111,7 +7318,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7138,7 +7346,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7165,7 +7374,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7192,7 +7402,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7219,7 +7430,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7246,7 +7458,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7273,7 +7486,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7300,7 +7514,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7327,7 +7542,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7354,7 +7570,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7381,7 +7598,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7408,7 +7626,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_in_iso_iso_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7648,7 +7867,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_dp_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7675,7 +7895,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_dn_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7702,7 +7923,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_d_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7729,7 +7951,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_se0_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7756,7 +7979,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_oe_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7783,7 +8007,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_rx_enable_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7810,7 +8035,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_dp_pullup_en_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7837,7 +8063,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_dn_pullup_en_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7864,7 +8091,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_pins_drive_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7893,7 +8121,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_config_use_diff_rcvr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7920,7 +8149,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_config_tx_use_d_se0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7947,7 +8177,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_config_eop_single_bit (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7974,7 +8205,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_config_pinflip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8001,7 +8233,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_config_usb_ref_disable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8028,7 +8261,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_config_tx_osc_test_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8096,7 +8330,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_events_module_active (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -8123,7 +8358,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_events_disconnected (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -8150,7 +8386,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_events_bus_reset (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -8177,7 +8414,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_events_bus_not_idle (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -8217,7 +8455,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_avout_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8245,7 +8484,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_avsetup_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8273,7 +8513,8 @@ module usbdev_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_ctrl_rx_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_darjeeling/ip/ast/rtl/ast_reg_top.sv
@@ -230,7 +230,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -259,7 +259,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -288,7 +288,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -317,7 +317,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -346,7 +346,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -375,7 +375,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -404,7 +404,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -433,7 +433,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -462,7 +462,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h8),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -491,7 +491,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h9),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -520,7 +520,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'ha),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -549,7 +549,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hb),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -578,7 +578,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hc),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -607,7 +607,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hd),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -636,7 +636,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'he),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -665,7 +665,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -694,7 +694,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h10),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -723,7 +723,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h11),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -752,7 +752,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h12),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -781,7 +781,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h13),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -810,7 +810,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h14),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -839,7 +839,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h15),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -868,7 +868,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h16),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -897,7 +897,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h17),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -926,7 +926,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h18),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -955,7 +955,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h19),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -984,7 +984,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1a),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1013,7 +1013,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1b),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1042,7 +1042,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1c),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1071,7 +1071,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1d),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1121,7 +1121,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1151,7 +1151,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1181,7 +1181,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1211,7 +1211,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1241,7 +1241,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_darjeeling/ip/ast/rtl/ast_reg_top.sv
@@ -229,7 +229,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -257,7 +258,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -285,7 +287,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -313,7 +316,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -341,7 +345,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -369,7 +374,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -397,7 +403,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -425,7 +432,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -453,7 +461,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h8),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -481,7 +490,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h9),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -509,7 +519,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'ha),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -537,7 +548,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hb),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -565,7 +577,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hc),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +606,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hd),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -621,7 +635,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'he),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +664,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +693,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h10),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -705,7 +722,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h11),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -733,7 +751,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h12),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -761,7 +780,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h13),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -789,7 +809,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h14),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -817,7 +838,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h15),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -845,7 +867,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h16),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -873,7 +896,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h17),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -901,7 +925,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h18),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -929,7 +954,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h19),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -957,7 +983,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1a),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -985,7 +1012,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1b),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1013,7 +1041,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1c),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1041,7 +1070,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1d),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1090,7 +1120,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1119,7 +1150,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1148,7 +1180,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1177,7 +1210,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1206,7 +1240,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
@@ -166,7 +166,8 @@ module soc_proxy_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -194,7 +195,8 @@ module soc_proxy_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
@@ -167,7 +167,7 @@ module soc_proxy_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -196,7 +196,7 @@ module soc_proxy_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -1138,7 +1138,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1166,7 +1167,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1252,7 +1254,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_status_shadowed_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1279,7 +1282,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_status_shadowed_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1306,7 +1310,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1333,7 +1338,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_status_counter_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1373,7 +1379,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_config_log_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1400,7 +1407,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_config_log_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1428,7 +1436,8 @@ module ac_range_check_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_config_deny_cnt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1457,7 +1466,8 @@ module ac_range_check_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_deny_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1484,7 +1494,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_read_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1511,7 +1522,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_write_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1538,7 +1550,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_execute_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1565,7 +1578,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_no_match (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1592,7 +1606,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_racl_read (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1619,7 +1634,8 @@ module ac_range_check_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_racl_write (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1646,7 +1662,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_source_role (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1673,7 +1690,8 @@ module ac_range_check_reg_top
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_denied_ctn_uid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1700,7 +1718,8 @@ module ac_range_check_reg_top
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_status_deny_range_index (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1728,7 +1747,8 @@ module ac_range_check_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_log_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1757,7 +1777,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1786,7 +1807,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1815,7 +1837,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1844,7 +1867,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1873,7 +1897,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1902,7 +1927,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1931,7 +1957,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1960,7 +1987,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1989,7 +2017,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2018,7 +2047,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2047,7 +2077,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2076,7 +2107,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2105,7 +2137,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2134,7 +2167,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2163,7 +2197,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2192,7 +2227,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2221,7 +2257,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2250,7 +2287,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2279,7 +2317,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2308,7 +2347,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2337,7 +2377,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2366,7 +2407,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2395,7 +2437,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2424,7 +2467,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2453,7 +2497,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2482,7 +2527,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2511,7 +2557,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2540,7 +2587,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2569,7 +2617,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2598,7 +2647,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2627,7 +2677,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2656,7 +2707,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2690,7 +2742,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2724,7 +2777,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2758,7 +2812,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2792,7 +2847,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2826,7 +2882,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2860,7 +2917,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2894,7 +2952,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2928,7 +2987,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2962,7 +3022,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2996,7 +3057,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3030,7 +3092,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3064,7 +3127,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3098,7 +3162,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3132,7 +3197,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3166,7 +3232,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3200,7 +3267,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3234,7 +3302,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3268,7 +3337,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3302,7 +3372,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3336,7 +3407,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3370,7 +3442,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3404,7 +3477,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3438,7 +3512,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3472,7 +3547,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3506,7 +3582,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3540,7 +3617,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3574,7 +3652,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3608,7 +3687,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3642,7 +3722,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3676,7 +3757,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3710,7 +3792,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3744,7 +3827,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_base_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3778,7 +3862,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3812,7 +3897,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3846,7 +3932,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3880,7 +3967,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3914,7 +4002,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3948,7 +4037,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3982,7 +4072,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4016,7 +4107,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4050,7 +4142,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4084,7 +4177,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4118,7 +4212,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4152,7 +4247,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4186,7 +4282,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4220,7 +4317,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4254,7 +4352,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4288,7 +4387,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4322,7 +4422,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4356,7 +4457,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4390,7 +4492,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4424,7 +4527,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4458,7 +4562,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4492,7 +4597,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4526,7 +4632,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4560,7 +4667,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4594,7 +4702,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4628,7 +4737,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4662,7 +4772,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4696,7 +4807,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4730,7 +4842,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4764,7 +4877,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4798,7 +4912,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4832,7 +4947,8 @@ module ac_range_check_reg_top
     .DW      (30),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_limit_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4867,7 +4983,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_0_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4894,7 +5011,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_0_read_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4921,7 +5039,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_0_write_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4948,7 +5067,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_0_execute_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4975,7 +5095,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_0_log_denied_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5010,7 +5131,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_1_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5037,7 +5159,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_1_read_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5064,7 +5187,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_1_write_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5091,7 +5215,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_1_execute_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5118,7 +5243,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_1_log_denied_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5153,7 +5279,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_2_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5180,7 +5307,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_2_read_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5207,7 +5335,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_2_write_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5234,7 +5363,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_2_execute_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5261,7 +5391,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_2_log_denied_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5296,7 +5427,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_3_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5323,7 +5455,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_3_read_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5350,7 +5483,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_3_write_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5377,7 +5511,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_3_execute_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5404,7 +5539,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_3_log_denied_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5439,7 +5575,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_4_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5466,7 +5603,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_4_read_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5493,7 +5631,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_4_write_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5520,7 +5659,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_4_execute_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5547,7 +5687,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_4_log_denied_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5582,7 +5723,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_5_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5609,7 +5751,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_5_read_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5636,7 +5779,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_5_write_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5663,7 +5807,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_5_execute_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5690,7 +5835,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_5_log_denied_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5725,7 +5871,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_6_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5752,7 +5899,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_6_read_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5779,7 +5927,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_6_write_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5806,7 +5955,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_6_execute_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5833,7 +5983,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_6_log_denied_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5868,7 +6019,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_7_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5895,7 +6047,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_7_read_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5922,7 +6075,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_7_write_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5949,7 +6103,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_7_execute_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5976,7 +6131,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_7_log_denied_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6011,7 +6167,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_8_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6038,7 +6195,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_8_read_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6065,7 +6223,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_8_write_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6092,7 +6251,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_8_execute_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6119,7 +6279,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_8_log_denied_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6154,7 +6315,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_9_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6181,7 +6343,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_9_read_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6208,7 +6371,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_9_write_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6235,7 +6399,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_9_execute_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6262,7 +6427,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_9_log_denied_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6297,7 +6463,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_10_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6324,7 +6491,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_10_read_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6351,7 +6519,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_10_write_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6378,7 +6547,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_10_execute_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6405,7 +6575,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_10_log_denied_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6440,7 +6611,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_11_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6467,7 +6639,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_11_read_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6494,7 +6667,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_11_write_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6521,7 +6695,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_11_execute_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6548,7 +6723,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_11_log_denied_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6583,7 +6759,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_12_enable_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6610,7 +6787,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_12_read_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6637,7 +6815,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_12_write_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6664,7 +6843,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_12_execute_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6691,7 +6871,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_12_log_denied_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6726,7 +6907,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_13_enable_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6753,7 +6935,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_13_read_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6780,7 +6963,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_13_write_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6807,7 +6991,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_13_execute_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6834,7 +7019,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_13_log_denied_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6869,7 +7055,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_14_enable_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6896,7 +7083,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_14_read_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6923,7 +7111,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_14_write_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6950,7 +7139,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_14_execute_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6977,7 +7167,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_14_log_denied_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7012,7 +7203,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_15_enable_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7039,7 +7231,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_15_read_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7066,7 +7259,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_15_write_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7093,7 +7287,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_15_execute_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7120,7 +7315,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_15_log_denied_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7155,7 +7351,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_16_enable_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7182,7 +7379,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_16_read_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7209,7 +7407,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_16_write_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7236,7 +7435,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_16_execute_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7263,7 +7463,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_16_log_denied_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7298,7 +7499,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_17_enable_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7325,7 +7527,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_17_read_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7352,7 +7555,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_17_write_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7379,7 +7583,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_17_execute_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7406,7 +7611,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_17_log_denied_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7441,7 +7647,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_18_enable_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7468,7 +7675,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_18_read_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7495,7 +7703,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_18_write_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7522,7 +7731,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_18_execute_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7549,7 +7759,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_18_log_denied_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7584,7 +7795,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_19_enable_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7611,7 +7823,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_19_read_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7638,7 +7851,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_19_write_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7665,7 +7879,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_19_execute_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7692,7 +7907,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_19_log_denied_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7727,7 +7943,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_20_enable_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7754,7 +7971,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_20_read_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7781,7 +7999,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_20_write_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7808,7 +8027,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_20_execute_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7835,7 +8055,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_20_log_denied_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7870,7 +8091,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_21_enable_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7897,7 +8119,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_21_read_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7924,7 +8147,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_21_write_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7951,7 +8175,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_21_execute_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7978,7 +8203,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_21_log_denied_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8013,7 +8239,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_22_enable_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8040,7 +8267,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_22_read_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8067,7 +8295,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_22_write_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8094,7 +8323,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_22_execute_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8121,7 +8351,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_22_log_denied_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8156,7 +8387,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_23_enable_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8183,7 +8415,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_23_read_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8210,7 +8443,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_23_write_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8237,7 +8471,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_23_execute_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8264,7 +8499,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_23_log_denied_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8299,7 +8535,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_24_enable_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8326,7 +8563,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_24_read_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8353,7 +8591,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_24_write_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8380,7 +8619,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_24_execute_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8407,7 +8647,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_24_log_denied_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8442,7 +8683,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_25_enable_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8469,7 +8711,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_25_read_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8496,7 +8739,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_25_write_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8523,7 +8767,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_25_execute_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8550,7 +8795,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_25_log_denied_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8585,7 +8831,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_26_enable_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8612,7 +8859,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_26_read_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8639,7 +8887,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_26_write_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8666,7 +8915,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_26_execute_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8693,7 +8943,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_26_log_denied_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8728,7 +8979,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_27_enable_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8755,7 +9007,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_27_read_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8782,7 +9035,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_27_write_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8809,7 +9063,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_27_execute_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8836,7 +9091,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_27_log_denied_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8871,7 +9127,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_28_enable_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8898,7 +9155,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_28_read_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8925,7 +9183,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_28_write_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8952,7 +9211,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_28_execute_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8979,7 +9239,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_28_log_denied_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9014,7 +9275,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_29_enable_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9041,7 +9303,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_29_read_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9068,7 +9331,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_29_write_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9095,7 +9359,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_29_execute_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9122,7 +9387,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_29_log_denied_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9157,7 +9423,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_30_enable_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9184,7 +9451,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_30_read_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9211,7 +9479,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_30_write_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9238,7 +9507,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_30_execute_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9265,7 +9535,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_30_log_denied_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9300,7 +9571,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_31_enable_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9327,7 +9599,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_31_read_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9354,7 +9627,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_31_write_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9381,7 +9655,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_31_execute_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9408,7 +9683,8 @@ module ac_range_check_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_range_perm_31_log_denied_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9443,7 +9719,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_0_read_perm_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9479,7 +9756,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_0_write_perm_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9523,7 +9801,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_1_read_perm_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9559,7 +9838,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_1_write_perm_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9603,7 +9883,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_2_read_perm_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9639,7 +9920,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_2_write_perm_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9683,7 +9965,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_3_read_perm_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9719,7 +10002,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_3_write_perm_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9763,7 +10047,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_4_read_perm_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9799,7 +10084,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_4_write_perm_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9843,7 +10129,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_5_read_perm_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9879,7 +10166,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_5_write_perm_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9923,7 +10211,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_6_read_perm_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9959,7 +10248,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_6_write_perm_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10003,7 +10293,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_7_read_perm_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10039,7 +10330,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_7_write_perm_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10083,7 +10375,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_8_read_perm_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10119,7 +10412,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_8_write_perm_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10163,7 +10457,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_9_read_perm_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10199,7 +10494,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_9_write_perm_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10243,7 +10539,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_10_read_perm_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10279,7 +10576,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_10_write_perm_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10323,7 +10621,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_11_read_perm_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10359,7 +10658,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_11_write_perm_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10403,7 +10703,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_12_read_perm_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10439,7 +10740,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_12_write_perm_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10483,7 +10785,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_13_read_perm_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10519,7 +10822,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_13_write_perm_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10563,7 +10867,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_14_read_perm_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10599,7 +10904,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_14_write_perm_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10643,7 +10949,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_15_read_perm_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10679,7 +10986,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_15_write_perm_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10723,7 +11031,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_16_read_perm_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10759,7 +11068,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_16_write_perm_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10803,7 +11113,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_17_read_perm_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10839,7 +11150,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_17_write_perm_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10883,7 +11195,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_18_read_perm_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10919,7 +11232,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_18_write_perm_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10963,7 +11277,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_19_read_perm_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10999,7 +11314,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_19_write_perm_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11043,7 +11359,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_20_read_perm_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11079,7 +11396,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_20_write_perm_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11123,7 +11441,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_21_read_perm_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11159,7 +11478,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_21_write_perm_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11203,7 +11523,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_22_read_perm_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11239,7 +11560,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_22_write_perm_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11283,7 +11605,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_23_read_perm_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11319,7 +11642,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_23_write_perm_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11363,7 +11687,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_24_read_perm_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11399,7 +11724,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_24_write_perm_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11443,7 +11769,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_25_read_perm_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11479,7 +11806,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_25_write_perm_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11523,7 +11851,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_26_read_perm_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11559,7 +11888,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_26_write_perm_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11603,7 +11933,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_27_read_perm_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11639,7 +11970,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_27_write_perm_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11683,7 +12015,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_28_read_perm_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11719,7 +12052,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_28_write_perm_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11763,7 +12097,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_29_read_perm_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11799,7 +12134,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_29_write_perm_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11843,7 +12179,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_30_read_perm_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11879,7 +12216,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_30_write_perm_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11923,7 +12261,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_31_read_perm_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11959,7 +12298,8 @@ module ac_range_check_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_range_racl_policy_shadowed_31_write_perm_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -1139,7 +1139,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1168,7 +1168,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1255,7 +1255,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_status_shadowed_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1283,7 +1283,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_status_shadowed_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1311,7 +1311,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1339,7 +1339,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_status_counter_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1380,7 +1380,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_config_log_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1408,7 +1408,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_config_log_clear (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1437,7 +1437,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_config_deny_cnt_threshold (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1467,7 +1467,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_deny_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1495,7 +1495,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_read_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1523,7 +1523,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_write_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1551,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_execute_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1579,7 +1579,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_no_match (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1607,7 +1607,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_racl_read (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1635,7 +1635,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_racl_write (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1663,7 +1663,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_source_role (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1691,7 +1691,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_denied_ctn_uid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1719,7 +1719,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_status_deny_range_index (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1748,7 +1748,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_log_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1778,7 +1778,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1808,7 +1808,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1838,7 +1838,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1868,7 +1868,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1898,7 +1898,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1928,7 +1928,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1958,7 +1958,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1988,7 +1988,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2018,7 +2018,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2048,7 +2048,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2078,7 +2078,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2108,7 +2108,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2138,7 +2138,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2168,7 +2168,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2198,7 +2198,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2228,7 +2228,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2258,7 +2258,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2288,7 +2288,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2318,7 +2318,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2348,7 +2348,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2378,7 +2378,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2408,7 +2408,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2438,7 +2438,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2468,7 +2468,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2498,7 +2498,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2528,7 +2528,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2558,7 +2558,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2588,7 +2588,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2618,7 +2618,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2648,7 +2648,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2678,7 +2678,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2708,7 +2708,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2743,7 +2743,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2778,7 +2778,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2813,7 +2813,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2848,7 +2848,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2883,7 +2883,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2918,7 +2918,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2953,7 +2953,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2988,7 +2988,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3023,7 +3023,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3058,7 +3058,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3093,7 +3093,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3128,7 +3128,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3163,7 +3163,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3198,7 +3198,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3233,7 +3233,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3268,7 +3268,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3303,7 +3303,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3338,7 +3338,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3373,7 +3373,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3408,7 +3408,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3443,7 +3443,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3478,7 +3478,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3513,7 +3513,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3548,7 +3548,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3583,7 +3583,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3618,7 +3618,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3653,7 +3653,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3688,7 +3688,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3723,7 +3723,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3758,7 +3758,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3793,7 +3793,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3828,7 +3828,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_base_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3863,7 +3863,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3898,7 +3898,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3933,7 +3933,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3968,7 +3968,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4003,7 +4003,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4038,7 +4038,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4073,7 +4073,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4108,7 +4108,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4143,7 +4143,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4178,7 +4178,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4213,7 +4213,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4248,7 +4248,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4283,7 +4283,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4318,7 +4318,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4353,7 +4353,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4388,7 +4388,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4423,7 +4423,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4458,7 +4458,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4493,7 +4493,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4528,7 +4528,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4563,7 +4563,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4598,7 +4598,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4633,7 +4633,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4668,7 +4668,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4703,7 +4703,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4738,7 +4738,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4773,7 +4773,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4808,7 +4808,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4843,7 +4843,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4878,7 +4878,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4913,7 +4913,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4948,7 +4948,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (30'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_limit_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4984,7 +4984,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_0_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5012,7 +5012,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_0_read_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5040,7 +5040,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_0_write_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5068,7 +5068,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_0_execute_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5096,7 +5096,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_0_log_denied_access_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5132,7 +5132,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_1_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5160,7 +5160,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_1_read_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5188,7 +5188,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_1_write_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5216,7 +5216,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_1_execute_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5244,7 +5244,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_1_log_denied_access_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5280,7 +5280,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_2_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5308,7 +5308,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_2_read_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5336,7 +5336,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_2_write_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5364,7 +5364,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_2_execute_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5392,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_2_log_denied_access_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5428,7 +5428,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_3_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5456,7 +5456,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_3_read_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5484,7 +5484,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_3_write_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5512,7 +5512,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_3_execute_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5540,7 +5540,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_3_log_denied_access_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5576,7 +5576,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_4_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5604,7 +5604,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_4_read_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5632,7 +5632,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_4_write_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5660,7 +5660,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_4_execute_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5688,7 +5688,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_4_log_denied_access_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5724,7 +5724,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_5_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5752,7 +5752,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_5_read_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5780,7 +5780,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_5_write_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5808,7 +5808,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_5_execute_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5836,7 +5836,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_5_log_denied_access_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5872,7 +5872,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_6_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5900,7 +5900,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_6_read_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5928,7 +5928,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_6_write_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5956,7 +5956,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_6_execute_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5984,7 +5984,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_6_log_denied_access_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6020,7 +6020,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_7_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6048,7 +6048,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_7_read_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6076,7 +6076,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_7_write_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6104,7 +6104,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_7_execute_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6132,7 +6132,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_7_log_denied_access_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6168,7 +6168,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_8_enable_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6196,7 +6196,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_8_read_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6224,7 +6224,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_8_write_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6252,7 +6252,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_8_execute_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6280,7 +6280,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_8_log_denied_access_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6316,7 +6316,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_9_enable_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6344,7 +6344,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_9_read_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6372,7 +6372,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_9_write_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6400,7 +6400,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_9_execute_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6428,7 +6428,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_9_log_denied_access_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6464,7 +6464,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_10_enable_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6492,7 +6492,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_10_read_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6520,7 +6520,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_10_write_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6548,7 +6548,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_10_execute_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6576,7 +6576,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_10_log_denied_access_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6612,7 +6612,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_11_enable_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6640,7 +6640,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_11_read_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6668,7 +6668,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_11_write_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6696,7 +6696,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_11_execute_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6724,7 +6724,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_11_log_denied_access_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6760,7 +6760,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_12_enable_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6788,7 +6788,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_12_read_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6816,7 +6816,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_12_write_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6844,7 +6844,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_12_execute_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6872,7 +6872,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_12_log_denied_access_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6908,7 +6908,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_13_enable_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6936,7 +6936,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_13_read_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6964,7 +6964,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_13_write_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6992,7 +6992,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_13_execute_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7020,7 +7020,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_13_log_denied_access_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7056,7 +7056,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_14_enable_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7084,7 +7084,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_14_read_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7112,7 +7112,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_14_write_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7140,7 +7140,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_14_execute_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7168,7 +7168,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_14_log_denied_access_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7204,7 +7204,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_15_enable_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7232,7 +7232,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_15_read_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7260,7 +7260,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_15_write_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7288,7 +7288,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_15_execute_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7316,7 +7316,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_15_log_denied_access_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7352,7 +7352,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_16_enable_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7380,7 +7380,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_16_read_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7408,7 +7408,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_16_write_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7436,7 +7436,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_16_execute_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7464,7 +7464,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_16_log_denied_access_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7500,7 +7500,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_17_enable_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7528,7 +7528,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_17_read_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7556,7 +7556,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_17_write_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7584,7 +7584,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_17_execute_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7612,7 +7612,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_17_log_denied_access_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7648,7 +7648,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_18_enable_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7676,7 +7676,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_18_read_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7704,7 +7704,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_18_write_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7732,7 +7732,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_18_execute_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7760,7 +7760,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_18_log_denied_access_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7796,7 +7796,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_19_enable_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7824,7 +7824,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_19_read_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7852,7 +7852,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_19_write_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7880,7 +7880,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_19_execute_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7908,7 +7908,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_19_log_denied_access_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7944,7 +7944,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_20_enable_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7972,7 +7972,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_20_read_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8000,7 +8000,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_20_write_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8028,7 +8028,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_20_execute_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8056,7 +8056,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_20_log_denied_access_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8092,7 +8092,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_21_enable_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8120,7 +8120,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_21_read_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8148,7 +8148,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_21_write_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8176,7 +8176,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_21_execute_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8204,7 +8204,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_21_log_denied_access_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8240,7 +8240,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_22_enable_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8268,7 +8268,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_22_read_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8296,7 +8296,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_22_write_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8324,7 +8324,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_22_execute_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8352,7 +8352,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_22_log_denied_access_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8388,7 +8388,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_23_enable_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8416,7 +8416,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_23_read_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8444,7 +8444,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_23_write_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8472,7 +8472,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_23_execute_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8500,7 +8500,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_23_log_denied_access_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8536,7 +8536,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_24_enable_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8564,7 +8564,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_24_read_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8592,7 +8592,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_24_write_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8620,7 +8620,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_24_execute_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8648,7 +8648,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_24_log_denied_access_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8684,7 +8684,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_25_enable_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8712,7 +8712,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_25_read_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8740,7 +8740,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_25_write_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8768,7 +8768,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_25_execute_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8796,7 +8796,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_25_log_denied_access_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8832,7 +8832,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_26_enable_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8860,7 +8860,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_26_read_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8888,7 +8888,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_26_write_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8916,7 +8916,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_26_execute_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8944,7 +8944,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_26_log_denied_access_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8980,7 +8980,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_27_enable_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9008,7 +9008,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_27_read_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9036,7 +9036,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_27_write_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9064,7 +9064,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_27_execute_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9092,7 +9092,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_27_log_denied_access_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9128,7 +9128,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_28_enable_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9156,7 +9156,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_28_read_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9184,7 +9184,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_28_write_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9212,7 +9212,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_28_execute_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9240,7 +9240,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_28_log_denied_access_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9276,7 +9276,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_29_enable_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9304,7 +9304,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_29_read_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9332,7 +9332,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_29_write_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9360,7 +9360,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_29_execute_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9388,7 +9388,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_29_log_denied_access_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9424,7 +9424,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_30_enable_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9452,7 +9452,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_30_read_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9480,7 +9480,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_30_write_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9508,7 +9508,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_30_execute_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9536,7 +9536,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_30_log_denied_access_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9572,7 +9572,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_31_enable_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9600,7 +9600,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_31_read_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9628,7 +9628,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_31_write_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9656,7 +9656,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_31_execute_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9684,7 +9684,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_perm_31_log_denied_access_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9720,7 +9720,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_0_read_perm_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9757,7 +9757,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_0_write_perm_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9802,7 +9802,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_1_read_perm_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9839,7 +9839,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_1_write_perm_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9884,7 +9884,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_2_read_perm_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9921,7 +9921,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_2_write_perm_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9966,7 +9966,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_3_read_perm_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10003,7 +10003,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_3_write_perm_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10048,7 +10048,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_4_read_perm_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10085,7 +10085,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_4_write_perm_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10130,7 +10130,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_5_read_perm_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10167,7 +10167,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_5_write_perm_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10212,7 +10212,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_6_read_perm_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10249,7 +10249,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_6_write_perm_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10294,7 +10294,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_7_read_perm_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10331,7 +10331,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_7_write_perm_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10376,7 +10376,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_8_read_perm_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10413,7 +10413,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_8_write_perm_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10458,7 +10458,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_9_read_perm_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10495,7 +10495,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_9_write_perm_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10540,7 +10540,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_10_read_perm_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10577,7 +10577,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_10_write_perm_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10622,7 +10622,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_11_read_perm_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10659,7 +10659,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_11_write_perm_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10704,7 +10704,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_12_read_perm_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10741,7 +10741,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_12_write_perm_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10786,7 +10786,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_13_read_perm_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10823,7 +10823,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_13_write_perm_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10868,7 +10868,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_14_read_perm_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10905,7 +10905,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_14_write_perm_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10950,7 +10950,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_15_read_perm_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10987,7 +10987,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_15_write_perm_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11032,7 +11032,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_16_read_perm_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11069,7 +11069,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_16_write_perm_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11114,7 +11114,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_17_read_perm_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11151,7 +11151,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_17_write_perm_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11196,7 +11196,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_18_read_perm_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11233,7 +11233,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_18_write_perm_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11278,7 +11278,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_19_read_perm_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11315,7 +11315,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_19_write_perm_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11360,7 +11360,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_20_read_perm_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11397,7 +11397,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_20_write_perm_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11442,7 +11442,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_21_read_perm_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11479,7 +11479,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_21_write_perm_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11524,7 +11524,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_22_read_perm_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11561,7 +11561,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_22_write_perm_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11606,7 +11606,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_23_read_perm_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11643,7 +11643,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_23_write_perm_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11688,7 +11688,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_24_read_perm_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11725,7 +11725,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_24_write_perm_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11770,7 +11770,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_25_read_perm_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11807,7 +11807,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_25_write_perm_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11852,7 +11852,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_26_read_perm_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11889,7 +11889,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_26_write_perm_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11934,7 +11934,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_27_read_perm_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11971,7 +11971,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_27_write_perm_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12016,7 +12016,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_28_read_perm_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12053,7 +12053,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_28_write_perm_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12098,7 +12098,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_29_read_perm_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12135,7 +12135,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_29_write_perm_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12180,7 +12180,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_30_read_perm_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12217,7 +12217,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_30_write_perm_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12262,7 +12262,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_31_read_perm_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12299,7 +12299,7 @@ module ac_range_check_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_range_racl_policy_shadowed_31_write_perm_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -2559,7 +2559,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2586,7 +2587,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2613,7 +2615,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2640,7 +2643,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2669,7 +2673,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2696,7 +2701,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2723,7 +2729,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2750,7 +2757,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2847,7 +2855,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ping_timer_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2878,7 +2887,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ping_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2918,7 +2928,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ping_timer_en_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +2967,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +2997,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3014,7 +3027,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3043,7 +3057,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3072,7 +3087,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3101,7 +3117,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3130,7 +3147,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3159,7 +3177,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3188,7 +3207,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3217,7 +3237,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3246,7 +3267,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3275,7 +3297,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3327,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3333,7 +3357,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3362,7 +3387,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3391,7 +3417,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3420,7 +3447,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3449,7 +3477,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3478,7 +3507,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3507,7 +3537,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3536,7 +3567,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3565,7 +3597,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3594,7 +3627,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3623,7 +3657,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3652,7 +3687,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3681,7 +3717,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3710,7 +3747,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3739,7 +3777,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3768,7 +3807,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3797,7 +3837,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3826,7 +3867,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3855,7 +3897,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3884,7 +3927,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3913,7 +3957,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3942,7 +3987,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3971,7 +4017,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4000,7 +4047,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4029,7 +4077,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4058,7 +4107,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4087,7 +4137,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4116,7 +4167,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4145,7 +4197,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4227,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4203,7 +4257,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4232,7 +4287,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4261,7 +4317,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4290,7 +4347,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4319,7 +4377,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4348,7 +4407,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4377,7 +4437,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4406,7 +4467,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4435,7 +4497,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4464,7 +4527,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4493,7 +4557,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4522,7 +4587,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4551,7 +4617,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4580,7 +4647,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4609,7 +4677,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4638,7 +4707,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4667,7 +4737,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4696,7 +4767,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4725,7 +4797,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4754,7 +4827,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4783,7 +4857,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4812,7 +4887,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4841,7 +4917,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4870,7 +4947,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4899,7 +4977,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4928,7 +5007,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4957,7 +5037,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4986,7 +5067,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5015,7 +5097,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5044,7 +5127,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5073,7 +5157,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5102,7 +5187,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5131,7 +5217,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5160,7 +5247,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5189,7 +5277,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5218,7 +5307,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5247,7 +5337,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5276,7 +5367,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5305,7 +5397,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5334,7 +5427,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5363,7 +5457,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5487,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5421,7 +5517,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5450,7 +5547,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5479,7 +5577,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5508,7 +5607,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5537,7 +5637,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5566,7 +5667,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5595,7 +5697,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5624,7 +5727,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5653,7 +5757,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5682,7 +5787,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5711,7 +5817,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5740,7 +5847,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5769,7 +5877,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5798,7 +5907,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5827,7 +5937,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5856,7 +5967,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5885,7 +5997,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5914,7 +6027,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5946,7 +6060,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5987,7 +6102,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6028,7 +6144,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6069,7 +6186,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6110,7 +6228,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6151,7 +6270,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6192,7 +6312,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6233,7 +6354,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6274,7 +6396,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6315,7 +6438,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6356,7 +6480,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6397,7 +6522,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6438,7 +6564,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6479,7 +6606,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6520,7 +6648,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6561,7 +6690,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6602,7 +6732,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6643,7 +6774,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6684,7 +6816,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6725,7 +6858,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6766,7 +6900,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6807,7 +6942,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6848,7 +6984,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6889,7 +7026,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6930,7 +7068,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6971,7 +7110,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7012,7 +7152,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7053,7 +7194,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7094,7 +7236,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7135,7 +7278,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7176,7 +7320,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7217,7 +7362,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7258,7 +7404,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7299,7 +7446,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7340,7 +7488,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7381,7 +7530,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7422,7 +7572,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7463,7 +7614,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7504,7 +7656,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7545,7 +7698,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7586,7 +7740,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7627,7 +7782,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7668,7 +7824,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7709,7 +7866,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7750,7 +7908,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7791,7 +7950,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7832,7 +7992,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7873,7 +8034,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7914,7 +8076,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7955,7 +8118,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7996,7 +8160,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8037,7 +8202,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8078,7 +8244,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8119,7 +8286,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8160,7 +8328,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8201,7 +8370,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8242,7 +8412,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8283,7 +8454,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8324,7 +8496,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8365,7 +8538,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8406,7 +8580,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8447,7 +8622,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8488,7 +8664,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8529,7 +8706,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8570,7 +8748,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8611,7 +8790,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8652,7 +8832,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8693,7 +8874,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8734,7 +8916,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8775,7 +8958,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8816,7 +9000,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8857,7 +9042,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8898,7 +9084,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8939,7 +9126,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8980,7 +9168,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9021,7 +9210,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9062,7 +9252,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9103,7 +9294,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9144,7 +9336,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9185,7 +9378,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9226,7 +9420,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9267,7 +9462,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9308,7 +9504,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9349,7 +9546,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9390,7 +9588,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9431,7 +9630,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9472,7 +9672,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9513,7 +9714,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9554,7 +9756,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9595,7 +9798,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9636,7 +9840,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9677,7 +9882,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9718,7 +9924,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9759,7 +9966,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9800,7 +10008,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9841,7 +10050,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9882,7 +10092,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9923,7 +10134,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9964,7 +10176,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10005,7 +10218,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10046,7 +10260,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10087,7 +10302,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10128,7 +10344,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10169,7 +10386,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10210,7 +10428,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10251,7 +10470,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10292,7 +10512,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10333,7 +10554,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10374,7 +10596,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10415,7 +10638,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10456,7 +10680,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10497,7 +10722,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10538,7 +10764,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10579,7 +10806,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10620,7 +10848,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10661,7 +10890,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10702,7 +10932,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10743,7 +10974,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10784,7 +11016,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10825,7 +11058,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10866,7 +11100,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10907,7 +11142,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10948,7 +11184,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10989,7 +11226,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11030,7 +11268,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11071,7 +11310,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11112,7 +11352,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11153,7 +11394,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11194,7 +11436,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11235,7 +11478,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11276,7 +11520,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11317,7 +11562,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11358,7 +11604,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11399,7 +11646,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11440,7 +11688,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11481,7 +11730,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11522,7 +11772,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11563,7 +11814,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11604,7 +11856,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11645,7 +11898,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11686,7 +11940,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11727,7 +11982,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11768,7 +12024,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11809,7 +12066,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11850,7 +12108,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11891,7 +12150,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11932,7 +12192,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11973,7 +12234,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12014,7 +12276,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12055,7 +12318,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12096,7 +12360,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12137,7 +12402,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12178,7 +12444,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12219,7 +12486,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12260,7 +12528,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12301,7 +12570,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12342,7 +12612,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12383,7 +12654,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12424,7 +12696,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12465,7 +12738,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12506,7 +12780,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12547,7 +12822,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12588,7 +12864,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12629,7 +12906,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12670,7 +12948,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12711,7 +12990,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12752,7 +13032,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12793,7 +13074,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12834,7 +13116,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12875,7 +13158,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12916,7 +13200,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12957,7 +13242,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12998,7 +13284,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13039,7 +13326,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13080,7 +13368,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13121,7 +13410,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13162,7 +13452,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13203,7 +13494,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13244,7 +13536,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13285,7 +13578,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13326,7 +13620,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13367,7 +13662,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13408,7 +13704,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13449,7 +13746,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13490,7 +13788,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13531,7 +13830,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13572,7 +13872,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13613,7 +13914,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13654,7 +13956,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13695,7 +13998,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13736,7 +14040,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13777,7 +14082,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13818,7 +14124,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13859,7 +14166,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13900,7 +14208,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13941,7 +14250,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13982,7 +14292,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14023,7 +14334,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14064,7 +14376,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14105,7 +14418,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14146,7 +14460,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14187,7 +14502,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14228,7 +14544,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14269,7 +14586,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14310,7 +14628,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14351,7 +14670,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14389,7 +14709,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14418,7 +14739,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14447,7 +14769,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14476,7 +14799,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14505,7 +14829,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14534,7 +14859,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14563,7 +14889,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14592,7 +14919,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14621,7 +14949,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14650,7 +14979,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14679,7 +15009,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14708,7 +15039,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14737,7 +15069,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14766,7 +15099,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14795,7 +15129,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14824,7 +15159,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14853,7 +15189,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14882,7 +15219,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14911,7 +15249,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14940,7 +15279,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14969,7 +15309,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14998,7 +15339,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15027,7 +15369,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15056,7 +15399,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15085,7 +15429,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15114,7 +15459,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15143,7 +15489,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15172,7 +15519,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15201,7 +15549,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15230,7 +15579,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15259,7 +15609,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15288,7 +15639,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15317,7 +15669,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15346,7 +15699,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15375,7 +15729,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15404,7 +15759,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15433,7 +15789,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15462,7 +15819,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15491,7 +15849,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15520,7 +15879,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15549,7 +15909,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15578,7 +15939,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15607,7 +15969,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15636,7 +15999,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15665,7 +16029,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15694,7 +16059,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15723,7 +16089,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15752,7 +16119,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15781,7 +16149,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15810,7 +16179,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15839,7 +16209,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15868,7 +16239,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15897,7 +16269,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15926,7 +16299,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15955,7 +16329,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15984,7 +16359,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16013,7 +16389,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16042,7 +16419,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16071,7 +16449,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16100,7 +16479,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16129,7 +16509,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16158,7 +16539,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16187,7 +16569,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16216,7 +16599,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16245,7 +16629,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16274,7 +16659,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16303,7 +16689,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16332,7 +16719,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16361,7 +16749,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16390,7 +16779,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16419,7 +16809,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16448,7 +16839,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16477,7 +16869,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16506,7 +16899,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16535,7 +16929,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16564,7 +16959,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16593,7 +16989,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16622,7 +17019,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16651,7 +17049,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16680,7 +17079,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16709,7 +17109,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16738,7 +17139,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16767,7 +17169,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16796,7 +17199,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16825,7 +17229,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16854,7 +17259,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16883,7 +17289,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16912,7 +17319,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16941,7 +17349,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16970,7 +17379,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16999,7 +17409,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17028,7 +17439,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17057,7 +17469,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17086,7 +17499,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17115,7 +17529,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17144,7 +17559,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17173,7 +17589,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17202,7 +17619,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17231,7 +17649,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17260,7 +17679,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17289,7 +17709,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17318,7 +17739,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17347,7 +17769,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17376,7 +17799,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17405,7 +17829,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17434,7 +17859,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17463,7 +17889,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17492,7 +17919,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17521,7 +17949,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17550,7 +17979,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17582,7 +18012,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17623,7 +18054,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17664,7 +18096,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17705,7 +18138,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17746,7 +18180,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17787,7 +18222,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17828,7 +18264,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17870,7 +18307,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17912,7 +18350,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17954,7 +18393,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17996,7 +18436,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18038,7 +18479,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18080,7 +18522,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18122,7 +18565,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18160,7 +18604,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18189,7 +18634,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18218,7 +18664,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18247,7 +18694,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18276,7 +18724,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18305,7 +18754,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18334,7 +18784,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18362,7 +18813,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18394,7 +18846,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18430,7 +18883,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18466,7 +18920,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18502,7 +18957,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18538,7 +18994,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18574,7 +19031,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18610,7 +19068,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18646,7 +19105,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18682,7 +19142,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18718,7 +19179,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18755,7 +19217,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18797,7 +19260,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18854,7 +19318,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18894,7 +19359,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18935,7 +19401,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18975,7 +19442,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19015,7 +19483,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19055,7 +19524,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19095,7 +19565,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19164,7 +19635,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19196,7 +19668,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19232,7 +19705,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19268,7 +19742,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19304,7 +19779,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19340,7 +19816,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19376,7 +19853,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19412,7 +19890,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19448,7 +19927,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19484,7 +19964,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19520,7 +20001,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19557,7 +20039,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19599,7 +20082,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19656,7 +20140,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19696,7 +20181,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19737,7 +20223,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19777,7 +20264,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19817,7 +20305,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19857,7 +20346,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19897,7 +20387,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19966,7 +20457,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19998,7 +20490,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20034,7 +20527,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20070,7 +20564,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20106,7 +20601,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20142,7 +20638,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20178,7 +20675,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20214,7 +20712,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20250,7 +20749,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20286,7 +20786,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20322,7 +20823,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20359,7 +20861,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20401,7 +20904,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20458,7 +20962,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20498,7 +21003,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20539,7 +21045,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20579,7 +21086,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20619,7 +21127,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20659,7 +21168,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20699,7 +21209,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20768,7 +21279,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20800,7 +21312,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20836,7 +21349,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20872,7 +21386,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20908,7 +21423,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20944,7 +21460,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20980,7 +21497,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21016,7 +21534,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21052,7 +21571,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21088,7 +21608,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21124,7 +21645,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21161,7 +21683,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21203,7 +21726,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21260,7 +21784,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21300,7 +21825,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21341,7 +21867,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21381,7 +21908,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21421,7 +21949,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21461,7 +21990,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21501,7 +22031,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -2560,7 +2560,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2588,7 +2588,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2616,7 +2616,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2644,7 +2644,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2674,7 +2674,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2702,7 +2702,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2730,7 +2730,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2758,7 +2758,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2856,7 +2856,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ping_timer_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2888,7 +2888,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ping_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2929,7 +2929,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ping_timer_en_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2968,7 +2968,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2998,7 +2998,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3028,7 +3028,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3058,7 +3058,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3088,7 +3088,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3118,7 +3118,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3148,7 +3148,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3178,7 +3178,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3208,7 +3208,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3238,7 +3238,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3268,7 +3268,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3298,7 +3298,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3328,7 +3328,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3358,7 +3358,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3388,7 +3388,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3418,7 +3418,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3448,7 +3448,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3478,7 +3478,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3508,7 +3508,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3538,7 +3538,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3568,7 +3568,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3598,7 +3598,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3628,7 +3628,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3658,7 +3658,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3688,7 +3688,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3718,7 +3718,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3748,7 +3748,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3778,7 +3778,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3808,7 +3808,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3838,7 +3838,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3868,7 +3868,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3898,7 +3898,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3928,7 +3928,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3958,7 +3958,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3988,7 +3988,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4018,7 +4018,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4048,7 +4048,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4078,7 +4078,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4108,7 +4108,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4138,7 +4138,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4168,7 +4168,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4198,7 +4198,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4228,7 +4228,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4258,7 +4258,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4288,7 +4288,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4318,7 +4318,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4348,7 +4348,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4378,7 +4378,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4408,7 +4408,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4438,7 +4438,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4468,7 +4468,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4498,7 +4498,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4528,7 +4528,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4558,7 +4558,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4588,7 +4588,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4618,7 +4618,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4648,7 +4648,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4678,7 +4678,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4708,7 +4708,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4738,7 +4738,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4768,7 +4768,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4798,7 +4798,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4828,7 +4828,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4858,7 +4858,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4888,7 +4888,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4918,7 +4918,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4948,7 +4948,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4978,7 +4978,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5008,7 +5008,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5038,7 +5038,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5068,7 +5068,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5098,7 +5098,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5128,7 +5128,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5158,7 +5158,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5188,7 +5188,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5218,7 +5218,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5248,7 +5248,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5278,7 +5278,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5308,7 +5308,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5338,7 +5338,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5368,7 +5368,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5398,7 +5398,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5428,7 +5428,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5458,7 +5458,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5488,7 +5488,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5518,7 +5518,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5548,7 +5548,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5578,7 +5578,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5608,7 +5608,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5638,7 +5638,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5668,7 +5668,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5698,7 +5698,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5728,7 +5728,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5758,7 +5758,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5788,7 +5788,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5818,7 +5818,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5848,7 +5848,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5878,7 +5878,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5908,7 +5908,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5938,7 +5938,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5968,7 +5968,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5998,7 +5998,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6028,7 +6028,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6061,7 +6061,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6103,7 +6103,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6145,7 +6145,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6187,7 +6187,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6229,7 +6229,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6271,7 +6271,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6313,7 +6313,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6355,7 +6355,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6397,7 +6397,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6439,7 +6439,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6481,7 +6481,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6523,7 +6523,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6565,7 +6565,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6607,7 +6607,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6649,7 +6649,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6691,7 +6691,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6733,7 +6733,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6775,7 +6775,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6817,7 +6817,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6859,7 +6859,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +6901,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6943,7 +6943,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6985,7 +6985,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7027,7 +7027,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7069,7 +7069,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7111,7 +7111,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7153,7 +7153,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7195,7 +7195,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7237,7 +7237,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7279,7 +7279,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7321,7 +7321,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7363,7 +7363,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7405,7 +7405,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7447,7 +7447,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7489,7 +7489,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7531,7 +7531,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7573,7 +7573,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7615,7 +7615,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7657,7 +7657,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7699,7 +7699,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7741,7 +7741,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7783,7 +7783,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7825,7 +7825,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7867,7 +7867,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7909,7 +7909,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7951,7 +7951,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7993,7 +7993,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8035,7 +8035,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8077,7 +8077,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8119,7 +8119,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8161,7 +8161,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8203,7 +8203,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8245,7 +8245,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8287,7 +8287,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8329,7 +8329,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8371,7 +8371,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8413,7 +8413,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8455,7 +8455,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8497,7 +8497,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8539,7 +8539,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8581,7 +8581,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8623,7 +8623,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8665,7 +8665,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8707,7 +8707,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8749,7 +8749,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8791,7 +8791,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8833,7 +8833,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8875,7 +8875,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8917,7 +8917,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8959,7 +8959,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9001,7 +9001,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9043,7 +9043,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9085,7 +9085,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9127,7 +9127,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9169,7 +9169,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9211,7 +9211,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9253,7 +9253,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9295,7 +9295,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9337,7 +9337,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9379,7 +9379,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9421,7 +9421,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9463,7 +9463,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9505,7 +9505,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9547,7 +9547,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9589,7 +9589,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9631,7 +9631,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9673,7 +9673,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9715,7 +9715,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9757,7 +9757,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9799,7 +9799,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9841,7 +9841,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9883,7 +9883,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9925,7 +9925,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9967,7 +9967,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10009,7 +10009,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10051,7 +10051,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10093,7 +10093,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10135,7 +10135,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10177,7 +10177,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10219,7 +10219,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10261,7 +10261,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10303,7 +10303,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10345,7 +10345,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10387,7 +10387,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10429,7 +10429,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10471,7 +10471,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10513,7 +10513,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10555,7 +10555,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10597,7 +10597,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10639,7 +10639,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10681,7 +10681,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10723,7 +10723,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10765,7 +10765,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10807,7 +10807,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10849,7 +10849,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10891,7 +10891,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10933,7 +10933,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10975,7 +10975,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11017,7 +11017,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11059,7 +11059,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11101,7 +11101,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11143,7 +11143,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11185,7 +11185,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11227,7 +11227,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11269,7 +11269,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11311,7 +11311,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11353,7 +11353,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11395,7 +11395,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11437,7 +11437,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11479,7 +11479,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11521,7 +11521,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11563,7 +11563,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11605,7 +11605,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11647,7 +11647,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11689,7 +11689,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11731,7 +11731,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11773,7 +11773,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11815,7 +11815,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11857,7 +11857,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11899,7 +11899,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11941,7 +11941,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11983,7 +11983,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12025,7 +12025,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12067,7 +12067,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12109,7 +12109,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12151,7 +12151,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12193,7 +12193,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12235,7 +12235,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12277,7 +12277,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12319,7 +12319,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12361,7 +12361,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12403,7 +12403,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12445,7 +12445,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12487,7 +12487,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12529,7 +12529,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12571,7 +12571,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12613,7 +12613,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12655,7 +12655,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12697,7 +12697,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12739,7 +12739,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12781,7 +12781,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12823,7 +12823,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12865,7 +12865,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12907,7 +12907,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12949,7 +12949,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12991,7 +12991,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13033,7 +13033,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13075,7 +13075,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13117,7 +13117,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13159,7 +13159,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13201,7 +13201,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13243,7 +13243,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13285,7 +13285,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13327,7 +13327,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13369,7 +13369,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13411,7 +13411,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13453,7 +13453,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13495,7 +13495,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13537,7 +13537,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13579,7 +13579,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13621,7 +13621,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13663,7 +13663,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13705,7 +13705,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13747,7 +13747,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13789,7 +13789,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13831,7 +13831,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13873,7 +13873,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13915,7 +13915,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13957,7 +13957,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13999,7 +13999,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14041,7 +14041,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14083,7 +14083,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14125,7 +14125,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14167,7 +14167,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14209,7 +14209,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14251,7 +14251,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14293,7 +14293,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14335,7 +14335,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14377,7 +14377,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14419,7 +14419,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14461,7 +14461,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14503,7 +14503,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14545,7 +14545,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14587,7 +14587,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14629,7 +14629,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14671,7 +14671,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14710,7 +14710,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14740,7 +14740,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14770,7 +14770,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14800,7 +14800,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14830,7 +14830,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14860,7 +14860,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14890,7 +14890,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14920,7 +14920,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14950,7 +14950,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14980,7 +14980,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15010,7 +15010,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15040,7 +15040,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15070,7 +15070,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15100,7 +15100,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15130,7 +15130,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15160,7 +15160,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15190,7 +15190,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15220,7 +15220,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15250,7 +15250,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15280,7 +15280,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15310,7 +15310,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15340,7 +15340,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15370,7 +15370,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15400,7 +15400,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15430,7 +15430,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15460,7 +15460,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15490,7 +15490,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15520,7 +15520,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15550,7 +15550,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15580,7 +15580,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15610,7 +15610,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15640,7 +15640,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15670,7 +15670,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15700,7 +15700,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15730,7 +15730,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15760,7 +15760,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15790,7 +15790,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15820,7 +15820,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15850,7 +15850,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15880,7 +15880,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15910,7 +15910,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15940,7 +15940,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15970,7 +15970,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16000,7 +16000,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16030,7 +16030,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16060,7 +16060,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16090,7 +16090,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16120,7 +16120,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16150,7 +16150,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16180,7 +16180,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16210,7 +16210,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16240,7 +16240,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16270,7 +16270,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16300,7 +16300,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16330,7 +16330,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16360,7 +16360,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16390,7 +16390,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16420,7 +16420,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16450,7 +16450,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16480,7 +16480,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16510,7 +16510,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16540,7 +16540,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16570,7 +16570,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16600,7 +16600,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16630,7 +16630,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16660,7 +16660,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16690,7 +16690,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16720,7 +16720,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16750,7 +16750,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16780,7 +16780,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16810,7 +16810,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16840,7 +16840,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16870,7 +16870,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16900,7 +16900,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16930,7 +16930,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16960,7 +16960,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16990,7 +16990,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17020,7 +17020,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17050,7 +17050,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17080,7 +17080,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17110,7 +17110,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17140,7 +17140,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17170,7 +17170,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17200,7 +17200,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17230,7 +17230,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17260,7 +17260,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17290,7 +17290,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17320,7 +17320,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17350,7 +17350,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17380,7 +17380,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17410,7 +17410,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17440,7 +17440,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17470,7 +17470,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17500,7 +17500,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17530,7 +17530,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17560,7 +17560,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17590,7 +17590,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17620,7 +17620,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17650,7 +17650,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17680,7 +17680,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17710,7 +17710,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17740,7 +17740,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17770,7 +17770,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17800,7 +17800,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17830,7 +17830,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17860,7 +17860,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17890,7 +17890,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17920,7 +17920,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17950,7 +17950,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17980,7 +17980,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18013,7 +18013,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18055,7 +18055,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18097,7 +18097,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18139,7 +18139,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18181,7 +18181,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18223,7 +18223,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18265,7 +18265,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18308,7 +18308,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18351,7 +18351,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18394,7 +18394,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18437,7 +18437,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18480,7 +18480,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18523,7 +18523,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18566,7 +18566,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18605,7 +18605,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18635,7 +18635,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18665,7 +18665,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18695,7 +18695,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18725,7 +18725,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18755,7 +18755,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18785,7 +18785,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18814,7 +18814,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18847,7 +18847,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18884,7 +18884,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18921,7 +18921,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18958,7 +18958,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18995,7 +18995,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19032,7 +19032,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19069,7 +19069,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19106,7 +19106,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19143,7 +19143,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19180,7 +19180,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19218,7 +19218,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19261,7 +19261,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19319,7 +19319,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19360,7 +19360,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19402,7 +19402,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19443,7 +19443,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19484,7 +19484,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19525,7 +19525,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19566,7 +19566,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19636,7 +19636,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19669,7 +19669,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19706,7 +19706,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19743,7 +19743,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19780,7 +19780,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19817,7 +19817,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19854,7 +19854,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19891,7 +19891,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19928,7 +19928,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19965,7 +19965,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20002,7 +20002,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20040,7 +20040,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20083,7 +20083,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20141,7 +20141,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20182,7 +20182,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20224,7 +20224,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20265,7 +20265,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20306,7 +20306,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20347,7 +20347,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20388,7 +20388,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20458,7 +20458,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20491,7 +20491,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20528,7 +20528,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20565,7 +20565,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20602,7 +20602,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20639,7 +20639,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20676,7 +20676,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20713,7 +20713,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20750,7 +20750,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20787,7 +20787,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20824,7 +20824,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20862,7 +20862,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20905,7 +20905,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20963,7 +20963,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21004,7 +21004,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21046,7 +21046,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21087,7 +21087,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21128,7 +21128,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21169,7 +21169,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21210,7 +21210,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21280,7 +21280,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21313,7 +21313,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21350,7 +21350,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21387,7 +21387,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21424,7 +21424,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21461,7 +21461,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21498,7 +21498,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21535,7 +21535,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21572,7 +21572,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21609,7 +21609,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21646,7 +21646,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21684,7 +21684,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21727,7 +21727,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21785,7 +21785,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21826,7 +21826,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21868,7 +21868,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21909,7 +21909,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21950,7 +21950,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21991,7 +21991,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22032,7 +22032,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -529,7 +529,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -562,7 +562,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -590,7 +590,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -635,7 +635,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -667,7 +667,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -697,7 +697,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -725,7 +725,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -753,7 +753,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -783,7 +783,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -811,7 +811,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -839,7 +839,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_kmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -867,7 +867,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_otbn_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -897,7 +897,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -925,7 +925,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -953,7 +953,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_kmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -981,7 +981,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_otbn_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1010,7 +1010,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1102,7 +1102,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'he),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1162,7 +1162,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1263,7 +1263,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h1a),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1323,7 +1323,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1423,7 +1423,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h1a),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1483,7 +1483,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1522,7 +1522,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1550,7 +1550,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1578,7 +1578,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1606,7 +1606,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1634,7 +1634,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1662,7 +1662,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1690,7 +1690,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1720,7 +1720,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1748,7 +1748,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1776,7 +1776,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -528,7 +528,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -560,7 +561,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -587,7 +589,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +634,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -662,7 +666,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +696,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +724,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -745,7 +752,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -774,7 +782,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -801,7 +810,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -828,7 +838,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_kmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -855,7 +866,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_otbn_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -884,7 +896,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -911,7 +924,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -938,7 +952,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_kmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +980,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_otbn_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -993,7 +1009,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1027,7 +1044,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_en (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1083,7 +1101,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'he),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1142,7 +1161,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1185,7 +1205,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_en (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1241,7 +1262,8 @@ module clkmgr_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h1a),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1300,7 +1322,8 @@ module clkmgr_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1342,7 +1365,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_en (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1398,7 +1422,8 @@ module clkmgr_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h1a),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1457,7 +1482,8 @@ module clkmgr_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1495,7 +1521,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1522,7 +1549,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1549,7 +1577,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1576,7 +1605,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1603,7 +1633,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1630,7 +1661,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1657,7 +1689,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1686,7 +1719,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1713,7 +1747,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1740,7 +1775,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -310,7 +310,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -339,7 +339,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -408,7 +408,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -625,7 +625,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -654,7 +654,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -683,7 +683,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -712,7 +712,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -741,7 +741,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -770,7 +770,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_straps_data_in_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -799,7 +799,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_straps_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -830,7 +830,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_0_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -858,7 +858,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_0_continuous_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -886,7 +886,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_0_polarity_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -914,7 +914,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_0_input_select_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -942,7 +942,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_0_prescaler_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +973,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_1_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1001,7 +1001,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_1_continuous_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1029,7 +1029,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_1_polarity_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1057,7 +1057,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_1_input_select_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1085,7 +1085,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_1_prescaler_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1116,7 +1116,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_2_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1144,7 +1144,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_2_continuous_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1172,7 +1172,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_2_polarity_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1200,7 +1200,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_2_input_select_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1228,7 +1228,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_2_prescaler_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1259,7 +1259,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_3_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1287,7 +1287,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_3_continuous_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1315,7 +1315,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_3_polarity_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1343,7 +1343,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_3_input_select_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1371,7 +1371,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_3_prescaler_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1402,7 +1402,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_4_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1430,7 +1430,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_4_continuous_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1458,7 +1458,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_4_polarity_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1486,7 +1486,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_4_input_select_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1514,7 +1514,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_4_prescaler_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1545,7 +1545,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_5_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1573,7 +1573,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_5_continuous_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1601,7 +1601,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_5_polarity_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1629,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_5_input_select_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1657,7 +1657,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_5_prescaler_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1688,7 +1688,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_6_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1716,7 +1716,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_6_continuous_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1744,7 +1744,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_6_polarity_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1772,7 +1772,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_6_input_select_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1800,7 +1800,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_6_prescaler_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1831,7 +1831,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_7_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1859,7 +1859,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_7_continuous_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1887,7 +1887,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_7_polarity_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1915,7 +1915,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_7_input_select_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1943,7 +1943,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_ctrl_7_prescaler_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1973,7 +1973,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2003,7 +2003,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2033,7 +2033,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2063,7 +2063,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2093,7 +2093,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2123,7 +2123,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2153,7 +2153,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2183,7 +2183,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_inp_prd_cnt_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -309,7 +309,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +338,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -405,7 +407,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -621,7 +624,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +653,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +682,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -705,7 +711,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -733,7 +740,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -761,7 +769,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_straps_data_in_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -789,7 +798,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_straps_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -819,7 +829,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_0_enable_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -846,7 +857,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_0_continuous_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -873,7 +885,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_0_polarity_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -900,7 +913,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_0_input_select_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -927,7 +941,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_0_prescaler_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -957,7 +972,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_1_enable_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -984,7 +1000,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_1_continuous_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1011,7 +1028,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_1_polarity_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1038,7 +1056,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_1_input_select_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1065,7 +1084,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_1_prescaler_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1095,7 +1115,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_2_enable_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1122,7 +1143,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_2_continuous_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1149,7 +1171,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_2_polarity_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1176,7 +1199,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_2_input_select_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1203,7 +1227,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_2_prescaler_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1233,7 +1258,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_3_enable_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1260,7 +1286,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_3_continuous_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1287,7 +1314,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_3_polarity_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1314,7 +1342,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_3_input_select_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1341,7 +1370,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_3_prescaler_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1371,7 +1401,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_4_enable_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1398,7 +1429,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_4_continuous_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1425,7 +1457,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_4_polarity_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1452,7 +1485,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_4_input_select_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1479,7 +1513,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_4_prescaler_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1509,7 +1544,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_5_enable_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1536,7 +1572,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_5_continuous_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1563,7 +1600,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_5_polarity_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1590,7 +1628,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_5_input_select_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1617,7 +1656,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_5_prescaler_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1647,7 +1687,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_6_enable_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1674,7 +1715,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_6_continuous_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1701,7 +1743,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_6_polarity_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1728,7 +1771,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_6_input_select_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1755,7 +1799,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_6_prescaler_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1785,7 +1830,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_7_enable_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1812,7 +1858,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_7_continuous_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1839,7 +1886,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_7_polarity_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1866,7 +1914,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_7_input_select_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1893,7 +1942,8 @@ module gpio_reg_top
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_ctrl_7_prescaler_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1922,7 +1972,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1951,7 +2002,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1980,7 +2032,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2009,7 +2062,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2038,7 +2092,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2067,7 +2122,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2096,7 +2152,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2125,7 +2182,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_inp_prd_cnt_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -437,7 +437,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -464,7 +465,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +495,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -520,7 +523,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1624,7 +1628,8 @@ module otp_ctrl_core_reg_top (
     .DW      (14),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (14'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_direct_access_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1656,7 +1661,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_direct_access_wdata_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1688,7 +1694,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_direct_access_wdata_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1750,7 +1757,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_check_trigger_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1818,7 +1826,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_check_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1849,7 +1858,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_check_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1880,7 +1890,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_integrity_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1911,7 +1922,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_consistency_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1942,7 +1954,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_vendor_test_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1973,7 +1986,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_creator_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2004,7 +2018,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_owner_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2036,7 +2051,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ownership_slot_state_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2068,7 +2084,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rot_creator_auth_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2100,7 +2117,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rot_owner_auth_slot0_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2132,7 +2150,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rot_owner_auth_slot1_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2164,7 +2183,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_plat_integ_auth_slot0_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2196,7 +2216,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_plat_integ_auth_slot1_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2228,7 +2249,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_plat_owner_auth_slot0_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2260,7 +2282,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_plat_owner_auth_slot1_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2292,7 +2315,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_plat_owner_auth_slot2_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2324,7 +2348,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_plat_owner_auth_slot3_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2355,7 +2380,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ext_nvm_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2386,7 +2412,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rom_patch_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -438,7 +438,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -466,7 +466,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -496,7 +496,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -524,7 +524,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1629,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (14'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_direct_access_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1662,7 +1662,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_direct_access_wdata_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1695,7 +1695,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_direct_access_wdata_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1758,7 +1758,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_check_trigger_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1827,7 +1827,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_check_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1859,7 +1859,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_check_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1891,7 +1891,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_integrity_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1923,7 +1923,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_consistency_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1955,7 +1955,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_vendor_test_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1987,7 +1987,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_creator_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2019,7 +2019,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_owner_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2052,7 +2052,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ownership_slot_state_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2085,7 +2085,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rot_creator_auth_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2118,7 +2118,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rot_owner_auth_slot0_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2151,7 +2151,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rot_owner_auth_slot1_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2184,7 +2184,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_plat_integ_auth_slot0_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2217,7 +2217,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_plat_integ_auth_slot1_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2250,7 +2250,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_plat_owner_auth_slot0_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2283,7 +2283,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_plat_owner_auth_slot1_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2316,7 +2316,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_plat_owner_auth_slot2_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2349,7 +2349,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_plat_owner_auth_slot3_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2381,7 +2381,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ext_nvm_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2413,7 +2413,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rom_patch_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -200,7 +200,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -227,7 +228,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -254,7 +256,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -281,7 +284,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -308,7 +312,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +342,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -364,7 +370,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -391,7 +398,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -418,7 +426,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -445,7 +454,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -473,7 +483,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -502,7 +513,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -529,7 +541,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -556,7 +569,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -583,7 +597,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -610,7 +625,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -637,7 +653,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -664,7 +681,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +709,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +737,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +767,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -774,7 +795,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -801,7 +823,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -828,7 +851,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -857,7 +881,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -884,7 +909,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -911,7 +937,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -938,7 +965,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +993,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -992,7 +1021,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1019,7 +1049,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1079,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1075,7 +1107,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1102,7 +1135,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1129,7 +1163,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1158,7 +1193,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1185,7 +1221,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1212,7 +1249,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1239,7 +1277,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -201,7 +201,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -229,7 +229,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -257,7 +257,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -285,7 +285,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -313,7 +313,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -343,7 +343,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -371,7 +371,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -399,7 +399,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -427,7 +427,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -455,7 +455,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -484,7 +484,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -514,7 +514,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +542,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -570,7 +570,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -598,7 +598,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -626,7 +626,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -654,7 +654,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -682,7 +682,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -710,7 +710,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -738,7 +738,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +768,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -796,7 +796,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -824,7 +824,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -852,7 +852,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -882,7 +882,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -910,7 +910,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -938,7 +938,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -966,7 +966,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -994,7 +994,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1022,7 +1022,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1050,7 +1050,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1080,7 +1080,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1108,7 +1108,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1136,7 +1136,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1164,7 +1164,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1194,7 +1194,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1222,7 +1222,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1250,7 +1250,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1278,7 +1278,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -4477,7 +4477,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4506,7 +4507,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4535,7 +4537,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4564,7 +4567,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4596,7 +4600,8 @@ module pinmux_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4628,7 +4633,8 @@ module pinmux_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4660,7 +4666,8 @@ module pinmux_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4692,7 +4699,8 @@ module pinmux_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4721,7 +4729,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4750,7 +4759,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4779,7 +4789,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4808,7 +4819,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4837,7 +4849,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4866,7 +4879,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4895,7 +4909,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4924,7 +4939,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4953,7 +4969,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4982,7 +4999,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5011,7 +5029,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5040,7 +5059,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5072,7 +5092,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5104,7 +5125,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5136,7 +5158,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5168,7 +5191,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5200,7 +5224,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5232,7 +5257,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5264,7 +5290,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5296,7 +5323,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5328,7 +5356,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5360,7 +5389,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5422,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5424,7 +5455,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5453,7 +5485,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5482,7 +5515,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5511,7 +5545,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5540,7 +5575,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5569,7 +5605,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5598,7 +5635,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5627,7 +5665,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5656,7 +5695,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5685,7 +5725,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5714,7 +5755,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5743,7 +5785,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5772,7 +5815,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7829,7 +7873,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7858,7 +7903,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7887,7 +7933,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7916,7 +7963,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7945,7 +7993,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7974,7 +8023,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8003,7 +8053,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8032,7 +8083,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8061,7 +8113,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8090,7 +8143,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8119,7 +8173,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8148,7 +8203,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8177,7 +8233,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8206,7 +8263,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8235,7 +8293,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8264,7 +8323,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8293,7 +8353,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8322,7 +8383,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8351,7 +8413,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8380,7 +8443,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8409,7 +8473,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8438,7 +8503,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8467,7 +8533,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8496,7 +8563,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8525,7 +8593,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8554,7 +8623,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8583,7 +8653,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8612,7 +8683,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8641,7 +8713,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8670,7 +8743,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8699,7 +8773,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8728,7 +8803,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8757,7 +8833,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8786,7 +8863,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8815,7 +8893,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8844,7 +8923,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8873,7 +8953,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8902,7 +8983,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8931,7 +9013,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8960,7 +9043,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8989,7 +9073,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9018,7 +9103,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9047,7 +9133,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9076,7 +9163,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9105,7 +9193,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9134,7 +9223,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9163,7 +9253,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9192,7 +9283,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9221,7 +9313,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9250,7 +9343,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9279,7 +9373,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9308,7 +9403,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9337,7 +9433,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9366,7 +9463,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9395,7 +9493,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9424,7 +9523,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9453,7 +9553,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9482,7 +9583,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9511,7 +9613,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9540,7 +9643,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9569,7 +9673,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9598,7 +9703,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9627,7 +9733,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9656,7 +9763,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9685,7 +9793,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9714,7 +9823,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9743,7 +9853,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9772,7 +9883,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9801,7 +9913,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9830,7 +9943,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9859,7 +9973,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9888,7 +10003,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9917,7 +10033,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22284,7 +22401,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22311,7 +22429,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22338,7 +22457,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22365,7 +22485,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22392,7 +22513,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22419,7 +22541,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22446,7 +22569,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22473,7 +22597,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22500,7 +22625,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22527,7 +22653,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22554,7 +22681,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22581,7 +22709,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22610,7 +22739,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22639,7 +22769,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22668,7 +22799,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22697,7 +22829,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22726,7 +22859,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22755,7 +22889,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22784,7 +22919,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22813,7 +22949,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22842,7 +22979,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22871,7 +23009,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22900,7 +23039,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22929,7 +23069,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22961,7 +23102,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22993,7 +23135,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23025,7 +23168,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23057,7 +23201,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23089,7 +23234,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23121,7 +23267,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23153,7 +23300,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23185,7 +23333,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23217,7 +23366,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23249,7 +23399,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23281,7 +23432,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23313,7 +23465,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23345,7 +23498,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23377,7 +23531,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23409,7 +23564,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23441,7 +23597,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23473,7 +23630,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23505,7 +23663,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23537,7 +23696,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23569,7 +23729,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23601,7 +23762,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23633,7 +23795,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23665,7 +23828,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23697,7 +23861,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23727,7 +23892,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23754,7 +23920,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23781,7 +23948,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23808,7 +23976,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23835,7 +24004,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23862,7 +24032,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23889,7 +24060,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23916,7 +24088,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23943,7 +24116,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23970,7 +24144,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23997,7 +24172,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24024,7 +24200,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24051,7 +24228,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24078,7 +24256,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24105,7 +24284,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24132,7 +24312,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24159,7 +24340,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24186,7 +24368,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24213,7 +24396,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24240,7 +24424,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24267,7 +24452,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24294,7 +24480,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24321,7 +24508,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24348,7 +24536,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24375,7 +24564,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24402,7 +24592,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24429,7 +24620,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24456,7 +24648,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24483,7 +24676,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24510,7 +24704,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24537,7 +24732,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24564,7 +24760,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24594,7 +24791,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24621,7 +24819,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24648,7 +24847,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24675,7 +24875,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24702,7 +24903,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24729,7 +24931,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24756,7 +24959,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24783,7 +24987,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24810,7 +25015,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24837,7 +25043,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24864,7 +25071,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24891,7 +25099,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24918,7 +25127,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24945,7 +25155,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24972,7 +25183,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24999,7 +25211,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25026,7 +25239,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25053,7 +25267,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25080,7 +25295,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25107,7 +25323,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25134,7 +25351,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25161,7 +25379,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25188,7 +25407,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25215,7 +25435,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25242,7 +25463,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25269,7 +25491,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25296,7 +25519,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25323,7 +25547,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25350,7 +25575,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25377,7 +25603,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25404,7 +25631,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25431,7 +25659,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_1_en_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25461,7 +25690,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25488,7 +25718,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25515,7 +25746,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25542,7 +25774,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25569,7 +25802,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25596,7 +25830,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25623,7 +25858,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25650,7 +25886,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25677,7 +25914,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_2_en_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25706,7 +25944,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25735,7 +25974,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25764,7 +26004,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25793,7 +26034,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25822,7 +26064,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25851,7 +26094,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25880,7 +26124,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25909,7 +26154,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25938,7 +26184,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25967,7 +26214,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25996,7 +26244,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26025,7 +26274,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26054,7 +26304,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26083,7 +26334,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26112,7 +26364,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26141,7 +26394,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26170,7 +26424,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26199,7 +26454,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26228,7 +26484,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26257,7 +26514,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26286,7 +26544,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26315,7 +26574,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26344,7 +26604,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26373,7 +26634,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26402,7 +26664,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26431,7 +26694,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26460,7 +26724,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26489,7 +26754,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26518,7 +26784,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26547,7 +26814,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26576,7 +26844,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26605,7 +26874,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26634,7 +26904,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26663,7 +26934,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26692,7 +26964,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26721,7 +26994,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26750,7 +27024,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26779,7 +27054,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26808,7 +27084,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26837,7 +27114,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26866,7 +27144,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26895,7 +27174,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26924,7 +27204,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26953,7 +27234,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26982,7 +27264,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27011,7 +27294,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27040,7 +27324,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27069,7 +27354,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27098,7 +27384,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27127,7 +27414,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27156,7 +27444,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27185,7 +27474,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27214,7 +27504,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27243,7 +27534,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27272,7 +27564,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27301,7 +27594,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27330,7 +27624,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27359,7 +27654,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27388,7 +27684,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27417,7 +27714,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27446,7 +27744,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27475,7 +27774,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27504,7 +27804,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27533,7 +27834,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27562,7 +27864,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27591,7 +27894,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27620,7 +27924,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27649,7 +27954,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27678,7 +27984,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27707,7 +28014,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27736,7 +28044,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27765,7 +28074,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27794,7 +28104,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27826,7 +28137,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27858,7 +28170,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27890,7 +28203,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27922,7 +28236,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27954,7 +28269,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27986,7 +28302,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28018,7 +28335,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28050,7 +28368,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28082,7 +28401,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28114,7 +28434,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28146,7 +28467,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28178,7 +28500,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28210,7 +28533,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28242,7 +28566,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28274,7 +28599,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28306,7 +28632,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28338,7 +28665,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28370,7 +28698,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28402,7 +28731,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28434,7 +28764,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28466,7 +28797,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28498,7 +28830,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28530,7 +28863,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28562,7 +28896,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28594,7 +28929,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28626,7 +28962,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28658,7 +28995,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28690,7 +29028,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28722,7 +29061,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28754,7 +29094,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28786,7 +29127,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28818,7 +29160,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28850,7 +29193,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28882,7 +29226,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28914,7 +29259,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28946,7 +29292,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28978,7 +29325,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29010,7 +29358,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29042,7 +29391,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29074,7 +29424,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29106,7 +29457,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29138,7 +29490,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29170,7 +29523,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29202,7 +29556,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29234,7 +29589,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29266,7 +29622,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29298,7 +29655,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29330,7 +29688,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29362,7 +29721,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29394,7 +29754,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29426,7 +29787,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29458,7 +29820,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29490,7 +29853,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29522,7 +29886,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29554,7 +29919,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29586,7 +29952,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29618,7 +29985,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29650,7 +30018,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29682,7 +30051,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29714,7 +30084,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29746,7 +30117,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29778,7 +30150,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29810,7 +30183,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29842,7 +30216,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29874,7 +30249,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29906,7 +30282,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29938,7 +30315,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29970,7 +30348,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30002,7 +30381,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30034,7 +30414,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30066,7 +30447,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30098,7 +30480,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30130,7 +30513,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30162,7 +30546,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30194,7 +30579,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30226,7 +30612,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30258,7 +30645,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30290,7 +30678,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30322,7 +30711,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30354,7 +30744,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30386,7 +30777,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30418,7 +30810,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30450,7 +30843,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30482,7 +30876,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30514,7 +30909,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30546,7 +30942,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30578,7 +30975,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30610,7 +31008,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30642,7 +31041,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30674,7 +31074,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30706,7 +31107,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30738,7 +31140,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30770,7 +31173,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30802,7 +31206,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30834,7 +31239,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30866,7 +31272,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30898,7 +31305,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30930,7 +31338,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30962,7 +31371,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30994,7 +31404,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31026,7 +31437,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31058,7 +31470,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31090,7 +31503,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31122,7 +31536,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31154,7 +31569,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31186,7 +31602,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31218,7 +31635,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31250,7 +31668,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31282,7 +31701,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31314,7 +31734,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31346,7 +31767,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31378,7 +31800,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31410,7 +31833,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31442,7 +31866,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31474,7 +31899,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31506,7 +31932,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31538,7 +31965,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31570,7 +31998,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31602,7 +32031,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31634,7 +32064,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31666,7 +32097,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31698,7 +32130,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31730,7 +32163,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31762,7 +32196,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31794,7 +32229,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31826,7 +32262,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31858,7 +32295,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31890,7 +32328,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31922,7 +32361,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31954,7 +32394,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31986,7 +32427,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32018,7 +32460,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32050,7 +32493,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32082,7 +32526,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32114,7 +32559,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32146,7 +32592,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32178,7 +32625,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32210,7 +32658,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32242,7 +32691,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32274,7 +32724,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32306,7 +32757,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32338,7 +32790,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32370,7 +32823,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32402,7 +32856,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32434,7 +32889,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32466,7 +32922,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32495,7 +32952,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32524,7 +32982,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32553,7 +33012,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32582,7 +33042,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32611,7 +33072,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32640,7 +33102,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32669,7 +33132,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32698,7 +33162,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32731,7 +33196,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32764,7 +33230,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32797,7 +33264,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32830,7 +33298,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32863,7 +33332,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32896,7 +33366,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32929,7 +33400,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32962,7 +33434,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32995,7 +33468,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33022,7 +33496,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33049,7 +33524,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33082,7 +33558,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33109,7 +33586,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33136,7 +33614,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33169,7 +33648,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33196,7 +33676,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33223,7 +33704,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33256,7 +33738,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33283,7 +33766,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33310,7 +33794,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33343,7 +33828,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33370,7 +33856,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33397,7 +33884,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33430,7 +33918,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33457,7 +33946,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33484,7 +33974,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33517,7 +34008,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33544,7 +34036,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33571,7 +34064,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33604,7 +34098,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33631,7 +34126,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33658,7 +34154,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33691,7 +34188,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33724,7 +34222,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33757,7 +34256,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33790,7 +34290,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33823,7 +34324,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33856,7 +34358,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33889,7 +34392,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33922,7 +34426,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33954,7 +34459,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33986,7 +34492,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34018,7 +34525,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34050,7 +34558,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34082,7 +34591,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34114,7 +34624,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34146,7 +34657,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34178,7 +34690,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34210,7 +34723,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34237,7 +34751,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34264,7 +34779,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34291,7 +34807,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34318,7 +34835,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34345,7 +34863,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34372,7 +34891,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34399,7 +34919,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -4478,7 +4478,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4508,7 +4508,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4538,7 +4538,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4568,7 +4568,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4601,7 +4601,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4634,7 +4634,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4667,7 +4667,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4700,7 +4700,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4730,7 +4730,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4760,7 +4760,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4790,7 +4790,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4820,7 +4820,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4850,7 +4850,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4880,7 +4880,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4910,7 +4910,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4940,7 +4940,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4970,7 +4970,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5000,7 +5000,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5030,7 +5030,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5060,7 +5060,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5093,7 +5093,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5126,7 +5126,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5159,7 +5159,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5192,7 +5192,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5225,7 +5225,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5258,7 +5258,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5291,7 +5291,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5324,7 +5324,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5357,7 +5357,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5390,7 +5390,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5423,7 +5423,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5456,7 +5456,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5486,7 +5486,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5516,7 +5516,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5546,7 +5546,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5576,7 +5576,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5606,7 +5606,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5636,7 +5636,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5666,7 +5666,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5696,7 +5696,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5726,7 +5726,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5756,7 +5756,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5786,7 +5786,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5816,7 +5816,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7874,7 +7874,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7904,7 +7904,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7934,7 +7934,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7964,7 +7964,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7994,7 +7994,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8024,7 +8024,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8054,7 +8054,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8084,7 +8084,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8114,7 +8114,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8144,7 +8144,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8174,7 +8174,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8204,7 +8204,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8234,7 +8234,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8264,7 +8264,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8294,7 +8294,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8324,7 +8324,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8354,7 +8354,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8384,7 +8384,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8414,7 +8414,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8444,7 +8444,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8474,7 +8474,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8504,7 +8504,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8534,7 +8534,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8564,7 +8564,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8594,7 +8594,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8624,7 +8624,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8654,7 +8654,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8684,7 +8684,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8714,7 +8714,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8744,7 +8744,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8774,7 +8774,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8804,7 +8804,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8834,7 +8834,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8864,7 +8864,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8894,7 +8894,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8924,7 +8924,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8954,7 +8954,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8984,7 +8984,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9014,7 +9014,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9044,7 +9044,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9074,7 +9074,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9104,7 +9104,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9134,7 +9134,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9164,7 +9164,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9194,7 +9194,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9224,7 +9224,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9254,7 +9254,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9284,7 +9284,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9314,7 +9314,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9344,7 +9344,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9374,7 +9374,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9404,7 +9404,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9434,7 +9434,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9464,7 +9464,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9494,7 +9494,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9524,7 +9524,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9554,7 +9554,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9584,7 +9584,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9614,7 +9614,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9644,7 +9644,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9674,7 +9674,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9704,7 +9704,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9734,7 +9734,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9764,7 +9764,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9794,7 +9794,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9824,7 +9824,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9854,7 +9854,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9884,7 +9884,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9914,7 +9914,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9944,7 +9944,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9974,7 +9974,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10004,7 +10004,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10034,7 +10034,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22402,7 +22402,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22430,7 +22430,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22458,7 +22458,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22486,7 +22486,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22514,7 +22514,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22542,7 +22542,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22570,7 +22570,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22598,7 +22598,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22626,7 +22626,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22654,7 +22654,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22682,7 +22682,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22710,7 +22710,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22740,7 +22740,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22770,7 +22770,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22800,7 +22800,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22830,7 +22830,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22860,7 +22860,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22890,7 +22890,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22920,7 +22920,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22950,7 +22950,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22980,7 +22980,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23010,7 +23010,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23040,7 +23040,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23070,7 +23070,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23103,7 +23103,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23136,7 +23136,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23169,7 +23169,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23202,7 +23202,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23235,7 +23235,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23268,7 +23268,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23301,7 +23301,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23334,7 +23334,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23367,7 +23367,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23400,7 +23400,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23433,7 +23433,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23466,7 +23466,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23499,7 +23499,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23532,7 +23532,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23565,7 +23565,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23598,7 +23598,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23631,7 +23631,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23664,7 +23664,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23697,7 +23697,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23730,7 +23730,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23763,7 +23763,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23796,7 +23796,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23829,7 +23829,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23862,7 +23862,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23893,7 +23893,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23921,7 +23921,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23949,7 +23949,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23977,7 +23977,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24005,7 +24005,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24033,7 +24033,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24061,7 +24061,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24089,7 +24089,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24117,7 +24117,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24145,7 +24145,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24173,7 +24173,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24201,7 +24201,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24229,7 +24229,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24257,7 +24257,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24285,7 +24285,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24313,7 +24313,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24341,7 +24341,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24369,7 +24369,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24397,7 +24397,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24425,7 +24425,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24453,7 +24453,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24481,7 +24481,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24509,7 +24509,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24537,7 +24537,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24565,7 +24565,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24593,7 +24593,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24621,7 +24621,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24649,7 +24649,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24677,7 +24677,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24705,7 +24705,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24733,7 +24733,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24761,7 +24761,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24792,7 +24792,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24820,7 +24820,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24848,7 +24848,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24876,7 +24876,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24904,7 +24904,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24932,7 +24932,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24960,7 +24960,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24988,7 +24988,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25016,7 +25016,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25044,7 +25044,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25072,7 +25072,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25100,7 +25100,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25128,7 +25128,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25156,7 +25156,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25184,7 +25184,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25212,7 +25212,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25240,7 +25240,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25268,7 +25268,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25296,7 +25296,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25324,7 +25324,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25352,7 +25352,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25380,7 +25380,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25408,7 +25408,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25436,7 +25436,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25464,7 +25464,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25492,7 +25492,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25520,7 +25520,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25548,7 +25548,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25576,7 +25576,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25604,7 +25604,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25632,7 +25632,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25660,7 +25660,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_1_en_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25691,7 +25691,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25719,7 +25719,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25747,7 +25747,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25775,7 +25775,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25803,7 +25803,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25831,7 +25831,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25859,7 +25859,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25887,7 +25887,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25915,7 +25915,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_2_en_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25945,7 +25945,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25975,7 +25975,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26005,7 +26005,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26035,7 +26035,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26065,7 +26065,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26095,7 +26095,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26125,7 +26125,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26155,7 +26155,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26185,7 +26185,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26215,7 +26215,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26245,7 +26245,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26275,7 +26275,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26305,7 +26305,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26335,7 +26335,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26365,7 +26365,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26395,7 +26395,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26425,7 +26425,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26455,7 +26455,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26485,7 +26485,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26515,7 +26515,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26545,7 +26545,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26575,7 +26575,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26605,7 +26605,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26635,7 +26635,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26665,7 +26665,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26695,7 +26695,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26725,7 +26725,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26755,7 +26755,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26785,7 +26785,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26815,7 +26815,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26845,7 +26845,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26875,7 +26875,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26905,7 +26905,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26935,7 +26935,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26965,7 +26965,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26995,7 +26995,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27025,7 +27025,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27055,7 +27055,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27085,7 +27085,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27115,7 +27115,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27145,7 +27145,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27175,7 +27175,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27205,7 +27205,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27235,7 +27235,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27265,7 +27265,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27295,7 +27295,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27325,7 +27325,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27355,7 +27355,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27385,7 +27385,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27415,7 +27415,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27445,7 +27445,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27475,7 +27475,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27505,7 +27505,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27535,7 +27535,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27565,7 +27565,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27595,7 +27595,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27625,7 +27625,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27655,7 +27655,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27685,7 +27685,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27715,7 +27715,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27745,7 +27745,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27775,7 +27775,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27805,7 +27805,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27835,7 +27835,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27865,7 +27865,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27895,7 +27895,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27925,7 +27925,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27955,7 +27955,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27985,7 +27985,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28015,7 +28015,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28045,7 +28045,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28075,7 +28075,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28105,7 +28105,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28138,7 +28138,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28171,7 +28171,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28204,7 +28204,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28237,7 +28237,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28270,7 +28270,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28303,7 +28303,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28336,7 +28336,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28369,7 +28369,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28402,7 +28402,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28435,7 +28435,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28468,7 +28468,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28501,7 +28501,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28534,7 +28534,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28567,7 +28567,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28600,7 +28600,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28633,7 +28633,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28666,7 +28666,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28699,7 +28699,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28732,7 +28732,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28765,7 +28765,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28798,7 +28798,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28831,7 +28831,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28864,7 +28864,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28897,7 +28897,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28930,7 +28930,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28963,7 +28963,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28996,7 +28996,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29029,7 +29029,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29062,7 +29062,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29095,7 +29095,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29128,7 +29128,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29161,7 +29161,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29194,7 +29194,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29227,7 +29227,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29260,7 +29260,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29293,7 +29293,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29326,7 +29326,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29359,7 +29359,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29392,7 +29392,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29425,7 +29425,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29458,7 +29458,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29491,7 +29491,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29524,7 +29524,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29557,7 +29557,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29590,7 +29590,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29623,7 +29623,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29656,7 +29656,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29689,7 +29689,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29722,7 +29722,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29755,7 +29755,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29788,7 +29788,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29821,7 +29821,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29854,7 +29854,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29887,7 +29887,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29920,7 +29920,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29953,7 +29953,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29986,7 +29986,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30019,7 +30019,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30052,7 +30052,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30085,7 +30085,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30118,7 +30118,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30151,7 +30151,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30184,7 +30184,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30217,7 +30217,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30250,7 +30250,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30283,7 +30283,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30316,7 +30316,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30349,7 +30349,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30382,7 +30382,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30415,7 +30415,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30448,7 +30448,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30481,7 +30481,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30514,7 +30514,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30547,7 +30547,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30580,7 +30580,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30613,7 +30613,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30646,7 +30646,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30679,7 +30679,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30712,7 +30712,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30745,7 +30745,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30778,7 +30778,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30811,7 +30811,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30844,7 +30844,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30877,7 +30877,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30910,7 +30910,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30943,7 +30943,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30976,7 +30976,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31009,7 +31009,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31042,7 +31042,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31075,7 +31075,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31108,7 +31108,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31141,7 +31141,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31174,7 +31174,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31207,7 +31207,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31240,7 +31240,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31273,7 +31273,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31306,7 +31306,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31339,7 +31339,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31372,7 +31372,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31405,7 +31405,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31438,7 +31438,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31471,7 +31471,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31504,7 +31504,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31537,7 +31537,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31570,7 +31570,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31603,7 +31603,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31636,7 +31636,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31669,7 +31669,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31702,7 +31702,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31735,7 +31735,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31768,7 +31768,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31801,7 +31801,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31834,7 +31834,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31867,7 +31867,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31900,7 +31900,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31933,7 +31933,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31966,7 +31966,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31999,7 +31999,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32032,7 +32032,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32065,7 +32065,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32098,7 +32098,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32131,7 +32131,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32164,7 +32164,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32197,7 +32197,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32230,7 +32230,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32263,7 +32263,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32296,7 +32296,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32329,7 +32329,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32362,7 +32362,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32395,7 +32395,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32428,7 +32428,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32461,7 +32461,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32494,7 +32494,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32527,7 +32527,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32560,7 +32560,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32593,7 +32593,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32626,7 +32626,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32659,7 +32659,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32692,7 +32692,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32725,7 +32725,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32758,7 +32758,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32791,7 +32791,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32824,7 +32824,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32857,7 +32857,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32890,7 +32890,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32923,7 +32923,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32953,7 +32953,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32983,7 +32983,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33013,7 +33013,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33043,7 +33043,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33073,7 +33073,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33103,7 +33103,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33133,7 +33133,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33163,7 +33163,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -33197,7 +33197,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33231,7 +33231,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33265,7 +33265,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33299,7 +33299,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33333,7 +33333,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33367,7 +33367,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33401,7 +33401,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33435,7 +33435,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33469,7 +33469,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33497,7 +33497,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33525,7 +33525,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33559,7 +33559,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33587,7 +33587,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33615,7 +33615,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33649,7 +33649,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33677,7 +33677,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33705,7 +33705,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33739,7 +33739,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33767,7 +33767,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33795,7 +33795,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33829,7 +33829,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33857,7 +33857,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33885,7 +33885,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33919,7 +33919,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33947,7 +33947,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -33975,7 +33975,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34009,7 +34009,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34037,7 +34037,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34065,7 +34065,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34099,7 +34099,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34127,7 +34127,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34155,7 +34155,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34189,7 +34189,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34223,7 +34223,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34257,7 +34257,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34291,7 +34291,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34325,7 +34325,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34359,7 +34359,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34393,7 +34393,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34427,7 +34427,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -34460,7 +34460,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34493,7 +34493,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34526,7 +34526,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34559,7 +34559,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34592,7 +34592,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34625,7 +34625,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34658,7 +34658,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -34691,7 +34691,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -202,7 +202,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -231,7 +231,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -320,7 +320,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -348,7 +348,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -376,7 +376,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -404,7 +404,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -432,7 +432,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -460,7 +460,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -500,7 +500,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -530,7 +530,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -564,7 +564,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -592,7 +592,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -620,7 +620,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -648,7 +648,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -679,7 +679,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -707,7 +707,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -735,7 +735,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +763,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -792,7 +792,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -826,7 +826,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -854,7 +854,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -885,7 +885,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +913,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -942,7 +942,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -971,7 +971,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1054,7 +1054,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1083,7 +1083,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1112,7 +1112,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -201,7 +201,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -229,7 +230,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -317,7 +319,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -344,7 +347,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -371,7 +375,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -398,7 +403,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -425,7 +431,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -452,7 +459,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -491,7 +499,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -520,7 +529,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -553,7 +563,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -580,7 +591,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -607,7 +619,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -634,7 +647,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -664,7 +678,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +706,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +734,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -745,7 +762,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -773,7 +791,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -806,7 +825,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -833,7 +853,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -863,7 +884,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -890,7 +912,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -918,7 +941,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -946,7 +970,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1028,7 +1053,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1056,7 +1082,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1084,7 +1111,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -182,7 +182,8 @@ module racl_ctrl_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_policy_all_rd_wr_shadowed_read_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -218,7 +219,8 @@ module racl_ctrl_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_policy_all_rd_wr_shadowed_write_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -256,7 +258,8 @@ module racl_ctrl_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_policy_rot_private_shadowed_read_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -292,7 +295,8 @@ module racl_ctrl_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_policy_rot_private_shadowed_write_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -330,7 +334,8 @@ module racl_ctrl_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_policy_soc_rot_shadowed_read_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -366,7 +371,8 @@ module racl_ctrl_reg_top
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_policy_soc_rot_shadowed_write_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -452,7 +458,8 @@ module racl_ctrl_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_log_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -480,7 +487,8 @@ module racl_ctrl_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_log_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -507,7 +515,8 @@ module racl_ctrl_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_log_read_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -534,7 +543,8 @@ module racl_ctrl_reg_top
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_log_role (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -561,7 +571,8 @@ module racl_ctrl_reg_top
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_log_ctn_uid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +604,8 @@ module racl_ctrl_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_error_log_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -183,7 +183,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_policy_all_rd_wr_shadowed_read_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -220,7 +220,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_policy_all_rd_wr_shadowed_write_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -259,7 +259,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_policy_rot_private_shadowed_read_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -296,7 +296,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_policy_rot_private_shadowed_write_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -335,7 +335,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_policy_soc_rot_shadowed_read_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -372,7 +372,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_policy_soc_rot_shadowed_write_perm (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -459,7 +459,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_log_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -488,7 +488,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_log_overflow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -516,7 +516,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_log_read_access (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -544,7 +544,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_log_role (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -572,7 +572,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_log_ctn_uid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -605,7 +605,7 @@ module racl_ctrl_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_error_log_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -229,7 +229,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -258,7 +259,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -286,7 +288,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -314,7 +317,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -342,7 +346,8 @@ module rstmgr_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -371,7 +376,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -403,7 +409,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -431,7 +438,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -492,7 +500,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -524,7 +533,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -552,7 +562,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -614,7 +625,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -643,7 +655,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -672,7 +685,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -704,7 +718,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -736,7 +751,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +784,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -797,7 +814,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -824,7 +842,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -851,7 +870,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -230,7 +230,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -260,7 +260,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -289,7 +289,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -318,7 +318,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -347,7 +347,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -377,7 +377,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -410,7 +410,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -439,7 +439,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -501,7 +501,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -534,7 +534,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -563,7 +563,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -626,7 +626,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -656,7 +656,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -686,7 +686,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -719,7 +719,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -752,7 +752,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -785,7 +785,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -815,7 +815,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +843,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -871,7 +871,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1101,7 +1101,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1131,7 +1131,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1161,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1191,7 +1191,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1221,7 +1221,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1251,7 +1251,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1281,7 +1281,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1311,7 +1311,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1341,7 +1341,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1371,7 +1371,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1401,7 +1401,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1431,7 +1431,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1461,7 +1461,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1491,7 +1491,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1521,7 +1521,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1551,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1581,7 +1581,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1611,7 +1611,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1641,7 +1641,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1671,7 +1671,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1701,7 +1701,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1731,7 +1731,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1761,7 +1761,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1791,7 +1791,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1821,7 +1821,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1851,7 +1851,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1881,7 +1881,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1911,7 +1911,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1941,7 +1941,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1971,7 +1971,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2001,7 +2001,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2031,7 +2031,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2061,7 +2061,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2091,7 +2091,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2121,7 +2121,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2151,7 +2151,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2181,7 +2181,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2211,7 +2211,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2241,7 +2241,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2271,7 +2271,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2301,7 +2301,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2331,7 +2331,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2361,7 +2361,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2391,7 +2391,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2421,7 +2421,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2451,7 +2451,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2481,7 +2481,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2511,7 +2511,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2541,7 +2541,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2571,7 +2571,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2601,7 +2601,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2631,7 +2631,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2661,7 +2661,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2691,7 +2691,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2721,7 +2721,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2751,7 +2751,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2781,7 +2781,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2811,7 +2811,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2841,7 +2841,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2871,7 +2871,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2901,7 +2901,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2931,7 +2931,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2961,7 +2961,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2991,7 +2991,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3021,7 +3021,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3051,7 +3051,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3081,7 +3081,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3111,7 +3111,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3141,7 +3141,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3171,7 +3171,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3201,7 +3201,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3231,7 +3231,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3261,7 +3261,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3291,7 +3291,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3321,7 +3321,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3351,7 +3351,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3381,7 +3381,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3411,7 +3411,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3441,7 +3441,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3471,7 +3471,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3501,7 +3501,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3531,7 +3531,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3561,7 +3561,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3591,7 +3591,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3621,7 +3621,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3651,7 +3651,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3681,7 +3681,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3711,7 +3711,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3741,7 +3741,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3771,7 +3771,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3801,7 +3801,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3831,7 +3831,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3861,7 +3861,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3891,7 +3891,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3921,7 +3921,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3951,7 +3951,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3981,7 +3981,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4011,7 +4011,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4041,7 +4041,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4071,7 +4071,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4101,7 +4101,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4131,7 +4131,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4161,7 +4161,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4191,7 +4191,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4221,7 +4221,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4251,7 +4251,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4281,7 +4281,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4311,7 +4311,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4341,7 +4341,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4371,7 +4371,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4401,7 +4401,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4431,7 +4431,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4461,7 +4461,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4491,7 +4491,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4521,7 +4521,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4551,7 +4551,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4581,7 +4581,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4611,7 +4611,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4641,7 +4641,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4671,7 +4671,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4701,7 +4701,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4731,7 +4731,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4761,7 +4761,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4791,7 +4791,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4821,7 +4821,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4851,7 +4851,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4881,7 +4881,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4911,7 +4911,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4941,7 +4941,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4971,7 +4971,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5001,7 +5001,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5031,7 +5031,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5061,7 +5061,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5091,7 +5091,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5121,7 +5121,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5151,7 +5151,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5181,7 +5181,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5211,7 +5211,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5241,7 +5241,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5271,7 +5271,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5301,7 +5301,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5331,7 +5331,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5361,7 +5361,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5391,7 +5391,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5421,7 +5421,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5451,7 +5451,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5481,7 +5481,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5511,7 +5511,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5541,7 +5541,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5571,7 +5571,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5601,7 +5601,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5631,7 +5631,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5661,7 +5661,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5691,7 +5691,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5721,7 +5721,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5751,7 +5751,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5781,7 +5781,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5811,7 +5811,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5841,7 +5841,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5872,7 +5872,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5900,7 +5900,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5928,7 +5928,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5956,7 +5956,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5984,7 +5984,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6012,7 +6012,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6040,7 +6040,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6068,7 +6068,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6096,7 +6096,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6124,7 +6124,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6152,7 +6152,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6180,7 +6180,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6208,7 +6208,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6236,7 +6236,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6264,7 +6264,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6292,7 +6292,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6320,7 +6320,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6348,7 +6348,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6376,7 +6376,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6404,7 +6404,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6432,7 +6432,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6460,7 +6460,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6488,7 +6488,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6516,7 +6516,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6544,7 +6544,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6572,7 +6572,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6600,7 +6600,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6628,7 +6628,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6656,7 +6656,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6684,7 +6684,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6712,7 +6712,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6740,7 +6740,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6771,7 +6771,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6799,7 +6799,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6827,7 +6827,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6855,7 +6855,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6883,7 +6883,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6911,7 +6911,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6939,7 +6939,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6967,7 +6967,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6995,7 +6995,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7023,7 +7023,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7051,7 +7051,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7079,7 +7079,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7107,7 +7107,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7135,7 +7135,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7163,7 +7163,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7191,7 +7191,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7219,7 +7219,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7247,7 +7247,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7275,7 +7275,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7303,7 +7303,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7331,7 +7331,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7359,7 +7359,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7387,7 +7387,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7415,7 +7415,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7443,7 +7443,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7471,7 +7471,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7499,7 +7499,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7527,7 +7527,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7555,7 +7555,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7583,7 +7583,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7611,7 +7611,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7639,7 +7639,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7670,7 +7670,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7698,7 +7698,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7726,7 +7726,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7754,7 +7754,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7782,7 +7782,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7810,7 +7810,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7838,7 +7838,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7866,7 +7866,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7894,7 +7894,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7922,7 +7922,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7950,7 +7950,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7978,7 +7978,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8006,7 +8006,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8034,7 +8034,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8062,7 +8062,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8090,7 +8090,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8118,7 +8118,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8146,7 +8146,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8174,7 +8174,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8202,7 +8202,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8230,7 +8230,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8258,7 +8258,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8286,7 +8286,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8314,7 +8314,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8342,7 +8342,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8370,7 +8370,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8398,7 +8398,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8426,7 +8426,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8454,7 +8454,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8482,7 +8482,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8510,7 +8510,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8538,7 +8538,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8569,7 +8569,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8597,7 +8597,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8625,7 +8625,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8653,7 +8653,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8681,7 +8681,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8709,7 +8709,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8737,7 +8737,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8765,7 +8765,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8793,7 +8793,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8821,7 +8821,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8849,7 +8849,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8877,7 +8877,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8905,7 +8905,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8933,7 +8933,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8961,7 +8961,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8989,7 +8989,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9017,7 +9017,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9045,7 +9045,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9073,7 +9073,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9101,7 +9101,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9129,7 +9129,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9157,7 +9157,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9185,7 +9185,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9213,7 +9213,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9241,7 +9241,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9269,7 +9269,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9297,7 +9297,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9325,7 +9325,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9353,7 +9353,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9381,7 +9381,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9409,7 +9409,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9437,7 +9437,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9468,7 +9468,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9496,7 +9496,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9524,7 +9524,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9552,7 +9552,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9580,7 +9580,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9608,7 +9608,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9636,7 +9636,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9664,7 +9664,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9692,7 +9692,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9720,7 +9720,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9748,7 +9748,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9776,7 +9776,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9804,7 +9804,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9832,7 +9832,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9860,7 +9860,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9888,7 +9888,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9916,7 +9916,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9944,7 +9944,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9972,7 +9972,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10000,7 +10000,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10028,7 +10028,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10056,7 +10056,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10084,7 +10084,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10112,7 +10112,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10140,7 +10140,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10168,7 +10168,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10196,7 +10196,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10224,7 +10224,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10252,7 +10252,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10280,7 +10280,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10308,7 +10308,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10339,7 +10339,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10367,7 +10367,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10395,7 +10395,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10423,7 +10423,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10451,7 +10451,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10479,7 +10479,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10507,7 +10507,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10535,7 +10535,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10563,7 +10563,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10591,7 +10591,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10619,7 +10619,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10647,7 +10647,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10675,7 +10675,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10703,7 +10703,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10731,7 +10731,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10759,7 +10759,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10787,7 +10787,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10815,7 +10815,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10843,7 +10843,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10871,7 +10871,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10899,7 +10899,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10927,7 +10927,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10955,7 +10955,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10983,7 +10983,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11011,7 +11011,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11039,7 +11039,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11067,7 +11067,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11095,7 +11095,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11123,7 +11123,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11151,7 +11151,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11179,7 +11179,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11207,7 +11207,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11238,7 +11238,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11266,7 +11266,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11294,7 +11294,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11322,7 +11322,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11350,7 +11350,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11378,7 +11378,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11406,7 +11406,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11434,7 +11434,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11462,7 +11462,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11490,7 +11490,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11518,7 +11518,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11546,7 +11546,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11574,7 +11574,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11602,7 +11602,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11630,7 +11630,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11658,7 +11658,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11686,7 +11686,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11714,7 +11714,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11742,7 +11742,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11770,7 +11770,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11798,7 +11798,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11826,7 +11826,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11854,7 +11854,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11882,7 +11882,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11910,7 +11910,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11938,7 +11938,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11966,7 +11966,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11994,7 +11994,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12022,7 +12022,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12050,7 +12050,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12078,7 +12078,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12106,7 +12106,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12137,7 +12137,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12165,7 +12165,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12193,7 +12193,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12221,7 +12221,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12249,7 +12249,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12277,7 +12277,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12305,7 +12305,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12333,7 +12333,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12361,7 +12361,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12389,7 +12389,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12417,7 +12417,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12445,7 +12445,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12473,7 +12473,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12501,7 +12501,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12529,7 +12529,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12557,7 +12557,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12585,7 +12585,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12613,7 +12613,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12641,7 +12641,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12669,7 +12669,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12697,7 +12697,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12725,7 +12725,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12753,7 +12753,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12781,7 +12781,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12809,7 +12809,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12837,7 +12837,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12865,7 +12865,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12893,7 +12893,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12921,7 +12921,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12949,7 +12949,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12977,7 +12977,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13005,7 +13005,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13036,7 +13036,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13064,7 +13064,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13092,7 +13092,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13120,7 +13120,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13148,7 +13148,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13176,7 +13176,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13204,7 +13204,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13232,7 +13232,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13260,7 +13260,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13288,7 +13288,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13316,7 +13316,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13344,7 +13344,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13372,7 +13372,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13400,7 +13400,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13428,7 +13428,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13456,7 +13456,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13484,7 +13484,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13512,7 +13512,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13540,7 +13540,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13568,7 +13568,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13596,7 +13596,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13624,7 +13624,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13652,7 +13652,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13680,7 +13680,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13708,7 +13708,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13736,7 +13736,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13764,7 +13764,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13792,7 +13792,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13820,7 +13820,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13848,7 +13848,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13876,7 +13876,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13904,7 +13904,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13935,7 +13935,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13963,7 +13963,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13991,7 +13991,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14019,7 +14019,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14047,7 +14047,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14075,7 +14075,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14103,7 +14103,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14131,7 +14131,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14159,7 +14159,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14187,7 +14187,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14215,7 +14215,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14243,7 +14243,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14271,7 +14271,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14299,7 +14299,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14327,7 +14327,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14355,7 +14355,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14383,7 +14383,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14411,7 +14411,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14439,7 +14439,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14467,7 +14467,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14495,7 +14495,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14523,7 +14523,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14551,7 +14551,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14579,7 +14579,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14607,7 +14607,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14635,7 +14635,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14663,7 +14663,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14691,7 +14691,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14719,7 +14719,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14747,7 +14747,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14775,7 +14775,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14804,7 +14804,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14853,7 +14853,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1100,7 +1100,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1129,7 +1130,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1158,7 +1160,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1187,7 +1190,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1216,7 +1220,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1245,7 +1250,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1274,7 +1280,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1303,7 +1310,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1332,7 +1340,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1361,7 +1370,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1390,7 +1400,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1419,7 +1430,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1448,7 +1460,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1477,7 +1490,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1506,7 +1520,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1535,7 +1550,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1564,7 +1580,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1593,7 +1610,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1622,7 +1640,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1651,7 +1670,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1680,7 +1700,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1709,7 +1730,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1738,7 +1760,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1767,7 +1790,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1796,7 +1820,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1825,7 +1850,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1854,7 +1880,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1883,7 +1910,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1912,7 +1940,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1941,7 +1970,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1970,7 +2000,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1999,7 +2030,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2028,7 +2060,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2057,7 +2090,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2086,7 +2120,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2115,7 +2150,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2144,7 +2180,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2173,7 +2210,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2202,7 +2240,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2231,7 +2270,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2260,7 +2300,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2289,7 +2330,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2318,7 +2360,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2347,7 +2390,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2376,7 +2420,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2405,7 +2450,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2434,7 +2480,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2463,7 +2510,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2492,7 +2540,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2521,7 +2570,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2550,7 +2600,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2579,7 +2630,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2608,7 +2660,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2637,7 +2690,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2666,7 +2720,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2695,7 +2750,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2724,7 +2780,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2753,7 +2810,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2782,7 +2840,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2811,7 +2870,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2840,7 +2900,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2869,7 +2930,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2898,7 +2960,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2927,7 +2990,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2956,7 +3020,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2985,7 +3050,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3014,7 +3080,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3043,7 +3110,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3072,7 +3140,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3101,7 +3170,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3130,7 +3200,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3159,7 +3230,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3188,7 +3260,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3217,7 +3290,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3246,7 +3320,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3275,7 +3350,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3380,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3333,7 +3410,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3362,7 +3440,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3391,7 +3470,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3420,7 +3500,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3449,7 +3530,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3478,7 +3560,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3507,7 +3590,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3536,7 +3620,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3565,7 +3650,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3594,7 +3680,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3623,7 +3710,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3652,7 +3740,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3681,7 +3770,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3710,7 +3800,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3739,7 +3830,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3768,7 +3860,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3797,7 +3890,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3826,7 +3920,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3855,7 +3950,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3884,7 +3980,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3913,7 +4010,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3942,7 +4040,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3971,7 +4070,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4000,7 +4100,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4029,7 +4130,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4058,7 +4160,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4087,7 +4190,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4116,7 +4220,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4145,7 +4250,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4280,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4203,7 +4310,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4232,7 +4340,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4261,7 +4370,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4290,7 +4400,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4319,7 +4430,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4348,7 +4460,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4377,7 +4490,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4406,7 +4520,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4435,7 +4550,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4464,7 +4580,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4493,7 +4610,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4522,7 +4640,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4551,7 +4670,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4580,7 +4700,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4609,7 +4730,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4638,7 +4760,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4667,7 +4790,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4696,7 +4820,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4725,7 +4850,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4754,7 +4880,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4783,7 +4910,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4812,7 +4940,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4841,7 +4970,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4870,7 +5000,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4899,7 +5030,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4928,7 +5060,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4957,7 +5090,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4986,7 +5120,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5015,7 +5150,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5044,7 +5180,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5073,7 +5210,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5102,7 +5240,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5131,7 +5270,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5160,7 +5300,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5189,7 +5330,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5218,7 +5360,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5247,7 +5390,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5276,7 +5420,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5305,7 +5450,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5334,7 +5480,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5363,7 +5510,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5540,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5421,7 +5570,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5450,7 +5600,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5479,7 +5630,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5508,7 +5660,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5537,7 +5690,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5566,7 +5720,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5595,7 +5750,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5624,7 +5780,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5653,7 +5810,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5682,7 +5840,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5712,7 +5871,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5739,7 +5899,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5766,7 +5927,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5793,7 +5955,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5820,7 +5983,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5847,7 +6011,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5874,7 +6039,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5901,7 +6067,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5928,7 +6095,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5955,7 +6123,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5982,7 +6151,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6009,7 +6179,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6036,7 +6207,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6063,7 +6235,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6090,7 +6263,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6117,7 +6291,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6144,7 +6319,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6171,7 +6347,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6198,7 +6375,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6225,7 +6403,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6252,7 +6431,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6279,7 +6459,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6306,7 +6487,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6333,7 +6515,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6360,7 +6543,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6387,7 +6571,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6414,7 +6599,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6441,7 +6627,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6468,7 +6655,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6495,7 +6683,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6522,7 +6711,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6549,7 +6739,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6579,7 +6770,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6606,7 +6798,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6633,7 +6826,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6660,7 +6854,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6687,7 +6882,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6714,7 +6910,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6741,7 +6938,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6768,7 +6966,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6795,7 +6994,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6822,7 +7022,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6849,7 +7050,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6876,7 +7078,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6903,7 +7106,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6930,7 +7134,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6957,7 +7162,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6984,7 +7190,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7011,7 +7218,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7038,7 +7246,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7065,7 +7274,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7092,7 +7302,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7119,7 +7330,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7146,7 +7358,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7173,7 +7386,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7200,7 +7414,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7227,7 +7442,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7254,7 +7470,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7281,7 +7498,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7308,7 +7526,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7335,7 +7554,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7362,7 +7582,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7389,7 +7610,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7416,7 +7638,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7446,7 +7669,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7473,7 +7697,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7500,7 +7725,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7527,7 +7753,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7554,7 +7781,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7581,7 +7809,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7608,7 +7837,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7635,7 +7865,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7662,7 +7893,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7689,7 +7921,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7716,7 +7949,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7743,7 +7977,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7770,7 +8005,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7797,7 +8033,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7824,7 +8061,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7851,7 +8089,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7878,7 +8117,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7905,7 +8145,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7932,7 +8173,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7959,7 +8201,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7986,7 +8229,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8013,7 +8257,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8040,7 +8285,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8067,7 +8313,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8094,7 +8341,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8121,7 +8369,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8148,7 +8397,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8175,7 +8425,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8202,7 +8453,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8229,7 +8481,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8256,7 +8509,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8283,7 +8537,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8313,7 +8568,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8340,7 +8596,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8367,7 +8624,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8394,7 +8652,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8421,7 +8680,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8448,7 +8708,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8475,7 +8736,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8502,7 +8764,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8529,7 +8792,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8556,7 +8820,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8583,7 +8848,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8610,7 +8876,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8637,7 +8904,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8664,7 +8932,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8691,7 +8960,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8718,7 +8988,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8745,7 +9016,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8772,7 +9044,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8799,7 +9072,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8826,7 +9100,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8853,7 +9128,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8880,7 +9156,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8907,7 +9184,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8934,7 +9212,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8961,7 +9240,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8988,7 +9268,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9015,7 +9296,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9042,7 +9324,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9069,7 +9352,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9096,7 +9380,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9123,7 +9408,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9150,7 +9436,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9180,7 +9467,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9207,7 +9495,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9234,7 +9523,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9261,7 +9551,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9288,7 +9579,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9315,7 +9607,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9342,7 +9635,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9369,7 +9663,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9396,7 +9691,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9423,7 +9719,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9450,7 +9747,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9477,7 +9775,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9504,7 +9803,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9531,7 +9831,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9558,7 +9859,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9585,7 +9887,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9612,7 +9915,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9639,7 +9943,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9666,7 +9971,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9693,7 +9999,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9720,7 +10027,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9747,7 +10055,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9774,7 +10083,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9801,7 +10111,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9828,7 +10139,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9855,7 +10167,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9882,7 +10195,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9909,7 +10223,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9936,7 +10251,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9963,7 +10279,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9990,7 +10307,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10020,7 +10338,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10047,7 +10366,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10074,7 +10394,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10101,7 +10422,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10128,7 +10450,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10155,7 +10478,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10182,7 +10506,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10209,7 +10534,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10236,7 +10562,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10263,7 +10590,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10290,7 +10618,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10317,7 +10646,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10344,7 +10674,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10371,7 +10702,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10398,7 +10730,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10425,7 +10758,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10452,7 +10786,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10479,7 +10814,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10506,7 +10842,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10533,7 +10870,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10560,7 +10898,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10587,7 +10926,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10614,7 +10954,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10641,7 +10982,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10668,7 +11010,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10695,7 +11038,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10722,7 +11066,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10749,7 +11094,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10776,7 +11122,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10803,7 +11150,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10830,7 +11178,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10857,7 +11206,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10887,7 +11237,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10914,7 +11265,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10941,7 +11293,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10968,7 +11321,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10995,7 +11349,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11022,7 +11377,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11049,7 +11405,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11076,7 +11433,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11103,7 +11461,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11130,7 +11489,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11157,7 +11517,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11184,7 +11545,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11211,7 +11573,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11238,7 +11601,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11265,7 +11629,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11292,7 +11657,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11319,7 +11685,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11346,7 +11713,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11373,7 +11741,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11400,7 +11769,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11427,7 +11797,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11454,7 +11825,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11481,7 +11853,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11508,7 +11881,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11535,7 +11909,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11562,7 +11937,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11589,7 +11965,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11616,7 +11993,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11643,7 +12021,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11670,7 +12049,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11697,7 +12077,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11724,7 +12105,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11754,7 +12136,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11781,7 +12164,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11808,7 +12192,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11835,7 +12220,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11862,7 +12248,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11889,7 +12276,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11916,7 +12304,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11943,7 +12332,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11970,7 +12360,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11997,7 +12388,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12024,7 +12416,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12051,7 +12444,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12078,7 +12472,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12105,7 +12500,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12132,7 +12528,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12159,7 +12556,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12186,7 +12584,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12213,7 +12612,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12240,7 +12640,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12267,7 +12668,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12294,7 +12696,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12321,7 +12724,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12348,7 +12752,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12375,7 +12780,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12402,7 +12808,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12429,7 +12836,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12456,7 +12864,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12483,7 +12892,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12510,7 +12920,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12537,7 +12948,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12564,7 +12976,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12591,7 +13004,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12621,7 +13035,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12648,7 +13063,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12675,7 +13091,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12702,7 +13119,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12729,7 +13147,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12756,7 +13175,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12783,7 +13203,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12810,7 +13231,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12837,7 +13259,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12864,7 +13287,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12891,7 +13315,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12918,7 +13343,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12945,7 +13371,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12972,7 +13399,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12999,7 +13427,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13026,7 +13455,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13053,7 +13483,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13080,7 +13511,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13107,7 +13539,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13134,7 +13567,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13161,7 +13595,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13188,7 +13623,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13215,7 +13651,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13242,7 +13679,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13269,7 +13707,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13296,7 +13735,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13323,7 +13763,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13350,7 +13791,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13377,7 +13819,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13404,7 +13847,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13431,7 +13875,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13458,7 +13903,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13488,7 +13934,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13515,7 +13962,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13542,7 +13990,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13569,7 +14018,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13596,7 +14046,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13623,7 +14074,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13650,7 +14102,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13677,7 +14130,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13704,7 +14158,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13731,7 +14186,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13758,7 +14214,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13785,7 +14242,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13812,7 +14270,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13839,7 +14298,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13866,7 +14326,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13893,7 +14354,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13920,7 +14382,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13947,7 +14410,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13974,7 +14438,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14001,7 +14466,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14028,7 +14494,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14055,7 +14522,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14082,7 +14550,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14109,7 +14578,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14136,7 +14606,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14163,7 +14634,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14190,7 +14662,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14217,7 +14690,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14244,7 +14718,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14271,7 +14746,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14298,7 +14774,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14326,7 +14803,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14374,7 +14852,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -253,7 +253,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -281,7 +282,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +311,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +340,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -365,7 +369,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -393,7 +398,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +427,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +456,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -477,7 +485,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h8),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -505,7 +514,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h9),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -533,7 +543,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'ha),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -561,7 +572,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hb),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -589,7 +601,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hc),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -617,7 +630,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hd),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -645,7 +659,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'he),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -673,7 +688,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -701,7 +717,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h10),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -729,7 +746,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h11),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -757,7 +775,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h12),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -785,7 +804,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h13),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -813,7 +833,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h14),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -841,7 +862,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h15),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -869,7 +891,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h16),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -897,7 +920,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h17),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -925,7 +949,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h18),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -953,7 +978,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h19),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -981,7 +1007,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1a),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1009,7 +1036,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1b),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1065,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1c),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1065,7 +1094,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1d),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1093,7 +1123,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1e),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1121,7 +1152,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1f),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1149,7 +1181,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h20),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1177,7 +1210,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h21),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1205,7 +1239,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h22),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1233,7 +1268,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h23),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1297,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h24),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1289,7 +1326,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h25),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1338,7 +1376,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1367,7 +1406,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1396,7 +1436,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1425,7 +1466,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1454,7 +1496,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -254,7 +254,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -283,7 +283,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -312,7 +312,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -341,7 +341,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -370,7 +370,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -399,7 +399,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -428,7 +428,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -457,7 +457,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -486,7 +486,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h8),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -515,7 +515,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h9),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -544,7 +544,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'ha),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -573,7 +573,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hb),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -602,7 +602,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hc),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +631,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hd),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +660,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'he),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -689,7 +689,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +718,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h10),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +747,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h11),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -776,7 +776,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h12),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -805,7 +805,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h13),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -834,7 +834,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h14),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -863,7 +863,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h15),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -892,7 +892,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h16),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -921,7 +921,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h17),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -950,7 +950,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h18),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -979,7 +979,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h19),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1008,7 +1008,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1a),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1037,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1b),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1066,7 +1066,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1c),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1095,7 +1095,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1d),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1124,7 +1124,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1e),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1153,7 +1153,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1f),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1182,7 +1182,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h20),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1211,7 +1211,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h21),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1240,7 +1240,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h22),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1269,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h23),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1298,7 +1298,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h24),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1327,7 +1327,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h25),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1377,7 +1377,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1407,7 +1407,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1437,7 +1437,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1467,7 +1467,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1497,7 +1497,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -308,7 +308,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_io_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -335,7 +336,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_init_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -364,7 +366,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_io_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -391,7 +394,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_init_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +497,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -523,7 +528,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -550,7 +556,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -577,7 +584,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -604,7 +612,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +640,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +668,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -685,7 +696,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -712,7 +724,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -739,7 +752,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -766,7 +780,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -793,7 +808,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_trig_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -825,7 +841,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -857,7 +874,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -889,7 +907,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -921,7 +940,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -953,7 +973,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -985,7 +1006,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1017,7 +1039,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1049,7 +1072,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1081,7 +1105,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1113,7 +1138,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1145,7 +1171,8 @@ module sensor_ctrl_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_alert_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1178,7 +1205,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1205,7 +1233,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1232,7 +1261,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1259,7 +1289,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1286,7 +1317,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1313,7 +1345,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1340,7 +1373,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1367,7 +1401,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1394,7 +1429,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1421,7 +1457,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1448,7 +1485,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_en_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1478,7 +1516,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1505,7 +1544,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1532,7 +1572,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1559,7 +1600,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1586,7 +1628,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1613,7 +1656,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1640,7 +1684,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1667,7 +1712,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1694,7 +1740,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1721,7 +1768,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1748,7 +1796,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_alert_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1778,7 +1827,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1805,7 +1855,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1832,7 +1883,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1859,7 +1911,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1886,7 +1939,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1913,7 +1967,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1940,7 +1995,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1967,7 +2023,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1994,7 +2051,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2021,7 +2079,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2048,7 +2107,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2075,7 +2135,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_alert_val_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2104,7 +2165,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_ast_init_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2131,7 +2193,8 @@ module sensor_ctrl_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_io_pok (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2160,7 +2223,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_manual_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2189,7 +2253,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_manual_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2218,7 +2283,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_manual_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2247,7 +2313,8 @@ module sensor_ctrl_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_manual_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -309,7 +309,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_io_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +337,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_init_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -367,7 +367,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_io_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -395,7 +395,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_init_status_change (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -498,7 +498,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -529,7 +529,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -557,7 +557,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -585,7 +585,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -613,7 +613,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -641,7 +641,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -669,7 +669,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -697,7 +697,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -725,7 +725,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -753,7 +753,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -781,7 +781,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -809,7 +809,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_trig_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -842,7 +842,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -875,7 +875,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -908,7 +908,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -941,7 +941,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -974,7 +974,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1007,7 +1007,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1040,7 +1040,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1073,7 +1073,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1106,7 +1106,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1139,7 +1139,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1172,7 +1172,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1206,7 +1206,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1234,7 +1234,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1262,7 +1262,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1290,7 +1290,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1318,7 +1318,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1346,7 +1346,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1374,7 +1374,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1402,7 +1402,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1430,7 +1430,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1458,7 +1458,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1486,7 +1486,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_en_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1517,7 +1517,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1545,7 +1545,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1573,7 +1573,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1601,7 +1601,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1629,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1657,7 +1657,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1685,7 +1685,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1713,7 +1713,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1741,7 +1741,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1769,7 +1769,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1797,7 +1797,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_alert_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1828,7 +1828,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1856,7 +1856,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1884,7 +1884,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1912,7 +1912,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1940,7 +1940,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1968,7 +1968,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1996,7 +1996,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2024,7 +2024,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2052,7 +2052,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2080,7 +2080,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2108,7 +2108,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2136,7 +2136,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_alert_val_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2166,7 +2166,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_ast_init_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2194,7 +2194,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_io_pok (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2224,7 +2224,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_manual_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2254,7 +2254,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_manual_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2284,7 +2284,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_manual_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2314,7 +2314,7 @@ module sensor_ctrl_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_manual_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -1875,7 +1875,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1902,7 +1903,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1929,7 +1931,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1956,7 +1959,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1985,7 +1989,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2012,7 +2017,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2039,7 +2045,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2066,7 +2073,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2163,7 +2171,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ping_timer_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2194,7 +2203,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ping_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2234,7 +2244,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ping_timer_en_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2272,7 +2283,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2301,7 +2313,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2330,7 +2343,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2359,7 +2373,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2388,7 +2403,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2417,7 +2433,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2446,7 +2463,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2475,7 +2493,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2504,7 +2523,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2533,7 +2553,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2562,7 +2583,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2591,7 +2613,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2620,7 +2643,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2649,7 +2673,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2678,7 +2703,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2707,7 +2733,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2736,7 +2763,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2765,7 +2793,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2794,7 +2823,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2823,7 +2853,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2852,7 +2883,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2881,7 +2913,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2910,7 +2943,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2939,7 +2973,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2968,7 +3003,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2997,7 +3033,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3026,7 +3063,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3055,7 +3093,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3084,7 +3123,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3113,7 +3153,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3142,7 +3183,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3171,7 +3213,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3200,7 +3243,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3229,7 +3273,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3258,7 +3303,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3287,7 +3333,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3316,7 +3363,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3345,7 +3393,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3374,7 +3423,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3403,7 +3453,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3432,7 +3483,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3461,7 +3513,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3490,7 +3543,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3519,7 +3573,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3548,7 +3603,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3577,7 +3633,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3606,7 +3663,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3635,7 +3693,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3664,7 +3723,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3693,7 +3753,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3722,7 +3783,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3751,7 +3813,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3780,7 +3843,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3809,7 +3873,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3838,7 +3903,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3867,7 +3933,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3896,7 +3963,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3925,7 +3993,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3954,7 +4023,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3983,7 +4053,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4012,7 +4083,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4041,7 +4113,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4070,7 +4143,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4099,7 +4173,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4128,7 +4203,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4160,7 +4236,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4201,7 +4278,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4242,7 +4320,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4283,7 +4362,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4324,7 +4404,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4365,7 +4446,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4406,7 +4488,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4447,7 +4530,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4488,7 +4572,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4529,7 +4614,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4570,7 +4656,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4611,7 +4698,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4652,7 +4740,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4693,7 +4782,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4734,7 +4824,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4775,7 +4866,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4816,7 +4908,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4857,7 +4950,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4898,7 +4992,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4939,7 +5034,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4980,7 +5076,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5021,7 +5118,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5062,7 +5160,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5103,7 +5202,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5144,7 +5244,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5185,7 +5286,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5226,7 +5328,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5267,7 +5370,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5308,7 +5412,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5349,7 +5454,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5390,7 +5496,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5431,7 +5538,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5472,7 +5580,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5513,7 +5622,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5554,7 +5664,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5595,7 +5706,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5636,7 +5748,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5677,7 +5790,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5718,7 +5832,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5759,7 +5874,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5800,7 +5916,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5841,7 +5958,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5882,7 +6000,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5923,7 +6042,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5964,7 +6084,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6005,7 +6126,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6046,7 +6168,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6087,7 +6210,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6128,7 +6252,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6169,7 +6294,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6210,7 +6336,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6251,7 +6378,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6292,7 +6420,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6333,7 +6462,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6374,7 +6504,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6415,7 +6546,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6456,7 +6588,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6497,7 +6630,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6538,7 +6672,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6579,7 +6714,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6620,7 +6756,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6661,7 +6798,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6702,7 +6840,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6743,7 +6882,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6784,7 +6924,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_en_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6825,7 +6966,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6866,7 +7008,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6907,7 +7050,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6948,7 +7092,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6989,7 +7134,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7030,7 +7176,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7071,7 +7218,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7112,7 +7260,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7153,7 +7302,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7194,7 +7344,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7235,7 +7386,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7276,7 +7428,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7317,7 +7470,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7358,7 +7512,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7399,7 +7554,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7440,7 +7596,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7481,7 +7638,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7522,7 +7680,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7563,7 +7722,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7604,7 +7764,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7645,7 +7806,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7686,7 +7848,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7727,7 +7890,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7768,7 +7932,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7809,7 +7974,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7850,7 +8016,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7891,7 +8058,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7932,7 +8100,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7973,7 +8142,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8014,7 +8184,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8055,7 +8226,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8096,7 +8268,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8137,7 +8310,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8178,7 +8352,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8219,7 +8394,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8260,7 +8436,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8301,7 +8478,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8342,7 +8520,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8383,7 +8562,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8424,7 +8604,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8465,7 +8646,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8506,7 +8688,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8547,7 +8730,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8588,7 +8772,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8629,7 +8814,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8670,7 +8856,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8711,7 +8898,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8752,7 +8940,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8793,7 +8982,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8834,7 +9024,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8875,7 +9066,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8916,7 +9108,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8957,7 +9150,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8998,7 +9192,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9039,7 +9234,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9080,7 +9276,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9121,7 +9318,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9162,7 +9360,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9203,7 +9402,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9244,7 +9444,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9285,7 +9486,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9326,7 +9528,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9367,7 +9570,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9408,7 +9612,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9449,7 +9654,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_class_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9487,7 +9693,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9516,7 +9723,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9545,7 +9753,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9574,7 +9783,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9603,7 +9813,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9632,7 +9843,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9661,7 +9873,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9690,7 +9903,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9719,7 +9933,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9748,7 +9963,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9777,7 +9993,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9806,7 +10023,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9835,7 +10053,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9864,7 +10083,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9893,7 +10113,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9922,7 +10143,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9951,7 +10173,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9980,7 +10203,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10009,7 +10233,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10038,7 +10263,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10067,7 +10293,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10096,7 +10323,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10125,7 +10353,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10154,7 +10383,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10183,7 +10413,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10212,7 +10443,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10241,7 +10473,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10270,7 +10503,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10299,7 +10533,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10328,7 +10563,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10357,7 +10593,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10386,7 +10623,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10415,7 +10653,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10444,7 +10683,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10473,7 +10713,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10502,7 +10743,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10531,7 +10773,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10560,7 +10803,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10589,7 +10833,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10618,7 +10863,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10647,7 +10893,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10676,7 +10923,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10705,7 +10953,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10734,7 +10983,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10763,7 +11013,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10792,7 +11043,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10821,7 +11073,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10850,7 +11103,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10879,7 +11133,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10908,7 +11163,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10937,7 +11193,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10966,7 +11223,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10995,7 +11253,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11024,7 +11283,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11053,7 +11313,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11082,7 +11343,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11111,7 +11373,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11140,7 +11403,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11169,7 +11433,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11198,7 +11463,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11227,7 +11493,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11256,7 +11523,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11285,7 +11553,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11314,7 +11583,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11343,7 +11613,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_cause_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11372,7 +11643,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11401,7 +11673,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11430,7 +11703,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11459,7 +11733,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11488,7 +11763,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11517,7 +11793,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11546,7 +11823,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11578,7 +11856,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11619,7 +11898,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11660,7 +11940,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11701,7 +11982,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11742,7 +12024,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11783,7 +12066,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11824,7 +12108,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11866,7 +12151,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11908,7 +12194,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11950,7 +12237,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11992,7 +12280,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12034,7 +12323,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12076,7 +12366,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12118,7 +12409,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12156,7 +12448,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12185,7 +12478,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12214,7 +12508,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12243,7 +12538,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12272,7 +12568,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12301,7 +12598,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12330,7 +12628,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_loc_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12358,7 +12657,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12390,7 +12690,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12426,7 +12727,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12462,7 +12764,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12498,7 +12801,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12534,7 +12838,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12570,7 +12875,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12606,7 +12912,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12642,7 +12949,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12678,7 +12986,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12714,7 +13023,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12751,7 +13061,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12793,7 +13104,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12850,7 +13162,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12890,7 +13203,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12931,7 +13245,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12971,7 +13286,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13011,7 +13327,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13051,7 +13368,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13091,7 +13409,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classa_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13160,7 +13479,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13192,7 +13512,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13228,7 +13549,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13264,7 +13586,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13300,7 +13623,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13336,7 +13660,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13372,7 +13697,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13408,7 +13734,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13444,7 +13771,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13480,7 +13808,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13516,7 +13845,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13553,7 +13883,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13595,7 +13926,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13652,7 +13984,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13692,7 +14025,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13733,7 +14067,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13773,7 +14108,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13813,7 +14149,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13853,7 +14190,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13893,7 +14231,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classb_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13962,7 +14301,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13994,7 +14334,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14030,7 +14371,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14066,7 +14408,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14102,7 +14445,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14138,7 +14482,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14174,7 +14519,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14210,7 +14556,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14246,7 +14593,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14282,7 +14630,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14318,7 +14667,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14355,7 +14705,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14397,7 +14748,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14454,7 +14806,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14494,7 +14847,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14535,7 +14889,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14575,7 +14930,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14615,7 +14971,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14655,7 +15012,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14695,7 +15053,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classc_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14764,7 +15123,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14796,7 +15156,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14832,7 +15193,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14868,7 +15230,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14904,7 +15267,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14940,7 +15304,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14976,7 +15341,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15012,7 +15378,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15048,7 +15415,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15084,7 +15452,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15120,7 +15489,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15157,7 +15527,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15199,7 +15570,8 @@ module alert_handler_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15256,7 +15628,8 @@ module alert_handler_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15296,7 +15669,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15337,7 +15711,8 @@ module alert_handler_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15377,7 +15752,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15417,7 +15793,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15457,7 +15834,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15497,7 +15875,8 @@ module alert_handler_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_classd_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -1876,7 +1876,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1904,7 +1904,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1932,7 +1932,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1960,7 +1960,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1990,7 +1990,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classa (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2018,7 +2018,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classb (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2046,7 +2046,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classc (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2074,7 +2074,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_classd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2172,7 +2172,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ping_timer_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2204,7 +2204,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h100),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ping_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2245,7 +2245,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ping_timer_en_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2284,7 +2284,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2314,7 +2314,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2344,7 +2344,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2374,7 +2374,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2404,7 +2404,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2434,7 +2434,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2464,7 +2464,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2494,7 +2494,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2524,7 +2524,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2554,7 +2554,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2584,7 +2584,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2614,7 +2614,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2644,7 +2644,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2674,7 +2674,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2704,7 +2704,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2734,7 +2734,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2764,7 +2764,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2794,7 +2794,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2824,7 +2824,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2854,7 +2854,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2884,7 +2884,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2914,7 +2914,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2944,7 +2944,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2974,7 +2974,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3004,7 +3004,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3034,7 +3034,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3064,7 +3064,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3094,7 +3094,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3124,7 +3124,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3154,7 +3154,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3184,7 +3184,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3214,7 +3214,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3244,7 +3244,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3274,7 +3274,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3304,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3334,7 +3334,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3364,7 +3364,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3394,7 +3394,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3424,7 +3424,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3454,7 +3454,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3484,7 +3484,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3514,7 +3514,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3544,7 +3544,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3574,7 +3574,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3604,7 +3604,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3634,7 +3634,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3664,7 +3664,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3694,7 +3694,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3724,7 +3724,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3754,7 +3754,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3784,7 +3784,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3814,7 +3814,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3844,7 +3844,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3874,7 +3874,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3904,7 +3904,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3934,7 +3934,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3964,7 +3964,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3994,7 +3994,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4024,7 +4024,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4054,7 +4054,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4084,7 +4084,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4114,7 +4114,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4144,7 +4144,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4174,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4204,7 +4204,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4237,7 +4237,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4279,7 +4279,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4321,7 +4321,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4363,7 +4363,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4405,7 +4405,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4447,7 +4447,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4489,7 +4489,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4531,7 +4531,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4573,7 +4573,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4615,7 +4615,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4657,7 +4657,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4699,7 +4699,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4741,7 +4741,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4783,7 +4783,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4825,7 +4825,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4867,7 +4867,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4909,7 +4909,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4951,7 +4951,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4993,7 +4993,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5035,7 +5035,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5077,7 +5077,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5119,7 +5119,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5161,7 +5161,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5203,7 +5203,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5245,7 +5245,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5287,7 +5287,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5329,7 +5329,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5371,7 +5371,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5413,7 +5413,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5455,7 +5455,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5497,7 +5497,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5539,7 +5539,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5581,7 +5581,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5623,7 +5623,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5665,7 +5665,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5707,7 +5707,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5749,7 +5749,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5791,7 +5791,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5833,7 +5833,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5875,7 +5875,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5917,7 +5917,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5959,7 +5959,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6001,7 +6001,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6043,7 +6043,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6085,7 +6085,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6127,7 +6127,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6169,7 +6169,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6211,7 +6211,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6253,7 +6253,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6295,7 +6295,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6337,7 +6337,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6379,7 +6379,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6421,7 +6421,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6463,7 +6463,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6505,7 +6505,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6547,7 +6547,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6589,7 +6589,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6631,7 +6631,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6673,7 +6673,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6715,7 +6715,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6757,7 +6757,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6799,7 +6799,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6841,7 +6841,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6883,7 +6883,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6925,7 +6925,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_en_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6967,7 +6967,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7009,7 +7009,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7051,7 +7051,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7093,7 +7093,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7135,7 +7135,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7177,7 +7177,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7219,7 +7219,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7261,7 +7261,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7303,7 +7303,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7345,7 +7345,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7387,7 +7387,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7429,7 +7429,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7471,7 +7471,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7513,7 +7513,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7555,7 +7555,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7597,7 +7597,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7639,7 +7639,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7681,7 +7681,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7723,7 +7723,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7765,7 +7765,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7807,7 +7807,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7849,7 +7849,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7891,7 +7891,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7933,7 +7933,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7975,7 +7975,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8017,7 +8017,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8059,7 +8059,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8101,7 +8101,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8143,7 +8143,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8185,7 +8185,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8227,7 +8227,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8269,7 +8269,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8311,7 +8311,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8353,7 +8353,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8395,7 +8395,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8437,7 +8437,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8479,7 +8479,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8521,7 +8521,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8563,7 +8563,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8605,7 +8605,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8647,7 +8647,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8689,7 +8689,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8731,7 +8731,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8773,7 +8773,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8815,7 +8815,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8857,7 +8857,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8899,7 +8899,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8941,7 +8941,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8983,7 +8983,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9025,7 +9025,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9067,7 +9067,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9109,7 +9109,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9151,7 +9151,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9193,7 +9193,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9235,7 +9235,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9277,7 +9277,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9319,7 +9319,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9361,7 +9361,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9403,7 +9403,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9445,7 +9445,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9487,7 +9487,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9529,7 +9529,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9571,7 +9571,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9613,7 +9613,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9655,7 +9655,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_class_shadowed_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9694,7 +9694,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9724,7 +9724,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9754,7 +9754,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9784,7 +9784,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9814,7 +9814,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9844,7 +9844,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9874,7 +9874,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9904,7 +9904,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9934,7 +9934,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9964,7 +9964,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9994,7 +9994,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10024,7 +10024,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10054,7 +10054,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10084,7 +10084,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10114,7 +10114,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10144,7 +10144,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10174,7 +10174,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10204,7 +10204,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10234,7 +10234,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10264,7 +10264,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10294,7 +10294,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10324,7 +10324,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10354,7 +10354,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10384,7 +10384,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10414,7 +10414,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10444,7 +10444,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10474,7 +10474,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10504,7 +10504,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10534,7 +10534,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10564,7 +10564,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10594,7 +10594,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10624,7 +10624,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10654,7 +10654,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10684,7 +10684,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10714,7 +10714,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10744,7 +10744,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10774,7 +10774,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10804,7 +10804,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10834,7 +10834,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10864,7 +10864,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10894,7 +10894,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10924,7 +10924,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10954,7 +10954,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10984,7 +10984,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11014,7 +11014,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11044,7 +11044,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11074,7 +11074,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11104,7 +11104,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11134,7 +11134,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11164,7 +11164,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11194,7 +11194,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11224,7 +11224,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11254,7 +11254,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11284,7 +11284,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11314,7 +11314,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11344,7 +11344,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11374,7 +11374,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11404,7 +11404,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11434,7 +11434,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11464,7 +11464,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11494,7 +11494,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11524,7 +11524,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11554,7 +11554,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11584,7 +11584,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11614,7 +11614,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_cause_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11644,7 +11644,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11674,7 +11674,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11704,7 +11704,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11734,7 +11734,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11764,7 +11764,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11794,7 +11794,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11824,7 +11824,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11857,7 +11857,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11899,7 +11899,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11941,7 +11941,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11983,7 +11983,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12025,7 +12025,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12067,7 +12067,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12109,7 +12109,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_en_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12152,7 +12152,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12195,7 +12195,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12238,7 +12238,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12281,7 +12281,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12324,7 +12324,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12367,7 +12367,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12410,7 +12410,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_class_shadowed_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12449,7 +12449,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12479,7 +12479,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12509,7 +12509,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12539,7 +12539,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12569,7 +12569,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12599,7 +12599,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12629,7 +12629,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_loc_alert_cause_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12658,7 +12658,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12691,7 +12691,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12728,7 +12728,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12765,7 +12765,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12802,7 +12802,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12839,7 +12839,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12876,7 +12876,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12913,7 +12913,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12950,7 +12950,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12987,7 +12987,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13024,7 +13024,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13062,7 +13062,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13105,7 +13105,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13163,7 +13163,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13204,7 +13204,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13246,7 +13246,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13287,7 +13287,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13328,7 +13328,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13369,7 +13369,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13410,7 +13410,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classa_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13480,7 +13480,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13513,7 +13513,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13550,7 +13550,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13587,7 +13587,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13624,7 +13624,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13661,7 +13661,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13698,7 +13698,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13735,7 +13735,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13772,7 +13772,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13809,7 +13809,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13846,7 +13846,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13884,7 +13884,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13927,7 +13927,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13985,7 +13985,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14026,7 +14026,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14068,7 +14068,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14109,7 +14109,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14150,7 +14150,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14191,7 +14191,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14232,7 +14232,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classb_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14302,7 +14302,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14335,7 +14335,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14372,7 +14372,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14409,7 +14409,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14446,7 +14446,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14483,7 +14483,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14520,7 +14520,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14557,7 +14557,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14594,7 +14594,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14631,7 +14631,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14668,7 +14668,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14706,7 +14706,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14749,7 +14749,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14807,7 +14807,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14848,7 +14848,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14890,7 +14890,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14931,7 +14931,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14972,7 +14972,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15013,7 +15013,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15054,7 +15054,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classc_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15124,7 +15124,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15157,7 +15157,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15194,7 +15194,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15231,7 +15231,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15268,7 +15268,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15305,7 +15305,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15342,7 +15342,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_en_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15379,7 +15379,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15416,7 +15416,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15453,7 +15453,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15490,7 +15490,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_ctrl_shadowed_map_e3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15528,7 +15528,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_clr_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15571,7 +15571,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_clr_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15629,7 +15629,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_accum_thresh_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15670,7 +15670,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_timeout_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15712,7 +15712,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_crashdump_trigger_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15753,7 +15753,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase0_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15794,7 +15794,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase1_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15835,7 +15835,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase2_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15876,7 +15876,7 @@ module alert_handler_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_classd_phase3_cyc_shadowed (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -737,7 +737,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -770,7 +770,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -798,7 +798,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +843,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -875,7 +875,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -905,7 +905,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -933,7 +933,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -961,7 +961,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -989,7 +989,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1019,7 +1019,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1047,7 +1047,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1075,7 +1075,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_kmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1103,7 +1103,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_clk_main_otbn_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1133,7 +1133,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1161,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1189,7 +1189,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_kmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1217,7 +1217,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status_clk_main_otbn_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1246,7 +1246,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1337,7 +1337,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1397,7 +1397,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1d6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1498,7 +1498,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'hfa),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div2_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1558,7 +1558,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'he6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div2_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1659,7 +1659,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h82),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1719,7 +1719,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h6e),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1820,7 +1820,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1fe),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1880,7 +1880,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1980,7 +1980,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'hfa),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -2040,7 +2040,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'he6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -2079,7 +2079,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2107,7 +2107,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2135,7 +2135,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div2_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2163,7 +2163,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2191,7 +2191,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2219,7 +2219,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2247,7 +2247,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2275,7 +2275,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div2_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2303,7 +2303,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2331,7 +2331,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2359,7 +2359,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2389,7 +2389,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2417,7 +2417,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2445,7 +2445,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -736,7 +736,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +769,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -795,7 +797,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -839,7 +842,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -870,7 +874,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -899,7 +904,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -926,7 +932,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -953,7 +960,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -980,7 +988,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1009,7 +1018,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1036,7 +1046,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1063,7 +1074,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_kmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1090,7 +1102,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_clk_main_otbn_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1119,7 +1132,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1146,7 +1160,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1173,7 +1188,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_kmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1200,7 +1216,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status_clk_main_otbn_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1228,7 +1245,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1279,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_io_meas_ctrl_en (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1317,7 +1336,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1376,7 +1396,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1d6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1419,7 +1440,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_io_div2_meas_ctrl_en (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1475,7 +1497,8 @@ module clkmgr_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'hfa),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div2_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1534,7 +1557,8 @@ module clkmgr_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'he6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div2_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div2_i),
     .rst_ni  (rst_io_div2_ni),
@@ -1577,7 +1601,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_en (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1633,7 +1658,8 @@ module clkmgr_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h82),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1692,7 +1718,8 @@ module clkmgr_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h6e),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1735,7 +1762,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_en (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1791,7 +1819,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1fe),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1850,7 +1879,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1892,7 +1922,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_en (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1948,7 +1979,8 @@ module clkmgr_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'hfa),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -2007,7 +2039,8 @@ module clkmgr_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'he6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -2045,7 +2078,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2072,7 +2106,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2099,7 +2134,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div2_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2126,7 +2162,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2153,7 +2190,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2180,7 +2218,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2207,7 +2246,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2234,7 +2274,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div2_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2261,7 +2302,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2288,7 +2330,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2315,7 +2358,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2344,7 +2388,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2371,7 +2416,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2398,7 +2444,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1025,7 +1025,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1053,7 +1053,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1081,7 +1081,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1109,7 +1109,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1137,7 +1137,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1165,7 +1165,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1195,7 +1195,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1223,7 +1223,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1251,7 +1251,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1279,7 +1279,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1307,7 +1307,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1335,7 +1335,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1550,7 +1550,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1579,7 +1579,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1608,7 +1608,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1657,7 +1657,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1685,7 +1685,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1713,7 +1713,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_prog_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1741,7 +1741,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_erase_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1769,7 +1769,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_partition_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1797,7 +1797,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_info_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1825,7 +1825,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1857,7 +1857,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1890,7 +1890,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prog_type_en_normal (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1918,7 +1918,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prog_type_en_repair (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1947,7 +1947,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_erase_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1977,7 +1977,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2007,7 +2007,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2037,7 +2037,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2067,7 +2067,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2097,7 +2097,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2127,7 +2127,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2157,7 +2157,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2187,7 +2187,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2221,7 +2221,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2249,7 +2249,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2277,7 +2277,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2305,7 +2305,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2333,7 +2333,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2361,7 +2361,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2389,7 +2389,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2423,7 +2423,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2451,7 +2451,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2479,7 +2479,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2507,7 +2507,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2535,7 +2535,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2563,7 +2563,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2591,7 +2591,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2625,7 +2625,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2653,7 +2653,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2681,7 +2681,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2709,7 +2709,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2737,7 +2737,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2765,7 +2765,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2793,7 +2793,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2827,7 +2827,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2855,7 +2855,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2883,7 +2883,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2911,7 +2911,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2939,7 +2939,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2967,7 +2967,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2995,7 +2995,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3029,7 +3029,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3057,7 +3057,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3085,7 +3085,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3113,7 +3113,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3141,7 +3141,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3169,7 +3169,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3197,7 +3197,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3231,7 +3231,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3259,7 +3259,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3287,7 +3287,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3315,7 +3315,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3343,7 +3343,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3371,7 +3371,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3399,7 +3399,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3433,7 +3433,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3461,7 +3461,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3489,7 +3489,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3517,7 +3517,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3545,7 +3545,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3573,7 +3573,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3601,7 +3601,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3635,7 +3635,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3663,7 +3663,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3691,7 +3691,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3719,7 +3719,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3747,7 +3747,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3775,7 +3775,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3803,7 +3803,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3837,7 +3837,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3865,7 +3865,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3899,7 +3899,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3927,7 +3927,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3961,7 +3961,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3989,7 +3989,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4023,7 +4023,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4051,7 +4051,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4085,7 +4085,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4113,7 +4113,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4147,7 +4147,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4175,7 +4175,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4209,7 +4209,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4237,7 +4237,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4271,7 +4271,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4299,7 +4299,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4329,7 +4329,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4357,7 +4357,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4385,7 +4385,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4413,7 +4413,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4441,7 +4441,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4469,7 +4469,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4499,7 +4499,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4529,7 +4529,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4559,7 +4559,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4589,7 +4589,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4619,7 +4619,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4649,7 +4649,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4679,7 +4679,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4709,7 +4709,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4739,7 +4739,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4769,7 +4769,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4803,7 +4803,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4831,7 +4831,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4859,7 +4859,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4887,7 +4887,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4915,7 +4915,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4943,7 +4943,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4971,7 +4971,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5005,7 +5005,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5033,7 +5033,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5061,7 +5061,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5089,7 +5089,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5117,7 +5117,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5145,7 +5145,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5173,7 +5173,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5207,7 +5207,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5235,7 +5235,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5263,7 +5263,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5291,7 +5291,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5319,7 +5319,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5347,7 +5347,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5375,7 +5375,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5409,7 +5409,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5437,7 +5437,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5465,7 +5465,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5493,7 +5493,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5521,7 +5521,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5549,7 +5549,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5577,7 +5577,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5611,7 +5611,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5639,7 +5639,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5667,7 +5667,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5695,7 +5695,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5723,7 +5723,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5751,7 +5751,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5779,7 +5779,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5813,7 +5813,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5841,7 +5841,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5869,7 +5869,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5897,7 +5897,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5925,7 +5925,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5953,7 +5953,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5981,7 +5981,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6015,7 +6015,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6043,7 +6043,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6071,7 +6071,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6099,7 +6099,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6127,7 +6127,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6155,7 +6155,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6183,7 +6183,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6217,7 +6217,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6245,7 +6245,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6273,7 +6273,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6301,7 +6301,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6329,7 +6329,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6357,7 +6357,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6385,7 +6385,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6419,7 +6419,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6447,7 +6447,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6475,7 +6475,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6503,7 +6503,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6531,7 +6531,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6559,7 +6559,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6587,7 +6587,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6621,7 +6621,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6649,7 +6649,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6677,7 +6677,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6705,7 +6705,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6733,7 +6733,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6761,7 +6761,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6789,7 +6789,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6819,7 +6819,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6853,7 +6853,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6881,7 +6881,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6909,7 +6909,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6937,7 +6937,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6965,7 +6965,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6993,7 +6993,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7021,7 +7021,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7051,7 +7051,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7081,7 +7081,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7115,7 +7115,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7143,7 +7143,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7171,7 +7171,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7199,7 +7199,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7227,7 +7227,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7255,7 +7255,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7283,7 +7283,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7317,7 +7317,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7345,7 +7345,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7373,7 +7373,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7401,7 +7401,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7429,7 +7429,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7457,7 +7457,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7485,7 +7485,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7515,7 +7515,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7545,7 +7545,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7575,7 +7575,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7605,7 +7605,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7635,7 +7635,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7665,7 +7665,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7695,7 +7695,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7725,7 +7725,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7755,7 +7755,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7785,7 +7785,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7819,7 +7819,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7847,7 +7847,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7875,7 +7875,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7903,7 +7903,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7931,7 +7931,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7959,7 +7959,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7987,7 +7987,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8021,7 +8021,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8049,7 +8049,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8077,7 +8077,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8105,7 +8105,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8133,7 +8133,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8161,7 +8161,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8189,7 +8189,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8223,7 +8223,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8251,7 +8251,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8279,7 +8279,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8307,7 +8307,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8335,7 +8335,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8363,7 +8363,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8391,7 +8391,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8425,7 +8425,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8453,7 +8453,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8481,7 +8481,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8509,7 +8509,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8537,7 +8537,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8565,7 +8565,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8593,7 +8593,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8627,7 +8627,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8655,7 +8655,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8683,7 +8683,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8711,7 +8711,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8739,7 +8739,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8767,7 +8767,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8795,7 +8795,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8829,7 +8829,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8857,7 +8857,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8885,7 +8885,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8913,7 +8913,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8941,7 +8941,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8969,7 +8969,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8997,7 +8997,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9031,7 +9031,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9059,7 +9059,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9087,7 +9087,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9115,7 +9115,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9143,7 +9143,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9171,7 +9171,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9199,7 +9199,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9233,7 +9233,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9261,7 +9261,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9289,7 +9289,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9317,7 +9317,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9345,7 +9345,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9373,7 +9373,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9401,7 +9401,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9435,7 +9435,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9463,7 +9463,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9491,7 +9491,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9519,7 +9519,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9547,7 +9547,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9575,7 +9575,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9603,7 +9603,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9637,7 +9637,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9665,7 +9665,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9693,7 +9693,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9721,7 +9721,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9749,7 +9749,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9777,7 +9777,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9805,7 +9805,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9835,7 +9835,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9869,7 +9869,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9897,7 +9897,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9925,7 +9925,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9953,7 +9953,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9981,7 +9981,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10009,7 +10009,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10037,7 +10037,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10067,7 +10067,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10097,7 +10097,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10131,7 +10131,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10159,7 +10159,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10187,7 +10187,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10215,7 +10215,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10243,7 +10243,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10271,7 +10271,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10299,7 +10299,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10333,7 +10333,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10361,7 +10361,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10389,7 +10389,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10417,7 +10417,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10445,7 +10445,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10473,7 +10473,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10501,7 +10501,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10531,7 +10531,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_info_cfg_override_scramble_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10559,7 +10559,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_info_cfg_override_ecc_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10588,7 +10588,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10622,7 +10622,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10659,7 +10659,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10698,7 +10698,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_op_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10726,7 +10726,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_op_status_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10756,7 +10756,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10784,7 +10784,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rd_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10812,7 +10812,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_prog_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10840,7 +10840,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10868,7 +10868,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10896,7 +10896,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_initialized (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10942,7 +10942,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10970,7 +10970,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10998,7 +10998,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11026,7 +11026,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11054,7 +11054,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11082,7 +11082,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11110,7 +11110,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11138,7 +11138,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_macro_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11168,7 +11168,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11196,7 +11196,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_prog_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11224,7 +11224,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_lcmgr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11252,7 +11252,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_lcmgr_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11280,7 +11280,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_arb_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11308,7 +11308,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11336,7 +11336,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_phy_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11364,7 +11364,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_ctrl_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11392,7 +11392,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_fifo_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11422,7 +11422,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11450,7 +11450,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11478,7 +11478,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11506,7 +11506,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11534,7 +11534,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11562,7 +11562,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11590,7 +11590,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_seed_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11618,7 +11618,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_phy_relbl_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11646,7 +11646,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_phy_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11674,7 +11674,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_spurious_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11702,7 +11702,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_arb_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11730,7 +11730,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_host_gnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11759,7 +11759,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11790,7 +11790,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11818,7 +11818,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11848,7 +11848,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11878,7 +11878,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11908,7 +11908,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_alert_cfg_alert_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11936,7 +11936,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_alert_cfg_alert_trig (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11966,7 +11966,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11994,7 +11994,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_status_prog_normal_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12022,7 +12022,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_status_prog_repair_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12051,7 +12051,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_scratch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12081,7 +12081,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_lvl_prog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12109,7 +12109,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_lvl_rd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12138,7 +12138,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1024,7 +1024,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1051,7 +1052,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1078,7 +1080,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1108,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1132,7 +1136,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1159,7 +1164,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1188,7 +1194,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1215,7 +1222,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1242,7 +1250,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1278,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1306,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1323,7 +1334,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1537,7 +1549,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1565,7 +1578,8 @@ module flash_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1593,7 +1607,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1641,7 +1656,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1668,7 +1684,8 @@ module flash_ctrl_core_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1695,7 +1712,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_prog_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1722,7 +1740,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_erase_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1749,7 +1768,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_partition_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1776,7 +1796,8 @@ module flash_ctrl_core_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_info_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1803,7 +1824,8 @@ module flash_ctrl_core_reg_top (
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1834,7 +1856,8 @@ module flash_ctrl_core_reg_top (
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1866,7 +1889,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prog_type_en_normal (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1893,7 +1917,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prog_type_en_repair (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1921,7 +1946,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_erase_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1950,7 +1976,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1979,7 +2006,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2008,7 +2036,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2037,7 +2066,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2066,7 +2096,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2095,7 +2126,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2124,7 +2156,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2153,7 +2186,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2186,7 +2220,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2213,7 +2248,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2240,7 +2276,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2267,7 +2304,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2294,7 +2332,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2321,7 +2360,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2348,7 +2388,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2381,7 +2422,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2408,7 +2450,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2435,7 +2478,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2462,7 +2506,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2489,7 +2534,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2516,7 +2562,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2543,7 +2590,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2576,7 +2624,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2603,7 +2652,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2630,7 +2680,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2657,7 +2708,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2684,7 +2736,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2711,7 +2764,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2738,7 +2792,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2771,7 +2826,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2798,7 +2854,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2825,7 +2882,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2852,7 +2910,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2879,7 +2938,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2906,7 +2966,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2933,7 +2994,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2966,7 +3028,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2993,7 +3056,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3020,7 +3084,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3047,7 +3112,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3074,7 +3140,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3101,7 +3168,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3128,7 +3196,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3161,7 +3230,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3188,7 +3258,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3215,7 +3286,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3242,7 +3314,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3269,7 +3342,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3296,7 +3370,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3323,7 +3398,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3356,7 +3432,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3383,7 +3460,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3410,7 +3488,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3437,7 +3516,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3464,7 +3544,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3491,7 +3572,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3518,7 +3600,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3551,7 +3634,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3578,7 +3662,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3605,7 +3690,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3632,7 +3718,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3659,7 +3746,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3686,7 +3774,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3713,7 +3802,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3746,7 +3836,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3773,7 +3864,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3806,7 +3898,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3833,7 +3926,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3866,7 +3960,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3893,7 +3988,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3926,7 +4022,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3953,7 +4050,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3986,7 +4084,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4013,7 +4112,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4046,7 +4146,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4073,7 +4174,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4106,7 +4208,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4133,7 +4236,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4166,7 +4270,8 @@ module flash_ctrl_core_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4193,7 +4298,8 @@ module flash_ctrl_core_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4222,7 +4328,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4249,7 +4356,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4276,7 +4384,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4303,7 +4412,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4330,7 +4440,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4357,7 +4468,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4386,7 +4498,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4415,7 +4528,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4444,7 +4558,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4588,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4502,7 +4618,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4531,7 +4648,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4560,7 +4678,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4589,7 +4708,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4618,7 +4738,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4647,7 +4768,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4680,7 +4802,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4707,7 +4830,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4734,7 +4858,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4761,7 +4886,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4788,7 +4914,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4815,7 +4942,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4842,7 +4970,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4875,7 +5004,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4902,7 +5032,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4929,7 +5060,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4956,7 +5088,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4983,7 +5116,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5010,7 +5144,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5037,7 +5172,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5070,7 +5206,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5097,7 +5234,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5124,7 +5262,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5151,7 +5290,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5178,7 +5318,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5205,7 +5346,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5232,7 +5374,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5265,7 +5408,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5292,7 +5436,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5319,7 +5464,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5346,7 +5492,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5373,7 +5520,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5400,7 +5548,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5427,7 +5576,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5460,7 +5610,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5487,7 +5638,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5514,7 +5666,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5541,7 +5694,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5568,7 +5722,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5595,7 +5750,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5622,7 +5778,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5655,7 +5812,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5682,7 +5840,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5709,7 +5868,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5736,7 +5896,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5763,7 +5924,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5790,7 +5952,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5817,7 +5980,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5850,7 +6014,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5877,7 +6042,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5904,7 +6070,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5931,7 +6098,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5958,7 +6126,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5985,7 +6154,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6012,7 +6182,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6045,7 +6216,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6072,7 +6244,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6099,7 +6272,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6126,7 +6300,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6153,7 +6328,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6180,7 +6356,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6207,7 +6384,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6240,7 +6418,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6267,7 +6446,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6294,7 +6474,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6321,7 +6502,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6348,7 +6530,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6375,7 +6558,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6402,7 +6586,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6435,7 +6620,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6462,7 +6648,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6489,7 +6676,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6516,7 +6704,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6543,7 +6732,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6570,7 +6760,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6597,7 +6788,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6626,7 +6818,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6659,7 +6852,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6686,7 +6880,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6713,7 +6908,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6740,7 +6936,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6767,7 +6964,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6794,7 +6992,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6821,7 +7020,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6850,7 +7050,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6879,7 +7080,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6912,7 +7114,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6939,7 +7142,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6966,7 +7170,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6993,7 +7198,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7020,7 +7226,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7047,7 +7254,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7074,7 +7282,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7107,7 +7316,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7134,7 +7344,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7161,7 +7372,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7188,7 +7400,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7215,7 +7428,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7242,7 +7456,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7269,7 +7484,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7298,7 +7514,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7327,7 +7544,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7356,7 +7574,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7385,7 +7604,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7414,7 +7634,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7443,7 +7664,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7472,7 +7694,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7501,7 +7724,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7530,7 +7754,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7559,7 +7784,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7592,7 +7818,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7619,7 +7846,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7646,7 +7874,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7673,7 +7902,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7700,7 +7930,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7727,7 +7958,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7754,7 +7986,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7787,7 +8020,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7814,7 +8048,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7841,7 +8076,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7868,7 +8104,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7895,7 +8132,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7922,7 +8160,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7949,7 +8188,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7982,7 +8222,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8009,7 +8250,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8036,7 +8278,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8063,7 +8306,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8090,7 +8334,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8117,7 +8362,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8144,7 +8390,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8177,7 +8424,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8204,7 +8452,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8231,7 +8480,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8258,7 +8508,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8285,7 +8536,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8312,7 +8564,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8339,7 +8592,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8372,7 +8626,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8399,7 +8654,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8426,7 +8682,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8453,7 +8710,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8480,7 +8738,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8507,7 +8766,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8534,7 +8794,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8567,7 +8828,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8594,7 +8856,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8621,7 +8884,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8648,7 +8912,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8675,7 +8940,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8702,7 +8968,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8729,7 +8996,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8762,7 +9030,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8789,7 +9058,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8816,7 +9086,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8843,7 +9114,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8870,7 +9142,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8897,7 +9170,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8924,7 +9198,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8957,7 +9232,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8984,7 +9260,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9011,7 +9288,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9038,7 +9316,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9065,7 +9344,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9092,7 +9372,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9119,7 +9400,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9152,7 +9434,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9179,7 +9462,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9206,7 +9490,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9233,7 +9518,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9260,7 +9546,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9287,7 +9574,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9314,7 +9602,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9347,7 +9636,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9374,7 +9664,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9401,7 +9692,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9428,7 +9720,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9455,7 +9748,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9482,7 +9776,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9509,7 +9804,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9538,7 +9834,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9571,7 +9868,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9598,7 +9896,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9625,7 +9924,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9652,7 +9952,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9679,7 +9980,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9706,7 +10008,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9733,7 +10036,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9762,7 +10066,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9791,7 +10096,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9824,7 +10130,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9851,7 +10158,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9878,7 +10186,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9905,7 +10214,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9932,7 +10242,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9959,7 +10270,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9986,7 +10298,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10019,7 +10332,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10046,7 +10360,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10073,7 +10388,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10100,7 +10416,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10127,7 +10444,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10154,7 +10472,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10181,7 +10500,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10210,7 +10530,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_hw_info_cfg_override_scramble_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10237,7 +10558,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_hw_info_cfg_override_ecc_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10265,7 +10587,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10298,7 +10621,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10334,7 +10658,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10372,7 +10697,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_op_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10399,7 +10725,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_op_status_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10428,7 +10755,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10455,7 +10783,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rd_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10482,7 +10811,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_prog_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10509,7 +10839,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10536,7 +10867,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10563,7 +10895,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_initialized (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10608,7 +10941,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10635,7 +10969,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10662,7 +10997,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10689,7 +11025,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10716,7 +11053,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10743,7 +11081,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10770,7 +11109,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10797,7 +11137,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_macro_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10826,7 +11167,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10853,7 +11195,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_prog_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10880,7 +11223,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_lcmgr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10907,7 +11251,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_lcmgr_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10934,7 +11279,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_arb_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10961,7 +11307,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10988,7 +11335,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_phy_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11015,7 +11363,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_ctrl_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11042,7 +11391,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_fifo_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11071,7 +11421,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11098,7 +11449,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11125,7 +11477,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11152,7 +11505,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11179,7 +11533,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11206,7 +11561,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11233,7 +11589,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_seed_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11260,7 +11617,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_phy_relbl_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11287,7 +11645,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_phy_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11314,7 +11673,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_spurious_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11341,7 +11701,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_arb_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11368,7 +11729,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_host_gnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11396,7 +11758,8 @@ module flash_ctrl_core_reg_top (
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11426,7 +11789,8 @@ module flash_ctrl_core_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11453,7 +11817,8 @@ module flash_ctrl_core_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11482,7 +11847,8 @@ module flash_ctrl_core_reg_top (
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11511,7 +11877,8 @@ module flash_ctrl_core_reg_top (
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11540,7 +11907,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_alert_cfg_alert_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11567,7 +11935,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_alert_cfg_alert_trig (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11596,7 +11965,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11623,7 +11993,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_status_prog_normal_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11650,7 +12021,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_status_prog_repair_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11678,7 +12050,8 @@ module flash_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_scratch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11707,7 +12080,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_lvl_prog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11734,7 +12108,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_lvl_rd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11762,7 +12137,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -271,7 +271,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -304,7 +304,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -332,7 +332,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -362,7 +362,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -390,7 +390,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -418,7 +418,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -446,7 +446,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -474,7 +474,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -502,7 +502,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -530,7 +530,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +558,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -591,7 +591,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +619,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -647,7 +647,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -675,7 +675,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -703,7 +703,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -731,7 +731,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -759,7 +759,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -787,7 +787,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -815,7 +815,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +843,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -876,7 +876,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -904,7 +904,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -932,7 +932,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -960,7 +960,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -993,7 +993,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1021,7 +1021,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1049,7 +1049,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1077,7 +1077,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1105,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1138,7 +1138,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1166,7 +1166,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1194,7 +1194,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1222,7 +1222,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1250,7 +1250,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1278,7 +1278,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1306,7 +1306,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1334,7 +1334,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1362,7 +1362,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1395,7 +1395,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1423,7 +1423,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1455,7 +1455,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1487,7 +1487,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1519,7 +1519,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1551,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1583,7 +1583,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1616,7 +1616,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr13_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1644,7 +1644,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr13_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1677,7 +1677,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr14_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1705,7 +1705,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr14_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1738,7 +1738,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr15_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1766,7 +1766,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr15_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1799,7 +1799,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr16_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1827,7 +1827,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr16_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1860,7 +1860,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr17_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1888,7 +1888,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr17_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1920,7 +1920,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1952,7 +1952,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1982,7 +1982,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr20_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2010,7 +2010,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr20_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2038,7 +2038,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr20_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -270,7 +270,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -302,7 +303,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -329,7 +331,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -358,7 +361,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -385,7 +389,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -412,7 +417,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -439,7 +445,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -466,7 +473,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +501,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -520,7 +529,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -547,7 +557,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -579,7 +590,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -606,7 +618,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -633,7 +646,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +674,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -687,7 +702,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -714,7 +730,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -741,7 +758,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +786,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -795,7 +814,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -822,7 +842,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -854,7 +875,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -881,7 +903,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -908,7 +931,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -935,7 +959,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -967,7 +992,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -994,7 +1020,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1021,7 +1048,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1076,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1075,7 +1104,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1107,7 +1137,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1134,7 +1165,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1193,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1188,7 +1221,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1215,7 +1249,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1242,7 +1277,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1305,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1333,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1323,7 +1361,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1355,7 +1394,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1382,7 +1422,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1413,7 +1454,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1444,7 +1486,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1475,7 +1518,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1506,7 +1550,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1537,7 +1582,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1569,7 +1615,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr13_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1596,7 +1643,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr13_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1628,7 +1676,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr14_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1655,7 +1704,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr14_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1687,7 +1737,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr15_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1714,7 +1765,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr15_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1746,7 +1798,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr16_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1773,7 +1826,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr16_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1805,7 +1859,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr17_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1832,7 +1887,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr17_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1863,7 +1919,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1894,7 +1951,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1923,7 +1981,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr20_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1950,7 +2009,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr20_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1977,7 +2037,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr20_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -197,7 +197,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -225,7 +226,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -293,7 +295,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -509,7 +512,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -537,7 +541,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -565,7 +570,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +599,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -621,7 +628,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +657,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_straps_data_in_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +686,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_straps_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -198,7 +198,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -227,7 +227,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -296,7 +296,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +513,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +542,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -571,7 +571,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -600,7 +600,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -629,7 +629,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +658,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_straps_data_in_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -687,7 +687,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_straps_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -338,7 +338,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -365,7 +366,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -394,7 +396,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +424,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1173,7 +1177,8 @@ module otp_ctrl_core_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_direct_access_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1205,7 +1210,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_direct_access_wdata_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1237,7 +1243,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_direct_access_wdata_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1299,7 +1306,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_check_trigger_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1367,7 +1375,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_check_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1398,7 +1407,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_check_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1429,7 +1439,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_integrity_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1460,7 +1471,8 @@ module otp_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_consistency_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1491,7 +1503,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_vendor_test_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1522,7 +1535,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_creator_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1553,7 +1567,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_owner_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1585,7 +1600,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rot_creator_auth_codesign_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1617,7 +1633,8 @@ module otp_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rot_creator_auth_state_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -339,7 +339,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -367,7 +367,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -397,7 +397,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_otp_operation_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -425,7 +425,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_otp_error (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1178,7 +1178,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_direct_access_address (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1211,7 +1211,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_direct_access_wdata_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1244,7 +1244,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_direct_access_wdata_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1307,7 +1307,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_check_trigger_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1376,7 +1376,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_check_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1408,7 +1408,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_check_timeout (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1440,7 +1440,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_integrity_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1472,7 +1472,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_consistency_check_period (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1504,7 +1504,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_vendor_test_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1536,7 +1536,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_creator_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1568,7 +1568,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_owner_sw_cfg_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1601,7 +1601,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rot_creator_auth_codesign_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1634,7 +1634,7 @@ module otp_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rot_creator_auth_state_read_lock (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -200,7 +200,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -227,7 +228,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -254,7 +256,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -281,7 +284,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -308,7 +312,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +342,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -364,7 +370,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -391,7 +398,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -418,7 +426,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -445,7 +454,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -473,7 +483,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -502,7 +513,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -529,7 +541,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -556,7 +569,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -583,7 +597,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -610,7 +625,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -637,7 +653,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -664,7 +681,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -691,7 +709,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +737,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +767,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -774,7 +795,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -801,7 +823,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -828,7 +851,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -857,7 +881,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -884,7 +909,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -911,7 +937,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -938,7 +965,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +993,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -992,7 +1021,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1019,7 +1049,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1079,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1075,7 +1107,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1102,7 +1135,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1129,7 +1163,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1158,7 +1193,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1185,7 +1221,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1212,7 +1249,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1239,7 +1277,8 @@ module otp_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -201,7 +201,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -229,7 +229,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -257,7 +257,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -285,7 +285,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -313,7 +313,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (11'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -343,7 +343,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -371,7 +371,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -399,7 +399,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -427,7 +427,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -455,7 +455,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -484,7 +484,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -514,7 +514,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +542,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -570,7 +570,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -598,7 +598,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -626,7 +626,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -654,7 +654,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -682,7 +682,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -710,7 +710,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -738,7 +738,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +768,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -796,7 +796,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -824,7 +824,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -852,7 +852,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -882,7 +882,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -910,7 +910,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -938,7 +938,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -966,7 +966,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -994,7 +994,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1022,7 +1022,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1050,7 +1050,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1080,7 +1080,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1108,7 +1108,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1136,7 +1136,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1164,7 +1164,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1194,7 +1194,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1222,7 +1222,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1250,7 +1250,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1278,7 +1278,7 @@ module otp_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -4212,7 +4212,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4241,7 +4242,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4270,7 +4272,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4299,7 +4302,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4328,7 +4332,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4357,7 +4362,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4386,7 +4392,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4415,7 +4422,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4444,7 +4452,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4482,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4502,7 +4512,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4531,7 +4542,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4560,7 +4572,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4589,7 +4602,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4618,7 +4632,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4647,7 +4662,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4676,7 +4692,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4705,7 +4722,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4734,7 +4752,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4763,7 +4782,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4792,7 +4812,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4821,7 +4842,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4850,7 +4872,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4879,7 +4902,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4908,7 +4932,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4937,7 +4962,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4966,7 +4992,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4995,7 +5022,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5024,7 +5052,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5053,7 +5082,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5082,7 +5112,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5111,7 +5142,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5140,7 +5172,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5169,7 +5202,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5198,7 +5232,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5227,7 +5262,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5256,7 +5292,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5285,7 +5322,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5314,7 +5352,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5343,7 +5382,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5372,7 +5412,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5401,7 +5442,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5430,7 +5472,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5459,7 +5502,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5488,7 +5532,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5517,7 +5562,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5546,7 +5592,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5575,7 +5622,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5604,7 +5652,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5633,7 +5682,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5662,7 +5712,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5691,7 +5742,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5720,7 +5772,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5749,7 +5802,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5778,7 +5832,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5807,7 +5862,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5836,7 +5892,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5868,7 +5925,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5900,7 +5958,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5932,7 +5991,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5964,7 +6024,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5996,7 +6057,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6028,7 +6090,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6060,7 +6123,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6092,7 +6156,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6124,7 +6189,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6156,7 +6222,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6188,7 +6255,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6220,7 +6288,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6252,7 +6321,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6284,7 +6354,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6316,7 +6387,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6348,7 +6420,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6380,7 +6453,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6412,7 +6486,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6444,7 +6519,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6476,7 +6552,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6508,7 +6585,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6540,7 +6618,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6572,7 +6651,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6604,7 +6684,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6636,7 +6717,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6668,7 +6750,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6700,7 +6783,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6732,7 +6816,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6764,7 +6849,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6796,7 +6882,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6828,7 +6915,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6860,7 +6948,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6892,7 +6981,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6924,7 +7014,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6956,7 +7047,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6988,7 +7080,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7020,7 +7113,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7052,7 +7146,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7084,7 +7179,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7116,7 +7212,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7148,7 +7245,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7180,7 +7278,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7212,7 +7311,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7244,7 +7344,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7276,7 +7377,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7308,7 +7410,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7340,7 +7443,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7372,7 +7476,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7404,7 +7509,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7436,7 +7542,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7468,7 +7575,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7500,7 +7608,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7532,7 +7641,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7564,7 +7674,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7596,7 +7707,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7628,7 +7740,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7660,7 +7773,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7689,7 +7803,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7718,7 +7833,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7747,7 +7863,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7776,7 +7893,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7805,7 +7923,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7834,7 +7953,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7863,7 +7983,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7892,7 +8013,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7921,7 +8043,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7950,7 +8073,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7979,7 +8103,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8008,7 +8133,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8037,7 +8163,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8066,7 +8193,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8095,7 +8223,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8124,7 +8253,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8153,7 +8283,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8182,7 +8313,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8211,7 +8343,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8240,7 +8373,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8269,7 +8403,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8298,7 +8433,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8327,7 +8463,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8356,7 +8493,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8385,7 +8523,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8414,7 +8553,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8443,7 +8583,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8472,7 +8613,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8501,7 +8643,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8530,7 +8673,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8559,7 +8703,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8588,7 +8733,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8617,7 +8763,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8646,7 +8793,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8675,7 +8823,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8704,7 +8853,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8733,7 +8883,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8762,7 +8913,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8791,7 +8943,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8820,7 +8973,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8849,7 +9003,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8878,7 +9033,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8907,7 +9063,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8936,7 +9093,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8965,7 +9123,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8994,7 +9153,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9023,7 +9183,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9055,7 +9216,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9087,7 +9249,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9119,7 +9282,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9151,7 +9315,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9183,7 +9348,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9215,7 +9381,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9247,7 +9414,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9279,7 +9447,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9311,7 +9480,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9343,7 +9513,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9375,7 +9546,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9407,7 +9579,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9439,7 +9612,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9471,7 +9645,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9503,7 +9678,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9535,7 +9711,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9567,7 +9744,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9599,7 +9777,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9631,7 +9810,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9663,7 +9843,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9695,7 +9876,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9727,7 +9909,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9759,7 +9942,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9791,7 +9975,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9823,7 +10008,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9855,7 +10041,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9887,7 +10074,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9919,7 +10107,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9951,7 +10140,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9983,7 +10173,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10015,7 +10206,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10047,7 +10239,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10079,7 +10272,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10111,7 +10305,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10143,7 +10338,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10175,7 +10371,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10207,7 +10404,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10239,7 +10437,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10271,7 +10470,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10303,7 +10503,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10335,7 +10536,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10367,7 +10569,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10399,7 +10602,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10431,7 +10635,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10463,7 +10668,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10495,7 +10701,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10527,7 +10734,8 @@ module pinmux_reg_top (
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10556,7 +10764,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10585,7 +10794,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10614,7 +10824,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10643,7 +10854,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10672,7 +10884,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10701,7 +10914,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10730,7 +10944,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10759,7 +10974,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10788,7 +11004,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10817,7 +11034,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10846,7 +11064,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10875,7 +11094,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10904,7 +11124,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10933,7 +11154,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10962,7 +11184,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10991,7 +11214,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11020,7 +11244,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11049,7 +11274,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11078,7 +11304,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11107,7 +11334,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11136,7 +11364,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11165,7 +11394,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11194,7 +11424,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11223,7 +11454,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11252,7 +11484,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11281,7 +11514,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11310,7 +11544,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11339,7 +11574,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11368,7 +11604,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11397,7 +11634,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11426,7 +11664,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11455,7 +11694,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11484,7 +11724,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11513,7 +11754,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11542,7 +11784,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11571,7 +11814,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11600,7 +11844,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11629,7 +11874,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11658,7 +11904,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11687,7 +11934,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11716,7 +11964,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11745,7 +11994,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11774,7 +12024,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11803,7 +12054,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11832,7 +12084,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11861,7 +12114,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11890,7 +12144,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19862,7 +20117,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19891,7 +20147,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19920,7 +20177,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19949,7 +20207,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19978,7 +20237,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20007,7 +20267,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20036,7 +20297,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20065,7 +20327,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20094,7 +20357,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20123,7 +20387,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20152,7 +20417,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20181,7 +20447,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20210,7 +20477,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20239,7 +20507,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20268,7 +20537,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20297,7 +20567,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23031,7 +23302,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23058,7 +23330,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23085,7 +23358,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23112,7 +23386,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23139,7 +23414,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23166,7 +23442,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23193,7 +23470,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23220,7 +23498,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23247,7 +23526,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23274,7 +23554,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23301,7 +23582,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23328,7 +23610,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23355,7 +23638,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23382,7 +23666,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23409,7 +23694,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23436,7 +23722,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23463,7 +23750,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23490,7 +23778,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23517,7 +23806,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23544,7 +23834,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23571,7 +23862,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23598,7 +23890,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23625,7 +23918,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23652,7 +23946,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23679,7 +23974,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23706,7 +24002,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23733,7 +24030,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23760,7 +24058,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23787,7 +24086,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23814,7 +24114,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23841,7 +24142,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23868,7 +24170,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23898,7 +24201,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23925,7 +24229,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23952,7 +24257,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23979,7 +24285,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24006,7 +24313,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24033,7 +24341,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24060,7 +24369,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24087,7 +24397,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24114,7 +24425,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24141,7 +24453,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24168,7 +24481,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24195,7 +24509,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24222,7 +24537,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24249,7 +24565,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24276,7 +24593,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24305,7 +24623,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24334,7 +24653,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24363,7 +24683,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24392,7 +24713,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24421,7 +24743,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24450,7 +24773,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24479,7 +24803,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24508,7 +24833,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24537,7 +24863,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24566,7 +24893,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24595,7 +24923,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24624,7 +24953,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24653,7 +24983,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24682,7 +25013,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24711,7 +25043,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24740,7 +25073,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24769,7 +25103,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24798,7 +25133,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24827,7 +25163,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24856,7 +25193,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24885,7 +25223,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24914,7 +25253,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24943,7 +25283,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24972,7 +25313,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25001,7 +25343,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25030,7 +25373,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25059,7 +25403,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25088,7 +25433,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25117,7 +25463,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25146,7 +25493,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25175,7 +25523,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25204,7 +25553,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25233,7 +25583,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25262,7 +25613,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25291,7 +25643,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25320,7 +25673,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25349,7 +25703,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25378,7 +25733,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25407,7 +25763,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25436,7 +25793,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25465,7 +25823,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25494,7 +25853,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25523,7 +25883,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25552,7 +25913,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25581,7 +25943,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25610,7 +25973,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25639,7 +26003,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25671,7 +26036,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25703,7 +26069,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25735,7 +26102,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25767,7 +26135,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25799,7 +26168,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25831,7 +26201,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25863,7 +26234,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25895,7 +26267,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25927,7 +26300,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25959,7 +26333,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25991,7 +26366,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26023,7 +26399,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26055,7 +26432,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26087,7 +26465,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26119,7 +26498,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26151,7 +26531,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26183,7 +26564,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26215,7 +26597,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26247,7 +26630,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26279,7 +26663,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26311,7 +26696,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26343,7 +26729,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26375,7 +26762,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26407,7 +26795,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26439,7 +26828,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26471,7 +26861,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26503,7 +26894,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26535,7 +26927,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26567,7 +26960,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26599,7 +26993,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26631,7 +27026,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26663,7 +27059,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26695,7 +27092,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26727,7 +27125,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26759,7 +27158,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26791,7 +27191,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26823,7 +27224,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26855,7 +27257,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26887,7 +27290,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26919,7 +27323,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26951,7 +27356,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26983,7 +27389,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27015,7 +27422,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27047,7 +27455,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27079,7 +27488,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27111,7 +27521,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27143,7 +27554,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27175,7 +27587,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27207,7 +27620,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27239,7 +27653,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27271,7 +27686,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27303,7 +27719,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27335,7 +27752,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27367,7 +27785,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27399,7 +27818,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27431,7 +27851,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27463,7 +27884,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27495,7 +27917,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27527,7 +27950,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27559,7 +27983,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27591,7 +28016,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27623,7 +28049,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27655,7 +28082,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27687,7 +28115,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27719,7 +28148,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27751,7 +28181,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27783,7 +28214,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27815,7 +28247,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27847,7 +28280,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27879,7 +28313,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27911,7 +28346,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27943,7 +28379,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27975,7 +28412,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28007,7 +28445,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28039,7 +28478,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28071,7 +28511,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28103,7 +28544,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28135,7 +28577,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28167,7 +28610,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28199,7 +28643,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28231,7 +28676,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28263,7 +28709,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28295,7 +28742,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28327,7 +28775,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28359,7 +28808,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28391,7 +28841,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28423,7 +28874,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28455,7 +28907,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28487,7 +28940,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28519,7 +28973,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28551,7 +29006,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28583,7 +29039,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28615,7 +29072,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28647,7 +29105,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28677,7 +29136,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28704,7 +29164,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28731,7 +29192,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28758,7 +29220,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28785,7 +29248,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28812,7 +29276,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28839,7 +29304,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28866,7 +29332,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28893,7 +29360,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28920,7 +29388,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28947,7 +29416,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28974,7 +29444,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29001,7 +29472,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29028,7 +29500,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29055,7 +29528,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29082,7 +29556,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29111,7 +29586,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29140,7 +29616,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29169,7 +29646,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29198,7 +29676,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29227,7 +29706,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29256,7 +29736,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29285,7 +29766,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29314,7 +29796,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29343,7 +29826,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29372,7 +29856,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29401,7 +29886,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29430,7 +29916,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29459,7 +29946,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29488,7 +29976,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29517,7 +30006,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29546,7 +30036,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29578,7 +30069,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29610,7 +30102,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29642,7 +30135,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29674,7 +30168,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29706,7 +30201,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29738,7 +30234,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29770,7 +30267,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29802,7 +30300,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29834,7 +30333,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29866,7 +30366,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29898,7 +30399,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29930,7 +30432,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29962,7 +30465,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29994,7 +30498,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30026,7 +30531,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30058,7 +30564,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30090,7 +30597,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30122,7 +30630,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30154,7 +30663,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30186,7 +30696,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30218,7 +30729,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30250,7 +30762,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30282,7 +30795,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30314,7 +30828,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30346,7 +30861,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30378,7 +30894,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30410,7 +30927,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30442,7 +30960,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30474,7 +30993,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30506,7 +31026,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30538,7 +31059,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30570,7 +31092,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30599,7 +31122,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30628,7 +31152,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30657,7 +31182,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30686,7 +31212,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30715,7 +31242,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30744,7 +31272,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30773,7 +31302,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30802,7 +31332,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30835,7 +31366,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30868,7 +31400,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30901,7 +31434,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30934,7 +31468,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30967,7 +31502,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31000,7 +31536,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31033,7 +31570,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31066,7 +31604,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31099,7 +31638,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31126,7 +31666,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31153,7 +31694,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31186,7 +31728,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31213,7 +31756,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31240,7 +31784,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31273,7 +31818,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31300,7 +31846,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31327,7 +31874,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31360,7 +31908,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31387,7 +31936,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31414,7 +31964,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31447,7 +31998,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31474,7 +32026,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31501,7 +32054,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31534,7 +32088,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31561,7 +32116,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31588,7 +32144,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31621,7 +32178,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31648,7 +32206,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31675,7 +32234,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31708,7 +32268,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31735,7 +32296,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31762,7 +32324,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31795,7 +32358,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31828,7 +32392,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31861,7 +32426,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31894,7 +32460,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31927,7 +32494,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31960,7 +32528,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31993,7 +32562,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32026,7 +32596,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32058,7 +32629,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32090,7 +32662,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32122,7 +32695,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32154,7 +32728,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32186,7 +32761,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32218,7 +32794,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32250,7 +32827,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32282,7 +32860,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32314,7 +32893,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32341,7 +32921,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32368,7 +32949,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32395,7 +32977,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32422,7 +33005,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32449,7 +33033,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32476,7 +33061,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32503,7 +33089,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -4213,7 +4213,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4243,7 +4243,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4273,7 +4273,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4303,7 +4303,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4333,7 +4333,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4363,7 +4363,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4393,7 +4393,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4423,7 +4423,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4453,7 +4453,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4483,7 +4483,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4513,7 +4513,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4543,7 +4543,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4573,7 +4573,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4603,7 +4603,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4633,7 +4633,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4663,7 +4663,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4693,7 +4693,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4723,7 +4723,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4753,7 +4753,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4783,7 +4783,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4813,7 +4813,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4843,7 +4843,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4873,7 +4873,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4903,7 +4903,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4933,7 +4933,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4963,7 +4963,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4993,7 +4993,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5023,7 +5023,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5053,7 +5053,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5083,7 +5083,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5113,7 +5113,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5143,7 +5143,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5173,7 +5173,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5203,7 +5203,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5233,7 +5233,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5263,7 +5263,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5293,7 +5293,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5323,7 +5323,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5353,7 +5353,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5383,7 +5383,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5413,7 +5413,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5443,7 +5443,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5473,7 +5473,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5503,7 +5503,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5533,7 +5533,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5563,7 +5563,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5593,7 +5593,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5623,7 +5623,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5653,7 +5653,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5683,7 +5683,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5713,7 +5713,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5743,7 +5743,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5773,7 +5773,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5803,7 +5803,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5833,7 +5833,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5863,7 +5863,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5893,7 +5893,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5926,7 +5926,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5959,7 +5959,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5992,7 +5992,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6025,7 +6025,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6058,7 +6058,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6091,7 +6091,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6124,7 +6124,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6157,7 +6157,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6190,7 +6190,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6223,7 +6223,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6256,7 +6256,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6289,7 +6289,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6322,7 +6322,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6355,7 +6355,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6388,7 +6388,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6421,7 +6421,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6454,7 +6454,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6487,7 +6487,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6520,7 +6520,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6553,7 +6553,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6586,7 +6586,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6619,7 +6619,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6652,7 +6652,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6685,7 +6685,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6718,7 +6718,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6751,7 +6751,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6784,7 +6784,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6817,7 +6817,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6850,7 +6850,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6883,7 +6883,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6916,7 +6916,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6949,7 +6949,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6982,7 +6982,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7015,7 +7015,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7048,7 +7048,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7081,7 +7081,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7114,7 +7114,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7147,7 +7147,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7180,7 +7180,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7213,7 +7213,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7246,7 +7246,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7279,7 +7279,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7312,7 +7312,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7345,7 +7345,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7378,7 +7378,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7411,7 +7411,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7444,7 +7444,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7477,7 +7477,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7510,7 +7510,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7543,7 +7543,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7576,7 +7576,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7609,7 +7609,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7642,7 +7642,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7675,7 +7675,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7708,7 +7708,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7741,7 +7741,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7774,7 +7774,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7804,7 +7804,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7834,7 +7834,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7864,7 +7864,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7894,7 +7894,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7924,7 +7924,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7954,7 +7954,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7984,7 +7984,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8014,7 +8014,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8044,7 +8044,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8074,7 +8074,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8104,7 +8104,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8134,7 +8134,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8164,7 +8164,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8194,7 +8194,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8224,7 +8224,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8254,7 +8254,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8284,7 +8284,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8314,7 +8314,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8344,7 +8344,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8374,7 +8374,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8404,7 +8404,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8434,7 +8434,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8464,7 +8464,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8494,7 +8494,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8524,7 +8524,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8554,7 +8554,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8584,7 +8584,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8614,7 +8614,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8644,7 +8644,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8674,7 +8674,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8704,7 +8704,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8734,7 +8734,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8764,7 +8764,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8794,7 +8794,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8824,7 +8824,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8854,7 +8854,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8884,7 +8884,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8914,7 +8914,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8944,7 +8944,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8974,7 +8974,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9004,7 +9004,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9034,7 +9034,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9064,7 +9064,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9094,7 +9094,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9124,7 +9124,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9154,7 +9154,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9184,7 +9184,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9217,7 +9217,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9250,7 +9250,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9283,7 +9283,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9316,7 +9316,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9349,7 +9349,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9382,7 +9382,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9415,7 +9415,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9448,7 +9448,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9481,7 +9481,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9514,7 +9514,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9547,7 +9547,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9580,7 +9580,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9613,7 +9613,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9646,7 +9646,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9679,7 +9679,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9712,7 +9712,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9745,7 +9745,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9778,7 +9778,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9811,7 +9811,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9844,7 +9844,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9877,7 +9877,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9910,7 +9910,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9943,7 +9943,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9976,7 +9976,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10009,7 +10009,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10042,7 +10042,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10075,7 +10075,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10108,7 +10108,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10141,7 +10141,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10174,7 +10174,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10207,7 +10207,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10240,7 +10240,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10273,7 +10273,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10306,7 +10306,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10339,7 +10339,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10372,7 +10372,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10405,7 +10405,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10438,7 +10438,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10471,7 +10471,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10504,7 +10504,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10537,7 +10537,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10570,7 +10570,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10603,7 +10603,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10636,7 +10636,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10669,7 +10669,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10702,7 +10702,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10735,7 +10735,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (7'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10765,7 +10765,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10795,7 +10795,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10825,7 +10825,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10855,7 +10855,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10885,7 +10885,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10915,7 +10915,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10945,7 +10945,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10975,7 +10975,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11005,7 +11005,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11035,7 +11035,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11065,7 +11065,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11095,7 +11095,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11125,7 +11125,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11155,7 +11155,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11185,7 +11185,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11215,7 +11215,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11245,7 +11245,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11275,7 +11275,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11305,7 +11305,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11335,7 +11335,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11365,7 +11365,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11395,7 +11395,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11425,7 +11425,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11455,7 +11455,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11485,7 +11485,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11515,7 +11515,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11545,7 +11545,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11575,7 +11575,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11605,7 +11605,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11635,7 +11635,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11665,7 +11665,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11695,7 +11695,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11725,7 +11725,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11755,7 +11755,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11785,7 +11785,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11815,7 +11815,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11845,7 +11845,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11875,7 +11875,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11905,7 +11905,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11935,7 +11935,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11965,7 +11965,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11995,7 +11995,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12025,7 +12025,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12055,7 +12055,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12085,7 +12085,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12115,7 +12115,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12145,7 +12145,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20118,7 +20118,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20148,7 +20148,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20178,7 +20178,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20208,7 +20208,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20238,7 +20238,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20268,7 +20268,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20298,7 +20298,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20328,7 +20328,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20358,7 +20358,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20388,7 +20388,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20418,7 +20418,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20448,7 +20448,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20478,7 +20478,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20508,7 +20508,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20538,7 +20538,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -20568,7 +20568,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23303,7 +23303,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23331,7 +23331,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23359,7 +23359,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23387,7 +23387,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23415,7 +23415,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23443,7 +23443,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23471,7 +23471,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23499,7 +23499,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23527,7 +23527,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23555,7 +23555,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23583,7 +23583,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23611,7 +23611,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23639,7 +23639,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23667,7 +23667,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23695,7 +23695,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23723,7 +23723,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23751,7 +23751,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23779,7 +23779,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23807,7 +23807,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23835,7 +23835,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23863,7 +23863,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23891,7 +23891,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23919,7 +23919,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23947,7 +23947,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23975,7 +23975,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24003,7 +24003,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24031,7 +24031,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24059,7 +24059,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24087,7 +24087,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24115,7 +24115,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24143,7 +24143,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24171,7 +24171,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24202,7 +24202,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24230,7 +24230,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24258,7 +24258,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24286,7 +24286,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24314,7 +24314,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24342,7 +24342,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24370,7 +24370,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24398,7 +24398,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24426,7 +24426,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24454,7 +24454,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24482,7 +24482,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24510,7 +24510,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24538,7 +24538,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24566,7 +24566,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24594,7 +24594,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24624,7 +24624,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24654,7 +24654,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24684,7 +24684,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24714,7 +24714,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24744,7 +24744,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24774,7 +24774,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24804,7 +24804,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24834,7 +24834,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24864,7 +24864,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24894,7 +24894,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24924,7 +24924,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24954,7 +24954,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24984,7 +24984,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25014,7 +25014,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25044,7 +25044,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25074,7 +25074,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25104,7 +25104,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25134,7 +25134,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25164,7 +25164,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25194,7 +25194,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25224,7 +25224,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25254,7 +25254,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25284,7 +25284,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25314,7 +25314,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25344,7 +25344,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25374,7 +25374,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25404,7 +25404,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25434,7 +25434,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25464,7 +25464,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25494,7 +25494,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25524,7 +25524,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25554,7 +25554,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25584,7 +25584,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25614,7 +25614,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25644,7 +25644,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25674,7 +25674,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25704,7 +25704,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25734,7 +25734,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25764,7 +25764,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25794,7 +25794,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25824,7 +25824,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25854,7 +25854,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25884,7 +25884,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25914,7 +25914,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25944,7 +25944,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25974,7 +25974,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26004,7 +26004,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26037,7 +26037,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26070,7 +26070,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26103,7 +26103,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26136,7 +26136,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26169,7 +26169,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26202,7 +26202,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26235,7 +26235,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26268,7 +26268,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26301,7 +26301,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26334,7 +26334,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26367,7 +26367,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26400,7 +26400,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26433,7 +26433,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26466,7 +26466,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26499,7 +26499,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26532,7 +26532,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26565,7 +26565,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26598,7 +26598,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26631,7 +26631,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26664,7 +26664,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26697,7 +26697,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26730,7 +26730,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26763,7 +26763,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26796,7 +26796,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26829,7 +26829,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26862,7 +26862,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26895,7 +26895,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26928,7 +26928,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26961,7 +26961,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26994,7 +26994,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27027,7 +27027,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27060,7 +27060,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27093,7 +27093,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27126,7 +27126,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27159,7 +27159,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27192,7 +27192,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27225,7 +27225,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27258,7 +27258,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27291,7 +27291,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27324,7 +27324,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27357,7 +27357,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27390,7 +27390,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27423,7 +27423,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27456,7 +27456,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27489,7 +27489,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27522,7 +27522,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27555,7 +27555,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27588,7 +27588,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27621,7 +27621,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27654,7 +27654,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27687,7 +27687,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27720,7 +27720,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27753,7 +27753,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27786,7 +27786,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27819,7 +27819,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27852,7 +27852,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27885,7 +27885,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27918,7 +27918,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27951,7 +27951,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27984,7 +27984,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28017,7 +28017,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28050,7 +28050,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28083,7 +28083,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28116,7 +28116,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28149,7 +28149,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28182,7 +28182,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28215,7 +28215,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28248,7 +28248,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28281,7 +28281,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28314,7 +28314,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28347,7 +28347,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28380,7 +28380,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28413,7 +28413,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28446,7 +28446,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28479,7 +28479,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28512,7 +28512,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28545,7 +28545,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28578,7 +28578,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28611,7 +28611,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28644,7 +28644,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28677,7 +28677,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28710,7 +28710,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28743,7 +28743,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28776,7 +28776,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28809,7 +28809,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28842,7 +28842,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28875,7 +28875,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28908,7 +28908,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28941,7 +28941,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28974,7 +28974,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29007,7 +29007,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29040,7 +29040,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29073,7 +29073,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29106,7 +29106,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29137,7 +29137,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29165,7 +29165,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29193,7 +29193,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29221,7 +29221,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29249,7 +29249,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29277,7 +29277,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29305,7 +29305,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29333,7 +29333,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29361,7 +29361,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29389,7 +29389,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29417,7 +29417,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29445,7 +29445,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29473,7 +29473,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29501,7 +29501,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29529,7 +29529,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29557,7 +29557,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29587,7 +29587,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29617,7 +29617,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29647,7 +29647,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29677,7 +29677,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29707,7 +29707,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29737,7 +29737,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29767,7 +29767,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29797,7 +29797,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29827,7 +29827,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29857,7 +29857,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29887,7 +29887,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29917,7 +29917,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29947,7 +29947,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29977,7 +29977,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30007,7 +30007,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30037,7 +30037,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30070,7 +30070,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30103,7 +30103,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30136,7 +30136,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30169,7 +30169,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30202,7 +30202,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30235,7 +30235,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30268,7 +30268,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30301,7 +30301,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30334,7 +30334,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30367,7 +30367,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30400,7 +30400,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30433,7 +30433,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30466,7 +30466,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30499,7 +30499,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30532,7 +30532,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30565,7 +30565,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30598,7 +30598,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30631,7 +30631,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30664,7 +30664,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30697,7 +30697,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30730,7 +30730,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30763,7 +30763,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30796,7 +30796,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30829,7 +30829,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30862,7 +30862,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30895,7 +30895,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30928,7 +30928,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30961,7 +30961,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30994,7 +30994,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31027,7 +31027,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31060,7 +31060,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31093,7 +31093,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31123,7 +31123,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31153,7 +31153,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31183,7 +31183,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31213,7 +31213,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31243,7 +31243,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31273,7 +31273,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31303,7 +31303,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31333,7 +31333,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -31367,7 +31367,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31401,7 +31401,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31435,7 +31435,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31469,7 +31469,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31503,7 +31503,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31537,7 +31537,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31571,7 +31571,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31605,7 +31605,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31639,7 +31639,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31667,7 +31667,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31695,7 +31695,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31729,7 +31729,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31757,7 +31757,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31785,7 +31785,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31819,7 +31819,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31847,7 +31847,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31875,7 +31875,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31909,7 +31909,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31937,7 +31937,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31965,7 +31965,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -31999,7 +31999,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32027,7 +32027,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32055,7 +32055,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32089,7 +32089,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32117,7 +32117,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32145,7 +32145,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32179,7 +32179,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32207,7 +32207,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32235,7 +32235,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32269,7 +32269,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32297,7 +32297,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32325,7 +32325,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32359,7 +32359,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32393,7 +32393,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32427,7 +32427,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32461,7 +32461,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32495,7 +32495,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32529,7 +32529,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32563,7 +32563,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32597,7 +32597,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -32630,7 +32630,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32663,7 +32663,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32696,7 +32696,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32729,7 +32729,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32762,7 +32762,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32795,7 +32795,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32828,7 +32828,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -32861,7 +32861,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -207,7 +207,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -235,7 +236,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -323,7 +325,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -350,7 +353,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -377,7 +381,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -404,7 +409,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -431,7 +437,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -458,7 +465,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -497,7 +505,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -526,7 +535,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -559,7 +569,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -586,7 +597,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -613,7 +625,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -640,7 +653,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -667,7 +681,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -694,7 +709,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -724,7 +740,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -751,7 +768,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -778,7 +796,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -805,7 +824,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -832,7 +852,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -859,7 +880,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -887,7 +909,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -920,7 +943,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -947,7 +971,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -977,7 +1002,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1004,7 +1030,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1032,7 +1059,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1060,7 +1088,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1142,7 +1171,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1170,7 +1200,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1198,7 +1229,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -208,7 +208,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -237,7 +237,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -326,7 +326,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -354,7 +354,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -382,7 +382,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -410,7 +410,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -438,7 +438,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -466,7 +466,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -506,7 +506,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -536,7 +536,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -570,7 +570,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -598,7 +598,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -626,7 +626,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -654,7 +654,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -682,7 +682,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -710,7 +710,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -741,7 +741,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -769,7 +769,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -797,7 +797,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -825,7 +825,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -853,7 +853,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -881,7 +881,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -910,7 +910,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -944,7 +944,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -972,7 +972,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1003,7 +1003,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1031,7 +1031,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1060,7 +1060,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1089,7 +1089,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1172,7 +1172,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1201,7 +1201,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -1230,7 +1230,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -260,7 +260,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -290,7 +290,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -319,7 +319,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -348,7 +348,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -377,7 +377,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -407,7 +407,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -440,7 +440,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -469,7 +469,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -531,7 +531,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -564,7 +564,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -593,7 +593,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -656,7 +656,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -686,7 +686,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -716,7 +716,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -746,7 +746,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -776,7 +776,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -806,7 +806,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -836,7 +836,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -866,7 +866,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -899,7 +899,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -932,7 +932,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -965,7 +965,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -998,7 +998,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1031,7 +1031,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1064,7 +1064,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1097,7 +1097,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1130,7 +1130,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1160,7 +1160,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1188,7 +1188,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1216,7 +1216,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -259,7 +259,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -288,7 +289,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -316,7 +318,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -344,7 +347,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -372,7 +376,8 @@ module rstmgr_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -401,7 +406,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -433,7 +439,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -461,7 +468,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -522,7 +530,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -554,7 +563,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -582,7 +592,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -644,7 +655,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -673,7 +685,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -702,7 +715,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -731,7 +745,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -760,7 +775,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -789,7 +805,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -818,7 +835,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -847,7 +865,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -879,7 +898,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -911,7 +931,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -943,7 +964,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -975,7 +997,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1007,7 +1030,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1039,7 +1063,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1071,7 +1096,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1103,7 +1129,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1132,7 +1159,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1159,7 +1187,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1186,7 +1215,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1263,7 +1263,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1292,7 +1293,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1321,7 +1323,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1350,7 +1353,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1379,7 +1383,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1408,7 +1413,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1437,7 +1443,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1466,7 +1473,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1495,7 +1503,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1524,7 +1533,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1553,7 +1563,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1582,7 +1593,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1611,7 +1623,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1640,7 +1653,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1669,7 +1683,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1698,7 +1713,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1727,7 +1743,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1756,7 +1773,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1785,7 +1803,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1814,7 +1833,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1843,7 +1863,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1872,7 +1893,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1901,7 +1923,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1930,7 +1953,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1959,7 +1983,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1988,7 +2013,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2017,7 +2043,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2046,7 +2073,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2075,7 +2103,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2104,7 +2133,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2133,7 +2163,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2162,7 +2193,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2191,7 +2223,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2220,7 +2253,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2249,7 +2283,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2278,7 +2313,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2307,7 +2343,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2336,7 +2373,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2365,7 +2403,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2394,7 +2433,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2423,7 +2463,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2452,7 +2493,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2481,7 +2523,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2510,7 +2553,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2539,7 +2583,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2568,7 +2613,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2597,7 +2643,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2626,7 +2673,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2655,7 +2703,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2684,7 +2733,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2713,7 +2763,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2742,7 +2793,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2771,7 +2823,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2800,7 +2853,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2829,7 +2883,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2858,7 +2913,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2887,7 +2943,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2916,7 +2973,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2945,7 +3003,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2974,7 +3033,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3003,7 +3063,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3032,7 +3093,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3061,7 +3123,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3090,7 +3153,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3119,7 +3183,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3148,7 +3213,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3177,7 +3243,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3206,7 +3273,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3235,7 +3303,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3264,7 +3333,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3293,7 +3363,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3322,7 +3393,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3351,7 +3423,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3380,7 +3453,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3409,7 +3483,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3438,7 +3513,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3467,7 +3543,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3496,7 +3573,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3525,7 +3603,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3554,7 +3633,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3583,7 +3663,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3612,7 +3693,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3641,7 +3723,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3670,7 +3753,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3699,7 +3783,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3728,7 +3813,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3757,7 +3843,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3786,7 +3873,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3815,7 +3903,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3844,7 +3933,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3873,7 +3963,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3902,7 +3993,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3931,7 +4023,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3960,7 +4053,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3989,7 +4083,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4018,7 +4113,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4047,7 +4143,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4076,7 +4173,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4105,7 +4203,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4134,7 +4233,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4163,7 +4263,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4192,7 +4293,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4221,7 +4323,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4250,7 +4353,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4279,7 +4383,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4308,7 +4413,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4337,7 +4443,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4366,7 +4473,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4395,7 +4503,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4424,7 +4533,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4453,7 +4563,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4482,7 +4593,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4511,7 +4623,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4540,7 +4653,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4569,7 +4683,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4598,7 +4713,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4627,7 +4743,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4656,7 +4773,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4685,7 +4803,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4714,7 +4833,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4743,7 +4863,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4772,7 +4893,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4801,7 +4923,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4830,7 +4953,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4859,7 +4983,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4888,7 +5013,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4917,7 +5043,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4946,7 +5073,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4975,7 +5103,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5004,7 +5133,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5033,7 +5163,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5062,7 +5193,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5091,7 +5223,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5120,7 +5253,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5149,7 +5283,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5178,7 +5313,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5207,7 +5343,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5236,7 +5373,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5265,7 +5403,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5294,7 +5433,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5323,7 +5463,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5352,7 +5493,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5381,7 +5523,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5410,7 +5553,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5439,7 +5583,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5468,7 +5613,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5497,7 +5643,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5526,7 +5673,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5555,7 +5703,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5584,7 +5733,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5613,7 +5763,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5642,7 +5793,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5671,7 +5823,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5700,7 +5853,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5729,7 +5883,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5758,7 +5913,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5787,7 +5943,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5816,7 +5973,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5845,7 +6003,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5874,7 +6033,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5903,7 +6063,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5932,7 +6093,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5961,7 +6123,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5990,7 +6153,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6019,7 +6183,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6048,7 +6213,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6077,7 +6243,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6106,7 +6273,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6135,7 +6303,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6164,7 +6333,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6193,7 +6363,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6222,7 +6393,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6251,7 +6423,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6280,7 +6453,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6309,7 +6483,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6338,7 +6513,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6367,7 +6543,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6396,7 +6573,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6425,7 +6603,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6454,7 +6633,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6483,7 +6663,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6512,7 +6693,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6541,7 +6723,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6570,7 +6753,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6599,7 +6783,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6628,7 +6813,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6658,7 +6844,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6685,7 +6872,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6712,7 +6900,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6739,7 +6928,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6766,7 +6956,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6793,7 +6984,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6820,7 +7012,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6847,7 +7040,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6874,7 +7068,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +7096,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6928,7 +7124,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6955,7 +7152,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6982,7 +7180,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7009,7 +7208,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7036,7 +7236,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7063,7 +7264,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7090,7 +7292,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7117,7 +7320,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7144,7 +7348,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7171,7 +7376,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7198,7 +7404,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7225,7 +7432,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7252,7 +7460,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7279,7 +7488,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7306,7 +7516,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7333,7 +7544,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7360,7 +7572,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7387,7 +7600,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7414,7 +7628,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7441,7 +7656,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7468,7 +7684,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7495,7 +7712,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7525,7 +7743,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7552,7 +7771,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7579,7 +7799,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7606,7 +7827,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7633,7 +7855,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7660,7 +7883,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7687,7 +7911,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7714,7 +7939,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7741,7 +7967,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7768,7 +7995,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7795,7 +8023,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7822,7 +8051,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7849,7 +8079,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7876,7 +8107,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7903,7 +8135,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7930,7 +8163,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7957,7 +8191,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7984,7 +8219,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8011,7 +8247,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8038,7 +8275,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8065,7 +8303,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8092,7 +8331,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8119,7 +8359,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8146,7 +8387,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8173,7 +8415,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8200,7 +8443,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8227,7 +8471,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8254,7 +8499,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8281,7 +8527,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8308,7 +8555,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8335,7 +8583,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8362,7 +8611,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8392,7 +8642,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8419,7 +8670,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8446,7 +8698,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8473,7 +8726,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8500,7 +8754,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8527,7 +8782,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8554,7 +8810,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8581,7 +8838,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8608,7 +8866,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8635,7 +8894,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8662,7 +8922,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8689,7 +8950,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8716,7 +8978,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8743,7 +9006,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8770,7 +9034,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8797,7 +9062,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8824,7 +9090,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8851,7 +9118,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8878,7 +9146,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8905,7 +9174,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8932,7 +9202,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8959,7 +9230,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8986,7 +9258,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9013,7 +9286,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9040,7 +9314,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9067,7 +9342,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9094,7 +9370,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9121,7 +9398,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9148,7 +9426,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9175,7 +9454,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9202,7 +9482,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9229,7 +9510,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9259,7 +9541,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9286,7 +9569,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9313,7 +9597,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9340,7 +9625,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9367,7 +9653,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9394,7 +9681,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9421,7 +9709,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9448,7 +9737,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9475,7 +9765,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9502,7 +9793,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9529,7 +9821,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9556,7 +9849,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9583,7 +9877,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9610,7 +9905,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9637,7 +9933,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9664,7 +9961,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9691,7 +9989,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9718,7 +10017,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9745,7 +10045,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9772,7 +10073,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9799,7 +10101,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9826,7 +10129,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9853,7 +10157,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9880,7 +10185,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9907,7 +10213,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9934,7 +10241,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9961,7 +10269,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9988,7 +10297,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10015,7 +10325,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10042,7 +10353,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10069,7 +10381,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10096,7 +10409,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_3_p_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10126,7 +10440,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10153,7 +10468,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10180,7 +10496,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10207,7 +10524,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10234,7 +10552,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10261,7 +10580,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10288,7 +10608,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10315,7 +10636,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10342,7 +10664,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10369,7 +10692,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10396,7 +10720,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10423,7 +10748,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10450,7 +10776,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10477,7 +10804,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10504,7 +10832,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10531,7 +10860,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10558,7 +10888,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10585,7 +10916,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10612,7 +10944,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10639,7 +10972,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10666,7 +11000,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10693,7 +11028,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10720,7 +11056,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10747,7 +11084,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10774,7 +11112,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10801,7 +11140,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10828,7 +11168,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10855,7 +11196,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10882,7 +11224,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10909,7 +11252,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10936,7 +11280,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10963,7 +11308,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_4_p_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10993,7 +11339,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11020,7 +11367,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11047,7 +11395,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11074,7 +11423,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11101,7 +11451,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11128,7 +11479,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11155,7 +11507,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11182,7 +11535,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11209,7 +11563,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11236,7 +11591,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11263,7 +11619,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11290,7 +11647,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11317,7 +11675,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11344,7 +11703,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11371,7 +11731,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11398,7 +11759,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11425,7 +11787,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11452,7 +11815,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11479,7 +11843,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11506,7 +11871,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11533,7 +11899,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11560,7 +11927,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11587,7 +11955,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11614,7 +11983,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11641,7 +12011,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11668,7 +12039,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_5_p_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11698,7 +12070,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11725,7 +12098,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11752,7 +12126,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11779,7 +12154,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11806,7 +12182,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11833,7 +12210,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11860,7 +12238,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11887,7 +12266,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11914,7 +12294,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11941,7 +12322,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11968,7 +12350,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11995,7 +12378,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12022,7 +12406,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12049,7 +12434,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12076,7 +12462,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12103,7 +12490,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12130,7 +12518,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12157,7 +12546,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12184,7 +12574,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12211,7 +12602,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12238,7 +12630,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12265,7 +12658,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12292,7 +12686,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12319,7 +12714,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12346,7 +12742,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12373,7 +12770,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12400,7 +12798,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12427,7 +12826,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12454,7 +12854,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12481,7 +12882,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12508,7 +12910,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12535,7 +12938,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12565,7 +12969,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12592,7 +12997,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12619,7 +13025,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12646,7 +13053,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12673,7 +13081,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12700,7 +13109,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12727,7 +13137,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12754,7 +13165,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12781,7 +13193,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12808,7 +13221,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12835,7 +13249,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12862,7 +13277,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12889,7 +13305,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12916,7 +13333,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12943,7 +13361,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12970,7 +13389,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12997,7 +13417,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13024,7 +13445,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13051,7 +13473,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13078,7 +13501,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13105,7 +13529,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13132,7 +13557,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13159,7 +13585,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13186,7 +13613,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13213,7 +13641,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13240,7 +13669,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13267,7 +13697,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13294,7 +13725,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13321,7 +13753,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13348,7 +13781,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13375,7 +13809,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13402,7 +13837,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13432,7 +13868,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13459,7 +13896,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13486,7 +13924,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13513,7 +13952,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13540,7 +13980,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13567,7 +14008,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13594,7 +14036,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13621,7 +14064,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13648,7 +14092,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13675,7 +14120,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13702,7 +14148,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13729,7 +14176,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13756,7 +14204,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13783,7 +14232,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13810,7 +14260,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13837,7 +14288,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13864,7 +14316,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13891,7 +14344,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13918,7 +14372,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13945,7 +14400,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13972,7 +14428,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13999,7 +14456,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14026,7 +14484,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14053,7 +14512,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14080,7 +14540,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14107,7 +14568,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14134,7 +14596,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14161,7 +14624,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14188,7 +14652,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14215,7 +14680,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14242,7 +14708,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14269,7 +14736,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14299,7 +14767,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14326,7 +14795,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14353,7 +14823,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14380,7 +14851,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14407,7 +14879,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14434,7 +14907,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14461,7 +14935,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14488,7 +14963,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14515,7 +14991,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14542,7 +15019,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14569,7 +15047,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14596,7 +15075,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14623,7 +15103,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14650,7 +15131,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14677,7 +15159,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14704,7 +15187,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14731,7 +15215,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14758,7 +15243,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14785,7 +15271,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14812,7 +15299,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14839,7 +15327,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14866,7 +15355,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14893,7 +15383,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14920,7 +15411,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14947,7 +15439,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14974,7 +15467,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15001,7 +15495,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15028,7 +15523,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15055,7 +15551,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15082,7 +15579,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15109,7 +15607,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15136,7 +15635,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_3_e_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15166,7 +15666,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15193,7 +15694,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15220,7 +15722,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15247,7 +15750,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15274,7 +15778,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15301,7 +15806,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15328,7 +15834,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15355,7 +15862,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15382,7 +15890,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15409,7 +15918,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15436,7 +15946,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15463,7 +15974,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15490,7 +16002,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15517,7 +16030,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15544,7 +16058,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15571,7 +16086,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15598,7 +16114,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15625,7 +16142,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15652,7 +16170,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15679,7 +16198,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15706,7 +16226,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15733,7 +16254,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15760,7 +16282,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15787,7 +16310,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15814,7 +16338,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15841,7 +16366,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15868,7 +16394,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15895,7 +16422,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15922,7 +16450,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15949,7 +16478,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15976,7 +16506,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16003,7 +16534,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_4_e_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16033,7 +16565,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16060,7 +16593,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16087,7 +16621,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16114,7 +16649,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16141,7 +16677,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16168,7 +16705,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16195,7 +16733,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16222,7 +16761,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16249,7 +16789,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16276,7 +16817,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16303,7 +16845,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16330,7 +16873,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16357,7 +16901,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16384,7 +16929,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16411,7 +16957,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16438,7 +16985,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16465,7 +17013,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16492,7 +17041,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16519,7 +17069,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16546,7 +17097,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16573,7 +17125,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16600,7 +17153,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16627,7 +17181,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16654,7 +17209,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16681,7 +17237,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16708,7 +17265,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_5_e_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16736,7 +17294,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16784,7 +17343,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -1264,7 +1264,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1294,7 +1294,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1324,7 +1324,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1354,7 +1354,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1384,7 +1384,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1414,7 +1414,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1444,7 +1444,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1474,7 +1474,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1504,7 +1504,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1534,7 +1534,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1564,7 +1564,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1594,7 +1594,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1624,7 +1624,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1654,7 +1654,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1684,7 +1684,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1714,7 +1714,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1744,7 +1744,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1774,7 +1774,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1804,7 +1804,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1834,7 +1834,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1864,7 +1864,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1894,7 +1894,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1924,7 +1924,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1954,7 +1954,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1984,7 +1984,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2014,7 +2014,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2044,7 +2044,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2074,7 +2074,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2104,7 +2104,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2134,7 +2134,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2164,7 +2164,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2194,7 +2194,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2224,7 +2224,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2254,7 +2254,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2284,7 +2284,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2314,7 +2314,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2344,7 +2344,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2374,7 +2374,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2404,7 +2404,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2434,7 +2434,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2464,7 +2464,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2494,7 +2494,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2524,7 +2524,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2554,7 +2554,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2584,7 +2584,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2614,7 +2614,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2644,7 +2644,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2674,7 +2674,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2704,7 +2704,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2734,7 +2734,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2764,7 +2764,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2794,7 +2794,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2824,7 +2824,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2854,7 +2854,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2884,7 +2884,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2914,7 +2914,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2944,7 +2944,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2974,7 +2974,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3004,7 +3004,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3034,7 +3034,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3064,7 +3064,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3094,7 +3094,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3124,7 +3124,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3154,7 +3154,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3184,7 +3184,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3214,7 +3214,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3244,7 +3244,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3274,7 +3274,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3304,7 +3304,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3334,7 +3334,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3364,7 +3364,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3394,7 +3394,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3424,7 +3424,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3454,7 +3454,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3484,7 +3484,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3514,7 +3514,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3544,7 +3544,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3574,7 +3574,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3604,7 +3604,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3634,7 +3634,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3664,7 +3664,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3694,7 +3694,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3724,7 +3724,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3754,7 +3754,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3784,7 +3784,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3814,7 +3814,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3844,7 +3844,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3874,7 +3874,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3904,7 +3904,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3934,7 +3934,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3964,7 +3964,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3994,7 +3994,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4024,7 +4024,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4054,7 +4054,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4084,7 +4084,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4114,7 +4114,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4144,7 +4144,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4174,7 +4174,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4204,7 +4204,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4234,7 +4234,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4264,7 +4264,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4294,7 +4294,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4324,7 +4324,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4354,7 +4354,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4384,7 +4384,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4414,7 +4414,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4444,7 +4444,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4474,7 +4474,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4504,7 +4504,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4534,7 +4534,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4564,7 +4564,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4594,7 +4594,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4624,7 +4624,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4654,7 +4654,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4684,7 +4684,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4714,7 +4714,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4744,7 +4744,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4774,7 +4774,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4804,7 +4804,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4834,7 +4834,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4864,7 +4864,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4894,7 +4894,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4924,7 +4924,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4954,7 +4954,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4984,7 +4984,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5014,7 +5014,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5044,7 +5044,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5074,7 +5074,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5104,7 +5104,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5134,7 +5134,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5164,7 +5164,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5194,7 +5194,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5224,7 +5224,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5254,7 +5254,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5284,7 +5284,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5314,7 +5314,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5344,7 +5344,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5374,7 +5374,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5404,7 +5404,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5434,7 +5434,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5464,7 +5464,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5494,7 +5494,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5524,7 +5524,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5554,7 +5554,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5584,7 +5584,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5614,7 +5614,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5644,7 +5644,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5674,7 +5674,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5704,7 +5704,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5734,7 +5734,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5764,7 +5764,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5794,7 +5794,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5824,7 +5824,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5854,7 +5854,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5884,7 +5884,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5914,7 +5914,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5944,7 +5944,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5974,7 +5974,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6004,7 +6004,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6034,7 +6034,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6064,7 +6064,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6094,7 +6094,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6124,7 +6124,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6154,7 +6154,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6184,7 +6184,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6214,7 +6214,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6244,7 +6244,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6274,7 +6274,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6304,7 +6304,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6334,7 +6334,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6364,7 +6364,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6394,7 +6394,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6424,7 +6424,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6454,7 +6454,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6484,7 +6484,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6514,7 +6514,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6544,7 +6544,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6574,7 +6574,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6604,7 +6604,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6634,7 +6634,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6664,7 +6664,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6694,7 +6694,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6724,7 +6724,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6754,7 +6754,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6784,7 +6784,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6814,7 +6814,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6845,7 +6845,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6873,7 +6873,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +6901,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6929,7 +6929,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6957,7 +6957,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6985,7 +6985,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7013,7 +7013,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7041,7 +7041,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7069,7 +7069,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7097,7 +7097,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7125,7 +7125,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7153,7 +7153,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7181,7 +7181,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7209,7 +7209,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7237,7 +7237,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7265,7 +7265,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7293,7 +7293,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7321,7 +7321,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7349,7 +7349,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7377,7 +7377,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7405,7 +7405,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7433,7 +7433,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7461,7 +7461,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7489,7 +7489,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7517,7 +7517,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7545,7 +7545,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7573,7 +7573,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7601,7 +7601,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7629,7 +7629,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7657,7 +7657,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7685,7 +7685,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7713,7 +7713,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7744,7 +7744,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7772,7 +7772,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7800,7 +7800,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7828,7 +7828,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7856,7 +7856,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7884,7 +7884,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7912,7 +7912,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7940,7 +7940,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7968,7 +7968,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7996,7 +7996,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8024,7 +8024,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8052,7 +8052,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8080,7 +8080,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8108,7 +8108,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8136,7 +8136,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8164,7 +8164,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8192,7 +8192,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8220,7 +8220,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8248,7 +8248,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8276,7 +8276,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8304,7 +8304,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8332,7 +8332,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8360,7 +8360,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8388,7 +8388,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8416,7 +8416,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8444,7 +8444,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8472,7 +8472,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8500,7 +8500,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8528,7 +8528,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8556,7 +8556,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8584,7 +8584,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8612,7 +8612,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8643,7 +8643,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8671,7 +8671,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8699,7 +8699,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8727,7 +8727,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8755,7 +8755,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8783,7 +8783,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8811,7 +8811,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8839,7 +8839,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8867,7 +8867,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8895,7 +8895,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8923,7 +8923,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8951,7 +8951,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8979,7 +8979,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9007,7 +9007,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9035,7 +9035,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9063,7 +9063,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9091,7 +9091,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9119,7 +9119,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9147,7 +9147,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9175,7 +9175,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9203,7 +9203,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9231,7 +9231,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9259,7 +9259,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9287,7 +9287,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9315,7 +9315,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9343,7 +9343,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9371,7 +9371,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9399,7 +9399,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9427,7 +9427,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9455,7 +9455,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9483,7 +9483,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9511,7 +9511,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9542,7 +9542,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9570,7 +9570,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9598,7 +9598,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9626,7 +9626,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9654,7 +9654,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9682,7 +9682,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9710,7 +9710,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9738,7 +9738,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9766,7 +9766,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9794,7 +9794,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9822,7 +9822,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9850,7 +9850,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9878,7 +9878,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9906,7 +9906,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9934,7 +9934,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9962,7 +9962,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9990,7 +9990,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10018,7 +10018,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10046,7 +10046,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10074,7 +10074,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10102,7 +10102,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10130,7 +10130,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10158,7 +10158,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10186,7 +10186,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10214,7 +10214,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10242,7 +10242,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10270,7 +10270,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10298,7 +10298,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10326,7 +10326,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10354,7 +10354,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10382,7 +10382,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10410,7 +10410,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_3_p_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10441,7 +10441,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10469,7 +10469,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10497,7 +10497,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10525,7 +10525,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10553,7 +10553,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10581,7 +10581,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10609,7 +10609,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10637,7 +10637,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10665,7 +10665,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10693,7 +10693,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10721,7 +10721,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10749,7 +10749,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10777,7 +10777,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10805,7 +10805,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10833,7 +10833,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10861,7 +10861,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10889,7 +10889,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10917,7 +10917,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10945,7 +10945,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10973,7 +10973,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11001,7 +11001,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11029,7 +11029,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11057,7 +11057,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11085,7 +11085,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11113,7 +11113,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11141,7 +11141,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11169,7 +11169,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11197,7 +11197,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11225,7 +11225,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11253,7 +11253,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11281,7 +11281,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11309,7 +11309,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_4_p_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11340,7 +11340,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11368,7 +11368,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11396,7 +11396,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11424,7 +11424,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11452,7 +11452,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11480,7 +11480,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11508,7 +11508,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11536,7 +11536,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11564,7 +11564,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11592,7 +11592,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11620,7 +11620,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11648,7 +11648,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11676,7 +11676,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11704,7 +11704,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11732,7 +11732,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11760,7 +11760,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11788,7 +11788,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11816,7 +11816,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11844,7 +11844,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11872,7 +11872,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11900,7 +11900,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11928,7 +11928,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11956,7 +11956,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11984,7 +11984,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12012,7 +12012,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12040,7 +12040,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_5_p_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12071,7 +12071,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12099,7 +12099,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12127,7 +12127,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12155,7 +12155,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12183,7 +12183,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12211,7 +12211,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12239,7 +12239,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12267,7 +12267,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12295,7 +12295,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12323,7 +12323,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12351,7 +12351,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12379,7 +12379,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12407,7 +12407,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12435,7 +12435,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12463,7 +12463,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12491,7 +12491,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12519,7 +12519,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12547,7 +12547,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12575,7 +12575,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12603,7 +12603,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12631,7 +12631,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12659,7 +12659,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12687,7 +12687,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12715,7 +12715,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12743,7 +12743,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12771,7 +12771,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12799,7 +12799,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12827,7 +12827,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12855,7 +12855,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12883,7 +12883,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12911,7 +12911,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12939,7 +12939,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12970,7 +12970,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12998,7 +12998,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13026,7 +13026,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13054,7 +13054,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13082,7 +13082,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13110,7 +13110,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13138,7 +13138,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13166,7 +13166,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13194,7 +13194,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13222,7 +13222,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13250,7 +13250,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13278,7 +13278,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13306,7 +13306,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13334,7 +13334,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13362,7 +13362,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13390,7 +13390,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13418,7 +13418,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13446,7 +13446,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13474,7 +13474,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13502,7 +13502,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13530,7 +13530,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13558,7 +13558,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13586,7 +13586,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13614,7 +13614,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13642,7 +13642,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13670,7 +13670,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13698,7 +13698,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13726,7 +13726,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13754,7 +13754,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13782,7 +13782,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13810,7 +13810,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13838,7 +13838,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13869,7 +13869,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13897,7 +13897,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13925,7 +13925,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13953,7 +13953,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -13981,7 +13981,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14009,7 +14009,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14037,7 +14037,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14065,7 +14065,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14093,7 +14093,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14121,7 +14121,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14149,7 +14149,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14177,7 +14177,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14205,7 +14205,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14233,7 +14233,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14261,7 +14261,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14289,7 +14289,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14317,7 +14317,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14345,7 +14345,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14373,7 +14373,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14401,7 +14401,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14429,7 +14429,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14457,7 +14457,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14485,7 +14485,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14513,7 +14513,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14541,7 +14541,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_88 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14569,7 +14569,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_89 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14597,7 +14597,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_90 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14625,7 +14625,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_91 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14653,7 +14653,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_92 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14681,7 +14681,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_93 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14709,7 +14709,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_94 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14737,7 +14737,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_95 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14768,7 +14768,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_96 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14796,7 +14796,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_97 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14824,7 +14824,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_98 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14852,7 +14852,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_99 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14880,7 +14880,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_100 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14908,7 +14908,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_101 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14936,7 +14936,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_102 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14964,7 +14964,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_103 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -14992,7 +14992,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_104 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15020,7 +15020,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_105 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15048,7 +15048,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_106 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15076,7 +15076,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_107 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15104,7 +15104,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_108 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15132,7 +15132,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_109 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15160,7 +15160,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_110 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15188,7 +15188,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_111 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15216,7 +15216,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_112 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15244,7 +15244,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_113 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15272,7 +15272,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_114 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15300,7 +15300,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_115 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15328,7 +15328,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_116 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15356,7 +15356,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_117 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15384,7 +15384,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_118 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15412,7 +15412,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_119 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15440,7 +15440,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_120 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15468,7 +15468,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_121 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15496,7 +15496,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_122 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15524,7 +15524,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_123 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15552,7 +15552,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_124 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15580,7 +15580,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_125 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15608,7 +15608,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_126 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15636,7 +15636,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_3_e_127 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15667,7 +15667,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_128 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15695,7 +15695,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_129 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15723,7 +15723,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_130 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15751,7 +15751,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_131 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15779,7 +15779,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_132 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15807,7 +15807,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_133 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15835,7 +15835,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_134 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15863,7 +15863,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_135 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15891,7 +15891,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_136 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15919,7 +15919,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_137 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15947,7 +15947,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_138 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -15975,7 +15975,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_139 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16003,7 +16003,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_140 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16031,7 +16031,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_141 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16059,7 +16059,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_142 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16087,7 +16087,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_143 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16115,7 +16115,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_144 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16143,7 +16143,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_145 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16171,7 +16171,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_146 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16199,7 +16199,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_147 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16227,7 +16227,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_148 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16255,7 +16255,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_149 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16283,7 +16283,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_150 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16311,7 +16311,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_151 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16339,7 +16339,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_152 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16367,7 +16367,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_153 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16395,7 +16395,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_154 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16423,7 +16423,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_155 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16451,7 +16451,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_156 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16479,7 +16479,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_157 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16507,7 +16507,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_158 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16535,7 +16535,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_4_e_159 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16566,7 +16566,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_160 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16594,7 +16594,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_161 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16622,7 +16622,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_162 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16650,7 +16650,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_163 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16678,7 +16678,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_164 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16706,7 +16706,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_165 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16734,7 +16734,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_166 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16762,7 +16762,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_167 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16790,7 +16790,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_168 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16818,7 +16818,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_169 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16846,7 +16846,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_170 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16874,7 +16874,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_171 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16902,7 +16902,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_172 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16930,7 +16930,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_173 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16958,7 +16958,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_174 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16986,7 +16986,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_175 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17014,7 +17014,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_176 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17042,7 +17042,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_177 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17070,7 +17070,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_178 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17098,7 +17098,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_179 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17126,7 +17126,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_180 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17154,7 +17154,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_181 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17182,7 +17182,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_182 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17210,7 +17210,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_183 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17238,7 +17238,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_184 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17266,7 +17266,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_5_e_185 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17295,7 +17295,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -17344,7 +17344,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_top.sv
@@ -253,7 +253,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -281,7 +282,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -309,7 +311,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -337,7 +340,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h3),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -365,7 +369,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -393,7 +398,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h5),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -421,7 +427,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -449,7 +456,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h7),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -477,7 +485,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h8),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -505,7 +514,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h9),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -533,7 +543,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'ha),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -561,7 +572,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hb),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -589,7 +601,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hc),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -617,7 +630,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hd),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -645,7 +659,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'he),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -673,7 +688,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -701,7 +717,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h10),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -729,7 +746,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h11),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -757,7 +775,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h12),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -785,7 +804,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h13),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -813,7 +833,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h14),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -841,7 +862,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h15),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -869,7 +891,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h16),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -897,7 +920,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h17),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -925,7 +949,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h18),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -953,7 +978,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h19),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -981,7 +1007,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1a),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1009,7 +1036,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1b),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1065,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1c),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1065,7 +1094,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1d),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1093,7 +1123,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1e),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1121,7 +1152,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1f),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1149,7 +1181,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h20),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1177,7 +1210,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h21),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1205,7 +1239,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h22),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1233,7 +1268,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h23),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1261,7 +1297,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h24),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1289,7 +1326,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h25),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_rega37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1338,7 +1376,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1367,7 +1406,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1396,7 +1436,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1425,7 +1466,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1454,7 +1496,8 @@ module ast_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_top.sv
@@ -254,7 +254,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -283,7 +283,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -312,7 +312,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -341,7 +341,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h3),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -370,7 +370,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h4),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -399,7 +399,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h5),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -428,7 +428,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -457,7 +457,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h7),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -486,7 +486,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h8),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -515,7 +515,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h9),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -544,7 +544,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'ha),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -573,7 +573,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hb),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -602,7 +602,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hc),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +631,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hd),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +660,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'he),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -689,7 +689,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -718,7 +718,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h10),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -747,7 +747,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h11),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -776,7 +776,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h12),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -805,7 +805,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h13),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -834,7 +834,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h14),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -863,7 +863,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h15),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -892,7 +892,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h16),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -921,7 +921,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h17),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -950,7 +950,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h18),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -979,7 +979,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h19),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1008,7 +1008,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1a),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1037,7 +1037,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1b),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1066,7 +1066,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h1c),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1095,7 +1095,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1d),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1124,7 +1124,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1e),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1153,7 +1153,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h1f),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1182,7 +1182,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h20),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1211,7 +1211,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h21),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1240,7 +1240,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h22),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1269,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h23),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1298,7 +1298,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h24),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1327,7 +1327,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h25),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_rega37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1377,7 +1377,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1407,7 +1407,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1437,7 +1437,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1467,7 +1467,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1497,7 +1497,7 @@ module ast_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_regb_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -624,7 +624,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -656,7 +657,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -683,7 +685,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -727,7 +730,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -758,7 +762,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -787,7 +792,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -814,7 +820,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -841,7 +848,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_io_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -868,7 +876,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -896,7 +905,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -924,7 +934,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_clk_hints_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -952,7 +963,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -985,7 +997,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_io_meas_ctrl_en (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1041,7 +1054,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1100,7 +1114,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1d6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1143,7 +1158,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_en (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1199,7 +1215,8 @@ module clkmgr_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h82),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1258,7 +1275,8 @@ module clkmgr_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h6e),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1301,7 +1319,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_en (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1357,7 +1376,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1fe),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1416,7 +1436,8 @@ module clkmgr_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1458,7 +1479,8 @@ module clkmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_en (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1514,7 +1536,8 @@ module clkmgr_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'hfa),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1573,7 +1596,8 @@ module clkmgr_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'he6),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1611,7 +1635,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1638,7 +1663,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1665,7 +1691,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1692,7 +1719,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1719,7 +1747,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1746,7 +1775,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1773,7 +1803,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1800,7 +1831,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1827,7 +1859,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1856,7 +1889,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1883,7 +1917,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1910,7 +1945,8 @@ module clkmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -625,7 +625,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +658,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -686,7 +686,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_extclk_ctrl_hi_speed_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -731,7 +731,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jitter_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +763,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -793,7 +793,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -821,7 +821,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_div2_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -849,7 +849,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_io_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -877,7 +877,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_enables_clk_usb_peri_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -906,7 +906,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -935,7 +935,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_clk_hints_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -964,7 +964,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_measure_ctrl_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1055,7 +1055,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1115,7 +1115,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1d6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_i),
     .rst_ni  (rst_io_ni),
@@ -1216,7 +1216,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h82),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1276,7 +1276,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h6e),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
     .rst_ni  (rst_io_div4_ni),
@@ -1377,7 +1377,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1fe),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1437,7 +1437,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h1ea),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
     .rst_ni  (rst_main_ni),
@@ -1537,7 +1537,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'hfa),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usb_meas_ctrl_shadowed_hi (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1597,7 +1597,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'he6),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_usb_meas_ctrl_shadowed_lo (
     .clk_i   (clk_usb_i),
     .rst_ni  (rst_usb_ni),
@@ -1636,7 +1636,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_shadow_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1664,7 +1664,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1692,7 +1692,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div4_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1720,7 +1720,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_main_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1748,7 +1748,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_usb_measure_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1776,7 +1776,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1804,7 +1804,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_io_div4_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1832,7 +1832,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_main_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1860,7 +1860,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_recov_err_code_usb_timeout_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1890,7 +1890,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_reg_intg (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1918,7 +1918,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_idle_cnt (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1946,7 +1946,7 @@ module clkmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fatal_err_code_shadow_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1024,7 +1024,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1051,7 +1052,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1078,7 +1080,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1108,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1132,7 +1136,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1159,7 +1164,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1188,7 +1194,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1215,7 +1222,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1242,7 +1250,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1278,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1306,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1323,7 +1334,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1537,7 +1549,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1565,7 +1578,8 @@ module flash_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1593,7 +1607,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1641,7 +1656,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1668,7 +1684,8 @@ module flash_ctrl_core_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1695,7 +1712,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_prog_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1722,7 +1740,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_erase_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1749,7 +1768,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_partition_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1776,7 +1796,8 @@ module flash_ctrl_core_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_info_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1803,7 +1824,8 @@ module flash_ctrl_core_reg_top (
     .DW      (12),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1834,7 +1856,8 @@ module flash_ctrl_core_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1866,7 +1889,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prog_type_en_normal (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1893,7 +1917,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prog_type_en_repair (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1921,7 +1946,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_erase_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1950,7 +1976,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1979,7 +2006,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2008,7 +2036,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2037,7 +2066,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2066,7 +2096,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2095,7 +2126,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2124,7 +2156,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2153,7 +2186,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_region_cfg_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2186,7 +2220,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2213,7 +2248,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2240,7 +2276,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2267,7 +2304,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2294,7 +2332,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2321,7 +2360,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2348,7 +2388,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2381,7 +2422,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2408,7 +2450,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2435,7 +2478,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2462,7 +2506,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2489,7 +2534,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2516,7 +2562,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2543,7 +2590,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2576,7 +2624,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2603,7 +2652,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2630,7 +2680,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2657,7 +2708,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2684,7 +2736,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2711,7 +2764,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2738,7 +2792,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2771,7 +2826,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2798,7 +2854,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2825,7 +2882,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2852,7 +2910,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2879,7 +2938,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2906,7 +2966,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2933,7 +2994,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2966,7 +3028,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2993,7 +3056,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3020,7 +3084,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3047,7 +3112,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3074,7 +3140,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3101,7 +3168,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3128,7 +3196,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3161,7 +3230,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3188,7 +3258,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3215,7 +3286,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3242,7 +3314,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3269,7 +3342,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3296,7 +3370,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3323,7 +3398,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3356,7 +3432,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3383,7 +3460,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3410,7 +3488,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3437,7 +3516,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3464,7 +3544,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3491,7 +3572,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3518,7 +3600,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3551,7 +3634,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3578,7 +3662,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3605,7 +3690,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3632,7 +3718,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3659,7 +3746,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3686,7 +3774,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3713,7 +3802,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_mp_region_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3746,7 +3836,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3773,7 +3864,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3806,7 +3898,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3833,7 +3926,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3866,7 +3960,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3893,7 +3988,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3926,7 +4022,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3953,7 +4050,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3986,7 +4084,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4013,7 +4112,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4046,7 +4146,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4073,7 +4174,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4106,7 +4208,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4133,7 +4236,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4166,7 +4270,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4193,7 +4298,8 @@ module flash_ctrl_core_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_region_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4222,7 +4328,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4249,7 +4356,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4276,7 +4384,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4303,7 +4412,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4330,7 +4440,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4357,7 +4468,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_default_region_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4386,7 +4498,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4415,7 +4528,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4444,7 +4558,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4473,7 +4588,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4502,7 +4618,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4531,7 +4648,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4560,7 +4678,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4589,7 +4708,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4618,7 +4738,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4647,7 +4768,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4680,7 +4802,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4707,7 +4830,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4734,7 +4858,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4761,7 +4886,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4788,7 +4914,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4815,7 +4942,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4842,7 +4970,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4875,7 +5004,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4902,7 +5032,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4929,7 +5060,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4956,7 +5088,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4983,7 +5116,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5010,7 +5144,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5037,7 +5172,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5070,7 +5206,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5097,7 +5234,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5124,7 +5262,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5151,7 +5290,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5178,7 +5318,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5205,7 +5346,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5232,7 +5374,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5265,7 +5408,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5292,7 +5436,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5319,7 +5464,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5346,7 +5492,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5373,7 +5520,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5400,7 +5548,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5427,7 +5576,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5460,7 +5610,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5487,7 +5638,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5514,7 +5666,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5541,7 +5694,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5568,7 +5722,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5595,7 +5750,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5622,7 +5778,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5655,7 +5812,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5682,7 +5840,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5709,7 +5868,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5736,7 +5896,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5763,7 +5924,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5790,7 +5952,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5817,7 +5980,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5850,7 +6014,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5877,7 +6042,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5904,7 +6070,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5931,7 +6098,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5958,7 +6126,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5985,7 +6154,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6012,7 +6182,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6045,7 +6216,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6072,7 +6244,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6099,7 +6272,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6126,7 +6300,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6153,7 +6328,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6180,7 +6356,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6207,7 +6384,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6240,7 +6418,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6267,7 +6446,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6294,7 +6474,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6321,7 +6502,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6348,7 +6530,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6375,7 +6558,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6402,7 +6586,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6435,7 +6620,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6462,7 +6648,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6489,7 +6676,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6516,7 +6704,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6543,7 +6732,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6570,7 +6760,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6597,7 +6788,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6626,7 +6818,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6659,7 +6852,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6686,7 +6880,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6713,7 +6908,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6740,7 +6936,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6767,7 +6964,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6794,7 +6992,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6821,7 +7020,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6850,7 +7050,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6879,7 +7080,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6912,7 +7114,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6939,7 +7142,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6966,7 +7170,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6993,7 +7198,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7020,7 +7226,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7047,7 +7254,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7074,7 +7282,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7107,7 +7316,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7134,7 +7344,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7161,7 +7372,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7188,7 +7400,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7215,7 +7428,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7242,7 +7456,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7269,7 +7484,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank0_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7298,7 +7514,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7327,7 +7544,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7356,7 +7574,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7385,7 +7604,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7414,7 +7634,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7443,7 +7664,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7472,7 +7694,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7501,7 +7724,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7530,7 +7754,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7559,7 +7784,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7592,7 +7818,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7619,7 +7846,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7646,7 +7874,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7673,7 +7902,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7700,7 +7930,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7727,7 +7958,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7754,7 +7986,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7787,7 +8020,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7814,7 +8048,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7841,7 +8076,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7868,7 +8104,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7895,7 +8132,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7922,7 +8160,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7949,7 +8188,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7982,7 +8222,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8009,7 +8250,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8036,7 +8278,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8063,7 +8306,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8090,7 +8334,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8117,7 +8362,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8144,7 +8390,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8177,7 +8424,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8204,7 +8452,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8231,7 +8480,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8258,7 +8508,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8285,7 +8536,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8312,7 +8564,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8339,7 +8592,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8372,7 +8626,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8399,7 +8654,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8426,7 +8682,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8453,7 +8710,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8480,7 +8738,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8507,7 +8766,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8534,7 +8794,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8567,7 +8828,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8594,7 +8856,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8621,7 +8884,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8648,7 +8912,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8675,7 +8940,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8702,7 +8968,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8729,7 +8996,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8762,7 +9030,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8789,7 +9058,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8816,7 +9086,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8843,7 +9114,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8870,7 +9142,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8897,7 +9170,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8924,7 +9198,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8957,7 +9232,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8984,7 +9260,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9011,7 +9288,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9038,7 +9316,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9065,7 +9344,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9092,7 +9372,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9119,7 +9400,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9152,7 +9434,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9179,7 +9462,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9206,7 +9490,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9233,7 +9518,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9260,7 +9546,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9287,7 +9574,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9314,7 +9602,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9347,7 +9636,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9374,7 +9664,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9401,7 +9692,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9428,7 +9720,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9455,7 +9748,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9482,7 +9776,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9509,7 +9804,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9538,7 +9834,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9571,7 +9868,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9598,7 +9896,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9625,7 +9924,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9652,7 +9952,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9679,7 +9980,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9706,7 +10008,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9733,7 +10036,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9762,7 +10066,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9791,7 +10096,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9824,7 +10130,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9851,7 +10158,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9878,7 +10186,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9905,7 +10214,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9932,7 +10242,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9959,7 +10270,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9986,7 +10298,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10019,7 +10332,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10046,7 +10360,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10073,7 +10388,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10100,7 +10416,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10127,7 +10444,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10154,7 +10472,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10181,7 +10500,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_bank1_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10210,7 +10530,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_hw_info_cfg_override_scramble_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10237,7 +10558,8 @@ module flash_ctrl_core_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_hw_info_cfg_override_ecc_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10265,7 +10587,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_bank_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10298,7 +10621,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10334,7 +10658,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10372,7 +10697,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_op_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10399,7 +10725,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_op_status_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10428,7 +10755,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10455,7 +10783,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_rd_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10482,7 +10811,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_prog_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10509,7 +10839,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10536,7 +10867,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10563,7 +10895,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_status_initialized (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10608,7 +10941,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10635,7 +10969,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10662,7 +10997,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10689,7 +11025,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10716,7 +11053,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10743,7 +11081,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10770,7 +11109,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10797,7 +11137,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_macro_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10826,7 +11167,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10853,7 +11195,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_prog_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10880,7 +11223,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_lcmgr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10907,7 +11251,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_lcmgr_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10934,7 +11279,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_arb_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10961,7 +11307,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10988,7 +11335,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_phy_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11015,7 +11363,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_ctrl_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11042,7 +11391,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_std_fault_status_fifo_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11071,7 +11421,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11098,7 +11449,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11125,7 +11477,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11152,7 +11505,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11179,7 +11533,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11206,7 +11561,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11233,7 +11589,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_seed_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11260,7 +11617,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_phy_relbl_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11287,7 +11645,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_phy_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11314,7 +11673,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_spurious_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11341,7 +11701,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_arb_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11368,7 +11729,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_host_gnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11396,7 +11758,8 @@ module flash_ctrl_core_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11426,7 +11789,8 @@ module flash_ctrl_core_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11453,7 +11817,8 @@ module flash_ctrl_core_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11482,7 +11847,8 @@ module flash_ctrl_core_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11511,7 +11877,8 @@ module flash_ctrl_core_reg_top (
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (16'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ecc_single_err_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11540,7 +11907,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_alert_cfg_alert_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11567,7 +11935,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_alert_cfg_alert_trig (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11596,7 +11965,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11623,7 +11993,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_status_prog_normal_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11650,7 +12021,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_phy_status_prog_repair_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11678,7 +12050,8 @@ module flash_ctrl_core_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_scratch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11707,7 +12080,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_lvl_prog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11734,7 +12108,8 @@ module flash_ctrl_core_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_lvl_rd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11762,7 +12137,8 @@ module flash_ctrl_core_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1025,7 +1025,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1053,7 +1053,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1081,7 +1081,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1109,7 +1109,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1137,7 +1137,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1165,7 +1165,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1195,7 +1195,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1223,7 +1223,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1251,7 +1251,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1279,7 +1279,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_rd_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1307,7 +1307,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_op_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1335,7 +1335,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable_corr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1550,7 +1550,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1579,7 +1579,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_exec (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1608,7 +1608,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_init (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1657,7 +1657,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_start (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1685,7 +1685,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_op (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1713,7 +1713,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_prog_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1741,7 +1741,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_erase_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1769,7 +1769,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_partition_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1797,7 +1797,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_info_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1825,7 +1825,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (12'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_num (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1857,7 +1857,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1890,7 +1890,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prog_type_en_normal (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1918,7 +1918,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prog_type_en_repair (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1947,7 +1947,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_erase_suspend (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1977,7 +1977,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2007,7 +2007,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2037,7 +2037,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2067,7 +2067,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2097,7 +2097,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2127,7 +2127,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2157,7 +2157,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2187,7 +2187,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_region_cfg_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2221,7 +2221,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2249,7 +2249,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2277,7 +2277,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2305,7 +2305,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2333,7 +2333,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2361,7 +2361,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2389,7 +2389,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2423,7 +2423,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2451,7 +2451,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2479,7 +2479,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2507,7 +2507,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2535,7 +2535,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2563,7 +2563,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2591,7 +2591,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2625,7 +2625,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2653,7 +2653,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2681,7 +2681,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2709,7 +2709,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2737,7 +2737,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2765,7 +2765,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2793,7 +2793,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2827,7 +2827,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2855,7 +2855,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2883,7 +2883,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2911,7 +2911,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2939,7 +2939,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2967,7 +2967,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2995,7 +2995,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3029,7 +3029,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3057,7 +3057,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3085,7 +3085,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3113,7 +3113,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3141,7 +3141,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3169,7 +3169,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3197,7 +3197,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3231,7 +3231,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3259,7 +3259,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3287,7 +3287,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3315,7 +3315,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3343,7 +3343,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3371,7 +3371,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3399,7 +3399,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3433,7 +3433,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3461,7 +3461,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3489,7 +3489,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3517,7 +3517,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3545,7 +3545,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3573,7 +3573,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3601,7 +3601,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3635,7 +3635,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3663,7 +3663,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3691,7 +3691,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3719,7 +3719,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3747,7 +3747,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3775,7 +3775,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3803,7 +3803,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3837,7 +3837,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3865,7 +3865,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3899,7 +3899,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3927,7 +3927,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3961,7 +3961,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3989,7 +3989,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4023,7 +4023,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4051,7 +4051,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4085,7 +4085,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4113,7 +4113,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4147,7 +4147,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4175,7 +4175,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4209,7 +4209,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4237,7 +4237,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4271,7 +4271,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4299,7 +4299,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_region_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4329,7 +4329,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4357,7 +4357,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4385,7 +4385,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4413,7 +4413,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4441,7 +4441,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4469,7 +4469,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_default_region_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4499,7 +4499,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4529,7 +4529,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4559,7 +4559,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4589,7 +4589,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4619,7 +4619,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4649,7 +4649,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4679,7 +4679,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4709,7 +4709,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4739,7 +4739,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4769,7 +4769,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4803,7 +4803,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4831,7 +4831,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4859,7 +4859,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4887,7 +4887,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4915,7 +4915,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4943,7 +4943,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4971,7 +4971,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5005,7 +5005,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5033,7 +5033,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5061,7 +5061,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5089,7 +5089,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5117,7 +5117,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5145,7 +5145,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5173,7 +5173,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5207,7 +5207,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5235,7 +5235,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5263,7 +5263,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5291,7 +5291,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5319,7 +5319,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5347,7 +5347,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5375,7 +5375,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5409,7 +5409,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5437,7 +5437,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5465,7 +5465,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5493,7 +5493,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5521,7 +5521,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5549,7 +5549,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5577,7 +5577,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5611,7 +5611,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5639,7 +5639,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5667,7 +5667,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5695,7 +5695,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5723,7 +5723,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5751,7 +5751,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5779,7 +5779,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5813,7 +5813,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5841,7 +5841,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5869,7 +5869,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5897,7 +5897,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5925,7 +5925,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5953,7 +5953,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5981,7 +5981,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6015,7 +6015,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6043,7 +6043,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6071,7 +6071,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6099,7 +6099,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6127,7 +6127,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6155,7 +6155,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6183,7 +6183,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6217,7 +6217,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6245,7 +6245,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6273,7 +6273,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6301,7 +6301,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6329,7 +6329,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6357,7 +6357,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6385,7 +6385,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6419,7 +6419,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6447,7 +6447,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6475,7 +6475,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6503,7 +6503,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6531,7 +6531,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6559,7 +6559,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6587,7 +6587,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6621,7 +6621,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6649,7 +6649,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6677,7 +6677,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6705,7 +6705,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6733,7 +6733,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6761,7 +6761,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6789,7 +6789,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6819,7 +6819,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6853,7 +6853,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6881,7 +6881,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6909,7 +6909,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6937,7 +6937,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6965,7 +6965,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6993,7 +6993,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7021,7 +7021,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7051,7 +7051,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7081,7 +7081,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7115,7 +7115,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7143,7 +7143,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7171,7 +7171,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7199,7 +7199,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7227,7 +7227,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7255,7 +7255,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7283,7 +7283,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7317,7 +7317,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7345,7 +7345,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7373,7 +7373,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7401,7 +7401,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7429,7 +7429,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7457,7 +7457,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7485,7 +7485,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank0_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7515,7 +7515,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7545,7 +7545,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7575,7 +7575,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7605,7 +7605,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7635,7 +7635,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7665,7 +7665,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7695,7 +7695,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7725,7 +7725,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7755,7 +7755,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7785,7 +7785,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7819,7 +7819,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7847,7 +7847,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7875,7 +7875,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7903,7 +7903,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7931,7 +7931,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7959,7 +7959,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7987,7 +7987,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8021,7 +8021,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8049,7 +8049,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8077,7 +8077,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8105,7 +8105,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8133,7 +8133,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8161,7 +8161,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8189,7 +8189,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8223,7 +8223,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8251,7 +8251,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8279,7 +8279,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8307,7 +8307,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8335,7 +8335,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8363,7 +8363,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8391,7 +8391,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8425,7 +8425,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8453,7 +8453,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8481,7 +8481,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8509,7 +8509,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8537,7 +8537,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8565,7 +8565,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8593,7 +8593,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8627,7 +8627,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8655,7 +8655,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8683,7 +8683,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8711,7 +8711,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8739,7 +8739,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8767,7 +8767,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8795,7 +8795,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8829,7 +8829,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8857,7 +8857,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8885,7 +8885,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8913,7 +8913,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8941,7 +8941,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8969,7 +8969,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8997,7 +8997,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9031,7 +9031,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9059,7 +9059,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9087,7 +9087,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9115,7 +9115,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9143,7 +9143,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9171,7 +9171,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9199,7 +9199,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9233,7 +9233,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9261,7 +9261,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9289,7 +9289,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9317,7 +9317,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9345,7 +9345,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9373,7 +9373,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9401,7 +9401,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9435,7 +9435,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9463,7 +9463,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9491,7 +9491,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9519,7 +9519,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9547,7 +9547,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9575,7 +9575,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9603,7 +9603,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9637,7 +9637,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9665,7 +9665,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9693,7 +9693,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9721,7 +9721,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9749,7 +9749,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9777,7 +9777,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9805,7 +9805,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info0_page_cfg_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9835,7 +9835,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9869,7 +9869,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9897,7 +9897,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9925,7 +9925,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9953,7 +9953,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9981,7 +9981,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10009,7 +10009,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10037,7 +10037,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info1_page_cfg_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10067,7 +10067,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10097,7 +10097,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10131,7 +10131,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10159,7 +10159,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10187,7 +10187,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10215,7 +10215,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10243,7 +10243,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10271,7 +10271,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10299,7 +10299,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10333,7 +10333,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10361,7 +10361,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10389,7 +10389,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10417,7 +10417,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10445,7 +10445,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10473,7 +10473,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10501,7 +10501,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank1_info2_page_cfg_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10531,7 +10531,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_info_cfg_override_scramble_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10559,7 +10559,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_info_cfg_override_ecc_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10588,7 +10588,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_bank_cfg_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10622,7 +10622,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10659,7 +10659,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10698,7 +10698,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_op_status_done (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10726,7 +10726,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_op_status_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10756,7 +10756,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rd_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10784,7 +10784,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_rd_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10812,7 +10812,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_prog_full (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10840,7 +10840,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10868,7 +10868,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10896,7 +10896,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_status_initialized (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10942,7 +10942,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10970,7 +10970,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10998,7 +10998,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11026,7 +11026,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11054,7 +11054,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11082,7 +11082,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11110,7 +11110,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_update_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11138,7 +11138,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_macro_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11168,7 +11168,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11196,7 +11196,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_prog_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11224,7 +11224,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_lcmgr_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11252,7 +11252,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_lcmgr_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11280,7 +11280,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_arb_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11308,7 +11308,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11336,7 +11336,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_phy_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11364,7 +11364,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_ctrl_cnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11392,7 +11392,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_std_fault_status_fifo_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11422,7 +11422,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_op_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11450,7 +11450,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_mp_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11478,7 +11478,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_rd_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11506,7 +11506,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_prog_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11534,7 +11534,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_prog_win_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11562,7 +11562,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_prog_type_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11590,7 +11590,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_seed_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11618,7 +11618,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_phy_relbl_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11646,7 +11646,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_phy_storage_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11674,7 +11674,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_spurious_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11702,7 +11702,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_arb_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11730,7 +11730,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_host_gnt_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11759,7 +11759,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11790,7 +11790,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11818,7 +11818,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_cnt_ecc_single_err_cnt_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11848,7 +11848,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_addr_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11878,7 +11878,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (16'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ecc_single_err_addr_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11908,7 +11908,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_alert_cfg_alert_ack (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11936,7 +11936,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_alert_cfg_alert_trig (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11966,7 +11966,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_status_init_wip (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11994,7 +11994,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_status_prog_normal_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12022,7 +12022,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_phy_status_prog_repair_avail (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12051,7 +12051,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_scratch (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12081,7 +12081,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_lvl_prog (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12109,7 +12109,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'hf),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_lvl_rd (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12138,7 +12138,7 @@ module flash_ctrl_core_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fifo_rst (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -271,7 +271,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr0_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -304,7 +304,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -332,7 +332,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -362,7 +362,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -390,7 +390,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -418,7 +418,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -446,7 +446,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -474,7 +474,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -502,7 +502,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -530,7 +530,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +558,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr2_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -591,7 +591,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -619,7 +619,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -647,7 +647,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -675,7 +675,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -703,7 +703,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -731,7 +731,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -759,7 +759,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -787,7 +787,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -815,7 +815,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +843,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr3_field9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -876,7 +876,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -904,7 +904,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -932,7 +932,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -960,7 +960,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -993,7 +993,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1021,7 +1021,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1049,7 +1049,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1077,7 +1077,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1105,7 +1105,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1138,7 +1138,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1166,7 +1166,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1194,7 +1194,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1222,7 +1222,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1250,7 +1250,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1278,7 +1278,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1306,7 +1306,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1334,7 +1334,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1362,7 +1362,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr6_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1395,7 +1395,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1423,7 +1423,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1455,7 +1455,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1487,7 +1487,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1519,7 +1519,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1551,7 +1551,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1583,7 +1583,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1616,7 +1616,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr13_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1644,7 +1644,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr13_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1677,7 +1677,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr14_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1705,7 +1705,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr14_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1738,7 +1738,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr15_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1766,7 +1766,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr15_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1799,7 +1799,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr16_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1827,7 +1827,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr16_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1860,7 +1860,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr17_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1888,7 +1888,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr17_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1920,7 +1920,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1952,7 +1952,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1982,7 +1982,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr20_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2010,7 +2010,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr20_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2038,7 +2038,7 @@ module flash_ctrl_prim_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_csr20_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -270,7 +270,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr0_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -302,7 +303,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -329,7 +331,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr1_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -358,7 +361,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -385,7 +389,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -412,7 +417,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -439,7 +445,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -466,7 +473,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -493,7 +501,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -520,7 +529,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -547,7 +557,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr2_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -579,7 +590,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -606,7 +618,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -633,7 +646,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -660,7 +674,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -687,7 +702,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -714,7 +730,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -741,7 +758,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +786,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -795,7 +814,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -822,7 +842,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr3_field9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -854,7 +875,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -881,7 +903,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -908,7 +931,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -935,7 +959,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr4_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -967,7 +992,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -994,7 +1020,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1021,7 +1048,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1048,7 +1076,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1075,7 +1104,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr5_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1107,7 +1137,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1134,7 +1165,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1161,7 +1193,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1188,7 +1221,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1215,7 +1249,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1242,7 +1277,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1269,7 +1305,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1296,7 +1333,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1323,7 +1361,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr6_field8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1355,7 +1394,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1382,7 +1422,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr7_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1413,7 +1454,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1444,7 +1486,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1475,7 +1518,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1506,7 +1550,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1537,7 +1582,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1569,7 +1615,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (20'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr13_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1596,7 +1643,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr13_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1628,7 +1676,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr14_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1655,7 +1704,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr14_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1687,7 +1737,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr15_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1714,7 +1765,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr15_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1746,7 +1798,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr16_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1773,7 +1826,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr16_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1805,7 +1859,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr17_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1832,7 +1887,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr17_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1863,7 +1919,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1894,7 +1951,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1923,7 +1981,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr20_field0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1950,7 +2009,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr20_field1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1977,7 +2037,8 @@ module flash_ctrl_prim_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_csr20_field2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -197,7 +197,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -225,7 +226,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -293,7 +295,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -509,7 +512,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -537,7 +541,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -565,7 +570,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -593,7 +599,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -621,7 +628,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -649,7 +657,8 @@ module gpio_reg_top
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_straps_data_in_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -677,7 +686,8 @@ module gpio_reg_top
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_hw_straps_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -198,7 +198,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -227,7 +227,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -296,7 +296,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -513,7 +513,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_rising (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -542,7 +542,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_falling (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -571,7 +571,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_lvlhigh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -600,7 +600,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_ctrl_en_lvllow (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -629,7 +629,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ctrl_en_input_filter (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +658,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_straps_data_in_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -687,7 +687,7 @@ module gpio_reg_top
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_hw_straps_data_in (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -4027,7 +4027,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4057,7 +4057,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4087,7 +4087,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4117,7 +4117,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4147,7 +4147,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4177,7 +4177,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4207,7 +4207,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4237,7 +4237,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4267,7 +4267,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4297,7 +4297,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4327,7 +4327,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4357,7 +4357,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4387,7 +4387,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4417,7 +4417,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4447,7 +4447,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4477,7 +4477,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4507,7 +4507,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4537,7 +4537,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4567,7 +4567,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4597,7 +4597,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4627,7 +4627,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4657,7 +4657,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4687,7 +4687,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4717,7 +4717,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4747,7 +4747,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4777,7 +4777,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4807,7 +4807,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4837,7 +4837,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4867,7 +4867,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4897,7 +4897,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4927,7 +4927,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4957,7 +4957,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4987,7 +4987,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5017,7 +5017,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5047,7 +5047,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5077,7 +5077,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5107,7 +5107,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5137,7 +5137,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5170,7 +5170,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5203,7 +5203,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5236,7 +5236,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5269,7 +5269,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5302,7 +5302,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5335,7 +5335,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5368,7 +5368,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5401,7 +5401,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5434,7 +5434,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5467,7 +5467,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5500,7 +5500,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5533,7 +5533,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5566,7 +5566,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5599,7 +5599,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5632,7 +5632,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5665,7 +5665,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5698,7 +5698,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5731,7 +5731,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5764,7 +5764,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5797,7 +5797,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5830,7 +5830,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5863,7 +5863,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5896,7 +5896,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5929,7 +5929,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5962,7 +5962,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5995,7 +5995,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6028,7 +6028,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6061,7 +6061,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6094,7 +6094,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6127,7 +6127,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6160,7 +6160,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6193,7 +6193,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6226,7 +6226,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6259,7 +6259,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6292,7 +6292,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6325,7 +6325,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6358,7 +6358,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6391,7 +6391,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_periph_insel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6421,7 +6421,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6451,7 +6451,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6481,7 +6481,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6511,7 +6511,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6541,7 +6541,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6571,7 +6571,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6601,7 +6601,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6631,7 +6631,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6661,7 +6661,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6691,7 +6691,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6721,7 +6721,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6751,7 +6751,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6781,7 +6781,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6811,7 +6811,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6841,7 +6841,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6871,7 +6871,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6901,7 +6901,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6931,7 +6931,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6961,7 +6961,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6991,7 +6991,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7021,7 +7021,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7051,7 +7051,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7081,7 +7081,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7111,7 +7111,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7141,7 +7141,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7171,7 +7171,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7201,7 +7201,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7231,7 +7231,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7261,7 +7261,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7291,7 +7291,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7321,7 +7321,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7351,7 +7351,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7381,7 +7381,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7411,7 +7411,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7441,7 +7441,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7471,7 +7471,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7501,7 +7501,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7531,7 +7531,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7561,7 +7561,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7591,7 +7591,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7621,7 +7621,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7651,7 +7651,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7681,7 +7681,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7711,7 +7711,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7741,7 +7741,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7771,7 +7771,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7801,7 +7801,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7834,7 +7834,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7867,7 +7867,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7900,7 +7900,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7933,7 +7933,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7966,7 +7966,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7999,7 +7999,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8032,7 +8032,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8065,7 +8065,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8098,7 +8098,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8131,7 +8131,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8164,7 +8164,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8197,7 +8197,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8230,7 +8230,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8263,7 +8263,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8296,7 +8296,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8329,7 +8329,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8362,7 +8362,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8395,7 +8395,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8428,7 +8428,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8461,7 +8461,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8494,7 +8494,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8527,7 +8527,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8560,7 +8560,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8593,7 +8593,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8626,7 +8626,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8659,7 +8659,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8692,7 +8692,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8725,7 +8725,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8758,7 +8758,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8791,7 +8791,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8824,7 +8824,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8857,7 +8857,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8890,7 +8890,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8923,7 +8923,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8956,7 +8956,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8989,7 +8989,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9022,7 +9022,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9055,7 +9055,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9088,7 +9088,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9121,7 +9121,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9154,7 +9154,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9187,7 +9187,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9220,7 +9220,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9253,7 +9253,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9286,7 +9286,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9319,7 +9319,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9352,7 +9352,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_outsel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9382,7 +9382,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9412,7 +9412,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9442,7 +9442,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9472,7 +9472,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9502,7 +9502,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9532,7 +9532,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9562,7 +9562,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9592,7 +9592,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9622,7 +9622,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9652,7 +9652,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9682,7 +9682,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9712,7 +9712,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9742,7 +9742,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9772,7 +9772,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9802,7 +9802,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9832,7 +9832,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9862,7 +9862,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9892,7 +9892,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9922,7 +9922,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9952,7 +9952,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9982,7 +9982,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10012,7 +10012,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10042,7 +10042,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10072,7 +10072,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10102,7 +10102,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10132,7 +10132,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10162,7 +10162,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10192,7 +10192,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10222,7 +10222,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10252,7 +10252,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10282,7 +10282,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10312,7 +10312,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10342,7 +10342,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10372,7 +10372,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10402,7 +10402,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10432,7 +10432,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10462,7 +10462,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10492,7 +10492,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10522,7 +10522,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10552,7 +10552,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10582,7 +10582,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10612,7 +10612,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10642,7 +10642,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10672,7 +10672,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10702,7 +10702,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10732,7 +10732,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10762,7 +10762,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18735,7 +18735,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18765,7 +18765,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18795,7 +18795,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18825,7 +18825,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18855,7 +18855,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18885,7 +18885,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18915,7 +18915,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18945,7 +18945,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18975,7 +18975,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19005,7 +19005,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19035,7 +19035,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19065,7 +19065,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19095,7 +19095,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -19125,7 +19125,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21522,7 +21522,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21550,7 +21550,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21578,7 +21578,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21606,7 +21606,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21634,7 +21634,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21662,7 +21662,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21690,7 +21690,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21718,7 +21718,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21746,7 +21746,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21774,7 +21774,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21802,7 +21802,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21830,7 +21830,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21858,7 +21858,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21886,7 +21886,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21914,7 +21914,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21942,7 +21942,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21970,7 +21970,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21998,7 +21998,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22026,7 +22026,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22054,7 +22054,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22082,7 +22082,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22110,7 +22110,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22138,7 +22138,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22166,7 +22166,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22194,7 +22194,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22222,7 +22222,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22250,7 +22250,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22278,7 +22278,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22306,7 +22306,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22334,7 +22334,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22362,7 +22362,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22390,7 +22390,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22421,7 +22421,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22449,7 +22449,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22477,7 +22477,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22505,7 +22505,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22533,7 +22533,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22561,7 +22561,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22589,7 +22589,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22617,7 +22617,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22645,7 +22645,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22673,7 +22673,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22701,7 +22701,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22729,7 +22729,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22757,7 +22757,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22785,7 +22785,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22813,7 +22813,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22843,7 +22843,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22873,7 +22873,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22903,7 +22903,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22933,7 +22933,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22963,7 +22963,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22993,7 +22993,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23023,7 +23023,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23053,7 +23053,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23083,7 +23083,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23113,7 +23113,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23143,7 +23143,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23173,7 +23173,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23203,7 +23203,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23233,7 +23233,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23263,7 +23263,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23293,7 +23293,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23323,7 +23323,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23353,7 +23353,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23383,7 +23383,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23413,7 +23413,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23443,7 +23443,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23473,7 +23473,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23503,7 +23503,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23533,7 +23533,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23563,7 +23563,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23593,7 +23593,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23623,7 +23623,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23653,7 +23653,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23683,7 +23683,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23713,7 +23713,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23743,7 +23743,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23773,7 +23773,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23803,7 +23803,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23833,7 +23833,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23863,7 +23863,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23893,7 +23893,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23923,7 +23923,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23953,7 +23953,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23983,7 +23983,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24013,7 +24013,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24043,7 +24043,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24073,7 +24073,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24103,7 +24103,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24133,7 +24133,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24163,7 +24163,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24193,7 +24193,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24223,7 +24223,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24256,7 +24256,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24289,7 +24289,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24322,7 +24322,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24355,7 +24355,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24388,7 +24388,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24421,7 +24421,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24454,7 +24454,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24487,7 +24487,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24520,7 +24520,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24553,7 +24553,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24586,7 +24586,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24619,7 +24619,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24652,7 +24652,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24685,7 +24685,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24718,7 +24718,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24751,7 +24751,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24784,7 +24784,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24817,7 +24817,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24850,7 +24850,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24883,7 +24883,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24916,7 +24916,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24949,7 +24949,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24982,7 +24982,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25015,7 +25015,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25048,7 +25048,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25081,7 +25081,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25114,7 +25114,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25147,7 +25147,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25180,7 +25180,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25213,7 +25213,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25246,7 +25246,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25279,7 +25279,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25312,7 +25312,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25345,7 +25345,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25378,7 +25378,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25411,7 +25411,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25444,7 +25444,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25477,7 +25477,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25510,7 +25510,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25543,7 +25543,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25576,7 +25576,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25609,7 +25609,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25642,7 +25642,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25675,7 +25675,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25708,7 +25708,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25741,7 +25741,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25774,7 +25774,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25807,7 +25807,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25840,7 +25840,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25873,7 +25873,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25906,7 +25906,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25939,7 +25939,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25972,7 +25972,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26005,7 +26005,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26038,7 +26038,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26071,7 +26071,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26104,7 +26104,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26137,7 +26137,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26170,7 +26170,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26203,7 +26203,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26236,7 +26236,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26269,7 +26269,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26302,7 +26302,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26335,7 +26335,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26368,7 +26368,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26401,7 +26401,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26434,7 +26434,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26467,7 +26467,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26500,7 +26500,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26533,7 +26533,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26566,7 +26566,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26599,7 +26599,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26632,7 +26632,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26665,7 +26665,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26698,7 +26698,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26731,7 +26731,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26764,7 +26764,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26797,7 +26797,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26830,7 +26830,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26863,7 +26863,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26896,7 +26896,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26929,7 +26929,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26962,7 +26962,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26995,7 +26995,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27028,7 +27028,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27061,7 +27061,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27094,7 +27094,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27127,7 +27127,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27160,7 +27160,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27193,7 +27193,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27226,7 +27226,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27259,7 +27259,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27292,7 +27292,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27325,7 +27325,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_mio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27356,7 +27356,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27384,7 +27384,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27412,7 +27412,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27440,7 +27440,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27468,7 +27468,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27496,7 +27496,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27524,7 +27524,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27552,7 +27552,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27580,7 +27580,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27608,7 +27608,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27636,7 +27636,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27664,7 +27664,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27692,7 +27692,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27720,7 +27720,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27750,7 +27750,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27780,7 +27780,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27810,7 +27810,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27840,7 +27840,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27870,7 +27870,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27900,7 +27900,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27930,7 +27930,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27960,7 +27960,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27990,7 +27990,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28020,7 +28020,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28050,7 +28050,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28080,7 +28080,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28110,7 +28110,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28140,7 +28140,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28173,7 +28173,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28206,7 +28206,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28239,7 +28239,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28272,7 +28272,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28305,7 +28305,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28338,7 +28338,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28371,7 +28371,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28404,7 +28404,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28437,7 +28437,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28470,7 +28470,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28503,7 +28503,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28536,7 +28536,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28569,7 +28569,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28602,7 +28602,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28635,7 +28635,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28668,7 +28668,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28701,7 +28701,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28734,7 +28734,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28767,7 +28767,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28800,7 +28800,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28833,7 +28833,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28866,7 +28866,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28899,7 +28899,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28932,7 +28932,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28965,7 +28965,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28998,7 +28998,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29031,7 +29031,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29064,7 +29064,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29094,7 +29094,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29124,7 +29124,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29154,7 +29154,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29184,7 +29184,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29214,7 +29214,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29244,7 +29244,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29274,7 +29274,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29304,7 +29304,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -29338,7 +29338,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29372,7 +29372,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29406,7 +29406,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29440,7 +29440,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29474,7 +29474,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29508,7 +29508,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29542,7 +29542,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29576,7 +29576,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29610,7 +29610,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29638,7 +29638,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29666,7 +29666,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29700,7 +29700,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29728,7 +29728,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29756,7 +29756,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29790,7 +29790,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29818,7 +29818,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29846,7 +29846,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29880,7 +29880,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29908,7 +29908,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29936,7 +29936,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29970,7 +29970,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29998,7 +29998,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30026,7 +30026,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30060,7 +30060,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30088,7 +30088,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30116,7 +30116,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30150,7 +30150,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30178,7 +30178,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30206,7 +30206,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30240,7 +30240,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30268,7 +30268,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30296,7 +30296,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30330,7 +30330,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30364,7 +30364,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30398,7 +30398,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30432,7 +30432,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30466,7 +30466,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30500,7 +30500,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30534,7 +30534,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30568,7 +30568,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30601,7 +30601,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30634,7 +30634,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30667,7 +30667,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30700,7 +30700,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30733,7 +30733,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30766,7 +30766,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30799,7 +30799,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30832,7 +30832,7 @@ module pinmux_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -4026,7 +4026,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4055,7 +4056,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4084,7 +4086,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4113,7 +4116,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4142,7 +4146,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4171,7 +4176,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4200,7 +4206,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4229,7 +4236,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4258,7 +4266,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4287,7 +4296,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4316,7 +4326,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4345,7 +4356,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4374,7 +4386,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4403,7 +4416,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4432,7 +4446,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4461,7 +4476,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4490,7 +4506,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4519,7 +4536,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4548,7 +4566,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4577,7 +4596,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4606,7 +4626,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4635,7 +4656,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4664,7 +4686,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4693,7 +4716,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4722,7 +4746,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4751,7 +4776,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4780,7 +4806,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4809,7 +4836,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4838,7 +4866,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4867,7 +4896,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4896,7 +4926,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4925,7 +4956,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4954,7 +4986,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4983,7 +5016,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5012,7 +5046,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5041,7 +5076,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5070,7 +5106,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5099,7 +5136,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5131,7 +5169,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5163,7 +5202,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5195,7 +5235,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5227,7 +5268,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5259,7 +5301,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5291,7 +5334,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5323,7 +5367,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5355,7 +5400,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5387,7 +5433,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5419,7 +5466,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5451,7 +5499,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5483,7 +5532,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5515,7 +5565,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5547,7 +5598,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5579,7 +5631,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5611,7 +5664,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5643,7 +5697,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5675,7 +5730,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5707,7 +5763,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5739,7 +5796,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5771,7 +5829,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5803,7 +5862,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5835,7 +5895,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5867,7 +5928,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5899,7 +5961,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5931,7 +5994,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5963,7 +6027,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5995,7 +6060,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6027,7 +6093,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6059,7 +6126,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6091,7 +6159,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6123,7 +6192,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6155,7 +6225,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6187,7 +6258,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6219,7 +6291,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6251,7 +6324,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6283,7 +6357,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6315,7 +6390,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_periph_insel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6344,7 +6420,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6373,7 +6450,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6402,7 +6480,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6431,7 +6510,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6460,7 +6540,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6489,7 +6570,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6518,7 +6600,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6547,7 +6630,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6576,7 +6660,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6605,7 +6690,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6634,7 +6720,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6663,7 +6750,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6692,7 +6780,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6721,7 +6810,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6750,7 +6840,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6779,7 +6870,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6808,7 +6900,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6837,7 +6930,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6866,7 +6960,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6895,7 +6990,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6924,7 +7020,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6953,7 +7050,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6982,7 +7080,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7011,7 +7110,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7040,7 +7140,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7069,7 +7170,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7098,7 +7200,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7127,7 +7230,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7156,7 +7260,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7185,7 +7290,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7214,7 +7320,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7243,7 +7350,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7272,7 +7380,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7301,7 +7410,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7330,7 +7440,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7359,7 +7470,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7388,7 +7500,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7417,7 +7530,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7446,7 +7560,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7475,7 +7590,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7504,7 +7620,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7533,7 +7650,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7562,7 +7680,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7591,7 +7710,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7620,7 +7740,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7649,7 +7770,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7678,7 +7800,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7710,7 +7833,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7742,7 +7866,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7774,7 +7899,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7806,7 +7932,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7838,7 +7965,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7870,7 +7998,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7902,7 +8031,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7934,7 +8064,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7966,7 +8097,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7998,7 +8130,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8030,7 +8163,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8062,7 +8196,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8094,7 +8229,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8126,7 +8262,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8158,7 +8295,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8190,7 +8328,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8222,7 +8361,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8254,7 +8394,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8286,7 +8427,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8318,7 +8460,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8350,7 +8493,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8382,7 +8526,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8414,7 +8559,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8446,7 +8592,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8478,7 +8625,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8510,7 +8658,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8542,7 +8691,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8574,7 +8724,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8606,7 +8757,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8638,7 +8790,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8670,7 +8823,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8702,7 +8856,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8734,7 +8889,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8766,7 +8922,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8798,7 +8955,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8830,7 +8988,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8862,7 +9021,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8894,7 +9054,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8926,7 +9087,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8958,7 +9120,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8990,7 +9153,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9022,7 +9186,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9054,7 +9219,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9086,7 +9252,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9118,7 +9285,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9150,7 +9318,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9182,7 +9351,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_outsel_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9211,7 +9381,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9240,7 +9411,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9269,7 +9441,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9298,7 +9471,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9327,7 +9501,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9356,7 +9531,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9385,7 +9561,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9414,7 +9591,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9443,7 +9621,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9472,7 +9651,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9501,7 +9681,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9530,7 +9711,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9559,7 +9741,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9588,7 +9771,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9617,7 +9801,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9646,7 +9831,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9675,7 +9861,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9704,7 +9891,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9733,7 +9921,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9762,7 +9951,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9791,7 +9981,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9820,7 +10011,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9849,7 +10041,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9878,7 +10071,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9907,7 +10101,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9936,7 +10131,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9965,7 +10161,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -9994,7 +10191,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10023,7 +10221,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10052,7 +10251,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10081,7 +10281,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10110,7 +10311,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10139,7 +10341,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10168,7 +10371,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10197,7 +10401,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10226,7 +10431,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10255,7 +10461,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10284,7 +10491,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10313,7 +10521,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10342,7 +10551,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10371,7 +10581,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10400,7 +10611,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10429,7 +10641,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10458,7 +10671,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10487,7 +10701,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10516,7 +10731,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -10545,7 +10761,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_attr_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18517,7 +18734,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18546,7 +18764,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18575,7 +18794,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18604,7 +18824,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18633,7 +18854,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18662,7 +18884,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18691,7 +18914,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18720,7 +18944,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18749,7 +18974,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18778,7 +19004,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18807,7 +19034,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18836,7 +19064,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18865,7 +19094,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -18894,7 +19124,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_attr_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21290,7 +21521,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21317,7 +21549,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21344,7 +21577,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21371,7 +21605,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21398,7 +21633,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21425,7 +21661,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21452,7 +21689,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21479,7 +21717,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21506,7 +21745,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21533,7 +21773,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21560,7 +21801,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21587,7 +21829,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21614,7 +21857,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21641,7 +21885,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21668,7 +21913,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21695,7 +21941,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21722,7 +21969,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21749,7 +21997,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21776,7 +22025,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21803,7 +22053,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21830,7 +22081,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21857,7 +22109,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21884,7 +22137,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21911,7 +22165,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21938,7 +22193,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21965,7 +22221,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -21992,7 +22249,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22019,7 +22277,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22046,7 +22305,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22073,7 +22333,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22100,7 +22361,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22127,7 +22389,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_0_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22157,7 +22420,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22184,7 +22448,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22211,7 +22476,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22238,7 +22504,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22265,7 +22532,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22292,7 +22560,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22319,7 +22588,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22346,7 +22616,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22373,7 +22644,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22400,7 +22672,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22427,7 +22700,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22454,7 +22728,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22481,7 +22756,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22508,7 +22784,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22535,7 +22812,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_status_1_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22564,7 +22842,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22593,7 +22872,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22622,7 +22902,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22651,7 +22932,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22680,7 +22962,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22709,7 +22992,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22738,7 +23022,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22767,7 +23052,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22796,7 +23082,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22825,7 +23112,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22854,7 +23142,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22883,7 +23172,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22912,7 +23202,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22941,7 +23232,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22970,7 +23262,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -22999,7 +23292,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23028,7 +23322,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23057,7 +23352,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23086,7 +23382,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23115,7 +23412,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23144,7 +23442,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23173,7 +23472,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23202,7 +23502,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23231,7 +23532,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23260,7 +23562,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23289,7 +23592,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23318,7 +23622,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23347,7 +23652,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23376,7 +23682,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23405,7 +23712,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23434,7 +23742,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23463,7 +23772,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23492,7 +23802,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23521,7 +23832,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23550,7 +23862,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23579,7 +23892,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23608,7 +23922,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23637,7 +23952,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23666,7 +23982,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23695,7 +24012,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23724,7 +24042,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23753,7 +24072,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23782,7 +24102,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23811,7 +24132,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23840,7 +24162,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23869,7 +24192,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23898,7 +24222,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_regwen_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23930,7 +24255,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23962,7 +24288,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -23994,7 +24321,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24026,7 +24354,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24058,7 +24387,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24090,7 +24420,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24122,7 +24453,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24154,7 +24486,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24186,7 +24519,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24218,7 +24552,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24250,7 +24585,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24282,7 +24618,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24314,7 +24651,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24346,7 +24684,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24378,7 +24717,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24410,7 +24750,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24442,7 +24783,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24474,7 +24816,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24506,7 +24849,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24538,7 +24882,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24570,7 +24915,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24602,7 +24948,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24634,7 +24981,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24666,7 +25014,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24698,7 +25047,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24730,7 +25080,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24762,7 +25113,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24794,7 +25146,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24826,7 +25179,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24858,7 +25212,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24890,7 +25245,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24922,7 +25278,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24954,7 +25311,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -24986,7 +25344,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25018,7 +25377,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25050,7 +25410,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25082,7 +25443,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25114,7 +25476,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25146,7 +25509,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25178,7 +25542,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25210,7 +25575,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25242,7 +25608,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25274,7 +25641,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25306,7 +25674,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25338,7 +25707,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25370,7 +25740,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25402,7 +25773,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_en_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25434,7 +25806,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25466,7 +25839,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25498,7 +25872,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25530,7 +25905,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25562,7 +25938,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25594,7 +25971,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25626,7 +26004,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25658,7 +26037,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25690,7 +26070,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25722,7 +26103,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25754,7 +26136,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25786,7 +26169,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25818,7 +26202,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25850,7 +26235,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25882,7 +26268,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25914,7 +26301,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25946,7 +26334,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -25978,7 +26367,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26010,7 +26400,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26042,7 +26433,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26074,7 +26466,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26106,7 +26499,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26138,7 +26532,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26170,7 +26565,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26202,7 +26598,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26234,7 +26631,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26266,7 +26664,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26298,7 +26697,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26330,7 +26730,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26362,7 +26763,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26394,7 +26796,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26426,7 +26829,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26458,7 +26862,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26490,7 +26895,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26522,7 +26928,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26554,7 +26961,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26586,7 +26994,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26618,7 +27027,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26650,7 +27060,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26682,7 +27093,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26714,7 +27126,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26746,7 +27159,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26778,7 +27192,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26810,7 +27225,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26842,7 +27258,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26874,7 +27291,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26906,7 +27324,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_mio_pad_sleep_mode_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26936,7 +27355,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26963,7 +27383,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -26990,7 +27411,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27017,7 +27439,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27044,7 +27467,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27071,7 +27495,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27098,7 +27523,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27125,7 +27551,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27152,7 +27579,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27179,7 +27607,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27206,7 +27635,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27233,7 +27663,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27260,7 +27691,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27287,7 +27719,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_status_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27316,7 +27749,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27345,7 +27779,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27374,7 +27809,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27403,7 +27839,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27432,7 +27869,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27461,7 +27899,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27490,7 +27929,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27519,7 +27959,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27548,7 +27989,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27577,7 +28019,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27606,7 +28049,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27635,7 +28079,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27664,7 +28109,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27693,7 +28139,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_regwen_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27725,7 +28172,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27757,7 +28205,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27789,7 +28238,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27821,7 +28271,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27853,7 +28304,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27885,7 +28337,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27917,7 +28370,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27949,7 +28403,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -27981,7 +28436,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28013,7 +28469,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28045,7 +28502,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28077,7 +28535,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28109,7 +28568,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28141,7 +28601,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_en_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28173,7 +28634,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28205,7 +28667,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28237,7 +28700,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28269,7 +28733,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28301,7 +28766,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28333,7 +28799,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28365,7 +28832,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28397,7 +28865,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28429,7 +28898,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28461,7 +28931,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28493,7 +28964,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28525,7 +28997,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28557,7 +29030,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28589,7 +29063,8 @@ module pinmux_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h2),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_dio_pad_sleep_mode_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28618,7 +29093,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28647,7 +29123,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28676,7 +29153,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28705,7 +29183,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28734,7 +29213,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28763,7 +29243,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28792,7 +29273,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28821,7 +29303,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -28854,7 +29337,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -28887,7 +29371,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -28920,7 +29405,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -28953,7 +29439,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -28986,7 +29473,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29019,7 +29507,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29052,7 +29541,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29085,7 +29575,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_en_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29118,7 +29609,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_mode_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29145,7 +29637,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_filter_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29172,7 +29665,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_0_miodio_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29205,7 +29699,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_mode_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29232,7 +29727,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_filter_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29259,7 +29755,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_1_miodio_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29292,7 +29789,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_mode_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29319,7 +29817,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_filter_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29346,7 +29845,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_2_miodio_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29379,7 +29879,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_mode_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29406,7 +29907,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_filter_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29433,7 +29935,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_3_miodio_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29466,7 +29969,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_mode_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29493,7 +29997,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_filter_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29520,7 +30025,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_4_miodio_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29553,7 +30059,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_mode_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29580,7 +30087,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_filter_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29607,7 +30115,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_5_miodio_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29640,7 +30149,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_mode_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29667,7 +30177,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_filter_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29694,7 +30205,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_6_miodio_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29727,7 +30239,8 @@ module pinmux_reg_top (
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_mode_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29754,7 +30267,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_filter_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29781,7 +30295,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_7_miodio_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29814,7 +30329,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29847,7 +30363,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29880,7 +30397,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29913,7 +30431,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29946,7 +30465,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -29979,7 +30499,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30012,7 +30533,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30045,7 +30567,8 @@ module pinmux_reg_top (
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_cnt_th_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30077,7 +30600,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30109,7 +30633,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30141,7 +30666,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30173,7 +30699,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30205,7 +30732,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30237,7 +30765,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30269,7 +30798,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30301,7 +30831,8 @@ module pinmux_reg_top (
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (6'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_detector_padsel_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -30333,7 +30864,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_0 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30360,7 +30892,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_1 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30387,7 +30920,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_2 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30414,7 +30948,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_3 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30441,7 +30976,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_4 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30468,7 +31004,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_5 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30495,7 +31032,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_6 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -30522,7 +31060,8 @@ module pinmux_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wkup_cause_cause_7 (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -196,7 +196,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -225,7 +225,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -314,7 +314,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -342,7 +342,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -370,7 +370,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -398,7 +398,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -426,7 +426,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -454,7 +454,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -494,7 +494,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -524,7 +524,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -558,7 +558,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -586,7 +586,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -614,7 +614,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -645,7 +645,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -673,7 +673,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -701,7 +701,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -730,7 +730,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +763,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -793,7 +793,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -822,7 +822,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -851,7 +851,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -934,7 +934,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -963,7 +963,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -992,7 +992,7 @@ module pwrmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -195,7 +195,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -223,7 +224,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_intr_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -311,7 +313,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_low_power_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -338,7 +341,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_core_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -365,7 +369,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_io_clk_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -392,7 +397,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_usb_clk_en_lp (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -419,7 +425,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_usb_clk_en_active (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -446,7 +453,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_control_main_pd_n (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -485,7 +493,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cfg_cdc_sync (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -514,7 +523,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -547,7 +557,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -574,7 +585,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -601,7 +613,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wakeup_en_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -631,7 +644,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -658,7 +672,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -685,7 +700,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_status_val_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -713,7 +729,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -745,7 +762,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -774,7 +792,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -802,7 +821,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_escalate_reset_status (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -830,7 +850,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_wake_info_capture_dis (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -912,7 +933,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_reg_intg_err (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -940,7 +962,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_esc_timeout (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),
@@ -968,7 +991,8 @@ module pwrmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_fault_status_main_pd_glitch (
     // sync clock and reset required for this register
     .clk_i   (clk_lc_i),

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -230,7 +230,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
     .Mubi    (1'b1),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -260,7 +260,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -289,7 +289,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -318,7 +318,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -347,7 +347,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -377,7 +377,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -410,7 +410,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -439,7 +439,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -501,7 +501,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -534,7 +534,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -563,7 +563,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -626,7 +626,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -656,7 +656,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -686,7 +686,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -719,7 +719,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -752,7 +752,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -785,7 +785,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -815,7 +815,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -843,7 +843,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -871,7 +871,7 @@ module rstmgr_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -229,7 +229,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h9),
-    .Mubi    (1'b1)
+    .Mubi    (1'b1),
+    .UsesDs  (1'b1)
   ) u_reset_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -258,7 +259,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_por (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -286,7 +288,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_low_power_exit (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -314,7 +317,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_sw_reset (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -342,7 +346,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_reset_info_hw_req (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -371,7 +376,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -403,7 +409,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -431,7 +438,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_alert_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -492,7 +500,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_regwen (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -524,7 +533,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_info_ctrl_en (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -552,7 +562,8 @@ module rstmgr_reg_top (
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_cpu_info_ctrl_index (
     // sync clock and reset required for this register
     .clk_i   (clk_por_i),
@@ -614,7 +625,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -643,7 +655,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -672,7 +685,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -704,7 +718,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -736,7 +751,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -768,7 +784,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_sw_rst_ctrl_n_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -797,7 +814,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_reg_intg_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -824,7 +842,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_reset_consistency_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -851,7 +870,8 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_err_code_fsm_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -672,7 +672,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -701,7 +702,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -730,7 +732,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -759,7 +762,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -788,7 +792,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -817,7 +822,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -846,7 +852,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -875,7 +882,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -904,7 +912,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -933,7 +942,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -962,7 +972,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -991,7 +1002,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1020,7 +1032,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1049,7 +1062,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1078,7 +1092,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1107,7 +1122,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1136,7 +1152,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1165,7 +1182,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1194,7 +1212,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1223,7 +1242,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1252,7 +1272,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1281,7 +1302,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1310,7 +1332,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1339,7 +1362,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1368,7 +1392,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1397,7 +1422,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1426,7 +1452,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1455,7 +1482,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1484,7 +1512,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1513,7 +1542,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1542,7 +1572,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1571,7 +1602,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1600,7 +1632,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1629,7 +1662,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1658,7 +1692,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1687,7 +1722,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1716,7 +1752,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1745,7 +1782,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1774,7 +1812,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1803,7 +1842,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1832,7 +1872,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1861,7 +1902,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1890,7 +1932,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1919,7 +1962,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1948,7 +1992,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1977,7 +2022,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2006,7 +2052,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2035,7 +2082,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2064,7 +2112,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2093,7 +2142,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2122,7 +2172,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2151,7 +2202,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2180,7 +2232,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2209,7 +2262,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2238,7 +2292,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2267,7 +2322,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2296,7 +2352,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2325,7 +2382,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2354,7 +2412,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2383,7 +2442,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2412,7 +2472,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2441,7 +2502,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2470,7 +2532,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2499,7 +2562,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2528,7 +2592,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2557,7 +2622,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2586,7 +2652,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2615,7 +2682,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2644,7 +2712,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2673,7 +2742,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2702,7 +2772,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2731,7 +2802,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2760,7 +2832,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2789,7 +2862,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2818,7 +2892,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2847,7 +2922,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2876,7 +2952,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2905,7 +2982,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2934,7 +3012,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2963,7 +3042,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2992,7 +3072,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3021,7 +3102,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3050,7 +3132,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3079,7 +3162,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3108,7 +3192,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3137,7 +3222,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3166,7 +3252,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3195,7 +3282,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_prio_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3225,7 +3313,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3252,7 +3341,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3279,7 +3369,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3306,7 +3397,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3333,7 +3425,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3360,7 +3453,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3387,7 +3481,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3414,7 +3509,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3441,7 +3537,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3468,7 +3565,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3495,7 +3593,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3522,7 +3621,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3549,7 +3649,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3576,7 +3677,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3603,7 +3705,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3630,7 +3733,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3657,7 +3761,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3684,7 +3789,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3711,7 +3817,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3738,7 +3845,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3765,7 +3873,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3792,7 +3901,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3819,7 +3929,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3846,7 +3957,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3873,7 +3985,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3900,7 +4013,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3927,7 +4041,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3954,7 +4069,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3981,7 +4097,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4008,7 +4125,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4035,7 +4153,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4062,7 +4181,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4092,7 +4212,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4119,7 +4240,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4146,7 +4268,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4173,7 +4296,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4200,7 +4324,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4227,7 +4352,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4254,7 +4380,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4281,7 +4408,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4308,7 +4436,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4335,7 +4464,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4362,7 +4492,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4389,7 +4520,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4416,7 +4548,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4443,7 +4576,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4470,7 +4604,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4497,7 +4632,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4524,7 +4660,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4551,7 +4688,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4578,7 +4716,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4605,7 +4744,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4632,7 +4772,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4659,7 +4800,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4686,7 +4828,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4713,7 +4856,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4740,7 +4884,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4767,7 +4912,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4794,7 +4940,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4821,7 +4968,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4848,7 +4996,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4875,7 +5024,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4902,7 +5052,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4929,7 +5080,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4959,7 +5111,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4986,7 +5139,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5013,7 +5167,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5040,7 +5195,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5067,7 +5223,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5094,7 +5251,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5121,7 +5279,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5148,7 +5307,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5175,7 +5335,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5202,7 +5363,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5229,7 +5391,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5256,7 +5419,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5283,7 +5447,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5310,7 +5475,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5337,7 +5503,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5364,7 +5531,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5391,7 +5559,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5418,7 +5587,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5445,7 +5615,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5472,7 +5643,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5499,7 +5671,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5526,7 +5699,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5553,7 +5727,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5580,7 +5755,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5610,7 +5786,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5637,7 +5814,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5664,7 +5842,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5691,7 +5870,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5718,7 +5898,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5745,7 +5926,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5772,7 +5954,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5799,7 +5982,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5826,7 +6010,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5853,7 +6038,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5880,7 +6066,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5907,7 +6094,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5934,7 +6122,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5961,7 +6150,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5988,7 +6178,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6015,7 +6206,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6042,7 +6234,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6069,7 +6262,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6096,7 +6290,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6123,7 +6318,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6150,7 +6346,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6177,7 +6374,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6204,7 +6402,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6231,7 +6430,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6258,7 +6458,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6285,7 +6486,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6312,7 +6514,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6339,7 +6542,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6366,7 +6570,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6393,7 +6598,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6420,7 +6626,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6447,7 +6654,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6477,7 +6685,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6504,7 +6713,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6531,7 +6741,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6558,7 +6769,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6585,7 +6797,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6612,7 +6825,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6639,7 +6853,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6666,7 +6881,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6693,7 +6909,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6720,7 +6937,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6747,7 +6965,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6774,7 +6993,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6801,7 +7021,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6828,7 +7049,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6855,7 +7077,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6882,7 +7105,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6909,7 +7133,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6936,7 +7161,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6963,7 +7189,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6990,7 +7217,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7017,7 +7245,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7044,7 +7273,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7071,7 +7301,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7098,7 +7329,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7125,7 +7357,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7152,7 +7385,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7179,7 +7413,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7206,7 +7441,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7233,7 +7469,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7260,7 +7497,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7287,7 +7525,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7314,7 +7553,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7344,7 +7584,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7371,7 +7612,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7398,7 +7640,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7425,7 +7668,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7452,7 +7696,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7479,7 +7724,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7506,7 +7752,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7533,7 +7780,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7560,7 +7808,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7587,7 +7836,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7614,7 +7864,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7641,7 +7892,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7668,7 +7920,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7695,7 +7948,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7722,7 +7976,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7749,7 +8004,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7776,7 +8032,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7803,7 +8060,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7830,7 +8088,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7857,7 +8116,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7884,7 +8144,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7911,7 +8172,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7938,7 +8200,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7965,7 +8228,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7993,7 +8257,8 @@ module rv_plic_reg_top (
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8041,7 +8306,8 @@ module rv_plic_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
-    .Mubi    (1'b0)
+    .Mubi    (1'b0),
+    .UsesDs  (1'b1)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -673,7 +673,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -703,7 +703,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -733,7 +733,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -763,7 +763,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -793,7 +793,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -823,7 +823,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -853,7 +853,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -883,7 +883,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -913,7 +913,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -943,7 +943,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +973,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1003,7 +1003,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1033,7 +1033,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1063,7 +1063,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1093,7 +1093,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1123,7 +1123,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1153,7 +1153,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1183,7 +1183,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1213,7 +1213,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1243,7 +1243,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1273,7 +1273,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1303,7 +1303,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1333,7 +1333,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1363,7 +1363,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1393,7 +1393,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1423,7 +1423,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1453,7 +1453,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1483,7 +1483,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1513,7 +1513,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1543,7 +1543,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1573,7 +1573,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1603,7 +1603,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1633,7 +1633,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1663,7 +1663,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1693,7 +1693,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1723,7 +1723,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1753,7 +1753,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1783,7 +1783,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1813,7 +1813,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1843,7 +1843,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1873,7 +1873,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1903,7 +1903,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1933,7 +1933,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1963,7 +1963,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1993,7 +1993,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2023,7 +2023,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2053,7 +2053,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2083,7 +2083,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2113,7 +2113,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2143,7 +2143,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2173,7 +2173,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2203,7 +2203,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2233,7 +2233,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2263,7 +2263,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2293,7 +2293,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2323,7 +2323,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2353,7 +2353,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2383,7 +2383,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2413,7 +2413,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2443,7 +2443,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2473,7 +2473,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2503,7 +2503,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2533,7 +2533,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2563,7 +2563,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2593,7 +2593,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2623,7 +2623,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2653,7 +2653,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2683,7 +2683,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2713,7 +2713,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2743,7 +2743,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2773,7 +2773,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2803,7 +2803,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2833,7 +2833,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2863,7 +2863,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2893,7 +2893,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2923,7 +2923,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2953,7 +2953,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2983,7 +2983,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3013,7 +3013,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3043,7 +3043,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3073,7 +3073,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3103,7 +3103,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3133,7 +3133,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3163,7 +3163,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3193,7 +3193,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3223,7 +3223,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3253,7 +3253,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3283,7 +3283,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_prio_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3314,7 +3314,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3342,7 +3342,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3370,7 +3370,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3398,7 +3398,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3426,7 +3426,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3454,7 +3454,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3482,7 +3482,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3510,7 +3510,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3538,7 +3538,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3566,7 +3566,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3594,7 +3594,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3622,7 +3622,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3650,7 +3650,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3678,7 +3678,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3706,7 +3706,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3734,7 +3734,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3762,7 +3762,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3790,7 +3790,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3818,7 +3818,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3846,7 +3846,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3874,7 +3874,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3902,7 +3902,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3930,7 +3930,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3958,7 +3958,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -3986,7 +3986,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4014,7 +4014,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4042,7 +4042,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4070,7 +4070,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4098,7 +4098,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4126,7 +4126,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4154,7 +4154,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4182,7 +4182,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_0_p_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4213,7 +4213,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4241,7 +4241,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4269,7 +4269,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4297,7 +4297,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4325,7 +4325,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4353,7 +4353,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4381,7 +4381,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4409,7 +4409,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4437,7 +4437,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4465,7 +4465,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4493,7 +4493,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4521,7 +4521,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4549,7 +4549,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4577,7 +4577,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4605,7 +4605,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4633,7 +4633,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4661,7 +4661,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4689,7 +4689,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4717,7 +4717,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4745,7 +4745,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4773,7 +4773,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4801,7 +4801,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4829,7 +4829,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4857,7 +4857,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4885,7 +4885,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4913,7 +4913,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4941,7 +4941,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4969,7 +4969,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -4997,7 +4997,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5025,7 +5025,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5053,7 +5053,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5081,7 +5081,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_1_p_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5112,7 +5112,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5140,7 +5140,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5168,7 +5168,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5196,7 +5196,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5224,7 +5224,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5252,7 +5252,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5280,7 +5280,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5308,7 +5308,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5336,7 +5336,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5364,7 +5364,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5392,7 +5392,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5420,7 +5420,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5448,7 +5448,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5476,7 +5476,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5504,7 +5504,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5532,7 +5532,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5560,7 +5560,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5588,7 +5588,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5616,7 +5616,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5644,7 +5644,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5672,7 +5672,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5700,7 +5700,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5728,7 +5728,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5756,7 +5756,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ip_2_p_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5787,7 +5787,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5815,7 +5815,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5843,7 +5843,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5871,7 +5871,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5899,7 +5899,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5927,7 +5927,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5955,7 +5955,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -5983,7 +5983,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6011,7 +6011,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6039,7 +6039,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6067,7 +6067,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6095,7 +6095,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6123,7 +6123,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6151,7 +6151,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6179,7 +6179,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6207,7 +6207,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6235,7 +6235,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6263,7 +6263,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6291,7 +6291,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6319,7 +6319,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6347,7 +6347,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6375,7 +6375,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6403,7 +6403,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6431,7 +6431,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6459,7 +6459,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6487,7 +6487,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6515,7 +6515,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6543,7 +6543,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6571,7 +6571,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6599,7 +6599,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6627,7 +6627,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6655,7 +6655,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_0_e_31 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6686,7 +6686,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_32 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6714,7 +6714,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_33 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6742,7 +6742,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_34 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6770,7 +6770,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_35 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6798,7 +6798,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_36 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6826,7 +6826,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_37 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6854,7 +6854,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_38 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6882,7 +6882,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_39 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6910,7 +6910,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_40 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6938,7 +6938,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_41 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6966,7 +6966,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_42 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -6994,7 +6994,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_43 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7022,7 +7022,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_44 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7050,7 +7050,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_45 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7078,7 +7078,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_46 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7106,7 +7106,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_47 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7134,7 +7134,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_48 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7162,7 +7162,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_49 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7190,7 +7190,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_50 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7218,7 +7218,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_51 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7246,7 +7246,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_52 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7274,7 +7274,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_53 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7302,7 +7302,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_54 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7330,7 +7330,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_55 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7358,7 +7358,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_56 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7386,7 +7386,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_57 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7414,7 +7414,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_58 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7442,7 +7442,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_59 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7470,7 +7470,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_60 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7498,7 +7498,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_61 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7526,7 +7526,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_62 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7554,7 +7554,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_1_e_63 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7585,7 +7585,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_64 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7613,7 +7613,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_65 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7641,7 +7641,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_66 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7669,7 +7669,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_67 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7697,7 +7697,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_68 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7725,7 +7725,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_69 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7753,7 +7753,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_70 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7781,7 +7781,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_71 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7809,7 +7809,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_72 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7837,7 +7837,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_73 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7865,7 +7865,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_74 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7893,7 +7893,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_75 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7921,7 +7921,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_76 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7949,7 +7949,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_77 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -7977,7 +7977,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_78 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8005,7 +8005,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_79 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8033,7 +8033,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_80 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8061,7 +8061,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_81 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8089,7 +8089,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_82 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8117,7 +8117,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_83 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8145,7 +8145,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_84 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8173,7 +8173,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_85 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8201,7 +8201,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_86 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8229,7 +8229,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_ie0_2_e_87 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8258,7 +8258,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (2'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_threshold0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -8307,7 +8307,7 @@ module rv_plic_reg_top (
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0),
     .Mubi    (1'b0),
-    .UsesDs  (1'b1)
+    .UsesDs  (1'b0)
   ) u_msip0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -1059,6 +1059,7 @@ ${bits.msb}\
     async_suffix = '_int' if reg.async_clk else ''
     qs_expr = f'{clk_base_name}{finst_name}_qs{async_suffix}' if field.swaccess.allows_read() else ''
     ds_expr = f'{clk_base_name}{finst_name}_ds{async_suffix}' if reg.async_clk and reg.is_hw_writable() else ''
+    uses_ds = "1'b1" if ds_expr else "1'b0"
 
 %>\
   % if reg.hwext:       ## if hwext, instantiate prim_subreg_ext
@@ -1125,7 +1126,7 @@ ${bits.msb}\
     .SwAccess(prim_subreg_pkg::SwAccess${field.swaccess.value[1].name.upper()}),
     .RESVAL  (${resval_expr}),
     .Mubi    (${mubi_expr}),
-    .UsesDs  (1'b1)
+    .UsesDs  (${uses_ds})
   ) u_${finst_name} (
       % if reg.sync_clk:
     // sync clock and reset required for this register

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -1124,7 +1124,8 @@ ${bits.msb}\
     .DW      (${field.bits.width()}),
     .SwAccess(prim_subreg_pkg::SwAccess${field.swaccess.value[1].name.upper()}),
     .RESVAL  (${resval_expr}),
-    .Mubi    (${mubi_expr})
+    .Mubi    (${mubi_expr}),
+    .UsesDs  (1'b1)
   ) u_${finst_name} (
       % if reg.sync_clk:
     // sync clock and reset required for this register


### PR DESCRIPTION
There are detailed descriptions in the commit messages, which also explain how to review the enormous commits. This nicely demonstrates the disadvantages of checking in auto-generated code :-)

The dead code was noticed when @KinzaQamar worked on coverage for `rv_plic` in Jasper.