### PR TITLE
[tlul,dv] Fix seq calling cip_tl_host_single_seq

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -251,7 +251,6 @@ class cip_base_vseq #(
 
     cip_tl_host_single_seq tl_seq;
     `uvm_create_on(tl_seq, tl_sequencer_h)
-    tl_seq.instr_type = instr_type;
     tl_seq.tl_intg_err_type = tl_intg_err_type;
     if (cfg.zero_delays) begin
       tl_seq.min_req_delay = 0;
@@ -259,10 +258,11 @@ class cip_base_vseq #(
     end
     tl_seq.req_abort_pct = req_abort_pct;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq,
-        addr  == local::addr;
-        write == local::write;
-        mask  == local::mask;
-        data  == local::data;)
+        addr        == local::addr;
+        write       == local::write;
+        mask        == local::mask;
+        data        == local::data;
+        instr_type  == local::instr_type;)
 
     csr_utils_pkg::increment_outstanding_access();
     fork begin : isolation_fork

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -11,8 +11,11 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
   `uvm_object_utils(cip_tl_host_single_seq)
   `uvm_object_new
 
-  rand mubi4_t  instr_type;
+  // Control knobs
   tl_intg_err_e tl_intg_err_type = TlIntgErrNone;
+
+  // Randomizable variables
+  rand bit [MuBi4Width-1:0] instr_type;
 
   constraint instr_type_c {
     soft instr_type == MuBi4False;
@@ -24,7 +27,7 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
     // set tl_intg_err_type first, as set_instr_type will trigger re-calculating integrity based on
     // the TLUL info and err_type
     req.tl_intg_err_type = tl_intg_err_type;
-    req.set_instr_type(instr_type);
+    req.set_instr_type(mubi4_t'(instr_type));
   endfunction
 
 endclass

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_buffered_enable_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_buffered_enable_vseq.sv
@@ -93,11 +93,11 @@ class rv_dm_buffered_enable_vseq extends rv_dm_base_vseq;
     // Randomise the sequence, but setting instr_type (so that this is a fetch), zeroing delays (no
     // need to wait!), making the chance of abortion zero and reading from the correct address
     // (0x300 within the block).
-    seq.instr_type = prim_mubi_pkg::MuBi4True;
     seq.min_req_delay = 0;
     seq.max_req_delay = 0;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(seq,
-                                   write == 1'b0; addr == 'h300 + mem_base_addr; mask == 4'hf;)
+                                   write == 1'b0; addr == 'h300 + mem_base_addr; mask == 4'hf;
+                                   instr_type == prim_mubi_pkg::MuBi4True;)
 
     csr_utils_pkg::increment_outstanding_access();
     `DV_SPINWAIT(`uvm_send_pri(seq, 100), "Timed out when sending fetch request")


### PR DESCRIPTION
- The PR #26631 introduced randomizable instr_type variable. But this change was not compatible with the task tl_access_sub, neither with the rv_dm_buffered_enable_vseq sequence. THey have been updatated to fit with this new way.
- And the field instr_type declaration has to be changed from mubi4_t to a bit vector as some sequences require to have this variable being randomized with some erroneous values.