### PR TITLE
[dv] Simplify use of dv_base_reg::atomic_en_shadow_wr

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -443,9 +443,9 @@ class dv_base_reg extends uvm_reg;
       shadow_update_err = 0;
       shadow_wr_staged  = 0;
       shadow_fatal_lock = 0;
-      // in case reset is issued during shadowed writes
-      void'(atomic_en_shadow_wr.try_get(1));
-      atomic_en_shadow_wr.put(1);
+      // Make a new copy of the shadow write semaphore, so that we don't need a shadowed write
+      // operation to complete if a reset happens in the middle of one.
+      atomic_en_shadow_wr = new(1);
     end
   endfunction
 


### PR DESCRIPTION
This code was trying to ensure that the semaphore had exactly one token in it. Knowing that it would only ever have at most one token, the code worked by trying to get that token if there was one and then putting a new token in.

Casting the result of the try_get() function to void causes a lint error from Verissimo. And there's a simpler way to get the same behaviour: just make a new semaphore!

This would be a problem if anything took a reference to the old semaphore (leaving a "dangling pointer") but a quick grep shows that this doesn't happen.