### PR TITLE
[hw,tlul_request_loopback,rtl] Avoid dropping responses by enqueuing the RAZWI response

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram_racl.sv
@@ -125,7 +125,7 @@ module tlul_adapter_sram_racl
     assign racl_error_o.valid = (rd_req & ~racl_read_allowed) | (wr_req & ~racl_write_allowed);
 
     tlul_request_loopback #(
-      .ErrorRsp(RaclErrorRsp)
+      .ErrorRsp ( RaclErrorRsp )
     ) u_loopback (
       .clk_i,
       .rst_ni,

--- a/hw/ip/tlul/rtl/tlul_request_loopback.sv
+++ b/hw/ip/tlul/rtl/tlul_request_loopback.sv
@@ -22,23 +22,46 @@ module tlul_request_loopback
   logic loopback_request;
   assign loopback_request = tl_h2d_i.a_valid & squash_req_i;
 
-  // Assemble the non-squashed request
-  always_comb begin
-    tl_h2d_o         = tl_h2d_i;
-    tl_h2d_o.a_valid = tl_h2d_i.a_valid & ~squash_req_i;
-  end
+  tlul_pkg::tl_h2d_t tl_muxed_h2d [2];
+  tlul_pkg::tl_d2h_t tl_muxed_d2h [2];
+  tlul_pkg::tl_h2d_t tl_error_h2d;
+  tlul_pkg::tl_d2h_t tl_error_d2h;
+
+  // Device port is Idx0
+  assign tl_h2d_o = tl_muxed_h2d[0];
+  assign tl_muxed_d2h[0] = tl_d2h_i;
+
+  // Error port is Idx1
+  assign tl_error_h2d = tl_muxed_h2d[1];
+  assign tl_muxed_d2h[1] = tl_error_d2h;
+
+  // Use a tlul_socket_1n to mux between the the genuine response and the error respone. The
+  // tlul_socket_1n keeps track for outstanding transactions and ensures that all transponses
+  // happen in the correct ordering.
+  tlul_socket_1n #(
+    .N(2),
+    .ExplicitErrs(0)
+  ) u_socket (
+    .clk_i,
+    .rst_ni,
+    .tl_h_i       (tl_h2d_i),
+    .tl_h_o       (tl_d2h_o),
+    .tl_d_o       (tl_muxed_h2d),
+    .tl_d_i       (tl_muxed_d2h),
+    .dev_select_i (loopback_request)
+  );
 
   // Assemble the All-Zero response with error set if the request is squashed
-  tlul_pkg::tl_d2h_t tl_razwi_rsp_pre_intg, tl_razwi_rsp;
-  logic loopback_request_q;
+  tlul_pkg::tl_d2h_t tl_razwi_rsp_pre_intg;
+  logic loopback_valid_q;
 
   prim_flop #(
     .Width(1)
   ) u_loopback_valid (
-    .clk_i  ( clk_i              ),
-    .rst_ni ( rst_ni             ),
-    .d_i    ( loopback_request   ),
-    .q_o    ( loopback_request_q )
+    .clk_i  ( clk_i                ),
+    .rst_ni ( rst_ni               ),
+    .d_i    ( tl_error_h2d.a_valid ),
+    .q_o    ( loopback_valid_q     )
   );
 
   logic [$bits(tlul_pkg::tl_d_op_e)-1:0] d_opcode_q;
@@ -46,10 +69,10 @@ module tlul_request_loopback
     .Width($bits(tlul_pkg::tl_d_op_e)),
     .ResetValue({AccessAck})
   ) u_rsp_opcode (
-    .clk_i  ( clk_i                                                  ),
-    .rst_ni ( rst_ni                                                 ),
-    .d_i    ( (tl_h2d_i.a_opcode == Get) ? AccessAckData : AccessAck ),
-    .q_o    ( d_opcode_q                                             )
+    .clk_i  ( clk_i                                                      ),
+    .rst_ni ( rst_ni                                                     ),
+    .d_i    ( (tl_error_h2d.a_opcode == Get) ? AccessAckData : AccessAck ),
+    .q_o    ( d_opcode_q                                                 )
   );
   assign tl_razwi_rsp_pre_intg.d_opcode = tlul_pkg::tl_d_op_e'(d_opcode_q);
 
@@ -58,7 +81,7 @@ module tlul_request_loopback
   ) u_rsp_size (
     .clk_i  ( clk_i                        ),
     .rst_ni ( rst_ni                       ),
-    .d_i    ( tl_h2d_i.a_size              ),
+    .d_i    ( tl_error_h2d.a_size          ),
     .q_o    ( tl_razwi_rsp_pre_intg.d_size )
   );
 
@@ -67,12 +90,12 @@ module tlul_request_loopback
   ) u_rsp_source (
     .clk_i  ( clk_i                          ),
     .rst_ni ( rst_ni                         ),
-    .d_i    ( tl_h2d_i.a_source              ),
+    .d_i    ( tl_error_h2d.a_source          ),
     .q_o    ( tl_razwi_rsp_pre_intg.d_source )
   );
 
   // Assemble the RAZWI (Return as Zero, Write Ignored) response
-  assign tl_razwi_rsp_pre_intg.d_valid = loopback_request_q;
+  assign tl_razwi_rsp_pre_intg.d_valid = loopback_valid_q;
   assign tl_razwi_rsp_pre_intg.a_ready = 1'b1;
 
   assign tl_razwi_rsp_pre_intg.d_param = '0;
@@ -84,10 +107,16 @@ module tlul_request_loopback
   // Compute integrity bits from the manually assembled RAZWI reponse
   tlul_rsp_intg_gen gen_intg_razwi_rsp (
     .tl_i ( tl_razwi_rsp_pre_intg ),
-    .tl_o ( tl_razwi_rsp          )
+    .tl_o ( tl_error_d2h          )
   );
 
-  // Mux response if request was squashed
-  assign tl_d2h_o = loopback_request_q ? tl_razwi_rsp : tl_d2h_i;
+  // Not all TLUL signals are read from the request muxed to the error leg
+  logic unused_tlul_signals;
+  assign unused_tlul_signals = ^{tl_error_h2d.a_param,
+                                 tl_error_h2d.a_address,
+                                 tl_error_h2d.a_mask,
+                                 tl_error_h2d.a_data,
+                                 tl_error_h2d.a_user,
+                                 tl_error_h2d.d_ready};
 
 endmodule


### PR DESCRIPTION
If the RAZWI response and the ordinary response of the TLUL port need to be served at the same time, one is currently dropped. Fix this by introducing a FIFO on the RAZWI response, which read port is set to 0 when an SRAM response is served.

Imagine SRAM control is fed with valid read requests. There are multiple outstanding requests in flight. Then, there is an invalid access, i.e, a ACL violation, which request ist looped back. If that happens at the same cycle an outstanding response is served, one is dropped, which causes a TLUL hang.