### PR TITLE
[ujson] Fix module identifier serialization

### DIFF
--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -11,14 +11,17 @@
 
 const uint32_t MODULE_ID = 0;
 
-static const char *basename(const char *file) {
+static const char *basename(const char *file, size_t *basename_len) {
   const char *f = file;
   // Go to the end of the string.
   while (*f)
     ++f;
   // Back up to the start of the last filename path component.
-  while (f > file && f[-1] != '/' && f[-1] != '\\')
+  *basename_len = 0;
+  while (f > file && f[-1] != '/' && f[-1] != '\\') {
+    ++(*basename_len);
     --f;
+  }
   return f;
 }
 
@@ -47,13 +50,10 @@ status_t status_create(absl_status_t code, uint32_t module_id, const char *file,
    */
   if (module_id == 0) {
     // First three characters of the filename.
-    const char *f = basename(file);
-    // Compute the name length (strlen() is not available).
-    size_t name_len = 0;
-    while (f[name_len])
-      name_len++;
-    module_id = name_len >= 3 ? MAKE_MODULE_ID(f[0], f[1], f[2])
-                              : MAKE_MODULE_ID('u', 'n', 'd');
+    size_t basename_len = 0;
+    const char *f = basename(file, &basename_len);
+    module_id = basename_len >= 3 ? MAKE_MODULE_ID(f[0], f[1], f[2])
+                                  : MAKE_MODULE_ID('u', 'n', 'd');
   }
   // At this point, the module_id is already packed into the correct bitfield.
   return (status_t){

--- a/sw/device/lib/base/status.c
+++ b/sw/device/lib/base/status.c
@@ -48,7 +48,12 @@ status_t status_create(absl_status_t code, uint32_t module_id, const char *file,
   if (module_id == 0) {
     // First three characters of the filename.
     const char *f = basename(file);
-    module_id = MAKE_MODULE_ID(f[0], f[1], f[2]);
+    // Compute the name length (strlen() is not available).
+    size_t name_len = 0;
+    while (f[name_len])
+      name_len++;
+    module_id = name_len >= 3 ? MAKE_MODULE_ID(f[0], f[1], f[2])
+                              : MAKE_MODULE_ID('u', 'n', 'd');
   }
   // At this point, the module_id is already packed into the correct bitfield.
   return (status_t){

--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -302,6 +302,16 @@ TEST_F(PrintfTest, StatusErrorAsJson) {
   EXPECT_EQ(buf_, absl::StrFormat("Hello, {\"Unknown\":[\"PRI\",%d]}\n", line));
 }
 
+TEST_F(PrintfTest, StatusErrorWithModuleId) {
+#define MODULE_ID MAKE_MODULE_ID('\\', '\\', '\\')
+  status_t value = UNKNOWN();
+  int line = __LINE__ - 1;
+  EXPECT_EQ(base_printf("Hello, %!r\n", value), 34);
+  EXPECT_EQ(buf_, absl::StrFormat(
+                      "Hello, {\"Unknown\":[\"\\\\\\\\\\\\\",%d]}\n", line));
+#undef MODULE_ID
+}
+
 TEST_F(PrintfTest, StatusErrorWithArg) {
   status_t value = INVALID_ARGUMENT(2);
   EXPECT_EQ(base_printf("Hello, %r\n", value), 33);


### PR DESCRIPTION
1. Fix potential `filename` out of bound access.  Although it's rarely to have filename's length be less than three, we don't have this kind of check.
2. Fix status serialization/deserialization inconsistency. Although it's rarely to have the module identifier contains "\\" character, we still want to serialize the module identifier properly in this case.
