### PR TITLE
[hw,rv_dm,rtl] Strap enable is genuinely used to ungate the DM

### DIFF
--- a/hw/ip/rv_dm/rtl/rv_dm_dmi_gate.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_dmi_gate.sv
@@ -119,9 +119,6 @@ module rv_dm_dmi_gate
     logic unused_strap_en_override;
     assign unused_strap_en_override = strap_en_override_i;
     assign strap_en                 = strap_en_i;
-
-    // Ensure that strap is never asserted
-    `ASSERT_NEVER(A_StrapNeverAsserted, strap_en)
   end
 
   /////////////////////////////


### PR DESCRIPTION
When no strap enable overwrite is possible (SecVolatileRawUnlockEn=0), the ordinary strap enable mechanism is still genuine. Don't assert that away.