### PR TITLE
[rescue] Implement the DFU protocol for rescue 

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/BUILD
+++ b/sw/device/silicon_creator/lib/rescue/BUILD
@@ -75,3 +75,40 @@ cc_library(
         "//sw/device/silicon_creator/lib:error",
     ],
 )
+
+cc_library(
+    name = "dfu",
+    srcs = [
+        "dfu.c",
+        "dfu_state_table.c",
+    ],
+    hdrs = [
+        "dfu.h",
+    ],
+    deps = [
+        ":rescue",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:usb",
+    ],
+)
+
+cc_library(
+    name = "rescue_usbdfu",
+    srcs = ["rescue_usb.c"],
+    deps = [
+        ":dfu",
+        ":rescue",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:pinmux",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:usb",
+    ],
+)

--- a/sw/device/silicon_creator/lib/rescue/dfu.c
+++ b/sw/device/silicon_creator/lib/rescue/dfu.c
@@ -1,0 +1,319 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/rescue/dfu.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+typedef struct rescue_mode_properties {
+  uint32_t mode;
+  bool dnload;
+  bool upload;
+} rescue_mode_properties_t;
+
+static const rescue_mode_properties_t mode_by_altsetting[] = {
+    {kRescueModeFirmware, true, false},
+    {kRescueModeFirmwareSlotB, true, false},
+    {kRescueModeOpenTitanID, false, true},
+    {kRescueModeBootLog, false, true},
+    {kRescueModeBootSvcRsp, true, true},
+    {kRescueModeOwnerPage0, true, true},
+    //{ kRescueModeOwnerPage1, false, true },
+};
+
+static rom_error_t validate_mode(uint32_t setting, rescue_state_t *state,
+                                 boot_data_t *bootdata) {
+  // Allow the `setting` to be either an index or a FourCC code.
+  // The the integer value is less than the arraysize, then its clearly an
+  // index.
+  if (setting >= ARRAYSIZE(mode_by_altsetting)) {
+    // All of the FourCC codes are going to be greater than any index.  Search
+    // the array for a matching FourCC code and use the index as the setting.
+    size_t i = 0;
+    for (; i < ARRAYSIZE(mode_by_altsetting); ++i) {
+      if (setting == mode_by_altsetting[i].mode) {
+        setting = i;
+        break;
+      }
+    }
+  }
+  if (setting >= ARRAYSIZE(mode_by_altsetting)) {
+    // Setting not found; Bad mode.
+    return kErrorRescueBadMode;
+  }
+
+  // The UART version of the protocol has to distinguish between send and recv
+  // targets for the same service (e.g. boot service has a request and a
+  // response mode).  Since DFU supports upload and download operations to the
+  // same target, we handle the "send" services first to stage data into the
+  // rescue buffer.
+  const rescue_mode_properties_t *mode = &mode_by_altsetting[setting];
+  rom_error_t error2 = kErrorOk;
+  rom_error_t error = rescue_validate_mode(mode->mode, state, bootdata);
+  if (error == kErrorOk && mode->upload) {
+    // DFU upload means send to the host.  We stage the data that would
+    // be sent to the rescue buffer.
+    rescue_send_handler(state, bootdata);
+  }
+  // BootSvc and OwnerPage are also recv (from the host) services.  Make sure
+  // we're set up to process a DFU download for those services.
+  if (mode->mode == kRescueModeBootSvcRsp) {
+    error2 = rescue_validate_mode(kRescueModeBootSvcReq, state, bootdata);
+  } else if (mode->mode == kRescueModeOwnerPage0) {
+    error2 = rescue_validate_mode(kRescueModeOwnerBlock, state, bootdata);
+  }
+
+  if (error == kErrorOk || error2 == kErrorOk) {
+    // If either the send or recv mode is ok, then setting the mode is ok.
+    // If only one is Ok, the send or recv handler will report the error when we
+    // try an unauthorized operation.
+    return kErrorOk;
+  }
+  // If neither is Ok, the report bad mode.
+  return kErrorRescueBadMode;
+}
+
+static rom_error_t dfu_control(dfu_ctx_t *ctx, usb_setup_data_t *setup) {
+  rom_error_t result = kErrorOk;
+  if (setup->request > kDfuReqAbort) {
+    ctx->dfu_state = kDfuStateError;
+    ctx->dfu_error = kDfuErrUnknown;
+    return kErrorUsbBadSetup;
+  }
+
+  dfu_state_transition_t *tr = &dfu_state_table[setup->request][ctx->dfu_state];
+
+  // Carry out the action for this state transition.
+  switch (tr->action) {
+    case kDfuActionNone:
+      // No action: move to the next state and ack the transaction.
+      ctx->dfu_state = tr->next[0];
+      dfu_transport_data(ctx, kUsbDirIn, NULL, 0, 0);
+      break;
+    case kDfuActionStall:
+      // Stall: move to the next state and stall the transport.
+      ctx->dfu_state = tr->next[0];
+      ctx->dfu_error = kDfuErrStalledPkt;
+      result = kErrorUsbBadSetup;
+      break;
+    case kDfuActionDataXfer:
+      // Check the length and download/upload.
+      // DFU-spec quirks:
+      // - We require that DnLoad transfers are always 2K blocks.  The last
+      //   block is allowed to be short.
+      // - We limit UpLoad transfers to a maximum of 2K.  We currently have
+      //   no ROM_EXT services that require more than a 2K UpLoad.
+      ctx->dfu_state = tr->next[setup->length == 0 ? 0 : 1];
+      // Length is good and the request is either upload/download.
+      if (setup->length <= sizeof(ctx->state.data) &&
+          (setup->request == kDfuReqDnLoad ||
+           setup->request == kDfuReqUpLoad)) {
+        if (setup->request == kDfuReqDnLoad) {
+          if (setup->length == 0 ||
+              ctx->state.offset < ctx->state.flash_limit) {
+            // If its a download (transfer to opentitan), perform the transfer
+            // into the rescue state buffer. For a zero-length request, simply
+            // ACK with a zero-length packet.
+            dfu_transport_data(ctx, setup->length == 0 ? kUsbDirIn : kUsbDirOut,
+                               ctx->state.data, setup->length, 0);
+          } else {
+            ctx->dfu_state = kDfuStateError;
+            ctx->dfu_error = kDfuErrAddress;
+            result = kErrorUsbBadSetup;
+          }
+        } else {
+          // If its an upload (transfer to the host), perform the transfer
+          // from the rescue state buffer. A prior `SetInterface` command will
+          // have staged the requested content into the buffer.
+          size_t length = (size_t)MIN(ctx->state.staged_len, setup->length);
+          usb_transfer_flags_t flags =
+              length < setup->length && length % 64 == 0
+                  ? kUsbTransferFlagsShortIn
+                  : 0;
+          dfu_transport_data(ctx, kUsbDirIn, ctx->state.data, length, flags);
+        }
+      } else {
+        ctx->dfu_state = kDfuStateError;
+        ctx->dfu_error = kDfuErrUnknown;
+        result = kErrorUsbBadSetup;
+      }
+      break;
+    case kDfuActionStatusResponse:
+      // Send a status response to the host.
+      ctx->dfu_state = tr->next[0];
+      ctx->status.status = (uint8_t)ctx->dfu_error;
+      ctx->status.poll_timeout[0] = 100;  // poll us every 100 milliseconds.
+      ctx->status.poll_timeout[1] = 0;
+      ctx->status.poll_timeout[2] = 0;
+      ctx->status.state = (uint8_t)ctx->dfu_state;
+      ctx->status.string = 0;
+      dfu_transport_data(ctx, kUsbDirIn, &ctx->status, sizeof(ctx->status), 0);
+      break;
+    case kDfuActionStateResponse:
+      // Send our current DFU state to the host.
+      ctx->dfu_state = tr->next[0];
+      dfu_transport_data(ctx, kUsbDirIn, &ctx->dfu_state, 1, 0);
+      break;
+    case kDfuActionClearError:
+      // Clear the current error.
+      ctx->dfu_state = tr->next[0];
+      ctx->dfu_error = kDfuErrOk;
+      dfu_transport_data(ctx, kUsbDirIn, NULL, 0, 0);
+      break;
+  }
+
+  return result;
+}
+
+static rom_error_t vendor_request(dfu_ctx_t *ctx, usb_setup_data_t *setup) {
+  switch (setup->request) {
+    // Proprietary vendor version of SetInterface that constructs the
+    // FourCC from the value and index fields.
+    case kDfuVendorSetMode: {
+      uint32_t mode = ((uint32_t)setup->value << 16) | setup->index;
+      if (validate_mode(mode, &ctx->state, ctx->bootdata) == kErrorOk) {
+        dfu_transport_data(ctx, kUsbDirIn, NULL, 0, 0);
+      } else {
+        return kErrorUsbBadSetup;
+      }
+    } break;
+    default:
+      return kErrorUsbBadSetup;
+  }
+  return kErrorOk;
+}
+
+static rom_error_t interface_request(dfu_ctx_t *ctx, usb_setup_data_t *setup) {
+  switch (setup->request) {
+    case kUsbSetupReqSetInterface:
+      if (validate_mode(setup->value, &ctx->state, ctx->bootdata) == kErrorOk) {
+        ctx->interface = (uint8_t)setup->value;
+        dfu_transport_data(ctx, kUsbDirIn, NULL, 0, 0);
+      } else {
+        return kErrorUsbBadSetup;
+      }
+      break;
+    case kUsbSetupReqGetInterface:
+      dfu_transport_data(ctx, kUsbDirIn, &ctx->interface,
+                         sizeof(ctx->interface), 0);
+      break;
+    default:
+      return kErrorUsbBadSetup;
+  }
+  return kErrorOk;
+}
+
+static rom_error_t set_configuration(dfu_ctx_t *ctx) {
+  ctx->dfu_error = kDfuErrOk;
+  ctx->dfu_state = kDfuStateIdle;
+  ctx->interface = 0;
+  validate_mode(ctx->interface, &ctx->state, ctx->bootdata);
+  ctx->ep0.configuration = ctx->ep0.next.configuration;
+  return kErrorOk;
+}
+
+void dfu_protocol_handler(void *_ctx, uint8_t ep, usb_transfer_flags_t flags,
+                          void *data) {
+  dfu_ctx_t *ctx = (dfu_ctx_t *)_ctx;
+  OT_DISCARD(ep);
+
+  // Handle event callbacks from the underlying transport (e.g. USB).
+
+  // If its SETUPDATA, its a USB or DFU request.
+  if (flags & kUsbTransferFlagsSetupData) {
+    usb_setup_data_t *setup = (usb_setup_data_t *)data;
+
+    rom_error_t error = kErrorOk;
+    if ((setup->request_type & kUsbReqTypeTypeMask) == kUsbReqTypeClass) {
+      // If its a class-level request, call the DFU control function.
+      error = dfu_control(ctx, setup);
+    } else if ((setup->request_type & kUsbReqTypeTypeMask) ==
+               kUsbReqTypeVendor) {
+      // If its a proprietary vendor request, we handle it here.
+      error = vendor_request(ctx, setup);
+
+    } else if ((setup->request_type & kUsbReqTypeRecipientMask) ==
+               kUsbReqTypeInterface) {
+      // If its an interface-level request, we handle it here.  These requests
+      // will be {Set,Get}Interface.  We use interface altsettings to control
+      // which services rescue is communicating with.
+      error = interface_request(ctx, setup);
+    } else {
+      // Otherwise, all other requests get mapped to the standard control
+      // endpoint function.
+      error = dfu_transport_setupdata(ctx, setup);
+      // Take care of the SetConfiguration command.
+      if (ctx->ep0.flags & kUsbControlFlagsPendingConfig) {
+        ctx->ep0.flags &= ~(unsigned)kUsbControlFlagsPendingConfig;
+        error = set_configuration(ctx);
+        if (error == kErrorOk) {
+          dfu_transport_data(ctx, kUsbDirIn, NULL, 0, 0);
+        }
+      }
+    }
+    dfu_transport_result(ctx, error);
+  }
+
+  // If we completed a transfer, process the completion.
+  if (flags & kUsbTransferFlagsDone) {
+    // Take care of the SetAddress command.
+    if (ctx->ep0.flags & kUsbControlFlagsPendingAddress) {
+      ctx->ep0.flags &= ~(unsigned)kUsbControlFlagsPendingAddress;
+      ctx->ep0.device_address = ctx->ep0.next.device_address;
+      usb_set_address(ctx->ep0.device_address);
+    }
+
+    size_t length = *(size_t *)data;
+    if (ctx->dfu_state == kDfuStateDnLoadSync) {
+      // If we're in the DnLoadSync state and we completed a transfer, that
+      // means the rescue buffer has data to process.
+      ctx->state.offset = (uint32_t)length;
+      while (ctx->state.offset < sizeof(ctx->state.data)) {
+        // Make sure the full buffer is filled.  Fill unused space with 0xFF.
+        ctx->state.data[ctx->state.offset++] = 0xFF;
+      }
+      // Pass the rescue buffer to the rescue receive handler.
+      rom_error_t error = rescue_recv_handler(&ctx->state, ctx->bootdata);
+      switch (error) {
+        case kErrorOk:
+          ctx->dfu_error = kDfuErrOk;
+          break;
+        default:
+          ctx->dfu_error = kDfuErrVendor;
+      }
+      // Back to DnLoadIdle state.
+      ctx->dfu_state = kDfuStateDnLoadIdle;
+    } else if (ctx->dfu_state == kDfuStateUpLoadIdle) {
+      if (length < kDfuTransferSize) {
+        ctx->dfu_state = kDfuStateIdle;
+      }
+      // The amount of staged data is now zero.
+      ctx->state.staged_len = 0;
+    }
+  }
+
+  if (flags & kUsbTransferFlagsReset) {
+    // A USB reset after we've been enumerated means software reset.
+    if (ctx->ep0.device_address && ctx->ep0.configuration) {
+      rstmgr_reset();
+    }
+  }
+
+  if (flags & kUsbTransferFlagsError) {
+    // If we've been enumerated, then move the DFU state machine into the error
+    // state.
+    if (ctx->ep0.device_address && ctx->ep0.configuration) {
+      ctx->dfu_state = kDfuStateError;
+      ctx->dfu_error = kDfuErrUnknown;
+    }
+  }
+}

--- a/sw/device/silicon_creator/lib/rescue/dfu.h
+++ b/sw/device/silicon_creator/lib/rescue/dfu.h
@@ -1,0 +1,253 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_RESCUE_DFU_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_RESCUE_DFU_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+#include "sw/device/silicon_creator/lib/rescue/rescue.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DFU states.
+ */
+typedef enum dfu_state {
+  kDfuStateAppIdle = 0,
+  kDfuStateAppDetach = 1,
+  kDfuStateIdle = 2,
+  kDfuStateDnLoadSync = 3,
+  kDfuStateDnLoadBusy = 4,
+  kDfuStateDnLoadIdle = 5,
+  kDfuStateManifestSync = 6,
+  kDfuStateManifest = 7,
+  kDfuStateManifestWaitReset = 8,
+  kDfuStateUpLoadIdle = 9,
+  kDfuStateError = 10,
+  kDfuStateTotalLength = 11,
+} dfu_state_t;
+
+/**
+ * DFU error codes.
+ */
+typedef enum dfu_err {
+  kDfuErrOk = 0,
+  kDfuErrTarget = 1,
+  kDfuErrFile = 2,
+  kDfuErrWrite = 3,
+  kDfuErrErase = 4,
+  kDfuErrCheckErased = 5,
+  kDfuErrProg = 6,
+  kDfuErrVerify = 7,
+  kDfuErrAddress = 8,
+  kDfuErrNotDone = 9,
+  kDfuErrFirmware = 10,
+  kDfuErrVendor = 11,
+  kDfuErrUsbReset = 12,
+  kDfuErrPowerOnReset = 13,
+  kDfuErrUnknown = 14,
+  kDfuErrStalledPkt = 15,
+} dfu_err_t;
+
+/**
+ * DFU requests (e.g SETUPDATA `bRequest`).
+ */
+typedef enum dfu_req {
+  kDfuReqDetach = 0,
+  kDfuReqDnLoad = 1,
+  kDfuReqUpLoad = 2,
+  kDfuReqGetStatus = 3,
+  kDfuReqClrStatus = 4,
+  kDfuReqGetState = 5,
+  kDfuReqAbort = 6,
+  kDfuReqTotalLength = 7,
+} dfu_req_t;
+
+/**
+ * DFU actions to take during a state transition.
+ */
+typedef enum dfu_action_t {
+  kDfuActionNone = 0,
+  kDfuActionStall,
+  kDfuActionDataXfer,
+  kDfuActionStatusResponse,
+  kDfuActionStateResponse,
+  kDfuActionClearError,
+  kDfuActionReset,
+} dfu_action_t;
+
+/**
+ * A DFU state transition.
+ *
+ * The action in taken and then a next state is chosen based on the action's
+ * result.
+ */
+typedef struct dfu_state_transition {
+  /**
+   * Holds a `dfu_action_t` specifying which action to take for the state
+   * transition.
+   */
+  uint8_t action;
+  /**
+   * Holds `dfu_state_t`.  Depending on the result of the `action`, the next
+   * state will be either next[0] or next[1].
+   */
+  uint8_t next[2];
+} dfu_state_transition_t;
+
+/**
+ * The DFU state table mapping actions and next states.
+ *
+ * We map determine the next state for each DFU request and initial state.
+ */
+extern dfu_state_transition_t dfu_state_table[kDfuReqTotalLength]
+                                             [kDfuStateTotalLength];
+
+/**
+ * The response to a DFU_GETSTATUS request.
+ */
+typedef struct dfu_getstatus {
+  /** The status of the most recent request. */
+  uint8_t status;
+  /** Minimum time (ms) that the host should wait before sending another
+   * DFU_GETSTATUS request. */
+  uint8_t poll_timeout[3];
+  /** The next state of the device after this response. */
+  uint8_t state;
+  /** An index of the status description in the string table. */
+  uint8_t string;
+} dfu_getstatus_t;
+
+/**
+ * The DFU rescue context.
+ */
+typedef struct dfu_ctx {
+  /** USB context for managing endpoint zero. */
+  usb_control_ctx_t ep0;
+  /** Rescue state. */
+  rescue_state_t state;
+  /** Pointer to bootdata. */
+  boot_data_t *bootdata;
+  /** Status buffer (used to respond to DfuReqGetStatus). */
+  dfu_getstatus_t status;
+  /** DFU state. */
+  uint8_t dfu_state;
+  /** DFU error. */
+  uint8_t dfu_error;
+  /** Currenty selected usb interface setting. */
+  uint8_t interface;
+} dfu_ctx_t;
+
+/**
+ * Start a DFU transfer.
+ *
+ * This is a simple wrapper around `usb_ep_transfer` that can be replaced at
+ * link-time with alternative transports (such as SPI).
+ *
+ * @param ctx The DFU context.
+ * @param dir The direction of the transfer.
+ * @param data The buffer to send or receive into.
+ * @param len The length of the buffer.
+ * @param flags The direction or other attributes assocated with the transfer.
+ */
+void dfu_transport_data(dfu_ctx_t *ctx, usb_dir_t dir, void *data, size_t len,
+                        usb_transfer_flags_t flags);
+
+/**
+ * Handle the transport's standard setupdata requests
+ *
+ * This is a simple wrapper around `usb_control_setupdata` that can be replaced
+ * at link-time with alternative transports (such as SPI).
+ *
+ * @param ctx The DFU context.
+ * @param setup A pointer to the setupdata.
+ * @return Result of handling the setupdata.
+ */
+rom_error_t dfu_transport_setupdata(dfu_ctx_t *ctx, usb_setup_data_t *setup);
+
+/**
+ * Report a result or error on the transport.
+ *
+ * On USB, if there is an error, this should stall the control endpoint.
+ *
+ * @param ctx The DFU context.
+ * @param result The Ok or Error result to signal on the transport.
+ */
+void dfu_transport_result(dfu_ctx_t *ctx, rom_error_t result);
+
+/**
+ * Implements the DFU protocol.
+ *
+ * For USB, this is the endpoint callback function.
+ *
+ * @param ctx A pointer to a `dfu_ctx_t`.
+ * @param ep The endpoint number for the callback.
+ * @param flags The condition for the callback.
+ * @param data Any extra data associated with the condition.
+ */
+void dfu_protocol_handler(void *ctx, uint8_t ep, usb_transfer_flags_t flags,
+                          void *data);
+
+/**
+ * Implementation constant.
+ */
+enum {
+  /**
+   * Device Class, SubClass and Protocol for DFU.
+   */
+  kDfuDeviceClass = 0xFE,
+  kDfuDeviceSubClass = 0x01,
+  kDfuDeviceProtocol = 0x02,
+
+  /**
+   * Constants for the DFU functional descriptor.
+   */
+  kDfuFuncDescLen = 9,
+  kDfuFuncDescType = 0x21,
+  kDfuFuncAttrCanDnLoad = 1,
+  kDfuFuncAttrCanUpLoad = 2,
+  kDfuFuncAttrManifestTolerant = 4,
+  kDfuFuncAttrWillDetach = 8,
+  kDfuFuncDetachTimeout = 32768,
+
+  /**
+   * We support a DFU transfer size of 2048.
+   * This needs to be the same size as the rescue_state_t::buffer.
+   */
+  kDfuTransferSize = 2048,
+
+  /**
+   * The DFU version is 1.1.
+   */
+  kDfuMajorVersion = 1,
+  kDfuMinorVersion = 1,
+
+  /**
+   * Vendor and Product IDs for the ROM_EXT.
+   * Since lowRISC does not yet have a USB vendor ID, Google has reserved
+   * product ID 0x023A to represent the OpenTitan ROM_EXT when in DFU
+   * rescue mode.
+   */
+  kUsbVendorGoogle = 0x18d1,
+  kUsbProuctRomExt = 0x023a,
+
+  /**
+   * A proprietary vendor request to set the DFU mode using a FourCC code
+   * instead of an AltSetting index. The FourCC code uses the SETUP_DATA 16-bit
+   * value and index fields to represent the 32-bit code.
+   */
+  kDfuVendorSetMode = 0x0b,
+
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_RESCUE_DFU_H_

--- a/sw/device/silicon_creator/lib/rescue/dfu_state_table.c
+++ b/sw/device/silicon_creator/lib/rescue/dfu_state_table.c
@@ -1,0 +1,117 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/rescue/dfu.h"
+
+// clang-format off
+// We map state transitions for every DFU request for every DFU state.
+//
+// The ROM_EXT will never be in the AppIdle or AppDetach states, but we include them
+// so that the state table is complete.
+dfu_state_transition_t dfu_state_table[kDfuReqTotalLength][kDfuStateTotalLength] = {
+    [kDfuReqDetach] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionNone, {kDfuStateAppDetach}},
+            [kDfuStateAppDetach] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateUpLoadIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateError] = {kDfuActionStall, {kDfuStateError}},
+        },
+    [kDfuReqDnLoad] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateAppDetach] = {kDfuActionStall, {kDfuStateError}},
+            // DataXfer chooses next[0] when length == 0, next[1] otherwise.
+            [kDfuStateIdle] = {kDfuActionDataXfer, {kDfuStateError, kDfuStateDnLoadSync}},
+            [kDfuStateDnLoadSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            // DataXfer chooses next[0] when length == 0, next[1] otherwise.
+            [kDfuStateDnLoadIdle] = {kDfuActionDataXfer, {kDfuStateManifestSync, kDfuStateDnLoadSync}},
+            [kDfuStateManifestSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateUpLoadIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateError] = {kDfuActionStall, {kDfuStateError}},
+        },
+    [kDfuReqUpLoad] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateAppDetach] = {kDfuActionStall, {kDfuStateError}},
+            // DataXfer chooses next[0] when length == 0, next[1] otherwise.
+            [kDfuStateIdle] = {kDfuActionDataXfer, {kDfuStateUpLoadIdle, kDfuStateUpLoadIdle}},
+            [kDfuStateDnLoadSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            // DataXfer chooses next[0] when length == 0, next[1] otherwise.
+            [kDfuStateUpLoadIdle] = {kDfuActionDataXfer, {kDfuStateIdle, kDfuStateUpLoadIdle}},
+            [kDfuStateError] = {kDfuActionStall, {kDfuStateError}},
+        },
+    [kDfuReqGetStatus] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionStatusResponse, {kDfuStateAppIdle}},
+            [kDfuStateAppDetach] = {kDfuActionStatusResponse, {kDfuStateAppDetach}},
+            [kDfuStateIdle] = {kDfuActionStatusResponse, {kDfuStateIdle}},
+            [kDfuStateDnLoadSync] = {kDfuActionStatusResponse, {kDfuStateDnLoadIdle}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadIdle] = {kDfuActionStatusResponse, {kDfuStateDnLoadIdle}},
+            [kDfuStateManifestSync] = {kDfuActionStatusResponse, {kDfuStateManifest}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateUpLoadIdle] = {kDfuActionStatusResponse, {kDfuStateUpLoadIdle}},
+            [kDfuStateError] = {kDfuActionStatusResponse, {kDfuStateError}},
+        },
+    [kDfuReqClrStatus] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateAppDetach] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateIdle] = {kDfuActionStall, {kDfuStateIdle}},
+            [kDfuStateDnLoadSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestSync] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateUpLoadIdle] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateError] = {kDfuActionClearError, {kDfuStateIdle}},
+        },
+    [kDfuReqGetState] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionStateResponse, {kDfuStateAppIdle}},
+            [kDfuStateAppDetach] = {kDfuActionStateResponse, {kDfuStateAppDetach}},
+            [kDfuStateIdle] = {kDfuActionStateResponse, {kDfuStateUpLoadIdle}},
+            [kDfuStateDnLoadSync] = {kDfuActionStateResponse, {kDfuStateDnLoadIdle}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadIdle] = {kDfuActionStateResponse, {kDfuStateDnLoadIdle}},
+            [kDfuStateManifestSync] = {kDfuActionStateResponse, {kDfuStateManifestSync}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateUpLoadIdle] = {kDfuActionStateResponse, {kDfuStateUpLoadIdle}},
+            [kDfuStateError] = {kDfuActionStateResponse, {kDfuStateError}},
+        },
+    [kDfuReqAbort] =
+        {
+            [kDfuStateAppIdle] = {kDfuActionStall, {kDfuStateAppIdle}},
+            [kDfuStateAppDetach] = {kDfuActionStall, {kDfuStateAppDetach}},
+            [kDfuStateIdle] = {kDfuActionNone, {kDfuStateIdle}},
+            [kDfuStateDnLoadSync] = {kDfuActionNone, {kDfuStateIdle}},
+            [kDfuStateDnLoadBusy] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateDnLoadIdle] = {kDfuActionNone, {kDfuStateIdle}},
+            [kDfuStateManifestSync] = {kDfuActionNone, {kDfuStateIdle}},
+            [kDfuStateManifest] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateManifestWaitReset] = {kDfuActionStall, {kDfuStateError}},
+            [kDfuStateUpLoadIdle] = {kDfuActionNone, {kDfuStateIdle}},
+            [kDfuStateError] = {kDfuActionStall, {kDfuStateError}},
+        },
+
+};
+// clang-format on

--- a/sw/device/silicon_creator/lib/rescue/rescue_usb.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_usb.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/rescue/dfu.h"
+#include "sw/device/silicon_creator/lib/rescue/rescue.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static const usb_device_descriptor_t device_desc = {
+    .length = (uint8_t)sizeof(usb_device_descriptor_t),
+    .descriptor_type = kUsbDescTypeDevice,
+    .bcd_usb = 0x0200,
+    .device_class = 0,
+    .device_sub_class = 0,
+    .device_protocol = 0,
+    .max_packet_size_0 = 64,
+    .vendor = kUsbVendorGoogle,
+    .product = kUsbProuctRomExt,
+    .bcd_device = 0x100,
+    .imanufacturer = 1,
+    .iproduct = 2,
+    .iserial_number = 3,
+    .num_configurations = 1,
+};
+
+#define DFU_INTERFACE_DSCR(alt)                          \
+  USB_INTERFACE_DSCR(/*inum=*/1, /*alt=*/alt, /*nep=*/0, \
+                     /*class=*/kDfuDeviceClass,          \
+                     /*subclass=*/kDfuDeviceSubClass,    \
+                     /*protocol=*/kDfuDeviceProtocol, /*iint=*/4 + alt)
+
+static const uint8_t config_desc[] = {
+    USB_CFG_DSCR_HEAD(
+        /*total_len=*/USB_CFG_DSCR_LEN + 6 * USB_INTERFACE_DSCR_LEN + 9,
+        /*nint=*/1),
+    DFU_INTERFACE_DSCR(0),
+    DFU_INTERFACE_DSCR(1),
+    DFU_INTERFACE_DSCR(2),
+    DFU_INTERFACE_DSCR(3),
+    DFU_INTERFACE_DSCR(4),
+    DFU_INTERFACE_DSCR(5),
+
+    /* DFU Functional Descriptor */
+    /*bLength=*/kDfuFuncDescLen,
+    /*bDescriptorType=*/kDfuFuncDescType,
+    /*bmAttributes=*/kDfuFuncAttrCanDnLoad | kDfuFuncAttrCanUpLoad |
+        kDfuFuncAttrManifestTolerant,
+    /*wDetachTimeout*/ (uint8_t)kDfuFuncDetachTimeout,
+    (uint8_t)(kDfuFuncDetachTimeout >> 8),
+    /*wTransferSize*/ (uint8_t)kDfuTransferSize,
+    (uint8_t)(kDfuTransferSize >> 8),
+    /*bcdDFUVersion*/ kDfuMajorVersion,
+    kDfuMinorVersion,
+};
+
+static const char lang_id[] = {
+    /* bLength=*/4,
+    /* bDescriptorType=*/3,
+    /* bString=*/0x09,
+    0x04,
+};
+
+// clang-format off
+static const char str_vendor[] = { USB_STRING_DSCR('G','o','o','g','l','e'), };
+static const char str_opentitan[] = { USB_STRING_DSCR('O','p','e','n','T','i','t','a','n'), };
+static const char str_resq[] = { USB_STRING_DSCR('R','e','s','c','u','e') };
+static const char str_resb[] = { USB_STRING_DSCR('R','e','s','c','u','e',' ','S','l','o','t','B')};
+static const char str_otid[] = { USB_STRING_DSCR('D','e','v','i','c','e','I','D') };
+static const char str_blog[] = { USB_STRING_DSCR('B','o','o','t','L','o','g') };
+static const char str_bsvc[] = { USB_STRING_DSCR('B','o','o','t','S','e','r','v','i','c','e','s') };
+static const char str_ownr[] = { USB_STRING_DSCR('O','w','n','e','r','s','h','i','p') };
+
+// Located in RAM so we can fill in the OpenTitan device ID.
+static char str_serialnumber[2 + 32];
+
+static const char *string_desc[] = {
+    lang_id,
+    str_vendor,
+    str_opentitan,
+    str_serialnumber,
+    str_resq,
+    str_resb,
+    str_otid,
+    str_blog,
+    str_bsvc,
+    str_ownr,
+    NULL,
+};
+// clang-format on
+
+// TODO: make sure we report this in the proper order.
+static void set_serialnumber(void) {
+  lifecycle_device_id_t dev;
+  lifecycle_device_id_get(&dev);
+  const char hex[] = "0123456789ABCDEF";
+
+  char *sn = str_serialnumber;
+  *sn++ = 2 + 32;
+  *sn++ = 3;
+  for (size_t w = 1; w < 3; ++w) {
+    uint8_t byte = (uint8_t)(dev.device_id[w] >> 24);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+    byte = (uint8_t)(dev.device_id[w] >> 16);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+    byte = (uint8_t)(dev.device_id[w] >> 8);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+    byte = (uint8_t)(dev.device_id[w] >> 0);
+    *sn++ = hex[byte >> 4];
+    *sn++ = 0;
+    *sn++ = hex[byte & 15];
+    *sn++ = 0;
+  }
+}
+
+void dfu_transport_data(dfu_ctx_t *ctx, usb_dir_t dir, void *data, size_t len,
+                        usb_transfer_flags_t flags) {
+  OT_DISCARD(ctx);
+  usb_ep_transfer((uint8_t)dir | 0, data, len, flags);
+}
+
+rom_error_t dfu_transport_setupdata(dfu_ctx_t *ctx, usb_setup_data_t *setup) {
+  return usb_control_setupdata(&ctx->ep0, setup);
+}
+
+void dfu_transport_result(dfu_ctx_t *ctx, rom_error_t result) {
+  OT_DISCARD(ctx);
+  if (result != kErrorOk) {
+    usb_ep_stall(0, true);
+  }
+}
+
+rom_error_t rescue_protocol(boot_data_t *bootdata,
+                            const owner_rescue_config_t *config) {
+  set_serialnumber();
+  dfu_ctx_t ctx = {
+      .bootdata = bootdata,
+      .ep0 =
+          {
+              .device_desc = &device_desc,
+              .config_desc = config_desc,
+              .string_desc = string_desc,
+          },
+      .dfu_state = kDfuStateIdle,
+      .dfu_error = kDfuErrOk,
+  };
+  dbg_printf("USB-DFU rescue ready\r\n");
+  rescue_state_init(&ctx.state, config);
+  pinmux_init_usb();
+  usb_init();
+  usb_ep_init(0, kUsbEpTypeControl, 0x40, dfu_protocol_handler, &ctx);
+  usb_enable(true);
+  while (true) {
+    usb_poll();
+  }
+  return kErrorOk;
+}


### PR DESCRIPTION
Implement the DFU state machine and control endpoint to manage transfer of data in and out of the chip.

USB AltSettings are used to permit the rescue protocol to communicate with different ROM_EXT services (e.g. boot-log, boot-services, device-id, etc).

This PR depends on #26622 and #26637.