### PR TITLE
[tlul,dv] Randomize instr_type to see EXECUTE type

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -11,8 +11,12 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
   `uvm_object_utils(cip_tl_host_single_seq)
   `uvm_object_new
 
-  mubi4_t instr_type                   = MuBi4False;
-  tl_intg_err_e       tl_intg_err_type = TlIntgErrNone;
+  rand mubi4_t  instr_type;
+  tl_intg_err_e tl_intg_err_type = TlIntgErrNone;
+
+  constraint instr_type_c {
+    soft instr_type == MuBi4False;
+  }
 
   virtual function void randomize_req(REQ req, int idx);
     super.randomize_req(req, idx);


### PR DESCRIPTION
- instr_type was never found enabled when running the sequence cip_tl_host_single_seq, this enables to see the EXECUTE command types on the bus on the top of READ and WRITE possibilities.
- this field is always set to MuBi4False by default but can be overriden by the user with an inline constraint when randomizing this sequence.