### PR TITLE
[manuf] remove noisy console prints during individualize

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -64,8 +64,6 @@ static status_t patch_ast_config_value(void) {
   TRY(manuf_flash_info_field_read(
       &flash_ctrl_state, kFlashInfoFieldAstIndividPatchVal, &ast_patch_value,
       kFlashInfoFieldAstIndividPatchValSizeIn32BitWords));
-  LOG_INFO("AST patch address offset = 0x%08x", ast_patch_addr_offset);
-  LOG_INFO("AST patch address value  = 0x%08x", ast_patch_value);
 
   // Check the address is within range before programming.
   if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) {
@@ -74,18 +72,14 @@ static status_t patch_ast_config_value(void) {
 
   // Only patch AST if the patch value is present.
   if (ast_patch_value != 0 && ast_patch_value != UINT32_MAX) {
+    LOG_INFO("Patching AST with:");
+    LOG_INFO("AST patch address offset = 0x%08x", ast_patch_addr_offset);
+    LOG_INFO("AST patch address value  = 0x%08x", ast_patch_value);
+
     // Write patch value.
     abs_mmio_write32(
         TOP_EARLGREY_AST_BASE_ADDR + ast_patch_addr_offset * sizeof(uint32_t),
         ast_patch_value);
-
-    // Read back AST calibration values loaded into CSRs.
-    LOG_INFO("AST Calibration Values (in CSRs):");
-    for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
-      LOG_INFO(
-          "Word %d = 0x%08x", i,
-          abs_mmio_read32(TOP_EARLGREY_AST_BASE_ADDR + i * sizeof(uint32_t)));
-    }
   }
 
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -185,7 +185,6 @@ cc_library(
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:otp_ctrl",
-        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing:otp_ctrl_testutils",
     ],

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -9,7 +9,6 @@
 #include "sw/device/lib/crypto/include/hash.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
-#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
@@ -82,9 +81,6 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
          kv[i].offset < kInvalidAstCfgOtpAddrHigh)) {
       continue;
     }
-    LOG_INFO(
-        "OTP Write: Partition (%d); Idx (%d); Offset (0x%x); Num Vals (%d)",
-        partition, i, kv[i].offset, kv[i].num_values);
     uint32_t offset;
     TRY(dif_otp_ctrl_relative_address(partition, kv[i].offset, &offset));
     switch (kv[i].type) {
@@ -270,9 +266,7 @@ status_t manuf_individualize_device_flash_data_default_cfg_check(
 
 status_t manuf_individualize_device_creator_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
-  LOG_INFO("Locking CreatorSwCfg partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg));
-  LOG_INFO("Done.");
   return OK_STATUS();
 }
 
@@ -315,9 +309,7 @@ status_t manuf_individualize_device_partition_expected_read(
 
 status_t manuf_individualize_device_owner_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
-  LOG_INFO("Locking OwnerSwCfg partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg));
-  LOG_INFO("Done.");
   return OK_STATUS();
 }
 
@@ -334,9 +326,7 @@ status_t manuf_individualize_device_rot_creator_auth_codesign(
   TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign,
                     kOtpKvRotCreatorAuthCodesign,
                     kOtpKvRotCreatorAuthCodesignSize));
-  LOG_INFO("Locking RotCreatorAuthCodesign partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign));
-  LOG_INFO("Done.");
   return OK_STATUS();
 }
 
@@ -344,9 +334,7 @@ status_t manuf_individualize_device_rot_creator_auth_state(
     const dif_otp_ctrl_t *otp_ctrl) {
   TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState,
                     kOtpKvRotCreatorAuthState, kOtpKvRotCreatorAuthStateSize));
-  LOG_INFO("Locking RotCreatorAuthState partition.");
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState));
-  LOG_INFO("Done.");
   return OK_STATUS();
 }
 


### PR DESCRIPTION
This removes noisy console prints during FT individualization binary execution. This is to optimize test execution in ATE environment.

Note: this depends on #26648, only review the last commit.