### PR TITLE
[hw,alert_handler,rtl] Properly size widths when NAlerts is a power of 2

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv.tpl
@@ -49,7 +49,7 @@ module ${module_instance_name}_ping_timer import ${module_instance_name}_pkg::*;
   output logic                     esc_ping_fail_o     // any of the esc senders failed
 );
 
-  localparam int unsigned IdDw = $clog2(NAlerts);
+  localparam int unsigned IdDw = prim_util_pkg::vbits(NAlerts + 1);
 
   // Entropy reseeding is triggered every time this counter expires.
   // The expected wait time between pings is 2**(PING_CNT_DW-1) on average.

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -49,7 +49,7 @@ module alert_handler_ping_timer import alert_handler_pkg::*; #(
   output logic                     esc_ping_fail_o     // any of the esc senders failed
 );
 
-  localparam int unsigned IdDw = $clog2(NAlerts);
+  localparam int unsigned IdDw = prim_util_pkg::vbits(NAlerts + 1);
 
   // Entropy reseeding is triggered every time this counter expires.
   // The expected wait time between pings is 2**(PING_CNT_DW-1) on average.

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -49,7 +49,7 @@ module alert_handler_ping_timer import alert_handler_pkg::*; #(
   output logic                     esc_ping_fail_o     // any of the esc senders failed
 );
 
-  localparam int unsigned IdDw = $clog2(NAlerts);
+  localparam int unsigned IdDw = prim_util_pkg::vbits(NAlerts + 1);
 
   // Entropy reseeding is triggered every time this counter expires.
   // The expected wait time between pings is 2**(PING_CNT_DW-1) on average.


### PR DESCRIPTION
Ensure that NAlerts fits into `IdDW`, otherwise the code in alert_handler_ping_timer fails:

```
logic [IdDw-1:0] id_to_ping_d, id_to_ping_q;
  // The subtraction below ensures that the alert ID is always in range. If
  // all alerts are enabled, an alert ID drawn in this way will always be
  // valid. This comes at the cost of a bias towards certain alert IDs that
  // will be pinged twice as often on average - but it ensures that we have
  // less alert IDs that need to be skipped since they are invalid.
  assign id_to_ping_d = (lfsr_state[PING_CNT_DW +: IdDw] >= NAlerts) ?
                        lfsr_state[PING_CNT_DW +: IdDw] - NAlerts    :
                        lfsr_state[PING_CNT_DW +: IdDw];
```
