### PR TITLE
[tools,topgen] Fix idempotency of _tplfunc_instance_name

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
@@ -15,7 +15,7 @@
   tool: xcelium
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: ${instance_vlnv("lowrisc:dv:ac_range_check_sim:0.1")}
+  fusesoc_core: ${instance_vlnv("lowrisc:dv:${module_instance_name}_sim:0.1")}
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/${module_instance_name}_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/top_darjeeling_ac_range_check.ipconfig.hjson
@@ -10,13 +10,6 @@
     nr_role_bits: 4
     nr_ctn_uid_bits: 5
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: xcelium
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:darjeeling_dv:ac_range_check_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:${module_instance_name}_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/ac_range_check_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
@@ -225,13 +225,6 @@
     ]
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
@@ -246,13 +246,6 @@
     with_alert_handler: true
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
@@ -8,13 +8,6 @@
     num_inp_period_counters: 8
     module_instance_name: gpio
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
@@ -2005,13 +2005,6 @@
       ]
     }
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
@@ -18,13 +18,6 @@
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_darjeeling_scan_role_pkg
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
@@ -73,13 +73,6 @@
     NumRomInputs: 3
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -63,13 +63,6 @@
       }
     ]
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -547,13 +547,6 @@
     with_alert_handler: true
     top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -10,13 +10,6 @@
     target: 1
     prio: 3
     topname: darjeeling
-    uniquified_modules:
-    {
-      gpio: gpio
-      racl_ctrl: racl_ctrl
-      ac_range_check: ac_range_check
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
@@ -149,11 +149,6 @@
     ]
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
@@ -261,11 +261,6 @@
     with_alert_handler: true
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
@@ -25,11 +25,6 @@
     size: 1048576
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
@@ -8,11 +8,6 @@
     num_inp_period_counters: 0
     module_instance_name: gpio
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
@@ -1986,11 +1986,6 @@
       ]
     }
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
@@ -18,11 +18,6 @@
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_earlgrey_scan_role_pkg
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -83,11 +83,6 @@
     NumRomInputs: 1
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -694,11 +694,6 @@
     with_alert_handler: true
     top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
@@ -10,11 +10,6 @@
     target: 1
     prio: 3
     topname: earlgrey
-    uniquified_modules:
-    {
-      gpio: gpio
-      alert_handler: alert_handler
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
@@ -238,10 +238,6 @@
     with_alert_handler: false
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
@@ -25,10 +25,6 @@
     size: 65536
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
@@ -8,10 +8,6 @@
     num_inp_period_counters: 0
     module_instance_name: gpio
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
@@ -18,10 +18,6 @@
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_englishbreakfast_scan_role_pkg
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
@@ -62,10 +62,6 @@
     NumRomInputs: 1
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -454,10 +454,6 @@
     with_alert_handler: false
     top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
@@ -10,10 +10,6 @@
     target: 1
     prio: 3
     topname: englishbreakfast
-    uniquified_modules:
-    {
-      gpio: gpio
-      rv_plic: rv_plic
-    }
+    uniquified_modules: {}
   }
 }

--- a/util/gen_testutils.py
+++ b/util/gen_testutils.py
@@ -27,9 +27,8 @@ import topgen.lib as topgen_lib
 from autogen_testutils.gen import gen_testutils
 from make_new_dif.ip import Ip
 
-# This file is $REPO_TOP/util/autogen_testutils.py, so it takes two parent()
-# calls to get back to the top.
-REPO_TOP = Path(__file__).resolve().parent.parent
+# This file is $REPO_TOP/util/gen_testutils.py, so parents[1] is the top.
+REPO_TOP = Path(__file__).resolve().parents[1]
 
 
 def main():

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -105,6 +105,11 @@ class IpTemplateRendererBase:
     def _replace_uniquified_prefix(self, core_name: str) -> str:
         uniquified_modules = self.ip_config.param_values.get("uniquified_modules", {})
         for name, uniq_name in uniquified_modules.items():
+            # This prevents applying the rename multiple times, like when the
+            # core file undergoes `module_instance_name` processing during
+            # template expansion, and is also subject to instance_vlnv.
+            if core_name == uniq_name or core_name.startswith(f'{uniq_name}_'):
+                return core_name
             if core_name.startswith(f'{name}_'):
                 return f'{uniq_name}_{core_name[len(name)+1:]}'
             elif core_name == name:

--- a/util/raclgen.py
+++ b/util/raclgen.py
@@ -14,8 +14,8 @@ from raclgen.lib import parse_racl_config, parse_racl_mapping, gen_md, gen_md_he
 from reggen.ip_block import IpBlock
 import topgen.lib as topgen_lib
 
-# This file is $REPO_TOP/util/, so it takes two parent() calls to get back to the top.
-REPO_TOP = Path(__file__).resolve().parent.parent
+# This file is under $REPO_TOP/util/, so parents[1] gets back to the top.
+REPO_TOP = Path(__file__).resolve().parents[1]
 
 
 def main():

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -74,6 +74,8 @@ class UniquifiedModules(object):
         self.modules: Dict[str, str] = {}
 
     def add_module(self, name: str, uniquified_name: str):
+        if name == uniquified_name:
+            return
         if (name in self.modules and uniquified_name != self.modules[name]):
             raise SystemExit(f"Multiple renames for module {name}")
         self.modules[name] = uniquified_name

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -422,10 +422,14 @@ def search_ips(ip_path: Path) -> List[str]:
 
 def get_ip_hjson_path(ip_name_snake: str, topcfg: ConfigT,
                       repotop: Path) -> Path:
+    """Return the location of an IP's hjson file for a given top.
+
+    This function should be called with the module['type'] for ipgen
+    modules, since find_module is called with use_base_template_type
+    set to False.
     """
-    Return the location of an IP's hjson file for a given top.
-    """
-    m = find_module(topcfg["module"], ip_name_snake)
+    m = find_module(topcfg["module"], ip_name_snake,
+                    use_base_template_type=False)
     if is_ipgen(m):
         data_dir = repotop / "hw/top_{}/ip_autogen/{}/data".format(
             topcfg["name"], ip_name_snake)


### PR DESCRIPTION
- It is possible a core file will be renamed during ipgen template expansion and again by _tplfunc_instance_vlnv. Avoid renaming it twice, thus preserving idempotency.
- Fix get_ip_hjson_path to search for modules using module['type'] instead of module['template_type'] as the name.
- Avoid trivial mappings in the uniquified names, e.g. {'a': 'a'}.