### PR TITLE
[dv,dma] Fix build warnings

### DIFF
--- a/hw/ip/dma/dv/env/dma_seq_item.sv
+++ b/hw/ip/dma/dv/env/dma_seq_item.sv
@@ -148,10 +148,10 @@ class dma_seq_item extends uvm_sequence_item;
   // data at multiple addresses.
   constraint src_config_c {
     src_addr_inc | src_chunk_wrap;
-  };
+  }
   constraint dst_config_c {
     dst_addr_inc | dst_chunk_wrap;
-  };
+  }
 
   constraint src_addr_c {
     // Set solve order to make sure source address is randomized correctly in case

--- a/hw/ip/dma/dv/env/dma_sys_tl_if.sv
+++ b/hw/ip/dma/dv/env/dma_sys_tl_if.sv
@@ -114,7 +114,7 @@ interface dma_sys_tl_if
 `ifdef INC_ASSERT
   // Not expected to handle simultaneous write and read requests with the current DMA implementation
   // and the behavior in this case has not been publicly specified.
-  `ASSERT_NEVER(DisjointReadAndWrite_A, sys_h2d.vld_vec[SysCmdWrite] & sys_h2d.vld_vec[SysCmdRead]);
+  `ASSERT_NEVER(DisjointReadAndWrite_A, sys_h2d.vld_vec[SysCmdWrite] & sys_h2d.vld_vec[SysCmdRead])
 `else
   // Not currently required; combinational logic only
   logic unused_clk = clk_i;

--- a/hw/ip/dma/dv/env/seq_lib/dma_abort_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_abort_vseq.sv
@@ -28,7 +28,7 @@ class dma_abort_vseq extends dma_generic_vseq;
   virtual function bit [15:0] choose_abort_delay();
     bit raise_abort;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(raise_abort, raise_abort dist { 0 := 20, 1 := 80};)
-    return raise_abort ? $urandom_range(1, 16'h3FF) : 16'b0;
+    return raise_abort ? 16'($urandom_range(1, 'h3FF)) : 16'h0;
   endfunction
 
   // Transaction is commencing

--- a/hw/ip/hmac/dv/cryptoc_dpi/hmac.c
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hmac.c
@@ -72,7 +72,7 @@ static void HMAC_init_LITE(LITE_HMAC_CTX *ctx, const void *key,
 
 void HMAC_SHA_init(LITE_HMAC_CTX *ctx, const void *key, unsigned int len) {
   SHA_init(&ctx->hash);
-  HMAC_init(ctx, key, len);
+  HMAC_init_LITE(ctx, key, len);
 }
 
 void HMAC_SHA256_init(LITE_HMAC_CTX *ctx, const void *key, unsigned int len) {

--- a/hw/ip/hmac/dv/cryptoc_dpi/hmac_wrap.c
+++ b/hw/ip/hmac/dv/cryptoc_dpi/hmac_wrap.c
@@ -17,7 +17,7 @@ const uint8_t *HMAC_SHA(const void *key, size_t key_len, const void *msg,
   HMAC_SHA_init(&ctx, key, key_len);
   // H(msg)
   HMAC_update(&ctx, msg, msg_len);
-  memcpy(hmac, HMAC_final(&ctx), SHA_DIGEST_SIZE);
+  memcpy(hmac, HMAC_final_LITE(&ctx), SHA_DIGEST_SIZE);
   return hmac;
 }
 


### PR DESCRIPTION
Fix up warnings in xcelium build of the DMA DV environment. This also addresses use of the non-LITE SHA functions from a 'LITE' context, which was functionally broken but the functions that do not explicitly specify the digest size appear not to be used now.