### PR TITLE
[tl,dv] Lots of cleanups (and some documentation) in `tl_seq_item.sv`

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -194,7 +194,11 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
     if (cfg.en_scb_tl_err_chk) begin
       // check tl packet integrity
-      void'(item.is_ok());
+      if (!item.is_ok()) begin
+        `uvm_error(`gfn,
+                   $sformatf("a_source: 0x%0h & d_source: 0x%0h mismatch",
+                             item.a_source, item.d_source))
+      end
       if (predict_tl_err(item, DataChannel, ral_name)) return;
     end
     if (cfg.en_scb_mem_chk && is_mem_addr(item, ral_name)) begin

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -233,8 +233,9 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       end
       sba_tl_access_q.push_back(item);
       // check tl packet integrity
-      // TODO: deal with item not being ok.
-      void'(item.is_ok(.throw_error(0)));
+      if (!item.is_ok()) begin
+        // TODO: deal with item not being ok.
+      end
       process_tl_sba_access(item, DataChannel);
     end
   endtask

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -158,7 +158,11 @@ class flash_ctrl_scoreboard #(
                 "Received eflash_tl d_chan item:\n%0s", item.sprint(uvm_default_line_printer)),
                 UVM_HIGH)
       // check tl packet integrity
-      void'(item.is_ok());
+      if (!item.is_ok()) begin
+        `uvm_error(`gfn,
+                   $sformatf("a_source: 0x%0h & d_source: 0x%0h mismatch",
+                             item.a_source, item.d_source))
+      end
 
       // check that address phase for this read is done
       `DV_CHECK_GT_FATAL(eflash_addr_phase_queue.size(), 0)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -158,7 +158,11 @@ class flash_ctrl_scoreboard #(
                 "Received eflash_tl d_chan item:\n%0s", item.sprint(uvm_default_line_printer)),
                 UVM_HIGH)
       // check tl packet integrity
-      void'(item.is_ok());
+      if (!item.is_ok()) begin
+        `uvm_error(`gfn,
+                   $sformatf("a_source: 0x%0h & d_source: 0x%0h mismatch",
+                             item.a_source, item.d_source))
+      end
 
       // check that address phase for this read is done
       `DV_CHECK_GT_FATAL(eflash_addr_phase_queue.size(), 0)

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -158,7 +158,11 @@ class flash_ctrl_scoreboard #(
                 "Received eflash_tl d_chan item:\n%0s", item.sprint(uvm_default_line_printer)),
                 UVM_HIGH)
       // check tl packet integrity
-      void'(item.is_ok());
+      if (!item.is_ok()) begin
+        `uvm_error(`gfn,
+                   $sformatf("a_source: 0x%0h & d_source: 0x%0h mismatch",
+                             item.a_source, item.d_source))
+      end
 
       // check that address phase for this read is done
       `DV_CHECK_GT_FATAL(eflash_addr_phase_queue.size(), 0)


### PR DESCRIPTION
This has got dramatically simpler since #26724 was merged (and I clearly hadn't noticed I'd almost filed the same thing twice). Rebased, it has just one commit, with the following commit message:

> [tl,dv] Simplify tl_seq_item::is_ok
>
> This was inspired by a lint warning from Verissimo about casting the return of the function to void. That was done because the function had a side-effect and could generate an error.
>
> But there aren't many call sites (two!), so we can easily move that behaviour to the call site, and this allows us to simplify/shorten things as well.
>
> (The diffstat on the commit doesn't look so great, but that's because we have three templated copies of the +5/-1 change in flash_ctrl_scoreboard.sv)
