### PR TITLE
[tl,rtl] Add a missing type to tlul_assert's EndpointType parameter

### DIFF
--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -8,7 +8,7 @@
 `include "prim_assert.sv"
 
 module tlul_assert #(
-  parameter EndpointType = "Device" // can be either "Host" or "Device"
+  parameter string EndpointType = "Device" // can be either "Host" or "Device"
 ) (
   input clk_i,
   input rst_ni,


### PR DESCRIPTION
The missing type causes a lint failure with some tools.