### PR TITLE
[gpio] Delay sampling of GPIO inputs to accommodate synchronizers

### DIFF
--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -49,6 +49,11 @@ static const uint32_t kGpioVals[] = {0xAAAAAAAA, 0x55555555, 0xA5A5A5A5,
 static void test_gpio_write(uint32_t write_val, uint32_t compare_mask) {
   CHECK_DIF_OK(dif_gpio_write_all(&gpio, write_val));
 
+  // The GPIO output signals are routed through pinmux back to the GPIO block
+  // and there are synchronizers involved so the inputs may not be available
+  // immediately, and may in fact arrive at different times.
+  busy_spin_micros(1);
+
   uint32_t read_val = 0;
   CHECK_DIF_OK(dif_gpio_read_all(&gpio, &read_val));
 


### PR DESCRIPTION
The inputs were being sampled too soon in `test_gpio_write` on the expectation that the outputs would all be visible at the GPIO inputs almost immediately, and that all inputs would change simultaneously. Even in DV simulation that is not the case because the CDC modeling introduces single-cycle latency on a random subset of the input signals.

Introduce a single microsecond delay which, for all practical clock frequencies, will ensure that the inputs have stabilized by the time they are sampled.