### PR TITLE
[dv] Correctly use uvm_component_param_utils in key_sideload_agent

### DIFF
--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent.sv
@@ -12,7 +12,7 @@ class key_sideload_agent#(
   .COV_T          (key_sideload_agent_cov#(KEY_T))
 );
 
-  `uvm_component_utils(key_sideload_agent#(KEY_T))
+  `uvm_component_param_utils(key_sideload_agent#(KEY_T))
 
   `uvm_component_new
 

--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent_cov.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent_cov.sv
@@ -5,7 +5,7 @@
 class key_sideload_agent_cov #(
     parameter type KEY_T = keymgr_pkg::hw_key_req_t
 ) extends dv_base_agent_cov #(key_sideload_agent_cfg#(KEY_T));
-  `uvm_component_utils(key_sideload_agent_cov#(KEY_T))
+  `uvm_component_param_utils(key_sideload_agent_cov#(KEY_T))
 
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg

--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -6,7 +6,7 @@ class key_sideload_driver#(
     parameter type KEY_T = keymgr_pkg::hw_key_req_t
 ) extends dv_base_driver #(.ITEM_T(key_sideload_item#(KEY_T)),
                            .CFG_T (key_sideload_agent_cfg#(KEY_T)));
-  `uvm_component_utils(key_sideload_driver#(KEY_T))
+  `uvm_component_param_utils(key_sideload_driver#(KEY_T))
 
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg

--- a/hw/dv/sv/key_sideload_agent/key_sideload_monitor.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_monitor.sv
@@ -9,7 +9,7 @@ class key_sideload_monitor #(
     .CFG_T  (key_sideload_agent_cfg#(KEY_T)),
     .COV_T  (key_sideload_agent_cov#(KEY_T))
   );
-  `uvm_component_utils(key_sideload_monitor#(KEY_T))
+  `uvm_component_param_utils(key_sideload_monitor#(KEY_T))
 
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg


### PR DESCRIPTION
A parameterised type needs this instead of just uvm_component_utils. Noticed by Verissimo and it's a pretty trivial fix.