### PR TITLE
[prim,rtl] Avoid using inside in a constant expression

### DIFF
--- a/hw/ip/prim/rtl/prim_subreg_arb.sv
+++ b/hw/ip/prim/rtl/prim_subreg_arb.sv
@@ -29,7 +29,7 @@ module prim_subreg_arb
 );
   import prim_mubi_pkg::*;
 
-  if (SwAccess inside {SwAccessRW, SwAccessWO}) begin : gen_w
+  if ((SwAccess == SwAccessRW) || (SwAccess == SwAccessWO)) begin : gen_w
     assign wr_en   = we | de;
     assign wr_data = (we == 1'b1) ? wd : d; // SW higher priority
     // Unused q - Prevent lint errors.


### PR DESCRIPTION
The SystemVerilog spec doesn't technically allow this because the stuff in this test is a constant expression ("constant_expression" in section A8.3 of the spec). But this doesn't allow an "inside_expression", unlike a normal expression.

How annoying! Expand the check to be explicit.

This was found by the Verissimo linting tool (thanks, guys!)