### PR TITLE
[flash_ctrl] Optimize the perms/config structs

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -58,7 +58,7 @@ boot_data_t kTestBootData = (boot_data_t){
  * @param enable New read, write, and erase permissions.
  */
 static void boot_data_pages_mp_set(hardened_bool_t perm) {
-  multi_bit_bool_t mubi_perm =
+  uint8_t mubi_perm =
       perm == kHardenedBoolTrue ? kMultiBitBool4True : kMultiBitBool4False;
   for (size_t i = 0; i < ARRAYSIZE(kPages); ++i) {
     flash_ctrl_info_perms_set(kPages[i], (flash_ctrl_perms_t){

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -441,21 +441,27 @@ rom_error_t flash_ctrl_info_erase(const flash_ctrl_info_page_t *info_page,
  * flash_ctrl config registers use 4-bits for boolean values. Use
  * `kMultiBitBool4True` to enable and `kMultiBitBool4False` to disable
  * permissions.
+ *
+ * The bitfields in this stuct match up with the bitfields in the peripheral
+ * register.
  */
 typedef struct flash_ctrl_perms {
+  uint32_t _pad0 : 4;
   /**
    * Read.
    */
-  multi_bit_bool_t read;
+  uint32_t read : 4;
   /**
    * Write.
    */
-  multi_bit_bool_t write;
+  uint32_t write : 4;
   /**
    * Erase.
    */
-  multi_bit_bool_t erase;
+  uint32_t erase : 4;
+  uint32_t _pad1 : 16;
 } flash_ctrl_perms_t;
+OT_ASSERT_SIZE(flash_ctrl_perms_t, 4);
 
 /**
  * Sets default access permissions for the data partition.
@@ -494,27 +500,26 @@ void flash_ctrl_info_perms_set(const flash_ctrl_info_page_t *info_page,
  * `kMultiBitBool4True` to enable and `kMultiBitBool4False` to disable
  * these settings.
  *
- * This struct has no padding, so it is safe to `memcmp()` without invoking UB.
+ * The bitfields in this stuct match up with the bitfields in the peripheral
+ * register.
  */
 typedef struct flash_ctrl_cfg {
+  uint32_t _pad0 : 16;
   /**
    * Scrambling.
    */
-  multi_bit_bool_t scrambling;
+  uint32_t scrambling : 4;
   /**
    * ECC.
    */
-  multi_bit_bool_t ecc;
+  uint32_t ecc : 4;
   /**
    * High endurance.
    */
-  multi_bit_bool_t he;
+  uint32_t he : 4;
+  uint32_t _pad1 : 4;
 } flash_ctrl_cfg_t;
-
-OT_ASSERT_MEMBER_OFFSET(flash_ctrl_cfg_t, scrambling, 0);
-OT_ASSERT_MEMBER_OFFSET(flash_ctrl_cfg_t, ecc, 4);
-OT_ASSERT_MEMBER_OFFSET(flash_ctrl_cfg_t, he, 8);
-OT_ASSERT_SIZE(flash_ctrl_cfg_t, 12);
+OT_ASSERT_SIZE(flash_ctrl_cfg_t, 4);
 
 /**
  * Sets default configuration settings for the data partition.

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -973,5 +973,51 @@ TEST_P(DataRegionProtectTestSuite, ProtectRegionReadWriteEraseEnabled) {
       kHardenedBoolFalse);
 }
 
+TEST(FlashCtrl, FlashPermissionBits) {
+  union Permissions {
+    flash_ctrl_perms_t perms;
+    uint32_t raw;
+  };
+
+  Permissions word = {
+      .perms =
+          {
+              .read = 1,
+              .write = 2,
+              .erase = 3,
+          },
+  };
+
+  EXPECT_EQ(1, bitfield_field32_read(word.raw,
+                                     FLASH_CTRL_MP_REGION_CFG_0_RD_EN_0_FIELD));
+  EXPECT_EQ(2, bitfield_field32_read(
+                   word.raw, FLASH_CTRL_MP_REGION_CFG_0_PROG_EN_0_FIELD));
+  EXPECT_EQ(3, bitfield_field32_read(
+                   word.raw, FLASH_CTRL_MP_REGION_CFG_0_ERASE_EN_0_FIELD));
+}
+
+TEST(FlashCtrl, FlashConfigurationBits) {
+  union Permissions {
+    flash_ctrl_cfg_t cfg;
+    uint32_t raw;
+  };
+
+  Permissions word = {
+      .cfg =
+          {
+              .scrambling = 1,
+              .ecc = 2,
+              .he = 3,
+          },
+  };
+
+  EXPECT_EQ(1, bitfield_field32_read(
+                   word.raw, FLASH_CTRL_MP_REGION_CFG_0_SCRAMBLE_EN_0_FIELD));
+  EXPECT_EQ(2, bitfield_field32_read(
+                   word.raw, FLASH_CTRL_MP_REGION_CFG_0_ECC_EN_0_FIELD));
+  EXPECT_EQ(3, bitfield_field32_read(word.raw,
+                                     FLASH_CTRL_MP_REGION_CFG_0_HE_EN_0_FIELD));
+}
+
 }  // namespace
 }  // namespace flash_ctrl_unittest

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
@@ -54,19 +54,19 @@ using MockFlashCtrl = testing::StrictMock<internal::MockFlashCtrl>;
 using NiceMockFlashCtrl = testing::NiceMock<internal::MockFlashCtrl>;
 
 MATCHER_P3(FlashPerms, read, write, erase, "") {
-  return ::testing::Value(
-      arg,
-      ::testing::AllOf(::testing::Field(&flash_ctrl_perms_t::read, read),
-                       ::testing::Field(&flash_ctrl_perms_t::write, write),
-                       ::testing::Field(&flash_ctrl_perms_t::erase, erase)));
+  // It would be nice to use `testing::Field` here, but that matcher does not
+  // work with bitfields.
+  return arg.read == static_cast<uint8_t>(read) &&
+         arg.write == static_cast<uint8_t>(write) &&
+         arg.erase == static_cast<uint8_t>(erase);
 }
 
 MATCHER_P3(FlashCfg, scrambling, ecc, he, "") {
-  return ::testing::Value(
-      arg, ::testing::AllOf(
-               ::testing::Field(&flash_ctrl_cfg_t::scrambling, scrambling),
-               ::testing::Field(&flash_ctrl_cfg_t::ecc, ecc),
-               ::testing::Field(&flash_ctrl_cfg_t::he, he)));
+  // It would be nice to use `testing::Field` here, but that matcher does not
+  // work with bitfields.
+  return arg.scrambling == static_cast<uint8_t>(scrambling) &&
+         arg.ecc == static_cast<uint8_t>(ecc) &&
+         arg.he == static_cast<uint8_t>(he);
 }
 
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -94,9 +94,9 @@ static void reverse(void *buf, size_t len) {
 
 static void secret_page_enable(multi_bit_bool_t read, multi_bit_bool_t write) {
   flash_ctrl_perms_t perm = {
-      .read = read,
-      .write = write,
-      .erase = write,
+      .read = (uint8_t)read,
+      .write = (uint8_t)write,
+      .erase = (uint8_t)write,
   };
   flash_ctrl_info_perms_set(&kFlashCtrlInfoPageOwnerSecret, perm);
 }


### PR DESCRIPTION
Use bitfields to lay out the flash permissions and configuration structures exactly as the registers in the flash_ctrl driver.  By using this arrangemnt, we can save 470 bytes over all calls for flash configuration.