### PR TITLE
[rv_plic,rtl] Remove some unnecessary templating

### DIFF
--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -170,7 +170,7 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
     .q_o(intr_src_synced)
   );
 
-  ${module_instance_name}_gateway #(
+  rv_plic_gateway #(
     .N_SOURCE   (NumSrc)
   ) u_gateway (
     .clk_i,
@@ -189,7 +189,7 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   // Target interrupt notification //
   ///////////////////////////////////
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
-    ${module_instance_name}_target #(
+    rv_plic_target #(
       .N_SOURCE    (NumSrc),
       .MAX_PRIO    (MAX_PRIO)
     ) u_target (

--- a/hw/ip_templates/rv_plic/rtl/rv_plic_gateway.sv
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic_gateway.sv
@@ -4,7 +4,7 @@
 //
 // RISC-V Platform-Level Interrupt Gateways module
 
-module ${module_instance_name}_gateway #(
+module rv_plic_gateway #(
   parameter int N_SOURCE = 32
 ) (
   input clk_i,

--- a/hw/ip_templates/rv_plic/rtl/rv_plic_target.sv
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic_target.sv
@@ -14,7 +14,7 @@
 
 `include "prim_assert.sv"
 
-module ${module_instance_name}_target #(
+module rv_plic_target #(
   parameter int N_SOURCE = 32,
   parameter int MAX_PRIO = 7,
 


### PR DESCRIPTION
The rv_plic_target and rv_plic_gateway modules don't really need to be templated. Instances can only differ because of different N_SOURCE and MAX_PRIO parameters.

Make things look a bit less magical by keeping everything concrete.