### PR TITLE
[gpio_smoketest] Bring up gpio_smoketest for Darjeeling

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -23,7 +23,7 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
     int addr;
     // Find how many bytes the SW allocate for SW_SYM_GPIO_VALS, then convert to word size.
     void'(dv_utils_pkg::sw_symbol_get_addr_size(
-              .elf_file({p_sequencer.cfg.sw_images[SwTypeTestSlotA], ".elf"}),
+              .elf_file({p_sequencer.cfg.sw_images[SwTypeCtn], ".elf"}),
               .symbol(SW_SYM_GPIO_VALS),
               .does_not_exist_ok(0),
               .addr(addr),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2007,6 +2007,7 @@ opentitan_test(
     srcs = ["gpio_smoketest.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         # Not compatible with the verilated top level.
         dicts.omit(
             EARLGREY_TEST_ENVS,

--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -74,8 +74,8 @@ bool test_main(void) {
       dt_periph_io_t periph_io =
           dt_gpio_periph_io(kGpioDt, kDtGpioPeriphIoGpio0 + i);
       dt_pad_t pad = kPinmuxTestutilsGpioPads[i];
-      CHECK_DIF_OK(dif_pinmux_mio_select_input(&pinmux, periph_io, pad));
-      CHECK_DIF_OK(dif_pinmux_mio_select_output(&pinmux, pad, periph_io));
+      CHECK_STATUS_OK(pinmux_testutils_connect(&pinmux, periph_io,
+                                               kDtPeriphIoDirInout, pad));
     }
   }
   CHECK_DIF_OK(dif_gpio_init_from_dt(kGpioDt, &gpio));


### PR DESCRIPTION
This PR brings up the top-level GPIO smoke test (`chip_sw_gpio_smoketest`) on Darjeeling, allowing it to pass in nightly regressions. Note that there is still a little work to be done before Darjeeling T-L sw tests can be executed directly from the master branch.