### PR TITLE
[rv_plic, fpv] No parasitic state in alert sender FSM while doing FPV

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/tb/assertions.tcl
+++ b/hw/ip_templates/rv_plic/fpv/tb/assertions.tcl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The intention to add this assertion is to make sure that while doing FPV there is not a
+# possibility to inject parasitic state to the state variable of alert sender FSM.
+assert -name RvPlicAlertSenderNoParasiticState \
+  {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/assertions.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/assertions.tcl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The intention to add this assertion is to make sure that while doing FPV there is not a
+# possibility to inject parasitic state to the state variable of alert sender FSM.
+assert -name RvPlicAlertSenderNoParasiticState \
+  {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/assertions.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/assertions.tcl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The intention to add this assertion is to make sure that while doing FPV there is not a
+# possibility to inject parasitic state to the state variable of alert sender FSM.
+assert -name RvPlicAlertSenderNoParasiticState \
+  {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/assertions.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/assertions.tcl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The intention to add this assertion is to make sure that while doing FPV there is not a
+# possibility to inject parasitic state to the state variable of alert sender FSM.
+assert -name RvPlicAlertSenderNoParasiticState \
+  {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}


### PR DESCRIPTION
This [assignment](https://github.com/lowRISC/opentitan/blob/73eaed7dd297a83cdde24e5a588b239234b29d98/hw/ip/prim/rtl/prim_alert_sender.sv#L249) is analyzed by jasper as a deadcode as we never inject a faulty state into the state registers of alert sender FSM. Hence, the default case statement needs a waivers. To make sure that this is always the case, a separate assertion is added which automatically fails if the state registers contains a parasitic state.