### PR TITLE
[silicon_creator] Add a small USB driver 

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -719,4 +719,35 @@ class SignConverter {
 // need to be saved.  The two that do not are `sp` and `gp` (x2 and x3).
 #define OT_CONTEXT_SIZE (OT_WORD_SIZE * 30)
 
+/**
+ * A macro that returns the minimum of two values.
+ *
+ * @param a First value.
+ * @param b Second value.
+ */
+#ifndef MIN
+#define MIN(a, b)       \
+  ({                    \
+    typeof(a) _a = (a); \
+    typeof(b) _b = (b); \
+    _a < _b ? _a : _b;  \
+  })
+#endif
+
+/**
+ * A macro that returns the maximum of two values.
+ *
+ * @param a First value.
+ * @param b Second value.
+ *
+ */
+#ifndef MAX
+#define MAX(a, b)       \
+  ({                    \
+    typeof(a) _a = (a); \
+    typeof(b) _b = (b); \
+    _a > _b ? _a : _b;  \
+  })
+#endif
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -14,10 +14,12 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
     "fpga_params",
     "opentitan_test",
     "qemu_params",
+    "silicon_params",
     "verilator_params",
 )
 
@@ -921,5 +923,60 @@ cc_library(
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+    ],
+)
+
+cc_library(
+    name = "usb",
+    srcs = [
+        "stdusb.c",
+        "usb.c",
+    ],
+    hdrs = [
+        "stdusb.h",
+        "usb.h",
+    ],
+    deps = [
+        "//hw/ip/usbdev/data:usbdev_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+opentitan_test(
+    name = "usb_functest",
+    srcs = ["usb_functest.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    fpga = fpga_params(
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/usb:silicon_creator_harness",
+    ),
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --vbus-sense-en=VBUS_SENSE_EN
+            --vbus-sense=VBUS_SENSE
+        """,
+        test_harness = "//sw/host/tests/chip/usb:silicon_creator_harness",
+    ),
+    verilator = verilator_params(
+        timeout = "long",
+        tags = ["broken"],
+    ),
+    deps = [
+        ":hmac",
+        ":pinmux",
+        ":rnd",
+        ":usb",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -201,6 +201,12 @@ void pinmux_init(void) {
   configure_output(kOutputUart0);
 }
 
+void pinmux_init_usb(void) {
+  // TODO: This might need to depend on sku-specific configuration.
+  pinmux_configure_input(kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+                         kTopEarlgreyPinmuxInselConstantOne);
+}
+
 uint32_t pinmux_read_straps(void) {
   uint32_t value = 0;
   value |= read_strap_pin(kInputSwStrap0);

--- a/sw/device/silicon_creator/lib/drivers/pinmux.h
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.h
@@ -75,6 +75,13 @@ uint32_t pinmux_read_straps(void);
  */
 bool pinmux_read_gpio(uint32_t gpio);
 
+/**
+ * Initialize the USB sense pin.
+ *
+ * This connects the UsbdevSense input to InselConstantOne.
+ */
+void pinmux_init_usb(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/stdusb.c
+++ b/sw/device/silicon_creator/lib/drivers/stdusb.c
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/stdusb.h"
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+
+static uint16_t zero;
+static uint16_t status;
+
+rom_error_t usb_control_setupdata(usb_control_ctx_t *ctx,
+                                  usb_setup_data_t *setup) {
+  rom_error_t result = kErrorUsbBadSetup;
+  switch (setup->request) {
+    case kUsbSetupReqGetDescriptor:
+      switch (setup->value >> 8) {
+        case kUsbDescTypeDevice:
+          return usb_ep_transfer(
+              kUsbDirIn | 0, (void *)ctx->device_desc,
+              (size_t)MIN(setup->length, ctx->device_desc->length), 0);
+        case kUsbDescTypeConfiguration: {
+          usb_configuration_descriptor_t *cfg =
+              (usb_configuration_descriptor_t *)ctx->config_desc;
+          return usb_ep_transfer(kUsbDirIn | 0, cfg,
+                                 (size_t)MIN(setup->length, cfg->total_length),
+                                 0);
+        }
+        case kUsbDescTypeString: {
+          size_t index = setup->value & 0xFF;
+          size_t n = 0;
+          while (ctx->string_desc[n] != NULL) {
+            ++n; /* count number of string descriptor */
+          }
+          if (index < n) {
+            return usb_ep_transfer(
+                kUsbDirIn | 0, (void *)ctx->string_desc[index],
+                (size_t)MIN(setup->length, ctx->string_desc[index][0]), 0);
+          }
+          break;
+        }
+        default:
+            /* nothing */;
+      }
+      break;
+
+    case kUsbSetupReqSetAddress:
+      // Note: You must handle SetAddress in your control endpoint
+      // callback after receiving notification that the transfer has
+      // completed (e.g. `kUsbTransferFlagsDone`).
+      ctx->next.device_address = (uint8_t)setup->value & 0x7f;
+      usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+      ctx->flags |= kUsbControlFlagsPendingAddress;
+      return kErrorOk;
+
+    case kUsbSetupReqSetConfiguration:
+      // Note: You must handle SetConfiguration in your control endpoint
+      // callback after returning from this function.
+      // - If you're able to handle the SetConfiguration request without
+      //   error, you must ack the transaction with a zero-length packet,
+      //   such as: `usb_ep_transfer(0, NULL, 0, kUsbTransferFlagsIn)
+      // - If you're unable to handle the SetConfiguration request,
+      //   you must stall: `usb_ep_stall(0)`.
+      usb_clear_all_toggles();
+      ctx->next.configuration = (uint8_t)setup->value;
+      ctx->flags |= kUsbControlFlagsPendingConfig;
+      return kErrorOk;
+
+    case kUsbSetupReqGetConfiguration:
+      return usb_ep_transfer(kUsbDirIn | 0, &ctx->configuration,
+                             sizeof(ctx->configuration), 0);
+
+    case kUsbSetupReqSetFeature:
+      switch (setup->value) {
+        case kUsbFeatureEndpointHalt:
+          RETURN_IF_ERROR(usb_ep_stall((uint8_t)setup->index, true));
+          return usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+        default:
+            /* nothing */;
+      }
+      break;
+
+    case kUsbSetupReqClearFeature:
+      switch (setup->value) {
+        case kUsbFeatureEndpointHalt:
+          usb_ep_clear_toggle((uint8_t)setup->index);
+          RETURN_IF_ERROR(usb_ep_stall((uint8_t)setup->index, false));
+          return usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+        default:
+            /* nothing */;
+      }
+      break;
+
+    case kUsbSetupReqGetStatus: {
+      uint8_t type = setup->request_type & kUsbReqTypeRecipientMask;
+      if (type == kUsbReqTypeDevice) {
+        status = kUsbStatusSelfPowered;
+      } else if (type == kUsbReqTypeEndpoint) {
+        bool halted;
+        usb_ep_stalled((uint8_t)setup->index, &halted);
+        status = halted ? kUsbStatusHalted : 0;
+      }
+      return usb_ep_transfer(kUsbDirIn | 0, &status, sizeof(status), 0);
+    }
+
+    case kUsbSetupReqSetInterface:
+      // We currently don't support alternate interfaces, so just ignore
+      // and send zero length packet for status phase.
+      return usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+
+    case kUsbSetupReqGetInterface:
+      return usb_ep_transfer(kUsbDirIn | 0, &zero, 1, 0);
+
+    case kUsbSetupReqSynchFrame:
+      return usb_ep_transfer(kUsbDirIn | 0, &zero, 2, 0);
+
+    default:
+        /* nothing */;
+  }
+  return result;
+}

--- a/sw/device/silicon_creator/lib/drivers/stdusb.h
+++ b/sw/device/silicon_creator/lib/drivers/stdusb.h
@@ -1,0 +1,298 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_STDUSB_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_STDUSB_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// SETUP requests
+typedef enum usb_setup_req {
+  kUsbSetupReqGetStatus = 0,
+  kUsbSetupReqClearFeature = 1,
+  kUsbSetupReqSetFeature = 3,
+  kUsbSetupReqSetAddress = 5,
+  kUsbSetupReqGetDescriptor = 6,
+  kUsbSetupReqSetDescriptor = 7,
+  kUsbSetupReqGetConfiguration = 8,
+  kUsbSetupReqSetConfiguration = 9,
+  kUsbSetupReqGetInterface = 10,
+  kUsbSetupReqSetInterface = 11,
+  kUsbSetupReqSynchFrame = 12
+} usb_setup_req_t;
+
+typedef enum usb_req_type {  // bmRequestType
+  kUsbReqTypeRecipientMask = 0x1f,
+  kUsbReqTypeDevice = 0,
+  kUsbReqTypeInterface = 1,
+  kUsbReqTypeEndpoint = 2,
+  kUsbReqTypeOther = 3,
+  kUsbReqTypeTypeMask = 0x60,
+  kUsbReqTypeStandard = 0,
+  kUsbReqTypeClass = 0x20,
+  kUsbReqTypeVendor = 0x40,
+  kUsbReqTypeReserved = 0x60,
+  kUsbReqTypeDirMask = 0x80,
+  kUsbReqTypeDirHostToDev = 0x00,
+  kUsbReqTypeDirDevToHost = 0x80,
+} usb_req_type_t;
+
+typedef enum usb_desc_type {  // Descriptor type (wValue hi)
+  kUsbDescTypeDevice = 1,
+  kUsbDescTypeConfiguration,
+  kUsbDescTypeString,
+  kUsbDescTypeInterface,
+  kUsbDescTypeEndpoint,
+  kUsbDescTypeDeviceQualifier,
+  kUsbDescTypeOtherSpeedConfiguration,
+  kUsbDescTypeInterfacePower,
+} usb_desc_type_t;
+
+typedef enum usb_feature_req {
+  kUsbFeatureEndpointHalt = 0,        // recipient is endpoint
+  kUsbFeatureDeviceRemoteWakeup = 1,  // recipient is device
+  kUsbFeatureTestMode = 2,            // recipient is device
+  kUsbFeatureBHnpEnable = 3,          // recipient is device only if OTG
+  kUsbFeatureAHnpSupport = 4,         // recipient is device only if OTG
+  kUsbFeatureAAltHnpSupport = 5       // recipient is device only if OTG
+} usb_feature_req_t;
+
+typedef enum usb_status {
+  kUsbStatusSelfPowered = 1,  // Device status request
+  kUsbStatusRemWake = 2,      // Device status request
+  kUsbStatusHalted = 1        // Endpoint status request
+} usb_status_t;
+
+typedef struct usb_setup_data {
+  uint8_t request_type;
+  uint8_t request;
+  uint16_t value;
+  uint16_t index;
+  uint16_t length;
+} usb_setup_data_t;
+OT_ASSERT_MEMBER_OFFSET(usb_setup_data_t, request_type, 0);
+OT_ASSERT_MEMBER_OFFSET(usb_setup_data_t, request, 1);
+OT_ASSERT_MEMBER_OFFSET(usb_setup_data_t, value, 2);
+OT_ASSERT_MEMBER_OFFSET(usb_setup_data_t, index, 4);
+OT_ASSERT_MEMBER_OFFSET(usb_setup_data_t, length, 6);
+OT_ASSERT_SIZE(usb_setup_data_t, 8);
+
+typedef struct usb_device_descriptor {
+  uint8_t length;
+  uint8_t descriptor_type;
+  uint16_t bcd_usb;
+  uint8_t device_class;
+  uint8_t device_sub_class;
+  uint8_t device_protocol;
+  uint8_t max_packet_size_0;
+  uint16_t vendor;
+  uint16_t product;
+  uint16_t bcd_device;
+  uint8_t imanufacturer;
+  uint8_t iproduct;
+  uint8_t iserial_number;
+  uint8_t num_configurations;
+} usb_device_descriptor_t;
+
+typedef struct usb_configuration_descriptor {
+  uint8_t length;
+  uint8_t descriptor_type;
+  uint16_t total_length;
+  uint8_t num_interfaces;
+  uint8_t configuration_value;
+  uint8_t iconfiguration;
+  uint8_t attributes;
+  uint8_t max_power;
+} usb_configuration_descriptor_t;
+
+typedef struct usb_interface_descriptor {
+  uint8_t length;
+  uint8_t descriptor_type;
+  uint8_t interface_number;
+  uint8_t alternate_setting;
+  uint8_t num_endpoints;
+  uint8_t interface_class;
+  uint8_t interface_sub_class;
+  uint8_t interface_protocol;
+  uint8_t iinterface;
+} usb_interface_descriptor_t;
+
+typedef struct usb_endpoint_descriptor {
+  uint8_t length;
+  uint8_t descriptor_type;
+  uint8_t endpoint_address;
+  uint8_t attributes;
+  uint16_t max_packet_size;
+  uint8_t interval;
+} usb_endpoint_descriptor_t;
+
+typedef struct usb_string_descriptor {
+  uint8_t length;
+  uint8_t descriptor_type;
+  uint16_t string[];
+} usb_string_descriptor_t;
+
+typedef enum usb_control_flags {
+  kUsbControlFlagsPendingAddress = 1,
+  kUsbControlFlagsPendingConfig = 2,
+} usb_control_flags_t;
+
+typedef struct usb_control_ctx {
+  usb_control_flags_t flags;
+  uint8_t device_address;
+  uint8_t configuration;
+  struct {
+    uint8_t device_address;
+    uint8_t configuration;
+  } next;
+  const usb_device_descriptor_t *device_desc;
+  const uint8_t *config_desc;
+  const char **string_desc;
+} usb_control_ctx_t;
+
+/**
+ * Handle standard USB requests for endpoint zero.
+ *
+ * @param ctx A pointer to a usb_control_ctx_t.
+ * @param setup A pointer to a SETUPDATA request to process.
+ * @return kErrorOk if handled, kErrorUsbBadSetup if a stall is needed.
+ *
+ * Notes: The caller has responsibilities upon observing certain bits
+ * set in usb_control_flags_t.
+ *
+ * 1. If you observe kUsbControlFlagsPendingAddress, you need to set the device
+ *    address in your control endpoint callback after the control transaction
+ *    has completed (e.g. `kUsbTransferFlagsDone`).
+ *
+ * 2. If you observe kUsbControlFlagsPendingConfig, you need to transition to
+ *    the new configuration in your control endpoint callback and finish the
+ *    control transaction.
+ *    - If you're able to handle the SetConfiguration request without
+ *      error, you must ack the transaction with a zero-length packet,
+ *      such as: `usb_ep_transfer(0, NULL, 0, kUsbTransferFlagsIn)
+ *    - If you're unable to handle the SetConfiguration request,
+ *      you must stall: `usb_ep_stall(0)`.
+ */
+rom_error_t usb_control_setupdata(usb_control_ctx_t *ctx,
+                                  usb_setup_data_t *setup);
+
+/**
+ * Macros to help with constructing the config descriptor.
+ */
+#define USB_CFG_DSCR_LEN 9
+#define USB_CFG_DSCR_HEAD(total_len, nint)                                   \
+  /* This is the actual configuration descriptor                 */          \
+  USB_CFG_DSCR_LEN,     /* bLength                                   */      \
+      2,                /* bDescriptorType                           */      \
+      (total_len)&0xff, /* wTotalLength[0]                           */      \
+      (total_len) >> 8, /* wTotalLength[1]                           */      \
+      (nint),           /* bNumInterfaces                            */      \
+      1,                /* bConfigurationValue                       */      \
+      0,                /* iConfiguration                            */      \
+      0xC0,             /* bmAttributes: must-be-one, self-powered   */      \
+      50 /* bMaxPower                                 */ /* MUST be followed \
+                                                            by (nint)        \
+                                                            Interface +      \
+                                                            Endpoint         \
+                                                            Descriptors */
+
+// KEEP BLANK LINE ABOVE, it is in the macro!
+
+#define USB_INTERFACE_DSCR_LEN 9
+#define USB_INTERFACE_DSCR(inum, alt, nep, class_, subclass, protocol, iint)   \
+  /* interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12 */         \
+  USB_INTERFACE_DSCR_LEN,            /* bLength                             */ \
+      4,                             /* bDescriptorType                     */ \
+      (inum),                        /* bInterfaceNumber                    */ \
+      (alt),                         /* bAlternateSetting                   */ \
+      (nep),                         /* bNumEndpoints                       */ \
+      (class_),                      /* bInterfaceClass (Vendor Specific)   */ \
+      (subclass),                    /* bInterfaceSubClass                  */ \
+      (protocol),                    /* bInterfaceProtocol                  */ \
+      (iint) /* iInterface        */ /* MUST be followed by                    \
+                                        (nep) Endpoint                         \
+                                        Descriptors */
+
+// KEEP BLANK LINE ABOVE, it is in the macro!
+
+#define USB_EP_DSCR_LEN 7
+#define USB_EP_DSCR(in, ep, attr, maxsize, interval)                          \
+  /* endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13   */       \
+  USB_EP_DSCR_LEN,                 /* bLength                              */ \
+      5,                           /* bDescriptorType                      */ \
+      (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
+      attr,                        /* bmAttributes                         */ \
+      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
+      (interval)                   /* bInterval                            */
+
+// KEEP BLANK LINE ABOVE, it is in the macro!
+#define USB_BULK_EP_DSCR(in, ep, maxsize, interval)                           \
+  /* endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13   */       \
+  USB_EP_DSCR_LEN,                 /* bLength                              */ \
+      5,                           /* bDescriptorType                      */ \
+      (ep) | (((in) << 7) & 0x80), /* bEndpointAddress, top bit set for IN */ \
+      0x02,                        /* bmAttributes (0x02=bulk, data)       */ \
+      (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
+      (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
+      (interval)                   /* bInterval                            */
+
+// KEEP BLANK LINE ABOVE, it is in the macro!
+
+/**
+ * A macro to help with constructing small (less than 32 chars) string
+ * descriptors.
+ */
+#define USB_STRING_DSCR(...)                                        \
+  2 + OT_VA_ARGS_COUNT(dummy, ##__VA_ARGS__) * 2,                   \
+      3 /* Missing comma intentional */                             \
+      OT_CAT(OT_CAT(USB_CHAR_, OT_VA_ARGS_COUNT(0, ##__VA_ARGS__)), \
+             _)(__VA_ARGS__)
+
+#define USB_CHAR_1_(x) , x, 0
+#define USB_CHAR_2_(x, ...) , x, 0 USB_CHAR_1_(__VA_ARGS__)
+#define USB_CHAR_3_(x, ...) , x, 0 USB_CHAR_2_(__VA_ARGS__)
+#define USB_CHAR_4_(x, ...) , x, 0 USB_CHAR_3_(__VA_ARGS__)
+#define USB_CHAR_5_(x, ...) , x, 0 USB_CHAR_4_(__VA_ARGS__)
+#define USB_CHAR_6_(x, ...) , x, 0 USB_CHAR_5_(__VA_ARGS__)
+#define USB_CHAR_7_(x, ...) , x, 0 USB_CHAR_6_(__VA_ARGS__)
+#define USB_CHAR_8_(x, ...) , x, 0 USB_CHAR_7_(__VA_ARGS__)
+#define USB_CHAR_9_(x, ...) , x, 0 USB_CHAR_8_(__VA_ARGS__)
+#define USB_CHAR_10_(x, ...) , x, 0 USB_CHAR_9_(__VA_ARGS__)
+#define USB_CHAR_11_(x, ...) , x, 0 USB_CHAR_10_(__VA_ARGS__)
+#define USB_CHAR_12_(x, ...) , x, 0 USB_CHAR_11_(__VA_ARGS__)
+#define USB_CHAR_13_(x, ...) , x, 0 USB_CHAR_12_(__VA_ARGS__)
+#define USB_CHAR_14_(x, ...) , x, 0 USB_CHAR_13_(__VA_ARGS__)
+#define USB_CHAR_15_(x, ...) , x, 0 USB_CHAR_14_(__VA_ARGS__)
+#define USB_CHAR_16_(x, ...) , x, 0 USB_CHAR_15_(__VA_ARGS__)
+#define USB_CHAR_17_(x, ...) , x, 0 USB_CHAR_16_(__VA_ARGS__)
+#define USB_CHAR_18_(x, ...) , x, 0 USB_CHAR_17_(__VA_ARGS__)
+#define USB_CHAR_19_(x, ...) , x, 0 USB_CHAR_18_(__VA_ARGS__)
+#define USB_CHAR_20_(x, ...) , x, 0 USB_CHAR_19_(__VA_ARGS__)
+#define USB_CHAR_21_(x, ...) , x, 0 USB_CHAR_20_(__VA_ARGS__)
+#define USB_CHAR_22_(x, ...) , x, 0 USB_CHAR_21_(__VA_ARGS__)
+#define USB_CHAR_23_(x, ...) , x, 0 USB_CHAR_22_(__VA_ARGS__)
+#define USB_CHAR_24_(x, ...) , x, 0 USB_CHAR_23_(__VA_ARGS__)
+#define USB_CHAR_25_(x, ...) , x, 0 USB_CHAR_24_(__VA_ARGS__)
+#define USB_CHAR_26_(x, ...) , x, 0 USB_CHAR_25_(__VA_ARGS__)
+#define USB_CHAR_27_(x, ...) , x, 0 USB_CHAR_26_(__VA_ARGS__)
+#define USB_CHAR_28_(x, ...) , x, 0 USB_CHAR_27_(__VA_ARGS__)
+#define USB_CHAR_29_(x, ...) , x, 0 USB_CHAR_28_(__VA_ARGS__)
+#define USB_CHAR_30_(x, ...) , x, 0 USB_CHAR_29_(__VA_ARGS__)
+#define USB_CHAR_31_(x, ...) , x, 0 USB_CHAR_30_(__VA_ARGS__)
+#define USB_CHAR_32_(x, ...) , x, 0 USB_CHAR_31_(__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_STDUSB_H_

--- a/sw/device/silicon_creator/lib/drivers/usb.c
+++ b/sw/device/silicon_creator/lib/drivers/usb.c
@@ -1,0 +1,496 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "usbdev_regs.h"
+
+#define USBDEV_NUM_BUFFERS 32
+#define CFG_PIN_FLIP false
+#define CFG_EN_DIFF_RCVR true
+#define CFG_TX_USE_D_SE0 false
+
+enum {
+  kBase = TOP_EARLGREY_USBDEV_BASE_ADDR,
+};
+
+// The buffer_pool is a bitmap of allocated buffers.
+// - One bits represent free buffers.
+// - Zero bits represent allocated buffers.
+static uint32_t buffer_pool;
+
+static inline void buffer_pool_init(void) {
+  // Our hardware has 32 buffers; set all one bits to indicate
+  // all buffers are free.
+  buffer_pool = UINT32_MAX;
+}
+
+static inline void buffer_pool_put(uint8_t id) {
+  HARDENED_CHECK_NE(buffer_pool, UINT32_MAX);
+  buffer_pool |= (1 << id);
+}
+
+static inline uint8_t buffer_pool_get(void) {
+  HARDENED_CHECK_NE(buffer_pool, 0);
+  uint8_t id = (uint8_t)bitfield_find_first_set32((int32_t)buffer_pool) - 1;
+  buffer_pool &= ~(1 << id);
+  return id;
+}
+
+static inline bool buffer_pool_empty(void) { return buffer_pool == 0; }
+
+usb_ep_info_t in_endpoints[USBDEV_PARAM_N_ENDPOINTS];
+usb_ep_info_t out_endpoints[USBDEV_PARAM_N_ENDPOINTS];
+
+// Copy memory into a USB buffer.
+// The USB register space only permits word writes, so we need to handle
+// buffer lengths that are not perfect multiples of the word size.
+// Note: src is required to be word aligned.
+static void copy_to_buffer(uint8_t id, const char *src, size_t len) {
+  uintptr_t buffer = kBase + USBDEV_BUFFER_REG_OFFSET + (uint32_t)id * 64;
+  volatile uint32_t *dst = (volatile uint32_t *)buffer;
+  while (len >= sizeof(uint32_t)) {
+    *dst++ = *(uint32_t *)src;
+    src += sizeof(uint32_t);
+    len -= sizeof(uint32_t);
+  }
+  uint32_t last = 0;
+  uint32_t shift = 0;
+  while (len > 0) {
+    last |= (uint32_t)*src << shift;
+    shift += 8;
+    src += 1;
+    len -= 1;
+  }
+  *dst = last;
+}
+
+// Copy from an USB buffer to memory.
+// The USB register space only permits word writes, so we need to handle
+// buffer lengths that are not perfect multiples of the word size.
+// Note: dst is required to be word aligned.
+static void copy_from_buffer(uint8_t id, char *dst, size_t len) {
+  uintptr_t buffer = kBase + USBDEV_BUFFER_REG_OFFSET + (uint32_t)id * 64;
+  volatile uint32_t *src = (volatile uint32_t *)buffer;
+
+  uint32_t *dst32 = (uint32_t *)dst;
+  while (len >= sizeof(uint32_t)) {
+    *dst32++ = *src++;
+    len -= sizeof(uint32_t);
+  }
+  if (len > 0) {
+    uint32_t last = *src;
+    dst = (char *)dst32;
+    while (len > 0) {
+      *dst++ = (char)last;
+      last >>= 8;
+      len -= 1;
+    }
+  }
+}
+
+// Configure the PHY according the define directives above.
+static void usb_phy_init(void) {
+  uint32_t phy_config = 0;
+  phy_config = bitfield_bit32_write(
+      phy_config, USBDEV_PHY_CONFIG_USE_DIFF_RCVR_BIT, CFG_EN_DIFF_RCVR);
+  phy_config = bitfield_bit32_write(
+      phy_config, USBDEV_PHY_CONFIG_TX_USE_D_SE0_BIT, CFG_TX_USE_D_SE0);
+  phy_config = bitfield_bit32_write(
+      phy_config, USBDEV_PHY_CONFIG_EOP_SINGLE_BIT_BIT, false);
+  phy_config = bitfield_bit32_write(phy_config, USBDEV_PHY_CONFIG_PINFLIP_BIT,
+                                    CFG_PIN_FLIP);
+  abs_mmio_write32(kBase + USBDEV_PHY_CONFIG_REG_OFFSET, phy_config);
+}
+
+// Performa a read/modify/write on a given register.
+static void usbreg_bit(uint32_t offset, uint32_t bit, bool value) {
+  uint32_t reg = abs_mmio_read32(kBase + offset);
+  reg = bitfield_bit32_write(reg, bit, value);
+  abs_mmio_write32(kBase + offset, reg);
+}
+
+// Set or clear STALL on an endpoint.
+rom_error_t usb_ep_stall(uint8_t ep, bool enable) {
+  uint8_t i = ep & kEpNumMask;
+  if (i >= USBDEV_PARAM_N_ENDPOINTS) {
+    return kErrorUsbBadEndpointNumber;
+  }
+  // We check for control endpoints here because control endpoints
+  // do not have the direction bit in their endpoint address.
+  if (ep & kUsbDirIn || in_endpoints[i].type & kUsbEpTypeControl) {
+    usbreg_bit(USBDEV_IN_STALL_REG_OFFSET, i, enable);
+  }
+  if ((ep & kUsbDirIn) == 0) {
+    usbreg_bit(USBDEV_OUT_STALL_REG_OFFSET, i, enable);
+  }
+  return kErrorOk;
+}
+
+void usb_ep_clear_toggle(uint8_t ep) {
+  uint8_t i = ep & kEpNumMask;
+  if (ep & kUsbDirIn) {
+    uint32_t reg =
+        bitfield_bit32_write(0, USBDEV_IN_DATA_TOGGLE_STATUS_OFFSET + i, false);
+    reg =
+        bitfield_bit32_write(reg, USBDEV_IN_DATA_TOGGLE_MASK_OFFSET + i, true);
+    abs_mmio_write32(kBase + USBDEV_IN_DATA_TOGGLE_REG_OFFSET, reg);
+  } else {
+    uint32_t reg = bitfield_bit32_write(
+        0, USBDEV_OUT_DATA_TOGGLE_STATUS_OFFSET + i, false);
+    reg =
+        bitfield_bit32_write(reg, USBDEV_OUT_DATA_TOGGLE_MASK_OFFSET + i, true);
+    abs_mmio_write32(kBase + USBDEV_OUT_DATA_TOGGLE_REG_OFFSET, reg);
+  }
+}
+
+void usb_clear_all_toggles(void) {
+  // We want to clear all endpoint toggles except endpoint zero.
+  uint32_t reg = (USBDEV_IN_DATA_TOGGLE_MASK_MASK & ~1u)
+                 << USBDEV_IN_DATA_TOGGLE_MASK_OFFSET;
+  // The bit layout for the IN and OUT toggle registers is identical.
+  abs_mmio_write32(kBase + USBDEV_IN_DATA_TOGGLE_REG_OFFSET, reg);
+  abs_mmio_write32(kBase + USBDEV_OUT_DATA_TOGGLE_REG_OFFSET, reg);
+}
+
+// Return whether an endpoint is stalled.
+rom_error_t usb_ep_stalled(uint8_t ep, bool *stalled) {
+  uint32_t reg = ep & kUsbDirIn ? abs_mmio_read32(USBDEV_IN_STALL_REG_OFFSET)
+                                : abs_mmio_read32(USBDEV_OUT_STALL_REG_OFFSET);
+  uint8_t i = ep & kEpNumMask;
+  if (i >= USBDEV_PARAM_N_ENDPOINTS) {
+    return kErrorUsbBadEndpointNumber;
+  }
+  *stalled = (reg & (1 << i)) != 0;
+  return kErrorOk;
+}
+
+rom_error_t usb_ep_init(uint8_t ep, usb_ep_type_t type,
+                        uint16_t max_packet_size, handler_t handler,
+                        void *user_ctx) {
+  uint8_t i = ep & kEpNumMask;
+  if (i >= USBDEV_PARAM_N_ENDPOINTS) {
+    return kErrorUsbBadEndpointNumber;
+  }
+  // If this is an OUT endpoint, configure for out transactions,
+  // but don't enable receive (we'll do that in usb_ep_transfer).
+  if ((ep & kUsbDirIn) == 0 || type & kUsbEpTypeControl) {
+    out_endpoints[i].type = type;
+    out_endpoints[i].max_packet_size = max_packet_size;
+    out_endpoints[i].transfer = (usb_transfer_t){0};
+    out_endpoints[i].handler = handler;
+    out_endpoints[i].user_ctx = user_ctx;
+
+    usbreg_bit(USBDEV_EP_OUT_ENABLE_REG_OFFSET, i, true);
+    // FIXME: sometimes protocols want to NAK OUT transactions
+    // while they're busy processing.  Currently, this driver
+    // doesn't support this mode of operation.
+    usbreg_bit(USBDEV_SET_NAK_OUT_REG_OFFSET, i, false);
+    usbreg_bit(USBDEV_RXENABLE_OUT_REG_OFFSET, i, false);
+  }
+  // If this is a CONTROL endpoint (e.g. handles SETUP_DATA),
+  // then enable SETUP and OUT.
+  if (type & kUsbEpTypeControl) {
+    usbreg_bit(USBDEV_RXENABLE_SETUP_REG_OFFSET, i, true);
+  }
+  // If this is an IN endpoint, enable for IN.
+  if ((ep & kUsbDirIn) != 0 || type & kUsbEpTypeControl) {
+    in_endpoints[i].type = type;
+    in_endpoints[i].max_packet_size = max_packet_size;
+    in_endpoints[i].transfer = (usb_transfer_t){0};
+    in_endpoints[i].handler = handler;
+    in_endpoints[i].user_ctx = user_ctx;
+
+    usbreg_bit(USBDEV_EP_IN_ENABLE_REG_OFFSET, i, true);
+  }
+
+  // Clear stall.
+  usb_ep_stall(ep, false);
+  return kErrorOk;
+}
+
+void fill_fifos(void) {
+  while (!buffer_pool_empty()) {
+    uint32_t status = abs_mmio_read32(kBase + USBDEV_USBSTAT_REG_OFFSET);
+    uint32_t av_setup_depth =
+        bitfield_field32_read(status, USBDEV_USBSTAT_AV_SETUP_DEPTH_FIELD);
+    if (av_setup_depth < 2) {
+      // Supply Available SETUP Buffer
+      uint8_t id = buffer_pool_get();
+      abs_mmio_write32(kBase + USBDEV_AVSETUPBUFFER_REG_OFFSET, id);
+    } else {
+      if (bitfield_bit32_read(status, USBDEV_USBSTAT_AV_OUT_FULL_BIT)) {
+        // The available OUT buffer FIFO is full.
+        break;
+      }
+      // Supply Available OUT Buffer
+      uint8_t id = buffer_pool_get();
+      abs_mmio_write32(kBase + USBDEV_AVOUTBUFFER_REG_OFFSET, id);
+    }
+  }
+}
+
+static bool rx_fifo_empty(void) {
+  uint32_t status = abs_mmio_read32(kBase + USBDEV_USBSTAT_REG_OFFSET);
+  return bitfield_bit32_read(status, USBDEV_USBSTAT_RX_EMPTY_BIT);
+}
+
+static void send_packet(uint8_t ep_index) {
+  usb_ep_info_t *endpoint = in_endpoints + ep_index;
+  size_t chunk = endpoint->max_packet_size < endpoint->transfer.len
+                     ? endpoint->max_packet_size
+                     : endpoint->transfer.len;
+  uint8_t buffer = buffer_pool_get();
+
+  if (chunk < endpoint->max_packet_size) {
+    // If the chunk is shorter than the endpoint size, then we can
+    // clear the ShortIn flag.
+    endpoint->transfer.flags &= ~(uint32_t)kUsbTransferFlagsShortIn;
+  }
+  copy_to_buffer(buffer, (char *)endpoint->transfer.data, chunk);
+  endpoint->transfer.data += chunk;
+  endpoint->transfer.len -= chunk;
+
+  uint32_t val = 0;
+  val = bitfield_field32_write(val, USBDEV_CONFIGIN_0_BUFFER_0_FIELD, buffer);
+  val = bitfield_field32_write(val, USBDEV_CONFIGIN_0_SIZE_0_FIELD, chunk);
+
+  // Mark the packet as ready for transmission
+  val = bitfield_bit32_write(val, USBDEV_CONFIGIN_0_RDY_0_BIT, true);
+  abs_mmio_write32(
+      kBase + USBDEV_CONFIGIN_0_REG_OFFSET + ep_index * sizeof(uint32_t), val);
+}
+
+rom_error_t usb_ep_transfer(uint8_t ep, void *data, size_t len,
+                            usb_transfer_flags_t flags) {
+  uint8_t i = ep & kEpNumMask;
+  if (i >= USBDEV_PARAM_N_ENDPOINTS) {
+    return kErrorUsbBadEndpointNumber;
+  }
+  usb_ep_info_t *endpoint = ep & kUsbDirIn ? in_endpoints : out_endpoints;
+  endpoint += i;
+
+  if (endpoint->type & kUsbEpTypeControl && len > 0) {
+    // Transfers of more than length zero on a control endpoint require a
+    // zero-length transfer in the opposite direction to finish the transaction.
+    flags |= kUsbTransferFlagsZlp;
+  }
+  endpoint->transfer.data = (char *)data;
+  endpoint->transfer.len = len;
+  endpoint->transfer.bytes_transfered = 0;
+  endpoint->transfer.flags = flags;
+  if (ep & kUsbDirIn) {
+    // IN transfer to host; send the first packet.
+    send_packet(i);
+  } else {
+    // OUT transfer from host; enable receiving OUT packets.
+    usbreg_bit(USBDEV_RXENABLE_OUT_REG_OFFSET, i, true);
+  }
+  return kErrorOk;
+}
+
+static void cancel_if_pending(uint8_t ep) {
+  uint32_t reg = abs_mmio_read32(kBase + USBDEV_CONFIGIN_0_REG_OFFSET +
+                                 ep * sizeof(uint32_t));
+  bool pending = bitfield_bit32_read(reg, USBDEV_CONFIGIN_0_PEND_0_BIT);
+  uint8_t buffer =
+      (uint8_t)bitfield_field32_read(reg, USBDEV_CONFIGIN_0_BUFFER_0_FIELD);
+  if (pending) {
+    buffer_pool_put(buffer);
+    abs_mmio_write32(
+        kBase + USBDEV_CONFIGIN_0_REG_OFFSET + ep * sizeof(uint32_t),
+        1 << USBDEV_CONFIGIN_0_PEND_0_BIT);
+  }
+}
+
+static void handle_in(void) {
+  // Handle IN transactions: return sent buffers to the buffer pool and send the
+  // next packet in any multi-packet transfers.
+  uint32_t sent = abs_mmio_read32(kBase + USBDEV_IN_SENT_REG_OFFSET);
+  for (uint8_t ep = 0; sent && ep < USBDEV_PARAM_N_ENDPOINTS; ++ep) {
+    if ((sent & (1 << ep)) == 0) {
+      continue;
+    }
+    sent &= ~(1 << ep);
+    usb_ep_info_t *endpoint = in_endpoints + ep;
+    uint32_t reg = abs_mmio_read32(kBase + USBDEV_CONFIGIN_0_REG_OFFSET +
+                                   ep * sizeof(uint32_t));
+    uint8_t buffer =
+        (uint8_t)bitfield_field32_read(reg, USBDEV_CONFIGIN_0_BUFFER_0_FIELD);
+    abs_mmio_write32(
+        kBase + USBDEV_CONFIGIN_0_REG_OFFSET + ep * sizeof(uint32_t),
+        1 << USBDEV_CONFIGIN_0_PEND_0_BIT);
+    buffer_pool_put(buffer);
+    // Clear IN_SENT bit (rw1c).
+    abs_mmio_write32(kBase + USBDEV_IN_SENT_REG_OFFSET, 1 << ep);
+    uint32_t error = 0;
+    if (bitfield_bit32_read(reg, USBDEV_CONFIGIN_0_PEND_0_BIT)) {
+      // Was there a cancelled transaction?
+      error = kUsbTransferFlagsError;
+    } else {
+      // Record the bytes transferred.
+      endpoint->transfer.bytes_transfered +=
+          bitfield_field32_read(reg, USBDEV_CONFIGIN_0_SIZE_0_FIELD);
+
+      if (endpoint->transfer.len > 0 ||
+          (endpoint->transfer.len == 0 &&
+           (endpoint->transfer.flags & kUsbTransferFlagsShortIn))) {
+        // If there is more data to transfer or if we need to send a zero-length
+        // IN packet to complete the transfer, then send the packet.
+        send_packet(ep);
+        continue;
+      }
+    }
+
+    if (error == 0 && (endpoint->transfer.flags & kUsbTransferFlagsZlp)) {
+      // If this is a control transfer, we need to turn around with a
+      // zero-length OUT packet.
+      usb_ep_transfer(ep, NULL, 0, kUsbTransferFlagsZlpAck);
+      continue;
+    }
+
+    // Complete the transfer.
+    if ((endpoint->type & kUsbEpTypeControl) == 0) {
+      ep |= kUsbDirIn;
+    }
+    if (endpoint->transfer.flags & kUsbTransferFlagsZlpAck) {
+      endpoint->transfer.flags = 0;
+      endpoint = out_endpoints + ep;
+    }
+    endpoint->transfer.flags |= kUsbTransferFlagsDone | error;
+    endpoint->handler(endpoint->user_ctx, ep, endpoint->transfer.flags,
+                      &endpoint->transfer.bytes_transfered);
+  }
+}
+
+static void handle_out(void) {
+  usb_setup_data_t setup_data = {0};
+  // Handle OUT transactions:
+  // - Get SETUPDATA for control endpoints.
+  // - Copy from USB buffers into the receiver's buffer.
+  // - Return buffers to the buffer pool.
+  while (!rx_fifo_empty()) {
+    uint32_t rxfifo = abs_mmio_read32(kBase + USBDEV_RXFIFO_REG_OFFSET);
+    uint8_t ep = (uint8_t)bitfield_field32_read(rxfifo, USBDEV_RXFIFO_EP_FIELD);
+    uint32_t setup = bitfield_bit32_read(rxfifo, USBDEV_RXFIFO_SETUP_BIT);
+    uint32_t size = bitfield_field32_read(rxfifo, USBDEV_RXFIFO_SIZE_FIELD);
+    uint8_t buffer =
+        (uint8_t)bitfield_field32_read(rxfifo, USBDEV_RXFIFO_BUFFER_FIELD);
+    usb_ep_info_t *endpoint = out_endpoints + ep;
+
+    if (endpoint->handler == NULL) {
+      buffer_pool_put(buffer);
+      continue;
+    }
+    if (setup) {
+      // Send SETUP_DATA directly to the endpoint handler.
+      // TODO: Do we need to call cancel_if_pending here?
+      copy_from_buffer(buffer, (char *)&setup_data, sizeof(setup_data));
+      buffer_pool_put(buffer);
+      endpoint->handler(endpoint->user_ctx, ep, kUsbTransferFlagsSetupData,
+                        &setup_data);
+      continue;
+    }
+    // If size>transfer.len, then there is an error on this transfer.
+    uint32_t error = size > endpoint->transfer.len ? kUsbTransferFlagsError : 0;
+    size_t chunk =
+        size < endpoint->transfer.len ? size : endpoint->transfer.len;
+    copy_from_buffer(buffer, endpoint->transfer.data, chunk);
+    buffer_pool_put(buffer);
+    endpoint->transfer.data += chunk;
+    endpoint->transfer.len -= chunk;
+    endpoint->transfer.bytes_transfered += chunk;
+    if (error || endpoint->transfer.len == 0 ||
+        chunk < endpoint->max_packet_size) {
+      if (error == 0 && endpoint->transfer.flags & kUsbTransferFlagsZlp) {
+        // If this is a control transfer, we need to turn around the packet
+        // with a zero-length IN.
+        usb_ep_transfer(kUsbDirIn | ep, NULL, 0, kUsbTransferFlagsZlpAck);
+        continue;
+      }
+      // Complete the transfer.
+      if (endpoint->transfer.flags & kUsbTransferFlagsZlpAck) {
+        endpoint->transfer.flags = 0;
+        endpoint = in_endpoints + ep;
+      }
+      endpoint->transfer.flags |= kUsbTransferFlagsDone | error;
+      endpoint->handler(endpoint->user_ctx, ep, endpoint->transfer.flags,
+                        &endpoint->transfer.bytes_transfered);
+    }
+  }
+}
+
+static void handle_reset(void) {
+  // For each endpoint, cancel any existing transfers.
+  for (uint8_t ep = 0; ep < USBDEV_PARAM_N_ENDPOINTS; ++ep) {
+    cancel_if_pending(ep);
+    usb_ep_info_t *endpoint = in_endpoints + ep;
+    if (endpoint->handler) {
+      endpoint->transfer.flags = 0;
+      endpoint->transfer.data = NULL;
+      endpoint->transfer.len = 0;
+      // Send a reset notifiy for direction IN, but non-control endpoints.
+      // We'll send the reset notify for control endpoints with the OUT
+      // endpoints.
+      if ((endpoint->type & kUsbEpTypeControl) == 0) {
+        endpoint->handler(endpoint->user_ctx, kUsbDirIn | ep,
+                          kUsbTransferFlagsReset, NULL);
+      }
+    }
+    endpoint = out_endpoints + ep;
+    if (endpoint->handler) {
+      endpoint->transfer.flags = 0;
+      endpoint->transfer.data = NULL;
+      endpoint->transfer.len = 0;
+      endpoint->handler(endpoint->user_ctx, ep, kUsbTransferFlagsReset, NULL);
+    }
+  }
+}
+
+void usb_poll(void) {
+  uint32_t istate = abs_mmio_read32(kBase + USBDEV_INTR_STATE_REG_OFFSET);
+
+  if (bitfield_bit32_read(istate, USBDEV_INTR_COMMON_PKT_SENT_BIT)) {
+    handle_in();
+  }
+  // Re-fill FIFOs as needed.
+  fill_fifos();
+  if (bitfield_bit32_read(istate, USBDEV_INTR_COMMON_PKT_RECEIVED_BIT)) {
+    handle_out();
+  }
+
+  // Handle a USB reset condition.  Reclaim all pending buffers, zero out all
+  // pending transfers and call all endpoint calbacks with the reset flag.
+  if (bitfield_bit32_read(istate, USBDEV_INTR_COMMON_LINK_RESET_BIT)) {
+    handle_reset();
+  }
+  // TODO: We need to check istate for link error conditions and handle them.
+
+  // Ack interrupt bits.
+  abs_mmio_write32(kBase + USBDEV_INTR_STATE_REG_OFFSET, istate);
+}
+
+void usb_set_address(uint8_t device_address) {
+  uint32_t val = abs_mmio_read32(kBase + USBDEV_USBCTRL_REG_OFFSET);
+  val = bitfield_field32_write(val, USBDEV_USBCTRL_DEVICE_ADDRESS_FIELD,
+                               device_address);
+  abs_mmio_write32(kBase + USBDEV_USBCTRL_REG_OFFSET, val);
+}
+
+void usb_enable(bool en) {
+  uint32_t val = abs_mmio_read32(kBase + USBDEV_USBCTRL_REG_OFFSET);
+  val = bitfield_bit32_write(val, USBDEV_USBCTRL_ENABLE_BIT, en);
+  abs_mmio_write32(kBase + USBDEV_USBCTRL_REG_OFFSET, val);
+}
+
+void usb_init(void) {
+  usb_phy_init();
+  buffer_pool_init();
+  fill_fifos();
+}

--- a/sw/device/silicon_creator/lib/drivers/usb.h
+++ b/sw/device/silicon_creator/lib/drivers/usb.h
@@ -1,0 +1,203 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_USB_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_USB_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/drivers/stdusb.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Flags for endpoint configuration
+ */
+typedef enum usb_dir {
+  /** Endpoint is an IN endpoint */
+  kUsbDirIn = 0x80,
+  /** Endpoint is a OUT endpoint */
+  kUsbDirOut = 0,
+  /** Endpoint number mask */
+  kEpNumMask = 0xf,
+} usb_dir_t;
+
+typedef enum usb_ep_type {
+  /** Endpoint is a BULK endpoint */
+  kUsbEpTypeBulk = 0,
+  /** Endpoint is a INTERRUPT endpoint */
+  kUsbEpTypeInterrupt = 1,
+  /** Endpoint is a CONTROL endpoint */
+  kUsbEpTypeControl = 2,
+} usb_ep_type_t;
+
+/**
+ * Flags for managing usb transfers
+ */
+typedef enum usb_transfer_flags {
+  /** Transfer needs to terminate with a short or zero-length packet. */
+  kUsbTransferFlagsShortIn = 1,
+  /**
+   * Transfer is a control transfer: requires a zero-length packet in the
+   * opposite direction of the transfer to complete
+   */
+  kUsbTransferFlagsZlp = 2,
+  /**
+   * Transfer is the zero-length control transfer status packet.
+   */
+  kUsbTransferFlagsZlpAck = 0x0800,
+  /**
+   * Indicates a SETUP_DATA packet; the data argument of the callback points to
+   * a usb_setup_data_t.
+   */
+  kUsbTransferFlagsSetupData = 0x1000,
+  /**
+   * Indicates there was an error with the transaction.
+   */
+  kUsbTransferFlagsError = 0x2000,
+  /**
+   * Transfer is finished; the data argument of the callback points to a size_t
+   * indicating the number of bytes transferred.
+   */
+  kUsbTransferFlagsDone = 0x4000,
+  /** USB device was reset */
+  kUsbTransferFlagsReset = 0x8000,
+} usb_transfer_flags_t;
+
+/**
+ * Function pointer type for an endpoint handler.
+ *
+ * @param ctx A pointer to the context object supplied during endpoint
+ *            initialization.
+ * @param ep The endpoint address (including the direction flag).
+ * @param flags The usb transfer flags for this callback.
+ * @param data A pointer to data relevant to this callback (see the flags).
+ */
+typedef void (*handler_t)(void *ctx, uint8_t ep, usb_transfer_flags_t flags,
+                          void *data);
+
+/**
+ * An internal driver struct to manage endpoint transfers.
+ */
+typedef struct usb_transfer {
+  /** Pointer to data to transfer. */
+  char *data;
+  /** Length of data remaining to transfer. */
+  size_t len;
+  /** Number of bytes actually transferred. */
+  size_t bytes_transfered;
+  /** Flags associated with this transfer. */
+  usb_transfer_flags_t flags;
+} usb_transfer_t;
+
+/**
+ * An internal driver struct to manage each endpoint.
+ */
+typedef struct usb_ep_info {
+  /** Endpoint flags (e.g. control EP or other properties) */
+  usb_ep_type_t type;
+  /** The max packet size of this endpoint. */
+  uint16_t max_packet_size;
+  /** Any active transfer on this endpoint. */
+  usb_transfer_t transfer;
+  /** A handler to call for events on this endpoint. */
+  handler_t handler;
+  /** The user supplied context to pass to the handler. */
+  void *user_ctx;
+} usb_ep_info_t;
+
+/**
+ * Initialize the USB stack.
+ *
+ */
+void usb_init(void);
+
+/**
+ * Poll the USB device, driver transfers to completion and call endpoint
+ * callbacks.
+ *
+ */
+void usb_poll(void);
+
+/**
+ * Enable USB.
+ */
+void usb_enable(bool en);
+
+/**
+ * Set the USB address.
+ */
+void usb_set_address(uint8_t device_address);
+
+/**
+ * Initialize an USB endpoint.
+ *
+ * @param ep The endpoint address (including the direction flag).
+ * @param type The endpoint type (Bulk, Control).
+ * @param max_packet_size The endpoint max packet size.
+ * @param handler A handler to call when transactions complete on the endpoint.
+ * @param user_ctx A context pointer to pass to the handler.
+ * @return Error code.
+ */
+rom_error_t usb_ep_init(uint8_t ep, usb_ep_type_t type,
+                        uint16_t max_packet_size, handler_t handler,
+                        void *user_ctx);
+
+/**
+ * Stall or un-stall an endpoint.
+ *
+ * @param ep The endpoint address (including the direction flag).
+ * @param enable Whether to enable (true) or clear (false) the stall condition.
+ * @return Error code.
+ */
+rom_error_t usb_ep_stall(uint8_t ep, bool enable);
+
+/**
+ * Return whether an endpoint is stalled.
+ *
+ * @param ep The endpoint address (including the direction flag).
+ * @param stalled[out] Whether the endpoint is stalled.
+ * @return Error code.
+ */
+rom_error_t usb_ep_stalled(uint8_t ep, bool *stalled);
+
+/**
+ * Clear the data toggle on an endpoint.
+ * @param ep The endpoint address (including the direction flag).
+ */
+void usb_ep_clear_toggle(uint8_t ep);
+
+/**
+ * Clear the data toggle on all endpoints except endpoint zero.
+ */
+void usb_clear_all_toggles(void);
+
+/**
+ * Start a transfer on an endpoint.
+ *
+ *
+ * @param ep The endpoint address (including the direction flag).
+ *           Note: The other APIs (init, stall, stalled) do not require the
+ *           direction flag when operating on a control endpoint.  However,
+ *           since control endpoints may transfer data either in or out, you
+ *           must include the direction flag here.
+ * @param data The buffer to send or receive into.  Note: the pointer is
+ *             required to be word aligned.
+ * @param len The length of the buffer.
+ * @param flags The direction or other attributes assocated with the transfer.
+ * @return Error code.
+ */
+rom_error_t usb_ep_transfer(uint8_t ep, void *data, size_t len,
+                            usb_transfer_flags_t flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_USB_H_

--- a/sw/device/silicon_creator/lib/drivers/usb_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/usb_functest.c
@@ -1,0 +1,246 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+const usb_device_descriptor_t device_desc = {
+    .length = 18,
+    .descriptor_type = 1,
+    .bcd_usb = 0x0200,
+    .device_class = 0xFF,
+    .device_sub_class = 0xFF,
+    .device_protocol = 0xFF,
+    .max_packet_size_0 = 64,
+    .vendor = 0x18d1,
+    .product = 0x503a,
+    .bcd_device = 0x100,
+    .imanufacturer = 1,
+    .iproduct = 2,
+    .iserial_number = 3,
+    .num_configurations = 1,
+};
+
+const uint8_t config_desc[] = {
+    USB_CFG_DSCR_HEAD(
+        /*total_len=*/USB_CFG_DSCR_LEN + USB_INTERFACE_DSCR_LEN +
+            2 * USB_EP_DSCR_LEN,
+        /*nint=*/1),
+    USB_INTERFACE_DSCR(
+        /*inum=*/1,
+        /*alt=*/0,
+        /*nep=*/2,
+        /*class=*/0xFF,
+        /*subclass=*/0xFF,
+        /*protocol=*/1,
+        /*iint=*/0),
+    USB_BULK_EP_DSCR(
+        /*in=*/false,
+        /*ep=*/1,
+        /*maxsize=*/64,
+        /*interval=*/0),
+    USB_BULK_EP_DSCR(
+        /*in=*/true,
+        /*ep=*/2,
+        /*maxsize=*/64,
+        /*interval=*/0),
+};
+
+const char lang_id[] = {
+    /* bLength=*/4,
+    /* bDescriptorType=*/3,
+    /* bString=*/0x09,
+    0x04,
+};
+
+const char str_vendor[] = {
+    USB_STRING_DSCR('G', 'o', 'o', 'g', 'l', 'e'),
+};
+
+const char str_opentitan[] = {
+    USB_STRING_DSCR('O', 'p', 'e', 'n', 'T', 'i', 't', 'a', 'n'),
+};
+
+char str_serialnumber[2 + 32];
+
+const char *string_desc[] = {
+    lang_id, str_vendor, str_opentitan, str_serialnumber, NULL,
+};
+
+usb_control_ctx_t ep0 = {
+    .device_desc = &device_desc,
+    .config_desc = config_desc,
+    .string_desc = string_desc,
+};
+
+uint32_t work_buffer[16384];
+uint32_t test_exit;
+
+typedef enum test_req {
+  kTestReqRandomize = 1,
+  kTestReqDigest = 2,
+  kTestReqBulkIn = 3,
+  kTestReqBulkOut = 4,
+  kTestReqExit = 5,
+} test_req_t;
+
+void set_serialnumber(void) {
+  lifecycle_device_id_t dev;
+  lifecycle_device_id_get(&dev);
+  const char hex[] = "0123456789ABCDEF";
+
+  char *sn = str_serialnumber;
+  *sn++ = 2 + 32;
+  *sn++ = 3;
+  for (size_t w = 1; w < 3; ++w) {
+    uint8_t byte = (uint8_t)(dev.device_id[w] >> 24);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+    byte = (uint8_t)(dev.device_id[w] >> 16);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+    byte = (uint8_t)(dev.device_id[w] >> 8);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+    byte = (uint8_t)(dev.device_id[w] >> 0);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+  }
+}
+
+rom_error_t my_control(usb_setup_data_t *setup) {
+  switch (setup->request) {
+    case kTestReqRandomize:
+      base_printf("Randomize\r\n");
+      for (size_t i = 0; i < ARRAYSIZE(work_buffer); ++i) {
+        work_buffer[i] = rnd_uint32();
+      }
+      usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+      break;
+
+    case kTestReqDigest: {
+      base_printf("Digest sz=%u\r\n", (size_t)setup->value + 1);
+      hmac_digest_t digest;
+      hmac_sha256_configure(true);
+      hmac_sha256_start();
+      hmac_sha256_update(work_buffer, (size_t)setup->value + 1);
+      hmac_sha256_process();
+      hmac_sha256_final(&digest);
+      usb_ep_transfer(kUsbDirIn | 0, &digest, sizeof(digest), 0);
+      break;
+    }
+    case kTestReqBulkIn: {
+      size_t length = (size_t)setup->value + 1;
+      uint8_t ep = (uint8_t)setup->index;
+      base_printf("BulkIn ep=%u sz=%u\r\n", setup->index, length);
+      usb_ep_transfer(
+          kUsbDirIn | ep, work_buffer, length,
+          (length < sizeof(work_buffer) ? kUsbTransferFlagsShortIn : 0));
+      usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+      break;
+    }
+    case kTestReqBulkOut: {
+      size_t length = (size_t)setup->value + 1;
+      uint8_t ep = (uint8_t)setup->index;
+      base_printf("BulkOut ep=%u sz=%u\r\n", setup->index, length);
+      usb_ep_transfer(ep, work_buffer, length, 0);
+      usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+      break;
+    }
+    case kTestReqExit:
+      base_printf("Exit\r\n");
+      test_exit = 1;
+      usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+      break;
+    default:
+      return kErrorUsbBadSetup;
+  }
+  return kErrorOk;
+}
+
+void handler(void *ctx, uint8_t ep, usb_transfer_flags_t flags, void *data) {
+  OT_DISCARD(ctx);
+  if (flags & kUsbTransferFlagsSetupData) {
+    usb_setup_data_t *setup = (usb_setup_data_t *)data;
+    base_printf(
+        "SETUPDATA: type=%02x req=%02x value=%04x index=%04x len=%04x\r\n",
+        setup->request_type, setup->request, setup->value, setup->index,
+        setup->length);
+    rom_error_t error;
+    if ((setup->request_type & kUsbReqTypeTypeMask) == kUsbReqTypeVendor) {
+      error = my_control(setup);
+    } else {
+      error = usb_control_setupdata(&ep0, setup);
+    }
+    if (ep0.flags & kUsbControlFlagsPendingConfig) {
+      ep0.flags &= ~(unsigned)kUsbControlFlagsPendingConfig;
+      ep0.configuration = ep0.next.configuration;
+      LOG_INFO("set_configuration %u", ep0.configuration);
+      usb_ep_transfer(kUsbDirIn | 0, NULL, 0, 0);
+    }
+    if (error != kErrorOk) {
+      usb_ep_stall(0, true);
+    }
+  }
+  if (flags & kUsbTransferFlagsDone) {
+    if (ep0.flags & kUsbControlFlagsPendingAddress) {
+      ep0.flags &= ~(unsigned)kUsbControlFlagsPendingAddress;
+      ep0.device_address = ep0.next.device_address;
+      usb_set_address(ep0.device_address);
+      LOG_INFO("set_addr %u", ep0.device_address);
+    }
+
+    if (test_exit == 1) {
+      test_exit = 2;
+    }
+  }
+  if (ep != 0) {
+    int length = (flags & kUsbTransferFlagsDone) ? *(int *)data : -1;
+    base_printf("Event on EP%u: flags=%08x length=%d\r\n", ep, flags, length);
+  }
+}
+
+rom_error_t usb_test(void) {
+  set_serialnumber();
+  usb_init();
+  usb_ep_init(0x00, kUsbEpTypeControl, 0x40, handler, NULL);
+  usb_ep_init(0x01, kUsbEpTypeBulk, 0x40, handler, NULL);
+  usb_ep_init(0x82, kUsbEpTypeBulk, 0x40, handler, NULL);
+  usb_enable(true);
+  LOG_INFO("usb ready");
+  while (test_exit != 2) {
+    usb_poll();
+  }
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  pinmux_init_usb();
+  status_t result = OK_STATUS();
+  EXECUTE_TEST(result, usb_test);
+  return status_ok(result);
+}

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -56,6 +56,7 @@ enum module_ {
   kModuleOwnership =       MODULE_CODE('O', 'W'),
   kModulePersoTlv =        MODULE_CODE('P', 'T'),
   kModuleDice =            MODULE_CODE('D', 'C'),
+  kModuleUsb =             MODULE_CODE('U', 'S'),
   // clang-format on
 };
 
@@ -245,6 +246,9 @@ enum module_ {
   X(kErrorDiceCwtCoseKeyNotFound,     ERROR_(1, kModuleDice, kNotFound)), \
   X(kErrorDiceCwtCoseKeyBadSize,      ERROR_(1, kModuleDice, kInternal)), \
   X(kErrorDiceCwtKeyCoordsNotFound,   ERROR_(2, kModuleDice, kNotFound)), \
+  \
+  X(kErrorUsbBadSetup,                ERROR_(0, kModuleUsb, kInvalidArgument)), \
+  X(kErrorUsbBadEndpointNumber,       ERROR_(1, kModuleUsb, kInvalidArgument)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/tests/kmac_entropy_stress_test.c
+++ b/sw/device/tests/kmac_entropy_stress_test.c
@@ -14,8 +14,6 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
 dif_kmac_config_t kKmacTestCases[] = {
 
     //////////////////////////////////////////////////////////////////////////////
@@ -236,7 +234,7 @@ status_t test_kmac_config(dif_kmac_config_t *test_case) {
     } else {
       // If the hash counter threshold is not enabled (i.e. set to 0), the hash
       // counter maxes out at kHashCntMax and should not overflow
-      expected_hash_count = MIN(expected_hash_count + 1, kHashCntMax);
+      expected_hash_count = MIN(expected_hash_count + 1, (uint32_t)kHashCntMax);
     }
     TRY_CHECK(expected_hash_count == hash_count,
               "Unexpected hash counter value: Got %d, Expected %d", hash_count,

--- a/sw/host/tests/chip/usb/BUILD
+++ b/sw/host/tests/chip/usb/BUILD
@@ -84,3 +84,21 @@ rust_binary(
         "@crate_index//:serialport",
     ],
 )
+
+rust_binary(
+    name = "silicon_creator_harness",
+    srcs = [
+        "silicon_creator_harness.rs",
+    ],
+    deps = [
+        ":usb",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:hex",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:rand",
+        "@crate_index//:rusb",
+    ],
+)

--- a/sw/host/tests/chip/usb/silicon_creator_harness.rs
+++ b/sw/host/tests/chip/usb/silicon_creator_harness.rs
@@ -1,0 +1,225 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, ensure, Result};
+use clap::Parser;
+use rand::prelude::*;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use opentitanlib::crypto::sha256::Sha256Digest;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+use rusb::{Direction, Recipient, RequestType};
+use usb::{port_path_string, UsbDeviceHandle, UsbOpts};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console/USB timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "60s")]
+    timeout: Duration,
+
+    /// USB options.
+    #[command(flatten)]
+    usb: UsbOpts,
+
+    /// Do not wait for USB device to appear before continuing with the test.
+    #[arg(long, default_value_t = false)]
+    no_wait_for_usb_device: bool,
+
+    /// Executable to run after USB device connection.
+    /// This harness will spawn a process to execute and continue monitoring the UART
+    /// until the test passes (or fails). After that, the process will be killed.
+    /// Unless `no_wait_for_usb_device` is set, the harness will pass two extra arguments
+    /// to the executable to specify the bus and address of the USB device, as follows:
+    /// `--devide <bus>:<addr>`.
+    #[arg(long)]
+    exec: Option<PathBuf>,
+
+    /// Arguments to pass to the executable.
+    #[arg(long)]
+    exec_arg: Vec<std::ffi::OsString>,
+}
+
+fn wait_for_device(opts: &Opts) -> Result<UsbDeviceHandle> {
+    log::info!("waiting for device...");
+    let mut devices = opts.usb.wait_for_device(opts.timeout)?;
+    if devices.is_empty() {
+        bail!("no USB device found");
+    }
+    if devices.len() > 1 {
+        log::error!("several USB devices found:");
+        for dev in devices {
+            log::error!(
+                "- bus={} address={}",
+                dev.device().bus_number(),
+                dev.device().address()
+            );
+        }
+        bail!("several USB devices found");
+    }
+    let device = devices.remove(0);
+    log::info!(
+        "device found at bus={}, address={}, path={}",
+        device.device().bus_number(),
+        device.device().address(),
+        port_path_string(&device.device())?
+    );
+    Ok(device)
+}
+
+#[repr(u8)]
+#[allow(dead_code)]
+enum TestReq {
+    Randomize = 1,
+    Digest,
+    BulkIn,
+    BulkOut,
+    Exit,
+}
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+const RQTYPE: u8 = rusb::request_type(Direction::In, RequestType::Vendor, Recipient::Device);
+
+fn receive_random_buffer(dev: &UsbDeviceHandle, short_len: Option<usize>) -> Result<()> {
+    let mut buffer = vec![0u8; 65536];
+    // Determine if the test requests a shorter length than the full buffer length.
+    // We pass this (possibly short) length in the `value` field of the control transactions
+    // to indicate to the DUT the actual length.
+    // We compute the length minus one because the `value` field is a u16 and we have a
+    // maximum size of 65536.
+    let length = (short_len.unwrap_or(buffer.len()) - 1) as u16;
+
+    // Randomize the device buffer and get the device's digest of the buffer.
+    dev.read_control(RQTYPE, TestReq::Randomize as u8, 0, 0, &mut [], TIMEOUT)?;
+    let mut dev_digest = [0u8; 32];
+    dev.read_control(
+        RQTYPE,
+        TestReq::Digest as u8,
+        length,
+        0,
+        &mut dev_digest,
+        TIMEOUT,
+    )?;
+
+    // Transfer the buffer from device to host.
+    log::info!("Starting bulk transfer");
+    dev.read_control(RQTYPE, TestReq::BulkIn as u8, length, 2, &mut [], TIMEOUT)?;
+    let t0 = Instant::now();
+
+    // Attempt to receive the full 64K buffer.  For shorter transactions, this
+    // tests the DUT properly finishes short transactions.
+    let len = dev.read_bulk(0x82, &mut buffer, TIMEOUT)?;
+    let t1 = Instant::now();
+    log::info!("Received {len} bytes in {}us", (t1 - t0).as_micros());
+    let buf_digest = Sha256Digest::hash(&buffer[..len]);
+    log::info!("DevDigest = {}", hex::encode(dev_digest));
+    log::info!("BufDigest = {}", hex::encode(buf_digest.as_ref()));
+    assert_eq!(len, length as usize + 1);
+    assert_eq!(dev_digest, buf_digest.as_ref());
+    Ok(())
+}
+
+fn send_random_buffer(dev: &UsbDeviceHandle, short_len: Option<usize>) -> Result<()> {
+    let mut buffer = vec![0u8; 65536];
+    // Determine if the test requests a shorter length than the full buffer length.
+    // We pass this (possibly short) length in the `value` field of the control transactions
+    // to indicate to the DUT the actual length.
+    // We compute the length minus one because the `value` field is a u16 and we have a
+    // maximum size of 65536.
+    let length = (short_len.unwrap_or(buffer.len()) - 1) as u16;
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut buffer);
+
+    // Tell the DUT that we will transfer 65536 bytes.  For short transactions,
+    // this tests whether the DUT correctly understands shorter transactions.
+    dev.read_control(
+        RQTYPE,
+        TestReq::BulkOut as u8,
+        (buffer.len() - 1) as u16,
+        1,
+        &mut [],
+        TIMEOUT,
+    )?;
+    // Write the (possibly short) buffer to the device.
+    let t0 = Instant::now();
+    let slice = &buffer[0..(length as usize + 1)];
+    let len = dev.write_bulk(0x01, slice, TIMEOUT)?;
+    if len < buffer.len() && len % 64 == 0 {
+        // If the transfer was a multiple of the endpoint size, send a
+        // zero-length transfer to finish the transaction.
+        dev.write_bulk(0x01, &[], TIMEOUT)?;
+    }
+    let t1 = Instant::now();
+    log::info!("Sent {len} bytes in {}us", (t1 - t0).as_micros());
+    let buf_digest = Sha256Digest::hash(slice);
+    let mut dev_digest = [0u8; 32];
+    dev.read_control(
+        RQTYPE,
+        TestReq::Digest as u8,
+        length,
+        0,
+        &mut dev_digest,
+        TIMEOUT,
+    )?;
+    log::info!("DevDigest = {}", hex::encode(dev_digest));
+    log::info!("BufDigest = {}", hex::encode(buf_digest.as_ref()));
+    assert_eq!(len, length as usize + 1);
+    assert_eq!(dev_digest, buf_digest.as_ref());
+    Ok(())
+}
+
+fn test_exit(dev: &UsbDeviceHandle) -> Result<()> {
+    dev.read_control(RQTYPE, TestReq::Exit as u8, 0, 0, &mut [], TIMEOUT)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    // Wait until test is running.
+    let uart = transport.uart("console")?;
+    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    // Enable VBUS sense on the board if necessary.
+    if opts.usb.vbus_control_available() {
+        opts.usb.enable_vbus(&transport, true)?;
+    }
+    // Sense VBUS if available.
+    if opts.usb.vbus_sense_available() {
+        ensure!(
+            opts.usb.vbus_present(&transport)?,
+            "OT USB does not appear to be connected to a host (VBUS not detected)"
+        );
+    }
+
+    let device = wait_for_device(&opts)?;
+    device.claim_interface(1)?;
+
+    execute_test!(receive_random_buffer, &device, None);
+    execute_test!(receive_random_buffer, &device, Some(65535));
+    execute_test!(receive_random_buffer, &device, Some(65536 - 64));
+    execute_test!(send_random_buffer, &device, None);
+    execute_test!(send_random_buffer, &device, Some(65535));
+    execute_test!(send_random_buffer, &device, Some(65536 - 64));
+    test_exit(&device)?;
+
+    // Wait for test to pass.
+    log::info!("wait for pass...");
+    let res = UartConsole::wait_for(&*uart, r"PASS|FAIL", opts.timeout)?;
+    match res[0].as_str() {
+        "PASS" => (),
+        "FAIL" => bail!("device code reported a failure"),
+        _ => (),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
Create a small USB driver meant to be used in silicon_creator code.

1. Implement a basic no-interrupts driver for the OpenTitan USB
   peripheral.  The driver manages the USB peripheral buffers, endpoint
   transfers and SETUPDATA on the control endpoint.  Higher level
   protocols register a callback function with the endpoints.
2. Implement a standard USB control endpoint handler.  This handler
   should be called in response to any SETUPDATA requests on endpoint
   zero.
3. Add a basic test to check device enumeration and configuration and
   data transfers.