### PR TITLE
[dv] Add some missing calls to the uvm_object_utils macro

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -13,6 +13,8 @@
 // the memory element and its size and depth information is available. Pass the instance to the UVM
 // side via uvm_config_db.
 class mem_bkdr_util extends uvm_object;
+  `uvm_object_utils(mem_bkdr_util)
+
   // Hierarchical path to the memory.
   protected string path;
 

--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -23,6 +23,7 @@ interface prim_count_if #(
   string signal_forced;
 
   class prim_count_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
+    `uvm_object_utils(prim_count_if_proxy)
     `uvm_object_new
 
     logic [Width-1:0] orig_value;

--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -24,6 +24,7 @@ interface prim_double_lfsr_if #(
   string signal_for_restore = $sformatf("%s.lfsr_state[1]", path);
 
   class prim_double_lfsr_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
+    `uvm_object_utils(prim_double_lfsr_if_proxy)
     `uvm_object_new
 
     logic [Width-1:0] orig_value;

--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -49,6 +49,8 @@ interface prim_onehot_check_if #(
     logic [AddrWidth-1:0]   addr_orig_value;
     logic                   en_orig_value;
 
+    `uvm_object_utils(prim_onehot_check_if_proxy)
+
     function new(string name = "");
       super.new(name);
     endfunction : new
@@ -137,6 +139,7 @@ interface prim_onehot_check_if #(
   endclass : prim_onehot_check_if_proxy
 
   class prim_onehot_check_with_addr_fault_if_proxy extends prim_onehot_check_if_proxy;
+    `uvm_object_utils(prim_onehot_check_with_addr_fault_if_proxy)
 
     covergroup onehot_with_addr_fault_cg (string name) with function sample(
           onehot_fault_type_e onehot_fault_type);
@@ -170,6 +173,7 @@ interface prim_onehot_check_if #(
   endclass : prim_onehot_check_with_addr_fault_if_proxy
 
   class prim_onehot_check_without_addr_fault_if_proxy extends prim_onehot_check_if_proxy;
+    `uvm_object_utils(prim_onehot_check_without_addr_fault_if_proxy)
 
     covergroup onehot_without_addr_fault_cg (string name) with function sample(
           onehot_fault_type_e onehot_fault_type);

--- a/hw/dv/sv/sec_cm/prim_singleton_fifo_if.sv
+++ b/hw/dv/sv/sec_cm/prim_singleton_fifo_if.sv
@@ -28,6 +28,8 @@ interface prim_singleton_fifo_if #(
   class prim_singleton_fifo_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
     logic orig_value;
 
+    `uvm_object_utils(prim_singleton_fifo_if_proxy)
+
     function new(string name="");
       super.new(name);
     endfunction

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -32,6 +32,7 @@ interface prim_sparse_fsm_flop_if #(
 
   class prim_sparse_fsm_flop_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
     `uvm_object_new
+    `uvm_object_utils(prim_sparse_fsm_flop_if_proxy)
 
     logic [Width-1:0] orig_value;
 

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_bkdr_util.sv
@@ -5,6 +5,7 @@
 // Specialization of the `mem_bkdr_util` class for SRAM's encrypted read/write operations.
 
 class sram_ctrl_bkdr_util extends mem_bkdr_util;
+  `uvm_object_utils(sram_ctrl_bkdr_util)
 
   // Initialize the class instance.
   // `extra_bits_per_subword` is the width of any additional metadata that is not captured in the


### PR DESCRIPTION
These are classes that derive from uvm_object and Verissimo correctly points out that we should probably register them properly with the database.