### PR TITLE
[dv] Correct foreach syntax in dv_report_catcher

### DIFF
--- a/hw/dv/sv/dv_utils/dv_report_catcher.sv
+++ b/hw/dv/sv/dv_utils/dv_report_catcher.sv
@@ -16,7 +16,7 @@ class dv_report_catcher extends uvm_report_catcher;
     string id = get_id();
     if (m_changed_sev.exists(id)) begin
       string report_msg = get_message();
-      foreach (m_changed_sev[id][msg]) begin
+      foreach (m_changed_sev[id, msg]) begin
         if (uvm_re_match(msg, report_msg)) begin
           set_severity(m_changed_sev[id][msg]);
         end


### PR DESCRIPTION
It turns out that foreach doesn't iterate over multi-dimensional arrays like that. Apparently, we tested with tools that do what we wanted, but the Verissimo tool correctly points out that the standard doesn't require it to work.

Switch to a form that is allowed.