### PR TITLE
Eliminate ROM_EXT `.data` sections

### DIFF
--- a/sw/device/silicon_creator/lib/cert/cert.c
+++ b/sw/device/silicon_creator/lib/cert/cert.c
@@ -12,14 +12,6 @@ static_assert(kCertX509Asn1SerialNumberSizeInBytes <= kHmacDigestNumBytes,
               "The ASN.1 encoded X.509 serial number field should be <= the "
               "size of a SHA256 digest.");
 
-// Reusable buffer for checking x509 serial number.
-static char expected_serial[kDiceX509SerialSizeBytes] = {
-    0x02,  // serialNumber tag
-    0x15,  // len = 1 + 20
-    0x00,  // zero pad when MSb == 1
-           // Remaining bytes will be filled during check.
-};
-
 uint32_t cert_x509_asn1_decode_size_header(const uint8_t *header) {
   if (header[0] != 0x30 || header[1] != 0x82) {
     return 0;
@@ -31,10 +23,18 @@ rom_error_t cert_x509_asn1_check_serial_number(const uint8_t *cert, size_t size,
                                                cert_key_id_t *expected_sn_bytes,
                                                hardened_bool_t *matches) {
   *matches = kHardenedBoolFalse;
-
   if (size < kDiceX509MinSizeBytes) {
     return kErrorCertInvalidSize;
   }
+
+  // We want the initializer for this to be `{0x02, 0x15, 0x00, ...}`, however
+  // that results in 23 bytes of .rodata, 20 of which we immediately overwrite
+  // by the memcpy below.  Initialization with code results in 16 bytes of
+  // rv32imc code.
+  char expected_serial[kDiceX509SerialSizeBytes];
+  expected_serial[0] = 0x02;
+  expected_serial[1] = 0x15;
+  expected_serial[2] = 0x00;
 
   // Prepare expected serial number.
   memcpy(&expected_serial[kDiceX509SerialHeaderSizeBytes], expected_sn_bytes,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -74,7 +74,7 @@ extern char _rom_ext_start_address[];
 extern const char _chip_info_start[];
 
 // Life cycle state of the chip.
-lifecycle_state_t lc_state = kLcStateProd;
+lifecycle_state_t lc_state;
 
 // Owner configuration details parsed from the onwer info pages.
 owner_config_t owner_config;


### PR DESCRIPTION
We want to avoid having a `.data` section in ROM and ROM_EXT code.

1. By initializing the `lc_state` global variable, we add to a `.data` section.  Since this value is initialized very early in `rom_ext_init`, we don't need a explicit initializer.
2. The dice cert serial number check was using a staticly initialized data item to keep the ASN.1 prefix around.  Manually initializing this prefix in code requires fewer bytes than the static initializer and doesn't require the initializer to be in `.data` or `.rodata`.