### PR TITLE
[topgen] Add GPIO to the list of uniquified ipgen IPs

### DIFF
--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
@@ -12,6 +12,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
@@ -227,6 +227,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
@@ -248,6 +248,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
@@ -10,6 +10,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
@@ -2007,6 +2007,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
@@ -20,6 +20,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
@@ -75,6 +75,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -65,6 +65,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -549,6 +549,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -12,6 +12,7 @@
     topname: darjeeling
     uniquified_modules:
     {
+      gpio: gpio
       racl_ctrl: racl_ctrl
       ac_range_check: ac_range_check
       alert_handler: alert_handler

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
@@ -151,6 +151,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
@@ -263,6 +263,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
@@ -27,6 +27,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
@@ -10,6 +10,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
@@ -1988,6 +1988,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
@@ -20,6 +20,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -85,6 +85,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -696,6 +696,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
@@ -12,6 +12,7 @@
     topname: earlgrey
     uniquified_modules:
     {
+      gpio: gpio
       alert_handler: alert_handler
       rv_plic: rv_plic
     }

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
@@ -240,6 +240,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
@@ -27,6 +27,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
@@ -10,6 +10,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
@@ -20,6 +20,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
@@ -64,6 +64,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -456,6 +456,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
@@ -12,6 +12,7 @@
     topname: englishbreakfast
     uniquified_modules:
     {
+      gpio: gpio
       rv_plic: rv_plic
     }
   }

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -784,13 +784,14 @@ def generate_racl(top: ConfigT, module: ConfigT, out_path: Path) -> None:
 
 def _get_gpio_params(top: ConfigT) -> ParamsT:
     """Extracts parameters for GPIO ipgen."""
+    module = lib.find_module(top["module"], "gpio")
+    uniquified_modules.add_module(module["template_type"], module["type"])
 
-    gpio = lib.find_module(top["module"], "gpio")
     params = {
         # TODO(#26553): Remove the following code once topgen automatically
         # incorporates template parameters.
-        "num_inp_period_counters": gpio.get("ipgen_param", {}).get("num_inp_period_counters", 0),
-        "module_instance_name": gpio["type"]
+        "num_inp_period_counters": module.get("ipgen_param", {}).get("num_inp_period_counters", 0),
+        "module_instance_name": module["type"]
     }
     return params
 


### PR DESCRIPTION
The GPIO was probably missed in https://github.com/lowRISC/opentitan/pull/26541 (it was added to ipgen in between). Lets add that to the list of uniquified IPs.