### PR TITLE
[dv] Simplify DV_EOT_PRINT_TLM_FIFO_CONTENTS macro

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -295,13 +295,11 @@
 
 // print non-empty tlm fifos that were uncompared at end of test
 `ifndef DV_EOT_PRINT_TLM_FIFO_CONTENTS
-`define DV_EOT_PRINT_TLM_FIFO_CONTENTS(TYP_, FIFO_, SEV_=error, ID_=`gfn) \
-  begin \
-    while (!FIFO_.is_empty()) begin \
-      TYP_ item; \
-      void'(FIFO_.try_get(item)); \
-      `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint()), ID_) \
-    end \
+`define DV_EOT_PRINT_TLM_FIFO_CONTENTS(TYP_, FIFO_, SEV_=error, ID_=`gfn)            \
+  forever begin                                                                      \
+    TYP_ item;                                                                       \
+    if (!FIFO_.try_get(item)) break;                                                 \
+    `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint()), ID_)  \
   end
 `endif
 

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -295,11 +295,13 @@
 
 // print non-empty tlm fifos that were uncompared at end of test
 `ifndef DV_EOT_PRINT_TLM_FIFO_CONTENTS
-`define DV_EOT_PRINT_TLM_FIFO_CONTENTS(TYP_, FIFO_, SEV_=error, ID_=`gfn)            \
-  forever begin                                                                      \
-    TYP_ item;                                                                       \
-    if (!FIFO_.try_get(item)) break;                                                 \
-    `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint()), ID_)  \
+`define DV_EOT_PRINT_TLM_FIFO_CONTENTS(TYP_, FIFO_, SEV_=error, ID_=`gfn)                          \
+  forever begin                                                                                    \
+    TYP_ item;                                                                                     \
+    int res = FIFO_.try_get(item);                                                                 \
+    if (res == 0) break;                                                                           \
+    if (res < 0) `dv_fatal($sformatf("Cannot read item from %s (type mismatch)", `"FIFO_`"), ID_)  \
+    `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint()), ID_)                \
   end
 `endif
 


### PR DESCRIPTION
This was inspired by a lint warning from Verissimo about the fact that we weren't looking at the result of try_get(). But we can structure things a bit differently, solving the problem and simplifying the code too. Do that!