### PR TITLE
[ownership, rescue] Fix errors

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -183,6 +183,7 @@ enum module_ {
   X(kErrorXModemUnknown,              ERROR_(9, kModuleXModem, kUnknown)), \
   X(kErrorXModemProtocol,             ERROR_(10, kModuleXModem, kInvalidArgument)), \
   X(kErrorXModemTooManyErrors,        ERROR_(11, kModuleXModem, kFailedPrecondition)), \
+  X(kErrorXModemBadLength,            ERROR_(12, kModuleXModem, kInvalidArgument)), \
   \
   /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
   X(kErrorRomExtInterrupt,            ERROR_(0, kModuleRomExtInterrupt, kUnknown)), \

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -145,8 +145,13 @@ rom_error_t owner_block_flash_info_check(
   if (info->header.length < sizeof(owner_flash_info_config_t)) {
     return kErrorOwnershipInvalidTagLength;
   }
-  size_t len = (info->header.length - sizeof(owner_flash_info_config_t)) /
-               sizeof(owner_info_page_t);
+  size_t len = (info->header.length - sizeof(owner_flash_info_config_t));
+  // Determine if the non-header length is an even multiple of the per-page
+  // configuration item size.
+  if (len % sizeof(owner_info_page_t) != 0) {
+    return kErrorOwnershipInvalidTagLength;
+  }
+  len /= sizeof(owner_info_page_t);
   const owner_info_page_t *config = info->config;
   for (size_t i = 0; i < len; ++i, ++config) {
     if (is_owner_page(config) != kHardenedBoolTrue) {
@@ -280,8 +285,13 @@ rom_error_t owner_block_flash_check(const owner_flash_config_t *flash) {
   if (flash->header.length < sizeof(owner_flash_config_t)) {
     return kErrorOwnershipInvalidTagLength;
   }
-  size_t len = (flash->header.length - sizeof(owner_flash_config_t)) /
-               sizeof(owner_flash_region_t);
+  size_t len = (flash->header.length - sizeof(owner_flash_config_t));
+  // Determine if the non-header length is an even multiple of the per-region
+  // configuration item size.
+  if (len % sizeof(owner_flash_region_t) != 0) {
+    return kErrorOwnershipInvalidTagLength;
+  }
+  len /= sizeof(owner_flash_region_t);
   if (len > kProtectSlots - kRomExtRegions) {
     return kErrorOwnershipFlashConfigLength;
   }
@@ -491,7 +501,7 @@ rom_error_t owner_block_rescue_apply(const owner_rescue_config_t *rescue) {
 
 rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
                                    uint32_t key_id, size_t *index) {
-  for (size_t i = 0; i < keyring->length; ++i) {
+  for (size_t i = 0; i < keyring->length && i < ARRAYSIZE(keyring->key); ++i) {
     uint32_t id = keyring->key[i]->data.id;
     if ((keyring->key[i]->key_alg & kOwnershipKeyAlgCategoryMask) ==
         kOwnershipKeyAlgCategoryHybrid) {

--- a/sw/device/silicon_creator/lib/ownership/owner_verify.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_verify.c
@@ -57,7 +57,7 @@ static rom_error_t owner_spx_verify(
   sigverify_spx_root_t actual_root;
   sigverify_spx_root_t expected_root;
   spx_public_key_root(key->data, expected_root.data);
-  size_t i;
+  uint32_t i;
   for (i = 0; launder32(i) < kSigverifySpxRootNumWords; ++i) {
     expected_root.data[i] ^= shares[i];
   }

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -93,8 +93,9 @@ static rom_error_t protocol(rescue_state_t *state, boot_data_t *bootdata) {
   xmodem_recv_start(iohandle);
   while (true) {
     HARDENED_RETURN_IF_ERROR(handle_send_modes(state, bootdata));
-    result = xmodem_recv_frame(iohandle, state->frame,
-                               state->data + state->offset, &rxlen, &command);
+    result = xmodem_recv_frame(
+        iohandle, state->frame, state->data + state->offset,
+        sizeof(state->data) - state->offset, &rxlen, &command);
     if (state->frame == 1 && result == kErrorXModemTimeoutStart) {
       xmodem_recv_start(iohandle);
       continue;

--- a/sw/device/silicon_creator/lib/rescue/xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/xmodem.c
@@ -83,7 +83,8 @@ void xmodem_ack(void *iohandle, bool ack) {
 }
 
 rom_error_t xmodem_recv_frame(void *iohandle, uint32_t frame, uint8_t *data,
-                              size_t *rxlen, uint8_t *unknown_rx) {
+                              size_t len_available, size_t *rxlen,
+                              uint8_t *unknown_rx) {
   uint8_t ch;
   size_t n = xmodem_read(iohandle, &ch, sizeof(ch), kXModemLongTimeout);
   if (n == 0) {
@@ -92,6 +93,10 @@ rom_error_t xmodem_recv_frame(void *iohandle, uint32_t frame, uint8_t *data,
     // Determine if we should expect a 1K or 128 byte block.
     size_t len = ch == kXModemStx ? 1024 : 128;
     uint8_t pkt[2];
+
+    if (len > len_available) {
+      return kErrorXModemBadLength;
+    }
 
     // Get the frame number and its inverse.
     n = xmodem_read(iohandle, pkt, sizeof(pkt), kXModemShortTimeout);

--- a/sw/device/silicon_creator/lib/rescue/xmodem.h
+++ b/sw/device/silicon_creator/lib/rescue/xmodem.h
@@ -35,12 +35,14 @@ void xmodem_cancel(void *iohandle);
  * @param iohandle An opaque user point associated with the io device.
  * @param frame The frame number expected (start at 1).
  * @param data Buffer to receive the data into.
+ * @param len_available Available space in the data buffer.
  * @param rxlen The length of data recieved.
  * @param unknown_rx The byte received when the error is kErrorXmodemUnknown.
  * @return Error value.
  */
 rom_error_t xmodem_recv_frame(void *iohandle, uint32_t frame, uint8_t *data,
-                              size_t *rxlen, uint8_t *unknown_rx);
+                              size_t len_available, size_t *rxlen,
+                              uint8_t *unknown_rx);
 
 /**
  * Send data using Xmodem-CRC.

--- a/sw/host/tests/xmodem/xmodem.rs
+++ b/sw/host/tests/xmodem/xmodem.rs
@@ -86,6 +86,7 @@ impl XmodemFirmware {
                     io,
                     frame,
                     buf.as_mut_ptr(),
+                    buf.len(),
                     &mut rxlen as *mut usize,
                     &mut unknown_rx as *mut u8,
                 ))


### PR DESCRIPTION
1. A loop variable of type `size_t` was being passed to `launder32` which accepts `uint32_t`.
2. There was a potential out-of-bounds access when receiving an xmodem frame.  Check that the buffer has enough space to receive the next frame.