### PR TITLE
[rom_ext] Disable compiler jump guards

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,10 +15,6 @@ build --strip='never'
 # warnings.
 build --features=-pedantic_warnings
 
-# Enable toolchain hardening features.
-# `guards` adds `unimp` guard instructions after unconditional jumps.
-build --features=guards
-
 # Use --config=disable_hardening to disable hardening to measure the
 # impact of the hardened sequences on code size.
 build:disable_hardening --features=-guards --copt=-DOT_DISABLE_HARDENING=1


### PR DESCRIPTION
The compiler `guards` feature is meant as a control flow integrity feature that inserts `unimp` sequences around branches to protect against instruction skips.

Unfortunately, the ROM_EXT has grown perilously close to its size limit and the `guards` feature results in an approximately 12% tax on code size.  By turning this feature off, we save about 5700 bytes of code space.