### PR TITLE
[opentitanlib] Prepare detached signatures for ownership

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -132,6 +132,7 @@ rust_library(
         "src/ownership/mod.rs",
         "src/ownership/owner.rs",
         "src/ownership/rescue.rs",
+        "src/ownership/signature.rs",
         "src/proxy/errors.rs",
         "src/proxy/handler.rs",
         "src/proxy/mod.rs",

--- a/sw/host/opentitanlib/src/chip/boot_svc.rs
+++ b/sw/host/opentitanlib/src/chip/boot_svc.rs
@@ -7,6 +7,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use serde_annotate::Annotate;
 use sha2::{Digest, Sha256};
+use sphincsplus::SpxSecretKey;
 use std::convert::TryFrom;
 use std::io::{Read, Write};
 
@@ -14,6 +15,7 @@ use super::ChipDataError;
 use crate::chip::boolean::HardenedBool;
 use crate::chip::rom_error::RomError;
 use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature};
+use crate::ownership::{DetachedSignature, OwnershipKeyAlg};
 use crate::with_unknown;
 
 with_unknown! {
@@ -501,6 +503,25 @@ impl OwnershipUnlockRequest {
         self.signature = key.digest_and_sign(&data[..Self::SIGNATURE_OFFSET])?;
         Ok(())
     }
+
+    pub fn detached_sign(
+        &mut self,
+        algorithm: OwnershipKeyAlg,
+        ecdsa_key: Option<&EcdsaPrivateKey>,
+        spx_key: Option<&SpxSecretKey>,
+    ) -> Result<DetachedSignature> {
+        self.signature = Default::default();
+        let mut data = Vec::new();
+        self.write(&mut data)?;
+        DetachedSignature::new(
+            &data[..Self::SIGNATURE_OFFSET],
+            BootSvcKind::OwnershipUnlockRequest.into(),
+            algorithm,
+            self.nonce,
+            ecdsa_key,
+            spx_key,
+        )
+    }
 }
 
 impl TryFrom<&[u8]> for OwnershipUnlockResponse {
@@ -557,6 +578,25 @@ impl OwnershipActivateRequest {
         self.write(&mut data)?;
         self.signature = key.digest_and_sign(&data[..Self::SIGNATURE_OFFSET])?;
         Ok(())
+    }
+
+    pub fn detached_sign(
+        &mut self,
+        algorithm: OwnershipKeyAlg,
+        ecdsa_key: Option<&EcdsaPrivateKey>,
+        spx_key: Option<&SpxSecretKey>,
+    ) -> Result<DetachedSignature> {
+        self.signature = Default::default();
+        let mut data = Vec::new();
+        self.write(&mut data)?;
+        DetachedSignature::new(
+            &data[..Self::SIGNATURE_OFFSET],
+            BootSvcKind::OwnershipActivateRequest.into(),
+            algorithm,
+            self.nonce,
+            ecdsa_key,
+            spx_key,
+        )
     }
 }
 

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -77,7 +77,7 @@ impl EcdsaPrivateKey {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Annotate)]
+#[derive(Debug, Clone, Serialize, Deserialize, Annotate)]
 pub struct EcdsaRawSignature {
     #[serde(with = "serde_bytes")]
     #[annotate(format = hexstr)]
@@ -142,7 +142,7 @@ impl EcdsaRawSignature {
         }
     }
 
-    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+    pub fn write(&self, dest: &mut impl Write) -> Result<usize> {
         ensure!(
             self.r.len() == 32,
             Error::InvalidSignature(anyhow!("bad r length: {}", self.r.len()))
@@ -153,7 +153,7 @@ impl EcdsaRawSignature {
         );
         dest.write_all(&self.r)?;
         dest.write_all(&self.s)?;
-        Ok(())
+        Ok(64)
     }
 
     pub fn to_vec(&self) -> Result<Vec<u8>> {

--- a/sw/host/opentitanlib/src/crypto/spx.rs
+++ b/sw/host/opentitanlib/src/crypto/spx.rs
@@ -33,6 +33,13 @@ impl TryFrom<&sphincsplus::SpxPublicKey> for SpxRawPublicKey {
     }
 }
 
+impl TryFrom<sphincsplus::SpxPublicKey> for SpxRawPublicKey {
+    type Error = Error;
+    fn try_from(v: SpxPublicKey) -> Result<Self, Self::Error> {
+        (&v).try_into()
+    }
+}
+
 impl FromStr for SpxRawPublicKey {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/sw/host/opentitanlib/src/ownership/misc.rs
+++ b/sw/host/opentitanlib/src/ownership/misc.rs
@@ -24,6 +24,7 @@ with_unknown! {
         FlashConfig = u32::from_le_bytes(*b"FLSH"),
         FlashInfoConfig = u32::from_le_bytes(*b"INFO"),
         Rescue = u32::from_le_bytes(*b"RESQ"),
+        DetachedSignature = u32::from_le_bytes(*b"SIGN"),
         NotPresent = u32::from_le_bytes(*b"ZZZZ"),
     }
 
@@ -35,6 +36,34 @@ with_unknown! {
         SpxPrehash = u32::from_le_bytes(*b"S+S2"),
         HybridSpxPure = u32::from_le_bytes(*b"H+Pu"),
         HybridSpxPrehash = u32::from_le_bytes(*b"H+S2"),
+    }
+}
+
+impl OwnershipKeyAlg {
+    pub fn is_detached(self) -> bool {
+        !matches!(self, Self::EcdsaP256)
+    }
+
+    pub fn is_ecdsa(self) -> bool {
+        matches!(
+            self,
+            Self::EcdsaP256 | Self::HybridSpxPure | Self::HybridSpxPrehash
+        )
+    }
+
+    pub fn is_spx(self) -> bool {
+        matches!(
+            self,
+            Self::SpxPure | Self::SpxPrehash | Self::HybridSpxPure | Self::HybridSpxPrehash
+        )
+    }
+
+    pub fn is_hybrid(self) -> bool {
+        matches!(self, Self::HybridSpxPure | Self::HybridSpxPrehash)
+    }
+
+    pub fn is_prehashed(self) -> bool {
+        matches!(self, Self::SpxPrehash | Self::HybridSpxPrehash)
     }
 }
 

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -10,13 +10,15 @@ mod flash_info;
 mod misc;
 pub mod owner;
 mod rescue;
+mod signature;
 
 pub use application_key::{ApplicationKeyDomain, OwnerApplicationKey};
 pub use flash::{FlashFlags, OwnerFlashConfig, OwnerFlashRegion};
 pub use flash_info::{OwnerFlashInfoConfig, OwnerInfoPage};
-pub use misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
+pub use misc::{HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
 pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
 pub use rescue::{CommandTag, OwnerRescueConfig, RescueProtocol};
+pub use signature::DetachedSignature;
 
 pub struct GlobalFlags;
 

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -2,17 +2,22 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, ensure, Result};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
+use sphincsplus::SpxSecretKey;
 use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 use super::misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
 use super::GlobalFlags;
-use super::{OwnerApplicationKey, OwnerFlashConfig, OwnerFlashInfoConfig, OwnerRescueConfig};
+use super::{
+    DetachedSignature, OwnerApplicationKey, OwnerFlashConfig, OwnerFlashInfoConfig,
+    OwnerRescueConfig,
+};
 use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaRawSignature};
+use crate::crypto::Error as CryptoError;
 use crate::with_unknown;
 
 with_unknown! {
@@ -219,10 +224,36 @@ impl OwnerBlock {
         })
     }
     pub fn sign(&mut self, key: &EcdsaPrivateKey) -> Result<()> {
+        ensure!(
+            self.ownership_key_alg == OwnershipKeyAlg::EcdsaP256,
+            CryptoError::SignFailed(anyhow!(
+                "Algorithm {} requires a detached signature",
+                self.ownership_key_alg
+            ))
+        );
         let mut data = Vec::new();
         self.write(&mut data)?;
         self.signature = key.digest_and_sign(&data[..Self::SIGNATURE_OFFSET])?;
         Ok(())
+    }
+
+    pub fn detached_sign(
+        &mut self,
+        nonce: u64,
+        ecdsa_key: Option<&EcdsaPrivateKey>,
+        spx_key: Option<&SpxSecretKey>,
+    ) -> Result<DetachedSignature> {
+        self.signature = Default::default();
+        let mut data = Vec::new();
+        self.write(&mut data)?;
+        DetachedSignature::new(
+            &data[..Self::SIGNATURE_OFFSET],
+            TlvTag::Owner.into(),
+            self.ownership_key_alg,
+            nonce,
+            ecdsa_key,
+            spx_key,
+        )
     }
 
     pub fn is_default_constraint(d: &[u32; 8]) -> bool {

--- a/sw/host/opentitanlib/src/ownership/signature.rs
+++ b/sw/host/opentitanlib/src/ownership/signature.rs
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use serde::{Deserialize, Serialize};
+use serde_annotate::Annotate;
+use sphincsplus::{SpxDomain, SpxSecretKey};
+use std::io::{Read, Write};
+
+use super::misc::{OwnershipKeyAlg, TlvHeader, TlvTag};
+use super::GlobalFlags;
+use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaRawSignature};
+use crate::crypto::sha256::Sha256Digest;
+use crate::crypto::Error;
+
+#[derive(Debug, Serialize, Deserialize, Annotate)]
+pub struct DetachedSignature {
+    #[serde(
+        skip_serializing_if = "GlobalFlags::not_debug",
+        default = "DetachedSignature::default_header"
+    )]
+    pub header: TlvHeader,
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
+    #[annotate(format=hex)]
+    pub reserved: [u32; 2],
+    #[serde(default)]
+    pub command: u32,
+    #[serde(default)]
+    pub algorithm: OwnershipKeyAlg,
+    #[serde(default)]
+    pub nonce: u64,
+    #[serde(default)]
+    pub ecdsa: Option<EcdsaRawSignature>,
+    #[serde(default)]
+    pub spx: Option<Vec<u8>>,
+}
+
+impl Default for DetachedSignature {
+    fn default() -> Self {
+        Self {
+            header: Self::default_header(),
+            reserved: [0, 0],
+            command: 0,
+            algorithm: OwnershipKeyAlg::Unknown,
+            nonce: 0,
+            ecdsa: None,
+            spx: None,
+        }
+    }
+}
+
+impl DetachedSignature {
+    const SIZE: usize = 8192;
+    const SPX_SIZE: usize = 7856;
+
+    fn default_header() -> TlvHeader {
+        TlvHeader::new(TlvTag::DetachedSignature, 0, "0.0")
+    }
+
+    pub fn read(src: &mut impl Read, header: TlvHeader) -> Result<Self> {
+        let mut reserved = [0u32; 2];
+        src.read_u32_into::<LittleEndian>(&mut reserved)?;
+        let command = src.read_u32::<LittleEndian>()?;
+        let algorithm = OwnershipKeyAlg(src.read_u32::<LittleEndian>()?);
+        let nonce = src.read_u64::<LittleEndian>()?;
+        let ecdsa = if algorithm.is_ecdsa() {
+            Some(EcdsaRawSignature::read(src)?)
+        } else {
+            None
+        };
+        let spx = if algorithm.is_spx() {
+            let mut spx = vec![0u8; Self::SPX_SIZE];
+            src.read_exact(&mut spx)?;
+            Some(spx)
+        } else {
+            None
+        };
+        Ok(Self {
+            header,
+            reserved,
+            command,
+            algorithm,
+            nonce,
+            ecdsa,
+            spx,
+        })
+    }
+
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        let header = TlvHeader::new(TlvTag::DetachedSignature, Self::SIZE, "0.0");
+        header.write(dest)?;
+        for x in &self.reserved {
+            dest.write_u32::<LittleEndian>(*x)?;
+        }
+        dest.write_u32::<LittleEndian>(self.command)?;
+        dest.write_u32::<LittleEndian>(u32::from(self.algorithm))?;
+        dest.write_u64::<LittleEndian>(self.nonce)?;
+        let mut len = 32;
+        if self.algorithm.is_ecdsa() {
+            let ecdsa = self.ecdsa.as_ref().ok_or_else(|| {
+                Error::InvalidSignature(anyhow!(
+                    "Algorithm {} requires an ECDSA signature",
+                    self.algorithm
+                ))
+            })?;
+            len += ecdsa.write(dest)?;
+        }
+        if self.algorithm.is_spx() {
+            let spx = self.spx.as_ref().ok_or_else(|| {
+                Error::InvalidSignature(anyhow!(
+                    "Algorithm {} requires an SPX signature",
+                    self.algorithm
+                ))
+            })?;
+            dest.write_all(spx.as_slice())?;
+            len += spx.len();
+        }
+
+        let pad = vec![0xffu8; Self::SIZE - len];
+        dest.write_all(&pad)?;
+        Ok(())
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<u8>> {
+        let mut result = Vec::new();
+        self.write(&mut result)?;
+        Ok(result)
+    }
+
+    pub fn new(
+        data: &[u8],
+        command: u32,
+        algorithm: OwnershipKeyAlg,
+        nonce: u64,
+        ecdsa_key: Option<&EcdsaPrivateKey>,
+        spx_key: Option<&SpxSecretKey>,
+    ) -> Result<Self> {
+        let digest = Sha256Digest::hash(data);
+        let ecdsa = if algorithm.is_ecdsa() {
+            let key = ecdsa_key.ok_or_else(|| {
+                Error::SignFailed(anyhow!("Algorithm {algorithm} requires an ECDSA key"))
+            })?;
+            Some(key.sign(&digest)?)
+        } else {
+            None
+        };
+        let spx = if algorithm.is_spx() {
+            let key = spx_key.ok_or_else(|| {
+                Error::SignFailed(anyhow!("Algorithm {algorithm} requires an SPX key"))
+            })?;
+            let (domain, msg) = if algorithm.is_prehashed() {
+                let domain = SpxDomain::PreHashedSha256;
+                (domain, digest.as_ref())
+            } else {
+                let domain = SpxDomain::Pure;
+                (domain, data)
+            };
+            Some(key.sign(domain, msg)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            header: Self::default_header(),
+            command,
+            algorithm,
+            nonce,
+            ecdsa,
+            spx,
+            ..Default::default()
+        })
+    }
+}

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -278,10 +278,13 @@ impl CommandDispatch for OwnershipUnlock {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let unlock = self
+        let (unlock, signature) = self
             .unlock
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
 
+        if self.unlock.algorithm.is_detached() && signature.is_some() {
+            log::warn!("The algorithm {} requires a detached signature, but rescue cannot deliver the detached signature as part of boot services.", self.unlock.algorithm);
+        }
         let context = context.downcast_ref::<RescueCommand>().unwrap();
         let rescue = context.params.create(transport)?;
         rescue.enter(transport, self.reset_target)?;
@@ -325,10 +328,13 @@ impl CommandDispatch for OwnershipActivate {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        let activate = self
+        let (activate, signature) = self
             .activate
             .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
 
+        if self.activate.algorithm.is_detached() && signature.is_some() {
+            log::warn!("The algorithm {} requires a detached signature, but rescue cannot deliver the detached signature as part of boot services.", self.activate.algorithm);
+        }
         let context = context.downcast_ref::<RescueCommand>().unwrap();
         let rescue = context.params.create(transport)?;
         rescue.enter(transport, self.reset_target)?;

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -42,12 +42,13 @@ pub fn ownership_unlock(
     unlock_key: &Path,
     next_owner: Option<&Path>,
 ) -> Result<()> {
-    let unlock = OwnershipUnlockParams {
+    let (unlock, _) = OwnershipUnlockParams {
         mode: Some(mode),
         nonce: Some(nonce),
         din: Some(din),
         next_owner: next_owner.map(|p| p.into()),
-        sign: Some(unlock_key.into()),
+        algorithm: OwnershipKeyAlg::EcdsaP256,
+        ecdsa_key: Some(unlock_key.into()),
         ..Default::default()
     }
     .apply_to(Option::<&mut std::fs::File>::None)?;
@@ -89,10 +90,11 @@ pub fn ownership_activate(
     din: u64,
     activate_key: &Path,
 ) -> Result<()> {
-    let activate = OwnershipActivateParams {
+    let (activate, _) = OwnershipActivateParams {
         nonce: Some(nonce),
         din: Some(din),
-        sign: Some(activate_key.into()),
+        algorithm: OwnershipKeyAlg::EcdsaP256,
+        ecdsa_key: Some(activate_key.into()),
         ..Default::default()
     }
     .apply_to(Option::<&mut std::fs::File>::None)?;


### PR DESCRIPTION
1. Create a DetachedSignature structure that can hold large signature entities.  Include a `command` word that identifies which entity this signature is for (e.g. ownership-unlock, ownership-activate, or ownership configuration) and a nonce that can be used to match the signature with the current command.
2. Update the signing helper functions to accept an algorithm type and both ECDSA and SPX keys.  Sign with the key appropriate to the algorithm type.
3. Plumb the return-type changes through to the opentitantool commands and ownership transfer testlib.