### PR TITLE
[hw,tlul_adapter_*_racl,rtl] Don't factor a_ready in squash decission

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
@@ -96,7 +96,7 @@ module tlul_adapter_sram_racl
       .out_o( racl_role_vec )
     );
 
-    logic req, rd_req, wr_req, racl_read_allowed, racl_write_allowed;
+    logic rd_req, wr_req, racl_read_allowed, racl_write_allowed, racl_error;
     logic [RaclPolicySelNumRanges-1:0] range_read_allowed;
     logic [RaclPolicySelNumRanges-1:0] range_write_allowed;
 
@@ -118,22 +118,22 @@ module tlul_adapter_sram_racl
     assign racl_read_allowed  = |range_read_allowed;
     assign racl_write_allowed = |range_write_allowed;
 
-    assign req                = tl_i.a_valid & tl_o.a_ready;
-    assign rd_req             = req & (tl_i.a_opcode == tlul_pkg::Get);
-    assign wr_req             = req & (tl_i.a_opcode == tlul_pkg::PutFullData |
-                                       tl_i.a_opcode == tlul_pkg::PutPartialData);
-    assign racl_error_o.valid = (rd_req & ~racl_read_allowed) | (wr_req & ~racl_write_allowed);
+    assign rd_req             = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::Get);
+    assign wr_req             = tl_i.a_valid & (tl_i.a_opcode == tlul_pkg::PutFullData |
+                                                tl_i.a_opcode == tlul_pkg::PutPartialData);
+    assign racl_error         = (rd_req & ~racl_read_allowed) | (wr_req & ~racl_write_allowed);
+    assign racl_error_o.valid = racl_error & tl_o.a_ready;
 
     tlul_request_loopback #(
       .ErrorRsp ( RaclErrorRsp )
     ) u_loopback (
       .clk_i,
       .rst_ni,
-      .squash_req_i ( racl_error_o.valid ),
-      .tl_h2d_i     ( tl_i               ),
-      .tl_d2h_o     ( tl_o               ),
-      .tl_h2d_o     ( tl_h2d_filtered    ),
-      .tl_d2h_i     ( tl_d2h_filtered    )
+      .squash_req_i ( racl_error      ),
+      .tl_h2d_i     ( tl_i            ),
+      .tl_d2h_o     ( tl_o            ),
+      .tl_h2d_o     ( tl_h2d_filtered ),
+      .tl_d2h_i     ( tl_d2h_filtered )
     );
 
     // Collect RACL error information


### PR DESCRIPTION
We don't need to wait for the device to decide squashing the request. We can do that without knowing that. This breaks a combinational loop where in the user of the adapter has a dependency on req_o on the gnt_i signal.