### PR TITLE
[rom_ext] rev ROM_EXT version number

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -7,7 +7,7 @@
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "103",
+    MINOR = "104",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
ROM_EXT binaries were recently rereleased/resigned (in #26570). This rev's the version number for the next release.