### PR TITLE
[doc] Disable mdBook's create-missing

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -482,7 +482,6 @@
   - [Build & Test Rules](./rules/opentitan/README.md)
     - [Top selection](./hw/top/README.md)
     - [FPGA Bitstreams](./hw/bitstream/README.md)
-    - [OTP Preload Image Generator](./util/design/README.md#otp_preload_image_generator)
   - [Device Libraries](./sw/device/lib/README.md)
     - [DIF Library](./sw/device/lib/dif/README.md)
       - [ADC Checklist](sw/device/lib/dif/dif_adc_ctrl.md)

--- a/book.toml
+++ b/book.toml
@@ -9,6 +9,9 @@ multilingual = false
 src = "."
 title = "OpenTitan Documentation"
 
+[build]
+create-missing = false
+
 [output.html]
 site-url = "book/"
 fold = { enable = true}


### PR DESCRIPTION
When set, this option automatically creates missing pages. This can be annoying if people accidently put fragments or URLs in the SUMMARY.md, which mdBook interprets as a missing page.