### PR TITLE
[pentest] Allow enabling countermeasures and report AST alerts

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -156,6 +156,8 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_aes_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Write the key into the AES block. Set and unset the trigger when
   // key_trigger is true.
@@ -214,6 +216,8 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -224,6 +228,8 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
   uj_output.err_status = codes;
   memcpy(uj_output.ciphertext, ciphertext.data, 16);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_aes_ciphertext_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -299,6 +305,8 @@ status_t handle_crypto_fi_kmac(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_kmac_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Configure and write key to the KMAC block. Set and unset the trigger when
   // key_trigger is true.
@@ -357,6 +365,8 @@ status_t handle_crypto_fi_kmac(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   TRY(dif_kmac_end(&kmac, &kmac_operation_state));
 
@@ -370,6 +380,8 @@ status_t handle_crypto_fi_kmac(ujson_t *uj) {
   memcpy(uj_output.digest, (uint8_t *)digest, 8);
   memcpy(uj_output.digest_2nd, (uint8_t *)digest_2nd, 8);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_kmac_digest_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -380,6 +392,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_kmac_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Configure and write key to the KMAC block.
   dif_kmac_operation_state_t kmac_operation_state;
@@ -405,6 +419,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -425,6 +441,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
   uj_output.err_status = codes;
   memcpy(uj_output.digest, (uint8_t *)digest, 8);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
 
   RESP_OK(ujson_serialize_crypto_fi_kmac_state_t, uj, &uj_output);
 
@@ -435,6 +453,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
 status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   crypto_fi_test_result_mult_t uj_output;
 
@@ -468,6 +488,8 @@ status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -483,6 +505,8 @@ status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
 
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -491,6 +515,8 @@ status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
 status_t handle_crypto_fi_shadow_reg_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   crypto_fi_test_result_mult_t uj_output;
 
@@ -547,6 +573,8 @@ status_t handle_crypto_fi_shadow_reg_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -567,6 +595,8 @@ status_t handle_crypto_fi_shadow_reg_read(ujson_t *uj) {
 
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -241,8 +241,14 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Init the AES block.
   TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
@@ -281,9 +287,8 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
       &rv_core_ibex));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -240,6 +240,8 @@ static inline void read_all_regs(uint32_t buffer[]) {
 static status_t read_otp_partitions(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t
       otp_data_read_res_vendor_test[(OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
@@ -277,6 +279,8 @@ static status_t read_otp_partitions(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Detect potential mismatch caused by faults.
   uint32_t res = 0;
@@ -318,6 +322,8 @@ static status_t read_otp_partitions(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -344,6 +350,8 @@ void not_increment_counter(void) __attribute__((optnone)) {
 status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Create translation descriptions.
   dif_rv_core_ibex_addr_translation_mapping_t increment_100x10_mapping = {
@@ -396,6 +404,8 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   uint32_t result_target = increment_100x1_remapped(0);
   // Compare values
@@ -417,6 +427,8 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -424,6 +436,8 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
 status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1 = {
@@ -454,6 +468,8 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1_read_back;
@@ -489,6 +505,8 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -497,6 +515,8 @@ status_t handle_ibex_fi_char_conditional_branch_beq(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -549,6 +569,8 @@ status_t handle_ibex_fi_char_conditional_branch_beq(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -560,6 +582,8 @@ status_t handle_ibex_fi_char_conditional_branch_beq(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -568,6 +592,8 @@ status_t handle_ibex_fi_char_conditional_branch_bge(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -620,6 +646,8 @@ status_t handle_ibex_fi_char_conditional_branch_bge(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -631,6 +659,8 @@ status_t handle_ibex_fi_char_conditional_branch_bge(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -639,6 +669,8 @@ status_t handle_ibex_fi_char_conditional_branch_bgeu(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -691,6 +723,8 @@ status_t handle_ibex_fi_char_conditional_branch_bgeu(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -702,6 +736,8 @@ status_t handle_ibex_fi_char_conditional_branch_bgeu(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -710,6 +746,8 @@ status_t handle_ibex_fi_char_conditional_branch_blt(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -762,6 +800,8 @@ status_t handle_ibex_fi_char_conditional_branch_blt(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -773,6 +813,8 @@ status_t handle_ibex_fi_char_conditional_branch_blt(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -781,6 +823,8 @@ status_t handle_ibex_fi_char_conditional_branch_bltu(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -833,6 +877,8 @@ status_t handle_ibex_fi_char_conditional_branch_bltu(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -844,6 +890,8 @@ status_t handle_ibex_fi_char_conditional_branch_bltu(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -852,6 +900,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -904,6 +954,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -915,6 +967,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -922,6 +976,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
 status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Write reference value into CSR.
   CSR_WRITE(CSR_REG_MSCRATCH, ref_values[0]);
@@ -949,6 +1005,8 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   uint32_t res = 0;
@@ -967,6 +1025,8 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -975,6 +1035,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Init x5 with reference value.
   asm volatile("li x5, %0" : : "i"(ref_values[0]));
@@ -1016,6 +1078,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   uj_output.result = 0;
@@ -1030,6 +1094,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1037,6 +1103,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
 status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!flash_init) {
     // Configure the data flash.
@@ -1105,6 +1173,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   ibex_fi_faulty_addresses_data_t uj_output;
@@ -1128,6 +1198,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1135,6 +1207,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!flash_init) {
     // Configure the data flash.
@@ -1178,6 +1252,8 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[32];
@@ -1199,6 +1275,8 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1207,6 +1285,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_complement_branch(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1230,6 +1310,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_complement_branch(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1240,6 +1322,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_complement_branch(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1249,6 +1333,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_unimp(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1269,6 +1355,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_unimp(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1279,6 +1367,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_unimp(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1288,6 +1378,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_2_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1308,6 +1400,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_2_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1318,6 +1412,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_2_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1327,6 +1423,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_3_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1347,6 +1445,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_3_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1357,6 +1457,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_3_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1366,6 +1468,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_4_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1386,6 +1490,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_4_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1396,6 +1502,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_4_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1405,6 +1513,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   hardened_bool_t value1 = HARDENED_BOOL_TRUE;
@@ -1422,6 +1532,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1432,6 +1544,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1440,6 +1554,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
 status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -1453,6 +1569,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1464,6 +1582,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1471,6 +1591,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t res_values[7];
   // Initialize temporary registers with reference values.
@@ -1488,6 +1610,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Load register values.
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -1516,6 +1640,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1523,6 +1649,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
 status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t res_values[6];
   // Initialize temporary registers with reference values.
@@ -1569,6 +1697,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Load register values.
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -1597,6 +1727,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   // Send result & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1604,6 +1736,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
 status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -1621,6 +1755,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1632,6 +1768,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1639,6 +1777,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Init t0...t6 with 0.
   init_temp_regs(0);
@@ -1667,6 +1807,8 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   ibex_fi_faulty_addresses_data_t uj_output;
   memset(uj_output.addresses, 0, sizeof(uj_output.addresses));
@@ -1686,6 +1828,8 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1707,6 +1851,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Get address of the ret. SRAM at the beginning of the owner section.
   uintptr_t sram_ret_buffer_addr =
@@ -1727,6 +1873,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   ibex_fi_faulty_addresses_data_t uj_output;
@@ -1755,6 +1903,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -1762,6 +1912,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
 status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -1784,6 +1936,8 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[32];
@@ -1805,6 +1959,8 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1813,6 +1969,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize SRAM region with inverse reference value.
   sram_main_buffer[0] = ~ref_values[0];
@@ -1924,6 +2082,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   uint32_t res_values[3];
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -1949,6 +2109,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1956,6 +2118,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
 status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -2103,6 +2267,8 @@ status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[64];
@@ -2124,6 +2290,8 @@ status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2131,6 +2299,8 @@ status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
 status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t result = 0;
@@ -2174,6 +2344,8 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2184,6 +2356,8 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   uj_output.result = result;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2193,6 +2367,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
   read_all_regs(registers);
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t result = 0;
@@ -2237,6 +2413,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2248,6 +2426,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
   memcpy(uj_output.registers, registers, sizeof(registers));
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_registers_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2255,6 +2435,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -2273,6 +2455,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2283,6 +2467,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2290,6 +2476,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -2310,6 +2498,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2320,6 +2510,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2327,6 +2519,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t addresses[8] = {0};
   uint32_t data[8] = {0};
@@ -2355,6 +2549,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2366,6 +2562,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
   memcpy(uj_output.data, data, sizeof(data));
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2447,6 +2645,8 @@ status_t handle_ibex_fi_otp_read_lock(ujson_t *uj) {
 status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint64_t faulty_token[kSecret0TestUnlockTokenSizeIn64BitWords];
   for (size_t i = 0; i < kSecret0TestUnlockTokenSizeIn64BitWords; i++) {
@@ -2460,6 +2660,11 @@ status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) {
   asm volatile(NOP10);
   pentest_set_trigger_low();
 
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
   TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
@@ -2470,6 +2675,8 @@ status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) {
       0;  // Writing to the locked OTP partition crashes the chip.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -2388,8 +2388,14 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Enable the flash.
   flash_info = dif_flash_ctrl_get_device_info();
@@ -2407,9 +2413,8 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
       &rv_core_ibex));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   // Initialize flash for the flash test and write reference values into page.
   flash_init = false;

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -67,6 +67,8 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
 status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read LC CTRL to get reference values.
   dif_lc_ctrl_state_t lc_state_ref;
@@ -82,6 +84,8 @@ status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Check if we have managed to manipulate the LC Controller.
   dif_lc_ctrl_state_t lc_state_cmp;
@@ -115,6 +119,8 @@ status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
   uj_output.counter = lc_count_cmp;
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_lc_ctrl_fi_corruption_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -154,6 +154,8 @@ status_t clear_otbn_load_checksum(void) {
 status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_beq);
@@ -170,6 +172,8 @@ status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
@@ -194,6 +198,8 @@ status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_cnt_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -205,6 +211,8 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bn_rshi);
@@ -228,6 +236,8 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read big_num_out from OTBN data memory.
   otbn_fi_big_num_out_t uj_output;
@@ -253,6 +263,8 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_big_num_out_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -264,6 +276,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bn_sel);
@@ -287,6 +301,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read big_num_out from OTBN data memory.
   otbn_fi_big_num_out_t uj_output;
@@ -312,6 +328,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_big_num_out_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -319,6 +337,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
 status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bn_wsrr);
@@ -338,6 +358,8 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -363,6 +385,8 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_data_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -371,6 +395,8 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
 status_t handle_otbn_fi_char_bne(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bne);
@@ -388,6 +414,8 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
   uj_output.result = 0;
@@ -410,6 +438,8 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_cnt_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -417,6 +447,8 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
 status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Config for the otbn.fi.char_dmem_access test.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_dmem_access);
@@ -436,6 +468,8 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -458,6 +492,8 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_data_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -466,6 +502,8 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
 status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Config for the otbn.fi.char_rf test.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_dmem_write);
@@ -619,6 +657,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -648,6 +688,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_array_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -656,6 +698,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_dmem_op_loop);
@@ -675,6 +719,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter);
@@ -696,6 +742,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -703,6 +751,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_reg_op_loop);
@@ -722,6 +772,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter);
@@ -743,6 +795,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -750,6 +804,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
 status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_jal);
@@ -766,6 +822,8 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
@@ -790,6 +848,8 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_cnt_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -797,6 +857,8 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
 status_t handle_otbn_fi_char_lw(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_lw);
@@ -819,6 +881,8 @@ status_t handle_otbn_fi_char_lw(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare reference values. 29 values as we are loading into 29 registers.
   otbn_fi_result_array_t uj_output;
@@ -848,6 +912,8 @@ status_t handle_otbn_fi_char_lw(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_array_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -868,6 +934,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Reference values for DMEM and IMEM.
   uint32_t dmem_array_ref[char_mem_num_words];
@@ -898,6 +966,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -957,6 +1027,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_mem_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -965,6 +1037,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
 status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Config for the otbn.fi.char_rf test.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_rf);
@@ -992,6 +1066,8 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -1041,6 +1117,8 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_rf_char_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1049,6 +1127,8 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_dmem_op_loop);
@@ -1068,6 +1148,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter);
@@ -1089,6 +1171,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1096,6 +1180,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_reg_op_loop);
@@ -1115,6 +1201,8 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter);
@@ -1136,6 +1224,8 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1208,6 +1298,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
   TRY(dif_otbn_set_ctrl_software_errs_fatal(&otbn, /*enable=*/false));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!key_sideloading_init) {
     // Setup keymanager for sideloading key into OTBN.
@@ -1232,6 +1324,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   uint32_t key_share_0_l, key_share_0_h;
@@ -1267,6 +1361,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_keys_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1274,6 +1370,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
 status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!load_integrity_init) {
     // Load the OTBN app and read the load checksum without FI to retrieve
@@ -1292,6 +1390,8 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back checksum.
   uint32_t load_checksum;
@@ -1335,6 +1435,8 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1346,6 +1448,8 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_pc);
@@ -1375,6 +1479,8 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
   otbn_busy_wait_for_done();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read pc_out from OTBN data memory.
   otbn_fi_pc_out_t uj_output;
@@ -1401,6 +1507,8 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_pc_out_t, uj, &uj_output);
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -1167,8 +1167,15 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+  ;
 
   // The load integrity, key sideloading, and char_mem tests get initialized at
   // the first run.
@@ -1178,9 +1185,8 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   char_mem_test_cfg_valid = false;
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -96,6 +96,8 @@ status_t otp_life_cycle_dump(uint32_t *buffer) {
 status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_hw_cfg_dump(otp_read32_result_hw_cfg_comp));
@@ -116,6 +118,8 @@ status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -133,6 +137,8 @@ status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_hwcfg_partition_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -180,6 +186,8 @@ status_t handle_otp_fi_init(ujson_t *uj) {
 status_t handle_otp_fi_life_cycle(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_life_cycle_dump(otp_read32_result_life_cycle_comp));
@@ -200,6 +208,8 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -217,6 +227,8 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_lifecycle_partition_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -225,6 +237,8 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
 status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_owner_sw_cfg_dump(otp_read32_result_owner_sw_cfg_comp));
@@ -245,6 +259,8 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -262,6 +278,8 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_ownerswcfg_partition_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -270,6 +288,8 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
 status_t handle_otp_fi_vendor_test(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_vendor_test_dump(otp_read32_result_vendor_test_comp));
@@ -290,6 +310,8 @@ status_t handle_otp_fi_vendor_test(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -307,6 +329,8 @@ status_t handle_otp_fi_vendor_test(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_vendortest_partition_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -159,6 +159,8 @@ static void entropy_conditioner_stop(const dif_entropy_src_t *entropy_src) {
 status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   TRY(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
 
@@ -194,6 +196,8 @@ status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -205,6 +209,8 @@ status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
   memcpy(uj_output.rand, entropy_bits, sizeof(entropy_bits));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_entropy_src_bias_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -213,6 +219,8 @@ status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
 status_t handle_rng_fi_firmware_override(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!firmware_override_init) {
     // Check if we keep heal tests enabled.
@@ -253,6 +261,8 @@ status_t handle_rng_fi_firmware_override(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -264,6 +274,8 @@ status_t handle_rng_fi_firmware_override(ujson_t *uj) {
   memcpy(uj_output.rand, buf, sizeof(buf));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_fw_overwrite_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -272,6 +284,8 @@ status_t handle_rng_fi_firmware_override(ujson_t *uj) {
 status_t handle_rng_fi_edn_bias(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   TRY(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
@@ -321,6 +335,8 @@ status_t handle_rng_fi_edn_bias(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -329,6 +345,8 @@ status_t handle_rng_fi_edn_bias(ujson_t *uj) {
   // Send result & ERR_STATUS to host.
   uj_output.collisions = collisions;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   uj_output.err_status = err_ibx;
   RESP_OK(ujson_serialize_rng_fi_edn_t, uj, &uj_output);
   return OK_STATUS();
@@ -337,6 +355,8 @@ status_t handle_rng_fi_edn_bias(ujson_t *uj) {
 status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
   // Enable entropy complex, CSRNG and EDN so Ibex can get entropy.
   // Configure entropy in auto_mode to avoid starving the system from entropy,
   // given that boot mode entropy has a limited number of generated bits.
@@ -372,6 +392,8 @@ status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -380,6 +402,8 @@ status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
   // Send result & ERR_STATUS to host.
   uj_output.collisions = collisions;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   uj_output.err_status = err_ibx;
   RESP_OK(ujson_serialize_rng_fi_edn_t, uj, &uj_output);
   return OK_STATUS();
@@ -438,6 +462,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_csrng_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   TRY(csrng_testutils_cmd_ready_wait(&csrng));
   TRY(dif_csrng_uninstantiate(&csrng));
@@ -485,6 +511,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -508,6 +536,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
   memcpy(uj_output.rand, rand_data_got, sizeof(rand_data_got));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_csrng_output_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -516,6 +546,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
 status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t received_data[kCsrngBiasFWFifoBufferSize];
   const dif_csrng_seed_material_t kEmptySeedMaterial = {0};
@@ -572,6 +604,8 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -584,6 +618,8 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   memcpy(uj_output.rand, received_data, sizeof(received_data));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_csrng_ov_output_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -397,8 +397,14 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralEntropy |
                    kPentestPeripheralCsrng | kPentestPeripheralEdn);
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -418,9 +424,8 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
   TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   firmware_override_init = false;
 
@@ -595,8 +600,14 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
   pentest_init(kPentestTriggerSourceAes,
                kPentestPeripheralIoDiv4 | kPentestPeripheralCsrng);
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -613,9 +624,8 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -88,8 +88,14 @@ status_t handle_rom_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Initialize rom_ctrl.
   mmio_region_t rom_ctrl_reg =
@@ -102,9 +108,8 @@ status_t handle_rom_fi_init(ujson_t *uj) {
       &rv_core_ibex));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -51,6 +51,8 @@ status_t handle_rom_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -70,6 +72,8 @@ status_t handle_rom_read(ujson_t *uj) {
   // Send the first 8 bytes of the digest and the alerts back to the host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rom_fi_digest_t, uj, &uj_output);
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/lib/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/lib/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sensor_ctrl",
         "//sw/device/lib/dif:sram_ctrl",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",

--- a/sw/device/tests/penetrationtests/firmware/lib/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/lib/BUILD
@@ -27,6 +27,7 @@ cc_library(
     deps = [
         "//hw/ip/aes:model",
         "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
@@ -44,6 +45,7 @@ cc_library(
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sram_ctrl",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:irq",

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -6,6 +6,7 @@
 
 #include "hw/ip/aes/model/aes.h"
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/macros.h"
@@ -22,6 +23,7 @@
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/dif/dif_sram_ctrl.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/irq.h"
@@ -35,6 +37,7 @@
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sram_ctrl_regs.h"  // Generated
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/crypto/drivers/otbn.h"
@@ -308,7 +311,11 @@ status_t pentest_read_device_id(uint32_t device_id[]) {
   return OK_STATUS();
 }
 
-void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr) {
+status_t pentest_configure_cpu(
+    bool disable_icache, bool disable_dummy_instr, bool enable_jittery_clock,
+    bool enable_sram_readback, bool *clock_jitter_locked, bool *clock_jitter_en,
+    bool *sram_main_readback_locked, bool *sram_ret_readback_locked,
+    bool *sram_main_readback_en, bool *sram_ret_readback_en) {
   uint32_t cpuctrl_csr;
   // Get current config.
   CSR_READ(CSR_REG_CPUCTRL, &cpuctrl_csr);
@@ -326,6 +333,65 @@ void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr) {
 
   // Write back config.
   CSR_WRITE(CSR_REG_CPUCTRL, cpuctrl_csr);
+
+  // Enable or disable the jittery clock.
+  dif_clkmgr_t clkmgr;
+  TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
+                      &clkmgr));
+
+  TRY(dif_clkmgr_jitter_enable_is_locked(&clkmgr, clock_jitter_locked));
+  dif_toggle_t clock_jitter_state;
+  TRY(dif_clkmgr_jitter_get_enabled(&clkmgr, &clock_jitter_state));
+
+  if (!*clock_jitter_locked) {
+    if (enable_jittery_clock) {
+      TRY(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
+    } else {
+      mmio_region_write32(clkmgr.base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET,
+                          kMultiBitBool4False);
+    }
+    TRY(dif_clkmgr_jitter_get_enabled(&clkmgr, &clock_jitter_state));
+  }
+
+  *clock_jitter_en = (clock_jitter_state == kDifToggleDisabled) ? false : true;
+
+  // Enable or disable SRAM main and ret readback feature.
+  dif_sram_ctrl_t sram_ctrl_ret;
+  dif_sram_ctrl_t sram_ctrl_main;
+  TRY(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR),
+      &sram_ctrl_ret));
+  TRY(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
+      &sram_ctrl_main));
+
+  dif_result_t ret_locked;
+  dif_result_t main_locked;
+  if (enable_sram_readback) {
+    ret_locked = dif_sram_ctrl_readback_set(&sram_ctrl_ret, kDifToggleEnabled);
+    main_locked =
+        dif_sram_ctrl_readback_set(&sram_ctrl_main, kDifToggleEnabled);
+  } else {
+    ret_locked = dif_sram_ctrl_readback_set(&sram_ctrl_ret, kDifToggleDisabled);
+    main_locked =
+        dif_sram_ctrl_readback_set(&sram_ctrl_main, kDifToggleDisabled);
+  }
+
+  uint32_t ret_status =
+      abs_mmio_read32(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR +
+                      SRAM_CTRL_READBACK_REG_OFFSET);
+  uint32_t main_status =
+      abs_mmio_read32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
+                      SRAM_CTRL_READBACK_REG_OFFSET);
+
+  // Report the configuration.
+  *sram_main_readback_locked = (main_locked == kDifLocked) ? true : false;
+  *sram_ret_readback_locked = (ret_locked == kDifLocked) ? true : false;
+
+  *sram_ret_readback_en = (ret_status == kMultiBitBool4True) ? true : false;
+  *sram_main_readback_en = (main_status == kMultiBitBool4True) ? true : false;
+
+  return OK_STATUS();
 }
 
 /**

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -23,6 +23,7 @@
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/dif/dif_sensor_ctrl.h"
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
@@ -37,7 +38,8 @@
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "sram_ctrl_regs.h"  // Generated
+#include "sensor_ctrl_regs.h"  // Generated.
+#include "sram_ctrl_regs.h"    // Generated
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/crypto/drivers/otbn.h"
@@ -88,6 +90,7 @@ static unsigned int trigger_bit_index = kTriggerHwGateBitIndex;
 static dif_gpio_t gpio;
 static dif_pinmux_t pinmux;
 static dif_rv_timer_t timer;
+static dif_sensor_ctrl_t sensor_ctrl;
 static dif_uart_t uart0;
 static dif_uart_t uart1;
 
@@ -204,6 +207,22 @@ status_t pentest_configure_entropy_source_max_reseed_interval(void) {
       }));
 #endif
   return OK_STATUS();
+}
+
+pentest_sensor_alerts_t pentest_get_sensor_alerts(void) {
+  pentest_sensor_alerts_t registered;
+  memset(registered.alerts, 0, sizeof(registered.alerts));
+  CHECK_DIF_OK(
+      dif_sensor_ctrl_get_fatal_events(&sensor_ctrl, &registered.alerts[0]));
+  CHECK_DIF_OK(
+      dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &registered.alerts[1]));
+  return registered;
+}
+
+void pentest_clear_sensor_recov_alerts(void) {
+  for (size_t it = 0; it < SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS; it++) {
+    CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, it));
+  }
 }
 
 pentest_registered_alerts_t pentest_get_triggered_alerts(void) {
@@ -486,6 +505,14 @@ static void pentest_init_csrng(void) {
 #endif
 }
 
+static void pentest_init_sensor_ctrl(void) {
+#if !OT_IS_ENGLISH_BREAKFAST
+  CHECK_DIF_OK(dif_sensor_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR),
+      &sensor_ctrl));
+#endif
+}
+
 /**
  * Initializes the EDN handle.
  */
@@ -597,6 +624,7 @@ void pentest_init(pentest_trigger_source_t trigger,
   pentest_init_timer();
   pentest_init_csrng();
   pentest_init_edn();
+  pentest_init_sensor_ctrl();
   sca_disable_peripherals(~enable);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -13,6 +13,10 @@ typedef struct pentest_registered_alerts {
   uint32_t alerts[3];
 } pentest_registered_alerts_t;
 
+typedef struct pentest_sensor_alerts {
+  uint32_t alerts[2];
+} pentest_sensor_alerts_t;
+
 /**
  * Trigger sources.
  *
@@ -155,6 +159,22 @@ typedef enum pentest_lfsr_context {
  * @return OK or error.
  */
 status_t pentest_configure_entropy_source_max_reseed_interval(void);
+
+/**
+ * Returns the registered alerts in the sensor controller.
+ *
+ * This function reads out the recov_alert and fatal_alert registers of the
+ * sensor controller. This controller collects the alerts of the AST.
+ *
+ * @return A struct containing which of the alerts were triggered during the
+ * test.
+ */
+pentest_sensor_alerts_t pentest_get_sensor_alerts(void);
+
+/**
+ * Clears the recoverable AST alerts in the sensor controller.
+ */
+void pentest_clear_sensor_recov_alerts(void);
 
 /**
  * Returns the registered alerts.

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -197,11 +197,33 @@ status_t pentest_read_device_id(uint32_t device_id[]);
  * remains at the original config that was set in the ROM. This implies that
  * dummy instructions could disabled even though disable_dummy_instr is False.
  *
+ * For enable_jittery_clock, the function first checks if the write protection
+ * for this register is enabled. Then, by setting enable_jittery_clock True or
+ * False, the jittery clock is enabled or disabled. When regwen is active, no
+ * change happens.
+ *
+ * For enable_sram_readback, the function first checks if the write protection
+ * for this register is enabled. Then, by setting enable_sram_readback True or
+ * False, the SRAM readback feature for the main and ret SRAM iss enabled or
+ * disabled. When regwen is active, no change happens.
+ *
  * @param disable_icache Disable the instruction cache.
  * @param disable_dummy_instr Disable the dummy instructions.
- *
+ * @param enable_jittery_clock: Enable/disable the jittery clock.
+ * @param enable_sram_readback: Enable/disable the SRAM readback feature.
+ * @param clock_jitter_locked: Jittery clock register is locked.
+ * @param clock_jitter_en: Jittery clock feature is enabled.
+ * @param sram_main_readback_locked: SRAM main readback register is locked.
+ * @param sram_ret_readback_locked: SRAM ret readback register is locked.
+ * @param sram_main_readback_en: SRAM main readback feature is enabled.
+ * @param sram_ret_readback_en: SRAM ret readback feature is enabled.
+ * @return OK or error.
  */
-void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr);
+status_t pentest_configure_cpu(
+    bool disable_icache, bool disable_dummy_instr, bool enable_jittery_clock,
+    bool enable_sram_readback, bool *clock_jitter_locked, bool *clock_jitter_en,
+    bool *sram_main_readback_locked, bool *sram_ret_readback_locked,
+    bool *sram_main_readback_en, bool *sram_ret_readback_en);
 
 /**
  * Initializes the peripherals (pinmux, uart, gpio, and timer) used by SCA code.

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -615,15 +615,18 @@ status_t handle_aes_pentest_init(ujson_t *uj) {
     return ABORTED();
   }
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_cpuctrl.icache_disable,
-                        uj_cpuctrl.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
@@ -133,7 +133,13 @@ status_t handle_edn_sca_init(ujson_t *uj) {
                    kPentestPeripheralCsrng | kPentestPeripheralEdn);
 
   // Disable the instruction cache and dummy instructions for SCA attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -143,6 +149,10 @@ status_t handle_edn_sca_init(ujson_t *uj) {
   // Configure the entropy complex. Set the reseed interval to max to avoid
   // reseed during the trigger window.
   TRY(pentest_configure_entropy_source_max_reseed_interval());
+
+  // Read device ID and return to host.
+  TRY(pentest_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
@@ -97,12 +97,17 @@ status_t handle_hmac_pentest_init(ujson_t *uj) {
                    kPentestPeripheralEdn | kPentestPeripheralHmac);
 
   // Disable the instruction cache and dummy instructions for SCA.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -125,15 +125,20 @@ status_t handle_ibex_pentest_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralKmac);
 
   // Disable the instruction cache and dummy instructions for SCA.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Key manager not initialized for the handle_ibex_sca_key_sideloading test.
   key_manager_init = false;
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -475,15 +475,18 @@ status_t handle_kmac_pentest_init(ujson_t *uj) {
 
   kmac_block_until_idle();
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_cpuctrl.icache_disable,
-                        uj_cpuctrl.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
@@ -494,14 +494,18 @@ status_t handle_otbn_pentest_init(ujson_t *uj) {
     return ABORTED();
   }
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -605,15 +605,18 @@ status_t handle_sha3_pentest_init(ujson_t *uj) {
 
   kmac_block_until_idle();
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_cpuctrl.icache_disable,
-                        uj_cpuctrl.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
@@ -37,7 +37,8 @@ UJSON_SERDE_STRUCT(CryptoFiKmacMode, crypto_fi_kmac_mode_t, CRYPTOFI_KMAC_MODE);
 #define CRYPTOFI_AES_CIPHERTEXT(field, string) \
     field(ciphertext, uint8_t, 16) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiAesCiphertext, crypto_fi_aes_ciphertext_t, CRYPTOFI_AES_CIPHERTEXT);
 
 #define CRYPTOFI_KMAC_STATE(field, string) \
@@ -45,20 +46,23 @@ UJSON_SERDE_STRUCT(FiAesCiphertext, crypto_fi_aes_ciphertext_t, CRYPTOFI_AES_CIP
     field(share1, uint8_t, 200) \
     field(digest, uint8_t, 8) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiKmacState, crypto_fi_kmac_state_t, CRYPTOFI_KMAC_STATE);
 
 #define CRYPTOFI_KMAC_DIGEST(field, string) \
     field(digest, uint8_t, 8) \
     field(digest_2nd, uint8_t, 8) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiKmacDigest, crypto_fi_kmac_digest_t, CRYPTOFI_KMAC_DIGEST);
 
 #define CRYPTOFI_TEST_RESULT_MULT(field, string) \
     field(result, uint32_t, 3) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(CRYPTOFITestResultMult, crypto_fi_test_result_mult_t, CRYPTOFI_TEST_RESULT_MULT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -53,47 +53,54 @@ UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_TEST_RESULT_REGISTERS(field, string) \
     field(result, uint32_t) \
     field(registers, uint32_t, 32) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiTestResultRegisters, ibex_fi_test_result_registers_t, IBEXFI_TEST_RESULT_REGISTERS);
 
 #define IBEXFI_TEST_RESULT_MULT(field, string) \
     field(result1, uint32_t) \
     field(result2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
 
 #define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
     field(loop_counter1, uint32_t) \
     field(loop_counter2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 #define IBEXFI_FAULTY_ADDRESSES_DATA(field, string) \
     field(err_status, uint32_t) \
     field(addresses, uint32_t, 8) \
     field(data, uint32_t, 8) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiFaultyAddressesData, ibex_fi_faulty_addresses_data_t, IBEXFI_FAULTY_ADDRESSES_DATA);
 
 #define IBEXFI_FAULTY_ADDRESSES(field, string) \
     field(err_status, uint32_t) \
     field(addresses, uint32_t, 8) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiFaultyAddresses, ibex_fi_faulty_addresses_t, IBEXFI_FAULTY_ADDRESSES);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
@@ -21,7 +21,8 @@ UJSON_SERDE_ENUM(LcCtrlFiSubcommand, lc_ctrl_fi_subcommand_t, LCCTRLFI_SUBCOMMAN
     field(state, uint32_t) \
     field(counter, uint32_t) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(LcCtrlFiCorruption, lc_ctrl_fi_corruption_t, LCCTRLFI_CORRUPTION);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
@@ -38,14 +38,16 @@ UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
     field(loop_counter, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
 
 #define OTBNFI_RESULT_OUTPUT(field, string) \
     field(result, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiResultOutput, otbn_fi_result_t, OTBNFI_RESULT_OUTPUT);
 
 #define OTBNFI_KEY_OUTPUT(field, string) \
@@ -53,7 +55,8 @@ UJSON_SERDE_STRUCT(OtbnFiResultOutput, otbn_fi_result_t, OTBNFI_RESULT_OUTPUT);
     field(keys, uint32_t, 4) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiKeyOutput, otbn_fi_keys_t, OTBNFI_KEY_OUTPUT);
 
 #define OTBNFI_MEM_CFG(field, string) \
@@ -71,7 +74,8 @@ UJSON_SERDE_STRUCT(OtbnFiMemCfg, otbn_fi_mem_cfg_t, OTBNFI_MEM_CFG);
     field(dmem_addr, uint32_t, 8) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiMemOutput, otbn_fi_mem_t, OTBNFI_MEM_OUTPUT);
 
 #define OTBNFI_DATA_OUTPUT(field, string) \
@@ -80,7 +84,8 @@ UJSON_SERDE_STRUCT(OtbnFiMemOutput, otbn_fi_mem_t, OTBNFI_MEM_OUTPUT);
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiDataOutput, otbn_fi_data_t, OTBNFI_DATA_OUTPUT);
 
 #define OTBNFI_RF_CHAR_OUTPUT(field, string) \
@@ -89,7 +94,8 @@ UJSON_SERDE_STRUCT(OtbnFiDataOutput, otbn_fi_data_t, OTBNFI_DATA_OUTPUT);
     field(faulty_wdr, uint32_t, 256) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiRfCharOutput, otbn_fi_rf_char_t, OTBNFI_RF_CHAR_OUTPUT);
 
 #define OTBNFI_RESULT_CNT_OUTPUT(field, string) \
@@ -97,7 +103,8 @@ UJSON_SERDE_STRUCT(OtbnFiRfCharOutput, otbn_fi_rf_char_t, OTBNFI_RF_CHAR_OUTPUT)
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiResultCntOutput, otbn_fi_result_cnt_t, OTBNFI_RESULT_CNT_OUTPUT);
 
 #define OTBNFI_RESULT_ARRAY(field, string) \
@@ -105,7 +112,8 @@ UJSON_SERDE_STRUCT(OtbnFiResultCntOutput, otbn_fi_result_cnt_t, OTBNFI_RESULT_CN
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiResultArray, otbn_fi_result_array_t, OTBNFI_RESULT_ARRAY);
 
 #define OTBNFI_BIG_NUM(field, string) \
@@ -117,7 +125,8 @@ UJSON_SERDE_STRUCT(OtbnFiBigNum, otbn_fi_big_num_t, OTBNFI_BIG_NUM);
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiBigNumOutput, otbn_fi_big_num_out_t, OTBNFI_BIG_NUM_OUTPUT);
 
 #define OTBNFI_PC(field, string) \
@@ -130,7 +139,8 @@ UJSON_SERDE_STRUCT(OtbnFiPc, otbn_fi_pc_t, OTBNFI_PC);
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiPcOutput, otbn_fi_pc_out_t, OTBNFI_PC_OUTPUT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otp_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otp_fi_commands.h
@@ -24,7 +24,8 @@ UJSON_SERDE_ENUM(OtpFiSubcommand, otp_fi_subcommand_t, OTPFI_SUBCOMMAND);
     field(vendor_test_fi, uint32_t, 16) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiVendortestPartition, otp_fi_vendortest_partition_t, OTPFI_VENDORTEST_PARTITION);
 
 #define OTPFI_OWNERSWCFG_PARTITION(field, string) \
@@ -32,7 +33,8 @@ UJSON_SERDE_STRUCT(OtpFiVendortestPartition, otp_fi_vendortest_partition_t, OTPF
     field(owner_sw_cfg_fi, uint32_t, 200) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiOwnerswcfgPartition, otp_fi_ownerswcfg_partition_t, OTPFI_OWNERSWCFG_PARTITION);
 
 #define OTPFI_HWCFG_PARTITION(field, string) \
@@ -40,7 +42,8 @@ UJSON_SERDE_STRUCT(OtpFiOwnerswcfgPartition, otp_fi_ownerswcfg_partition_t, OTPF
     field(hw_cfg_fi, uint32_t, 20) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiHwcfgPartition, otp_fi_hwcfg_partition_t, OTPFI_HWCFG_PARTITION);
 
 #define OTPFI_LIFECYCLE_PARTITION(field, string) \
@@ -48,7 +51,8 @@ UJSON_SERDE_STRUCT(OtpFiHwcfgPartition, otp_fi_hwcfg_partition_t, OTPFI_HWCFG_PA
     field(life_cycle_fi, uint32_t, 22) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiLifecyclePartition, otp_fi_lifecycle_partition_t, OTPFI_LIFECYCLE_PARTITION);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
@@ -11,13 +11,21 @@ extern "C" {
 
 // clang-format off
 
-#define PENETRATIONTEST_DEVICE_ID(field, string) \
-    field(device_id, uint32_t, 8)
-UJSON_SERDE_STRUCT(PenetrationtestDeviceId, penetrationtest_device_id_t, PENETRATIONTEST_DEVICE_ID);
+#define PENETRATIONTEST_DEVICE_INFO(field, string) \
+    field(device_id, uint32_t, 8) \
+    field(clock_jitter_locked, bool) \
+    field(clock_jitter_en, bool) \
+    field(sram_main_readback_locked, bool) \
+    field(sram_main_readback_en, bool) \
+    field(sram_ret_readback_locked, bool) \
+    field(sram_ret_readback_en, bool)
+UJSON_SERDE_STRUCT(PenetrationtestDeviceInfo, penetrationtest_device_info_t, PENETRATIONTEST_DEVICE_INFO);
 
 #define PENETRATIONTEST_CPUCTRL(field, string) \
     field(icache_disable, bool) \
-    field(dummy_instr_disable, bool)
+    field(dummy_instr_disable, bool) \
+    field(enable_jittery_clock, bool) \
+    field(enable_sram_readback, bool)
 UJSON_SERDE_STRUCT(PenetrationtesCpuctrl, penetrationtest_cpuctrl_t, PENETRATIONTEST_CPUCTRL);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/rng_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rng_fi_commands.h
@@ -34,33 +34,38 @@ UJSON_SERDE_STRUCT(CryptoFiCsrngMode, crypto_fi_csrng_mode_t, CRYPTOFI_CSRNG_MOD
     field(res, uint32_t) \
     field(rand, uint32_t, 16) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiCsrngOutput, rng_fi_csrng_output_t, RNGFI_CSRNG_OUTPUT);
 
 #define RNGFI_CSRNG_OV_OUTPUT(field, string) \
     field(res, uint32_t) \
     field(rand, uint32_t, 12) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiCsrngOvOutput, rng_fi_csrng_ov_output_t, RNGFI_CSRNG_OV_OUTPUT);
 
 #define RNGFI_ENTRBIAS_OUTPUT(field, string) \
     field(rand, uint32_t, 32) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiEntrBiasOutput, rng_fi_entropy_src_bias_t, RNGFI_ENTRBIAS_OUTPUT);
 
 #define RNGFI_FWOVERWRITE_OUTPUT(field, string) \
     field(rand, uint32_t, 32) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiFwOverwriteOutput, rng_fi_fw_overwrite_t, RNGFI_FWOVERWRITE_OUTPUT);
 
 #define RNGFI_EDN(field, string) \
     field(collisions, uint32_t) \
     field(rand, uint32_t, 16) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiEdn, rng_fi_edn_t, RNGFI_EDN);
 
 #define RNGFI_FWOVERWRITE_HEALTH(field, string) \

--- a/sw/device/tests/penetrationtests/json/rom_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rom_fi_commands.h
@@ -20,7 +20,8 @@ UJSON_SERDE_ENUM(RomFiSubcommand, rom_fi_subcommand_t, ROMFI_SUBCOMMAND);
 #define ROMFI_DIGEST(field, string) \
     field(digest, uint32_t, 8) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RomFiDigest, rom_fi_digest_t, ROMFI_DIGEST);
 
 // clang-format on


### PR DESCRIPTION
This PR consists of two commits:

- Allow enabling / disabling the SRAM readback feature as well as the jittery clock
- Read out and report the fatal / recoverable alerts from the AST