### PR TITLE
[clkmgr] Add DT extension

### DIFF
--- a/hw/ip_templates/clkmgr/defs.bzl.tpl
+++ b/hw/ip_templates/clkmgr/defs.bzl.tpl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 CLKMGR = opentitan_ip(
     name = "clkmgr",
     hjson = "//hw/top_${topname}/ip_autogen/clkmgr:data/clkmgr.hjson",
+    ipconfig = "//hw/top_${topname}/ip_autogen/clkmgr:data/top_${topname}_clkmgr.ipconfig.hjson",
+    extension = "//hw/top_${topname}/ip_autogen/clkmgr/util:dt",
 )

--- a/hw/ip_templates/clkmgr/util/BUILD.bazel.tpl
+++ b/hw/ip_templates/clkmgr/util/BUILD.bazel.tpl
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/ip_templates/clkmgr/util/dt.py
+++ b/hw/ip_templates/clkmgr/util/dt.py
@@ -1,0 +1,144 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Dict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import ClkmgrIpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software gateable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of gateable clocks.
+ */
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a gateable clock.
+ *
+ * The clocks are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the gateable clock, between 0 and `dt_clkmgr_sw_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is gateable.
+ */
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Get the number of software hintable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of hintable clocks.
+ */
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a hintable clock.
+ *
+ * The clocks sources are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the hintable clock, between 0 and `dt_clkmgr_hint_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is hintable.
+ */
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt) {
+  return %(sw_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.sw_clks[idx];
+}
+
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
+  return %(hint_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.hint_clks[idx];
+}
+"""
+
+
+class ClkmgrExt(Extension):
+    SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
+    HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
+        self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+    @staticmethod
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "clkmgr":
+            return ClkmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> StructType:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+        instance_id_enum = self.ip_helper.top_helper.instance_id_enum
+
+        st = StructType()
+        # Add field to list gateable clocks.
+        st.add_field(
+            name = self.SW_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(sw_clk_count),
+            ),
+            docstring = "List of gateable clocks, in the order of the register fields",
+        )
+        # Add field to list hintable clocks.
+        st.add_field(
+            name = self.HINT_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(hint_clk_count),
+            ),
+            docstring = "List of hintable clocks, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> Dict:
+        sw_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.sw_clks()):
+            sw_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        hint_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
+            hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+
+        return {
+            self.SW_CLOCKS_FIELD_NAME: sw_clks,
+            self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+
+        if pos == Extension.DtIpPos.HeaderEnd:
+            return HEADER_EXT_TEMPLATE
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_clk_count': sw_clk_count,
+                'hint_clk_count': hint_clk_count,
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/ip_templates/clkmgr/util/ipconfig.py
+++ b/hw/ip_templates/clkmgr/util/ipconfig.py
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the clkmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class ClkmgrIpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_clks(self) -> List[Dict]:
+        """
+        Return the list of software controllable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["sw_clks"].values()
+        ]
+
+    def hint_clks(self) -> List[Dict]:
+        """
+        Return the list of hintable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["hint_clks"].values()
+        ]

--- a/hw/top_darjeeling/ip_autogen/clkmgr/defs.bzl
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/defs.bzl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 CLKMGR = opentitan_ip(
     name = "clkmgr",
     hjson = "//hw/top_darjeeling/ip_autogen/clkmgr:data/clkmgr.hjson",
+    ipconfig = "//hw/top_darjeeling/ip_autogen/clkmgr:data/top_darjeeling_clkmgr.ipconfig.hjson",
+    extension = "//hw/top_darjeeling/ip_autogen/clkmgr/util:dt",
 )

--- a/hw/top_darjeeling/ip_autogen/clkmgr/util/BUILD.bazel
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/util/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/top_darjeeling/ip_autogen/clkmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/util/dt.py
@@ -1,0 +1,144 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Dict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import ClkmgrIpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software gateable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of gateable clocks.
+ */
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a gateable clock.
+ *
+ * The clocks are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the gateable clock, between 0 and `dt_clkmgr_sw_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is gateable.
+ */
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Get the number of software hintable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of hintable clocks.
+ */
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a hintable clock.
+ *
+ * The clocks sources are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the hintable clock, between 0 and `dt_clkmgr_hint_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is hintable.
+ */
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt) {
+  return %(sw_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.sw_clks[idx];
+}
+
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
+  return %(hint_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.hint_clks[idx];
+}
+"""
+
+
+class ClkmgrExt(Extension):
+    SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
+    HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
+        self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+    @staticmethod
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "clkmgr":
+            return ClkmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> StructType:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+        instance_id_enum = self.ip_helper.top_helper.instance_id_enum
+
+        st = StructType()
+        # Add field to list gateable clocks.
+        st.add_field(
+            name = self.SW_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(sw_clk_count),
+            ),
+            docstring = "List of gateable clocks, in the order of the register fields",
+        )
+        # Add field to list hintable clocks.
+        st.add_field(
+            name = self.HINT_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(hint_clk_count),
+            ),
+            docstring = "List of hintable clocks, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> Dict:
+        sw_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.sw_clks()):
+            sw_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        hint_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
+            hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+
+        return {
+            self.SW_CLOCKS_FIELD_NAME: sw_clks,
+            self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+
+        if pos == Extension.DtIpPos.HeaderEnd:
+            return HEADER_EXT_TEMPLATE
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_clk_count': sw_clk_count,
+                'hint_clk_count': hint_clk_count,
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/top_darjeeling/ip_autogen/clkmgr/util/ipconfig.py
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/util/ipconfig.py
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the clkmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class ClkmgrIpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_clks(self) -> List[Dict]:
+        """
+        Return the list of software controllable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["sw_clks"].values()
+        ]
+
+    def hint_clks(self) -> List[Dict]:
+        """
+        Return the list of hintable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["hint_clks"].values()
+        ]

--- a/hw/top_earlgrey/ip_autogen/clkmgr/defs.bzl
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/defs.bzl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 CLKMGR = opentitan_ip(
     name = "clkmgr",
     hjson = "//hw/top_earlgrey/ip_autogen/clkmgr:data/clkmgr.hjson",
+    ipconfig = "//hw/top_earlgrey/ip_autogen/clkmgr:data/top_earlgrey_clkmgr.ipconfig.hjson",
+    extension = "//hw/top_earlgrey/ip_autogen/clkmgr/util:dt",
 )

--- a/hw/top_earlgrey/ip_autogen/clkmgr/util/BUILD.bazel
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/util/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/top_earlgrey/ip_autogen/clkmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/util/dt.py
@@ -1,0 +1,144 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Dict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import ClkmgrIpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software gateable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of gateable clocks.
+ */
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a gateable clock.
+ *
+ * The clocks are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the gateable clock, between 0 and `dt_clkmgr_sw_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is gateable.
+ */
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Get the number of software hintable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of hintable clocks.
+ */
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a hintable clock.
+ *
+ * The clocks sources are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the hintable clock, between 0 and `dt_clkmgr_hint_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is hintable.
+ */
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt) {
+  return %(sw_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.sw_clks[idx];
+}
+
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
+  return %(hint_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.hint_clks[idx];
+}
+"""
+
+
+class ClkmgrExt(Extension):
+    SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
+    HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
+        self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+    @staticmethod
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "clkmgr":
+            return ClkmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> StructType:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+        instance_id_enum = self.ip_helper.top_helper.instance_id_enum
+
+        st = StructType()
+        # Add field to list gateable clocks.
+        st.add_field(
+            name = self.SW_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(sw_clk_count),
+            ),
+            docstring = "List of gateable clocks, in the order of the register fields",
+        )
+        # Add field to list hintable clocks.
+        st.add_field(
+            name = self.HINT_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(hint_clk_count),
+            ),
+            docstring = "List of hintable clocks, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> Dict:
+        sw_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.sw_clks()):
+            sw_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        hint_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
+            hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+
+        return {
+            self.SW_CLOCKS_FIELD_NAME: sw_clks,
+            self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+
+        if pos == Extension.DtIpPos.HeaderEnd:
+            return HEADER_EXT_TEMPLATE
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_clk_count': sw_clk_count,
+                'hint_clk_count': hint_clk_count,
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/top_earlgrey/ip_autogen/clkmgr/util/ipconfig.py
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/util/ipconfig.py
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the clkmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class ClkmgrIpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_clks(self) -> List[Dict]:
+        """
+        Return the list of software controllable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["sw_clks"].values()
+        ]
+
+    def hint_clks(self) -> List[Dict]:
+        """
+        Return the list of hintable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["hint_clks"].values()
+        ]

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/defs.bzl
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/defs.bzl
@@ -6,4 +6,6 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 CLKMGR = opentitan_ip(
     name = "clkmgr",
     hjson = "//hw/top_englishbreakfast/ip_autogen/clkmgr:data/clkmgr.hjson",
+    ipconfig = "//hw/top_englishbreakfast/ip_autogen/clkmgr:data/top_englishbreakfast_clkmgr.ipconfig.hjson",
+    extension = "//hw/top_englishbreakfast/ip_autogen/clkmgr/util:dt",
 )

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/util/BUILD.bazel
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/util/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "ipconfig",
+    srcs = ["ipconfig.py"],
+)
+
+py_library(
+    name = "dt",
+    srcs = ["dt.py"],
+    deps = [
+        ":ipconfig",
+        "//util/dtgen:helper",
+        "//util/topgen",
+    ],
+)

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/util/dt.py
@@ -1,0 +1,144 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""This contains a class which is used to help generate the device tables (DT)
+files.
+"""
+from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
+from topgen.lib import Name
+from typing import Dict
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from ipconfig import ClkmgrIpConfig  # noqa: E402
+
+HEADER_EXT_TEMPLATE = """
+/**
+ * Get the number of software gateable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of gateable clocks.
+ */
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a gateable clock.
+ *
+ * The clocks are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the gateable clock, between 0 and `dt_clkmgr_sw_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is gateable.
+ */
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx);
+
+/**
+ * Get the number of software hintable clocks.
+ *
+ * @param dt Instance of clkmgr.
+ * @return Number of hintable clocks.
+ */
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt);
+
+/**
+ * Get the instance ID of a hintable clock.
+ *
+ * The clocks sources are ordered as they appear in the registers.
+ *
+ * @param dt Instance of clkmgr.
+ * @param idx Index of the hintable clock, between 0 and `dt_clkmgr_hint_clock_count(dt)-1`.
+ * @return Instance ID of the device whose clock is hintable.
+ */
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx);
+"""
+
+SOURCE_EXT_TEMPLATE = """
+size_t dt_clkmgr_gateable_clock_count(dt_clkmgr_t dt) {
+  return %(sw_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_gateable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.sw_clks[idx];
+}
+
+size_t dt_clkmgr_hintable_clock_count(dt_clkmgr_t dt) {
+  return %(hint_clk_count)d;
+}
+
+dt_instance_id_t dt_clkmgr_hintable_clock(dt_clkmgr_t dt, size_t idx) {
+  return TRY_GET_DT(dt, kDtInstanceIdUnknown)->ext.hint_clks[idx];
+}
+"""
+
+
+class ClkmgrExt(Extension):
+    SW_CLOCKS_FIELD_NAME = Name(["sw", "clks"])
+    HINT_CLOCKS_FIELD_NAME = Name(["hint", "clks"])
+
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        if self.ip_helper.ipconfig is None:
+            raise RuntimeError("the clkmgr extension requires the ipconfig to be provided")
+        self.ipconfig = ClkmgrIpConfig(self.ip_helper.ipconfig)
+
+    @staticmethod
+    def create_ext(ip_helper: IpHelper):
+        if ip_helper.ip.name == "clkmgr":
+            return ClkmgrExt(ip_helper)
+
+    def extend_dt_ip(self) -> StructType:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+        instance_id_enum = self.ip_helper.top_helper.instance_id_enum
+
+        st = StructType()
+        # Add field to list gateable clocks.
+        st.add_field(
+            name = self.SW_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(sw_clk_count),
+            ),
+            docstring = "List of gateable clocks, in the order of the register fields",
+        )
+        # Add field to list hintable clocks.
+        st.add_field(
+            name = self.HINT_CLOCKS_FIELD_NAME,
+            field_type = ArrayMapType(
+                elem_type = ScalarType(instance_id_enum.name),
+                index_type = ScalarType("size_t"),
+                length = str(hint_clk_count),
+            ),
+            docstring = "List of hintable clocks, in the order of the register fields",
+        )
+        return st
+
+    def fill_dt_ip(self, m) -> Dict:
+        sw_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.sw_clks()):
+            sw_clks[str(idx)] = Name.from_snake_case(clk["module"])
+        hint_clks = {}
+        for (idx, clk) in enumerate(self.ipconfig.hint_clks()):
+            hint_clks[str(idx)] = Name.from_snake_case(clk["module"])
+
+        return {
+            self.SW_CLOCKS_FIELD_NAME: sw_clks,
+            self.HINT_CLOCKS_FIELD_NAME: hint_clks,
+        }
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        sw_clk_count = len(self.ipconfig.sw_clks())
+        hint_clk_count = len(self.ipconfig.hint_clks())
+
+        if pos == Extension.DtIpPos.HeaderEnd:
+            return HEADER_EXT_TEMPLATE
+        elif pos == Extension.DtIpPos.SourceEnd:
+            subs = {
+                'sw_clk_count': sw_clk_count,
+                'hint_clk_count': hint_clk_count,
+            }
+            return SOURCE_EXT_TEMPLATE % subs
+        else:
+            return ""

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/util/ipconfig.py
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/util/ipconfig.py
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""
+This contains a class to access the clkmgr's configuration from its ipconfig
+files.
+"""
+from typing import List, Dict
+
+
+class ClkmgrIpConfig:
+    def __init__(self, ipconfig: object):
+        """
+        Initialize an `IpConfig` from an already loaded and parsed `ipconfig.hjson`
+        file, as well as a top configuration.
+        """
+        self.param_values = ipconfig["param_values"]
+
+    def sw_clks(self) -> List[Dict]:
+        """
+        Return the list of software controllable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["sw_clks"].values()
+        ]
+
+    def hint_clks(self) -> List[Dict]:
+        """
+        Return the list of hintable clocks: each clock is described by a
+        dictionary with the following fields:
+        - `src`: clock source
+        - `module`: the module whose clock is controlled.
+
+        The list is ordered as in the description.
+        """
+        return [
+            {
+                "src": clk["src_name"],
+                "module": clk["endpoint_ip"],
+            }
+            for clk in self.param_values["typed_clocks"]["hint_clks"].values()
+        ]

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -145,6 +145,28 @@ dif_result_t dif_clkmgr_jitter_set_enabled(const dif_clkmgr_t *clkmgr,
   return kDifOk;
 }
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_find_gateable_clock(
+    const dif_clkmgr_t *clkmgr, dt_instance_id_t inst_id,
+    dif_clkmgr_gateable_clock_t *clock) {
+  if (clkmgr == NULL || clock == NULL) {
+    return kDifBadArg;
+  }
+  dt_clkmgr_t dt;
+  dif_result_t res = dif_clkmgr_get_dt(clkmgr, &dt);
+  if (res != kDifOk) {
+    return res;
+  }
+  // Query the DT to find the information.
+  for (size_t i = 0; i < dt_clkmgr_gateable_clock_count(dt); i++) {
+    if (dt_clkmgr_gateable_clock(dt, i) == inst_id) {
+      *clock = i;
+      return kDifOk;
+    }
+  }
+  return kDifError;
+}
+
 dif_result_t dif_clkmgr_gateable_clock_get_enabled(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_gateable_clock_t clock,
     dif_toggle_t *state) {
@@ -176,6 +198,28 @@ dif_result_t dif_clkmgr_gateable_clock_set_enabled(
                       clk_enables_val);
 
   return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_find_hintable_clock(
+    const dif_clkmgr_t *clkmgr, dt_instance_id_t inst_id,
+    dif_clkmgr_hintable_clock_t *clock) {
+  if (clkmgr == NULL || clock == NULL) {
+    return kDifBadArg;
+  }
+  dt_clkmgr_t dt;
+  dif_result_t res = dif_clkmgr_get_dt(clkmgr, &dt);
+  if (res != kDifOk) {
+    return res;
+  }
+  // Query the DT to find the information.
+  for (size_t i = 0; i < dt_clkmgr_hintable_clock_count(dt); i++) {
+    if (dt_clkmgr_hintable_clock(dt, i) == inst_id) {
+      *clock = i;
+      return kDifOk;
+    }
+  }
+  return kDifError;
 }
 
 dif_result_t dif_clkmgr_hintable_clock_get_enabled(

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -221,6 +221,31 @@ dif_result_t dif_clkmgr_jitter_set_enabled(const dif_clkmgr_t *clkmgr,
                                            dif_toggle_t new_state);
 
 /**
+ * Obtain the index of a gateable clock for a device.
+ *
+ * Given a module instance (identified by its instance ID), return the
+ * index of the gateable clock which controls this device and can be used
+ * with the clkmgr DIF.
+ *
+ * Example (find gateable clock of UART0):
+ * ```c
+ * dif_clkmgr_gateable_clock_t clock;
+ * CHECK_DIF_OK(dif_clkmgr_find_gateable_clock(
+ *     clkmgr, kDtInstanceIdUart0, &clock));
+ * ```
+ *
+ * @param clkmgr A clock manager handle.
+ * @param inst_id An instance ID.
+ * @param[out] clock The index of the clock.
+ * @return `kDifError` if no gateable clock matches the description,
+ * `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_find_gateable_clock(const dif_clkmgr_t *clkmgr,
+                                            dt_instance_id_t inst_id,
+                                            dif_clkmgr_gateable_clock_t *clock);
+
+/**
  * Check if a Gateable Clock is Enabled or Disabled.
  *
  * @param clkmgr Clock Manager Handle.
@@ -245,6 +270,31 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_gateable_clock_set_enabled(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_gateable_clock_t clock,
     dif_toggle_t new_state);
+
+/**
+ * Obtain the index of a hintable clock for a device.
+ *
+ * Given a module instance (identified by its instance ID), return the
+ * index of the hintable clock which controls this device and can be used
+ * with the clkmgr DIF.
+ *
+ * Example (find hintable clock of KMAC):
+ * ```c
+ * dif_clkmgr_hintable_clock_t clock;
+ * CHECK_DIF_OK(dif_clkmgr_find_hintable_clock(
+ *     clkmgr, kDtInstanceIdKmac, &clock));
+ * ```
+ *
+ * @param clkmgr A clock manager handle.
+ * @param inst_id An instance ID.
+ * @param[out] clock The index of the clock.
+ * @return `kDifError` if no hintable clock matches the description,
+ * `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_find_hintable_clock(const dif_clkmgr_t *clkmgr,
+                                            dt_instance_id_t inst_id,
+                                            dif_clkmgr_hintable_clock_t *clock);
 
 /**
  * Check if a Hintable Clock is Enabled or Disabled.


### PR DESCRIPTION
This extension provides the list of gateable and hintable clocks.

**Design of the clkmgr extension**

An important information needed to operate the clkmgr is the list of software gateable and hintable clocks. With the DT information, exposing the information is easy:

- it is possible to query the number of software gateable/hintable clocks,
- it is possible to query for clock which module instance it controls.

The API looks like this:
```c
/**
 * Get the number of software gateable clocks.
 *
 * @param dt Instance of clkmgr.
 * @return Number of gateable clocks.
 */
size_t dt_clkmgr_sw_clock_count(dt_clkmgr_t dt);

/**
 * Get the instance ID of a gateable clock.
 *
 * The wakeup sources are ordered as they appear in the registers.
 *
 * @param dt Instance of clkmgr.
 * @param idx Index of the gateable clock, between 0 and `dt_clkmgr_sw_clock_count(dt)-1`.
 * @return Instance ID of the device whose clock is gateable.
 */
dt_instance_id_t dt_clkmgr_sw_clock(dt_clkmgr_t dt, size_t idx);

/**
 * Get the number of software hintable clocks.
 *
 * @param dt Instance of clkmgr.
 * @return Number of hintale clocks.
 */
size_t dt_clkmgr_hint_clock_count(dt_clkmgr_t dt);

/**
 * Get the instance ID of a hintable clock.
 *
 * The wakeup sources are ordered as they appear in the registers.
 *
 * @param dt Instance of clkmgr.
 * @param idx Index of the hintable clock, between 0 and `dt_clkmgr_hint_clock_count(dt)-1`.
 * @return Instance ID of the device whose clock is hintable.
 */
dt_instance_id_t dt_clkmgr_hint_clock(dt_clkmgr_t dt, size_t idx);
```
Under the hood, this is just a simple table (earlgrey example):
```c
static const dt_desc_clkmgr_t clkmgr_desc[kDtClkmgrCount] = {
  [kDtClkmgrAon] = {
    .inst_id = kDtInstanceIdClkmgrAon,
    // fields omitted
    .ext = {
      .sw_clks = {
        [0] = kDtInstanceIdUart0,
        [1] = kDtInstanceIdSpiDevice,
        [2] = kDtInstanceIdSpiHost0,
        [3] = kDtInstanceIdUsbdev,
      },
      .hint_clks = {
        [0] = kDtInstanceIdAes,
        [1] = kDtInstanceIdHmac,
        [2] = kDtInstanceIdKmac,
        [3] = kDtInstanceIdOtbn,
      },
    },
  },
};
```