### PR TITLE
Ensure correct architecture toolchain is downloaded

### DIFF
--- a/util/get-toolchain.py
+++ b/util/get-toolchain.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 from pathlib import Path
 from urllib.request import urlopen, urlretrieve
+import platform
 
 log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
 
@@ -38,6 +39,17 @@ FILE_PATTERNS_TO_REWRITE = [
 def get_available_toolchain_info(version, kind):
     assert kind in ASSET_PREFIXES
 
+    # Check for supported architectures
+    machine = platform.machine()
+    if machine in ('x86_64', 'AMD64'):
+        arch = "x86_64"  # Release files use "x86_64" in the filename
+    elif machine in ('aarch64', 'arm64'):
+        arch = "aarch64"  # Release files use "aarch64" in the filename
+    else:
+        log.error("Unsupported machine architecture: %s", machine)
+        log.error("This toolchain only supports x86_64 and aarch64")
+        raise SystemExit(1)
+
     if version == 'latest':
         releases_url = '%s/%s' % (RELEASES_URL_BASE, version)
     else:
@@ -48,6 +60,7 @@ def get_available_toolchain_info(version, kind):
 
     for asset in release_info["assets"]:
         if (asset["name"].startswith(ASSET_PREFIXES[kind]) and
+            arch in asset["name"] and
                 asset["name"].endswith(ASSET_SUFFIX)):
             return {
                 'download_url': asset['browser_download_url'],
@@ -57,8 +70,8 @@ def get_available_toolchain_info(version, kind):
             }
 
     # No matching asset found for the toolchain kind requested
-    log.error("No available downloads found for %s toolchain version: %s",
-              kind, release_info['tag_name'])
+    log.error("No available downloads found for %s toolchain version %s on %s",
+              kind, release_info['tag_name'], arch)
     raise SystemExit(1)
 
 


### PR DESCRIPTION
This commit adds proper architecture detection to the RISC-V toolchain installation script to support multiple platforms:

- Import the platform module to detect system architecture
- Add detection for x86_64 and aarch64 architectures
- Handle both 'AMD64' (Windows) and 'x86_64' (Linux/macOS) as x86_64
- Support 'arm64' as an alias for 'aarch64' for macOS ARM machines
- Add clear error messages for unsupported architectures
- Filter assets by architecture to ensure proper toolchain selection

This change ensures the script downloads the correct toolchain variant based on the user's system architecture rather than downloading any available asset.