### PR TITLE
[otbn,dv] Correctly stringify names in otbn_env_cov

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -76,8 +76,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
   // A macro used for coverpoints for mnemonics. This expands to entries like
   //
-  //    bins mnem_add = {mnem_add};
-`define DEF_MNEM_BIN(NAME) bins NAME = {NAME}
+  //    bins mnem_add = {"mnem_add"};
+`define DEF_MNEM_BIN(NAME) bins NAME = {`"NAME`"}
 
   // Generate a bin for each mnemonic except ECALL
 `define DEF_MNEM_BINS_EXCEPT_ECALL                                     \
@@ -116,7 +116,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   `DEF_CSR(csr_load_checksum, "load_checksum");
   `DEF_CSR(csr_ctrl, "ctrl");
 `undef DEF_CSR
-`define DEF_CSR_BIN(NAME) bins NAME = {NAME}
+`define DEF_CSR_BIN(NAME) bins NAME = {`"NAME`"}
 
   // Cross one, two or three coverpoints with mnemonic_cp.
   //


### PR DESCRIPTION
The code didn't do what I intended (back in 2021!) and Verissimo points out that it doesn't make sense.

I intended this to expand to things like

    bins foo = {"foo"};

rather than

    bins foo = {foo};

(which doesn't really make any sense!)