### PR TITLE
[rescue] Implement the DFU protocol over SPI 

### DIFF
--- a/sw/device/silicon_creator/lib/bootstrap.c
+++ b/sw/device/silicon_creator/lib/bootstrap.c
@@ -319,7 +319,7 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
 }
 
 rom_error_t enter_bootstrap(void) {
-  spi_device_init();
+  spi_device_init_bootstrap();
 
   // Bootstrap event loop.
   bootstrap_state_t state = kBootstrapStateErase;

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -36,6 +36,7 @@ filegroup(
         "rstmgr.h",
         "spi_device.c",
         "spi_device.h",
+        "spi_device_bfpt.h",
     ],
 )
 
@@ -810,8 +811,14 @@ dual_cc_library(
     ),
     hdrs = dual_inputs(
         host = ["mock_spi_device.h"],
-        shared = ["spi_device.h"],
+        shared = [
+            "spi_device.h",
+            "spi_device_bfpt.h",
+        ],
     ),
+    copts = [
+        "-Wno-gnu-flexible-array-initializer",
+    ],
     deps = dual_inputs(
         device = [
             "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
@@ -7,7 +7,14 @@
 namespace rom_test {
 extern "C" {
 
-void spi_device_init(void) { MockSpiDevice::Instance().Init(); }
+void spi_device_init(uint8_t log2_density, const void *sfdp_table,
+                     size_t sfdp_len) {
+  MockSpiDevice::Instance().Init(log2_density, sfdp_table, sfdp_len);
+}
+
+void spi_device_init_bootstrap(void) {
+  MockSpiDevice::Instance().InitBootstrap();
+}
 
 rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
   return MockSpiDevice::Instance().CmdGet(cmd);

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
@@ -16,7 +16,8 @@ namespace internal {
  */
 class MockSpiDevice : public global_mock::GlobalMock<MockSpiDevice> {
  public:
-  MOCK_METHOD(void, Init, ());
+  MOCK_METHOD(void, Init, (uint8_t /*log2_density*/, const void *, size_t));
+  MOCK_METHOD(void, InitBootstrap, ());
   MOCK_METHOD(rom_error_t, CmdGet, (spi_device_cmd_t *));
   MOCK_METHOD(void, FlashStatusClear, ());
   MOCK_METHOD(uint32_t, FlashStatusGet, ());

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/spi_device_bfpt.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "flash_ctrl_regs.h"
@@ -39,6 +40,16 @@ enum {
    * (JESD216F 6.2.1).
    */
   kSfdpSignature = 0x50444653,
+  /**
+   * LSB of the 2-byte device ID.
+   *
+   * Density is expressed as log2(flash size in bytes).
+   */
+  kSpiDeviceJedecDensity = 20,
+  /**
+   * Size of the SFDP table in words.
+   */
+  kSpiDeviceSfdpTableNumWords = 27,
   /**
    * Number of parameter headers in the SFDP data structure (JESD216F 6.2.2).
    *
@@ -90,38 +101,6 @@ enum {
 
 static_assert(kBfptTablePointer % sizeof(uint32_t) == 0,
               "BFPT must be word-aligned");
-
-/**
- * Computes the width of a field in a Basic Flash Parameters Table (BFPT) word.
- *
- * @param upper Upper (start) bit of the field (inclusive).
- * @param lower Lower (end) bit of the field (inclusive).
- */
-#define BFPT_FIELD_WIDTH(upper, lower) ((upper) - (lower) + 1)
-
-/**
- * Computes the mask for a field in a BFPT word.
- *
- * @param upper Upper (start) bit of the field (inclusive).
- * @param lower Lower (end) bit of the field (inclusive).
- */
-#define BFPT_FIELD_MASK(upper, lower) \
-  (((UINT64_C(1) << BFPT_FIELD_WIDTH(upper, lower)) - 1) << (lower))
-
-/**
- * Computes the value of a field in a BFPT word.
- *
- * Bits outside the field are left as 1s. This macro is intended for expanding a
- * list of fields, e.g. `BFPT_WORD_1`, to compute the value of a BFPT word using
- * bitwise AND.
- *
- * @param upper Upper (start) bit of the field (inclusive).
- * @param lower Lower (end) bit of the field (inclusive).
- * @param value Value of the field.
- */
-#define BFPT_FIELD_VALUE(upper, lower, value) \
-  ((uint32_t)~BFPT_FIELD_MASK(upper, lower) | \
-   (BFPT_FIELD_MASK(upper, lower) & ((uint32_t)(value) << (uint32_t)(lower))))
 
 // Note: Words below are numbered starting from 1 to match JESD216F. Some fields
 // that are not supported by OpenTitan are merged for the sake of conciseness.
@@ -466,6 +445,7 @@ typedef struct cmd_info {
    * area if a larger payload is received.
    */
   bool handled_in_sw;
+  bool data_to_host;
 } cmd_info_t;
 
 /**
@@ -493,10 +473,18 @@ static void cmd_info_set(cmd_info_t cmd_info) {
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CMD_INFO_0_BUSY_0_BIT,
                              cmd_info.handled_in_sw);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CMD_INFO_0_VALID_0_BIT, true);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CMD_INFO_0_PAYLOAD_DIR_0_BIT,
+                             cmd_info.data_to_host);
   abs_mmio_write32(kBase + cmd_info.reg_offset, reg);
 }
 
-void spi_device_init(void) {
+void spi_device_init_bootstrap(void) {
+  spi_device_init(kSpiDeviceJedecDensity, &kSpiDeviceSfdpTable,
+                  sizeof(kSpiDeviceSfdpTable));
+}
+
+void spi_device_init(uint8_t log2_density, const void *sfdp_table,
+                     size_t sfdp_len) {
   // CPOL = 0, CPHA = 0, MSb-first TX and RX, 3-byte addressing.
   uint32_t reg = bitfield_bit32_write(0, SPI_DEVICE_CFG_TX_ORDER_BIT, false);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_RX_ORDER_BIT, false);
@@ -526,15 +514,15 @@ void spi_device_init(void) {
   reg = bitfield_field32_write(reg, SPI_DEVICE_DEV_ID_CHIP_GEN_FIELD,
                                hw_rev.product_id);
   reg = bitfield_field32_write(reg, SPI_DEVICE_DEV_ID_DENSITY_FIELD,
-                               kSpiDeviceJedecDensity);
+                               log2_density);
   reg = bitfield_field32_write(reg, SPI_DEVICE_JEDEC_ID_MF_FIELD,
                                kSpiDeviceJedecManufId);
   abs_mmio_write32(kBase + SPI_DEVICE_JEDEC_ID_REG_OFFSET, reg);
 
   // Write SFDP table to the reserved region in spi_device buffer.
   uint32_t dest = kSfdpAreaStartAddr;
-  const char *table = (const char *)&kSpiDeviceSfdpTable;
-  for (size_t i = 0; i < kSpiDeviceSfdpTableNumWords; ++i) {
+  const char *table = (const char *)sfdp_table;
+  for (size_t i = 0; i < sfdp_len / sizeof(uint32_t); ++i) {
     abs_mmio_write32(dest, read_32(table));
     dest += sizeof(uint32_t);
     table += sizeof(uint32_t);
@@ -661,4 +649,59 @@ void spi_device_flash_status_clear(void) {
 
 uint32_t spi_device_flash_status_get(void) {
   return abs_mmio_read32(kBase + SPI_DEVICE_FLASH_STATUS_REG_OFFSET);
+}
+
+uint32_t spi_device_control(void) {
+  return abs_mmio_read32(kBase + SPI_DEVICE_CFG_REG_OFFSET);
+}
+
+void spi_device_enable_mailbox(uint32_t address) {
+  // Enable the SPI mailbox at the given address.
+  abs_mmio_write32(kBase + SPI_DEVICE_MAILBOX_ADDR_REG_OFFSET, address);
+  uint32_t cfg_reg = abs_mmio_read32(kBase + SPI_DEVICE_CFG_REG_OFFSET);
+  cfg_reg = bitfield_bit32_write(cfg_reg, SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1);
+  abs_mmio_write32(kBase + SPI_DEVICE_CFG_REG_OFFSET, cfg_reg);
+
+  // Turn on internal processing of Read, ReadSfdp, ReadJedecId and ReadStatus.
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_INTERCEPT_EN_STATUS_BIT, true);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_INTERCEPT_EN_JEDEC_BIT, true);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_INTERCEPT_EN_SFDP_BIT, true);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_INTERCEPT_EN_MBX_BIT, true);
+  abs_mmio_write32(kBase + SPI_DEVICE_INTERCEPT_EN_REG_OFFSET, reg);
+
+  // Configure the READ command (CMD_INFO_5).
+  cmd_info_set((cmd_info_t){
+      .reg_offset = SPI_DEVICE_CMD_INFO_5_REG_OFFSET,
+      .op_code = kSpiDeviceOpcodeRead,
+      .address = true,
+      .dummy_cycles = 0,
+      .handled_in_sw = false,
+      .data_to_host = true,
+  });
+}
+
+void spi_device_copy_to_egress(uint32_t egress_offset, const void *data,
+                               size_t len) {
+  const uint32_t *src = (const uint32_t *)data;
+  volatile uint32_t *dst =
+      (volatile uint32_t *)(uintptr_t)(kBase +
+                                       SPI_DEVICE_EGRESS_BUFFER_REG_OFFSET +
+                                       egress_offset);
+
+  while (len > sizeof(uint32_t)) {
+    *dst++ = *src++;
+    len -= sizeof(uint32_t);
+  }
+  if (len > 0) {
+    uint32_t val = 0;
+    uint32_t shift = 0;
+    const char *s = (const char *)src;
+    while (len > 0) {
+      val |= (uint32_t)*s++ << shift;
+      shift += 8;
+      len -= 1;
+    }
+    *dst = val;
+  }
 }

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -34,20 +34,7 @@ enum {
   kSpiDeviceJedecContCode = 0x7f,
   kSpiDeviceJedecContCodeCount = 12,
   kSpiDeviceJedecManufId = 0xef,
-  /**
-   * LSB of the 2-byte device ID.
-   *
-   * Density is expressed as log2(flash size in bytes).
-   */
-  kSpiDeviceJedecDensity = 20,
-  /**
-   * Size of the JEDEC Basic Flash Parameter Table (BFPT) in words.
-   */
-  kSpiDeviceBfptNumWords = 23,
-  /**
-   * Size of the SFDP table in words.
-   */
-  kSpiDeviceSfdpTableNumWords = 27,
+
   /**
    * Address value used when a command does not have an address.
    *
@@ -59,6 +46,14 @@ enum {
 
 // TODO(#11740): Auto-generated macros for HW constants.
 enum {
+  /**
+   * Size of the JEDEC Basic Flash Parameter Table (BFPT) in words.
+   *
+   * Note: This is the size of the BFPT table in spi_device.c used for ROM
+   * bootstrap. Other users may define their own SFDP tables with a different
+   * BFPT.
+   */
+  kSpiDeviceBfptNumWords = 23,
   /**
    * Size of the SFDP area in spi_device egress buffer in bytes.
    *
@@ -100,6 +95,13 @@ enum {
  * received, spi_device overwrites the contents of the payload buffer.
  */
 typedef enum spi_device_opcode {
+  /**
+   * READ command.
+   *
+   * This command is handled by the spi_device. Upon receiving this command,
+   * spi_device sends the data from either the SPI mailbox or egress buffer.
+   */
+  kSpiDeviceOpcodeRead = 0x03,
   /**
    * READ_STATUS command.
    *
@@ -273,7 +275,10 @@ typedef struct spi_device_sfdp_table {
    */
   spi_device_param_header_t bfpt_header;
   /**
-   * Basic Flash Parameters Table (BFPT).
+   * Basic Flash Parameter Table (BFPT) (JESD216F 6.4).
+   *
+   * This is a mandatory table defined by JEDEC that identifies some of the
+   * basic features of a SPI protocol flash memory device.
    */
   spi_device_bfpt_t bfpt;
 } spi_device_sfdp_table_t;
@@ -283,9 +288,6 @@ OT_ASSERT_MEMBER_OFFSET(spi_device_sfdp_table_t, bfpt, 16);
 OT_ASSERT_SIZE(spi_device_sfdp_table_t, 108);
 static_assert(sizeof(spi_device_sfdp_table_t) <= kSpiDeviceSfdpAreaNumBytes,
               "SFDP table must fit in the space provided by spi_device");
-static_assert(sizeof(spi_device_sfdp_table_t) ==
-                  kSpiDeviceSfdpTableNumWords * sizeof(uint32_t),
-              "`kSpiDeviceSfdpTableNumWords` is incorrect");
 
 // Note: Declared here to be able to use in tests.
 extern const spi_device_sfdp_table_t kSpiDeviceSfdpTable;
@@ -302,7 +304,29 @@ extern const spi_device_sfdp_table_t kSpiDeviceSfdpTable;
  *   - READ_JEDEC_ID
  *   - READ_SFDP
  */
-void spi_device_init(void);
+void spi_device_init_bootstrap(void);
+
+/**
+ * Initializes the spi_device in flash mode.
+ *
+ * This function initializes the spi_device in the following configuration:
+ * - CPOL = 0, CPHA = 0 (clock low in idle, data sampled on rising clock edge).
+ * - MSb-first bit order for RX and TX.
+ * - Flash mode with 3-byte addressing.
+ * - The given `sfdp_table` is written to the SFDP area in the buffer.
+ * - Commands:
+ *   - READ_JEDEC_ID
+ *   - READ_SFDP
+ *
+ * @param log2_density The density to be reported by READ_JEDEC_ID (the log2
+ *                     flash size in bytes).
+ * @param sfdp_table The SFDP table to program into the SFDP area. The table
+ *                 must be word aligned.
+ * @param sfdp_len The length of the SFDP table in bytes. The length must be
+ *                 a multiple of 4 bytes.
+ */
+void spi_device_init(uint8_t log2_density, const void *sfdp_table,
+                     size_t sfdp_len);
 
 /**
  * A SPI flash command.
@@ -358,6 +382,24 @@ void spi_device_flash_status_clear(void);
  */
 OT_WARN_UNUSED_RESULT
 uint32_t spi_device_flash_status_get(void);
+
+/**
+ * Enables the SPI mailbox at the given SPI address.
+ *
+ * @param address The SPI address of the mailbox.
+ */
+void spi_device_enable_mailbox(uint32_t address);
+
+/**
+ * Copies data to the SPI egress buffer.
+ *
+ * @param egress_offset Destination offset in the egress buffer.
+ * @param data Pointer to data to copy into the egress buffer.  The data must
+ *             be word aligned.
+ * @param len Length of data to copy into the egress buffer.
+ */
+void spi_device_copy_to_egress(uint32_t egress_offset, const void *data,
+                               size_t len);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/spi_device_bfpt.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_bfpt.h
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SPI_DEVICE_BFPT_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SPI_DEVICE_BFPT_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Computes the width of a field in a Basic Flash Parameters Table (BFPT) word.
+ *
+ * @param upper Upper (start) bit of the field (inclusive).
+ * @param lower Lower (end) bit of the field (inclusive).
+ */
+#define BFPT_FIELD_WIDTH(upper, lower) ((upper) - (lower) + 1)
+
+/**
+ * Computes the mask for a field in a BFPT word.
+ *
+ * @param upper Upper (start) bit of the field (inclusive).
+ * @param lower Lower (end) bit of the field (inclusive).
+ */
+#define BFPT_FIELD_MASK(upper, lower) \
+  (((UINT64_C(1) << BFPT_FIELD_WIDTH(upper, lower)) - 1) << (lower))
+
+/**
+ * Computes the value of a field in a BFPT word.
+ *
+ * Bits outside the field are left as 1s. This macro is intended for expanding a
+ * list of fields, e.g. `BFPT_WORD_1`, to compute the value of a BFPT word using
+ * bitwise AND.
+ *
+ * @param upper Upper (start) bit of the field (inclusive).
+ * @param lower Lower (end) bit of the field (inclusive).
+ * @param value Value of the field.
+ */
+#define BFPT_FIELD_VALUE(upper, lower, value) \
+  ((uint32_t)~BFPT_FIELD_MASK(upper, lower) | \
+   (BFPT_FIELD_MASK(upper, lower) & ((uint32_t)(value) << (uint32_t)(lower))))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SPI_DEVICE_BFPT_H_

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -162,7 +162,7 @@ TEST_F(InitTest, Init) {
                          {SPI_DEVICE_CMD_INFO_WRDI_VALID_BIT, 1},
                      });
 
-  spi_device_init();
+  spi_device_init_bootstrap();
 }
 
 TEST_F(SpiDeviceTest, FlashStatusClear) {

--- a/sw/device/silicon_creator/lib/rescue/BUILD
+++ b/sw/device/silicon_creator/lib/rescue/BUILD
@@ -113,3 +113,24 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:usb",
     ],
 )
+
+cc_library(
+    name = "rescue_spidfu",
+    srcs = [
+        "rescue_spi.c",
+        "sfdp.c",
+        "sfdp.h",
+    ],
+    deps = [
+        ":dfu",
+        ":rescue",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:spi_device",
+        "//sw/device/silicon_creator/lib/drivers:usb",
+    ],
+)

--- a/sw/device/silicon_creator/lib/rescue/dfu.h
+++ b/sw/device/silicon_creator/lib/rescue/dfu.h
@@ -134,6 +134,8 @@ typedef struct dfu_ctx {
   rescue_state_t state;
   /** Pointer to bootdata. */
   boot_data_t *bootdata;
+  /** Expected receive length (upload) */
+  uint32_t expected_len;
   /** Status buffer (used to respond to DfuReqGetStatus). */
   dfu_getstatus_t status;
   /** DFU state. */

--- a/sw/device/silicon_creator/lib/rescue/rescue_spi.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_spi.c
@@ -1,0 +1,133 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+#include "sw/device/silicon_creator/lib/drivers/usb.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/rescue/dfu.h"
+#include "sw/device/silicon_creator/lib/rescue/rescue.h"
+#include "sw/device/silicon_creator/lib/rescue/sfdp.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  /**
+   * Base address of the spi_device registers.
+   */
+  kBase = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+  /**
+   * The flash buffer is a 2K region within the egress buffer, starting at the
+   * beginning of the egress buffer.
+   */
+  kFlashBuffer = 0,
+  /**
+   * The mailbox buffer is a 1K region within the egress buffer starting at 2K
+   */
+  kMailboxBuffer = 2048,
+  /**
+   * The mailbox address is located at SPI address 0x800.
+   */
+  kMailboxAddress = 0x800,
+};
+
+extern uint32_t spi_device_control(void);
+
+void dfu_transport_data(dfu_ctx_t *ctx, usb_dir_t dir, void *data, size_t len,
+                        usb_transfer_flags_t flags) {
+  if (dir & kUsbDirIn) {
+    // IN transactions get copied into the SPI egress buffer.
+    spi_device_copy_to_egress(kFlashBuffer, data, len);
+  } else {
+    // We set the total expected length for OUT transactions here.
+    // The processing of the data packets happens in the main loop in response
+    // to PAGE_PROGRAM opcodes.
+    ctx->expected_len = len;
+  }
+}
+
+rom_error_t dfu_transport_setupdata(dfu_ctx_t *ctx, usb_setup_data_t *setup) {
+  OT_DISCARD(ctx);
+  OT_DISCARD(setup);
+  // We don't handle most of the standard setupdata requests over SPI.
+  //
+  // We do handle SetInterface/GetInterface in the main DFU handler; those
+  // requests are used to set the ROM_EXT service that the client wants to
+  // interact with.
+  return kErrorUsbBadSetup;
+}
+
+void dfu_transport_result(dfu_ctx_t *ctx, rom_error_t result) {
+  OT_DISCARD(ctx);
+  uint32_t value = result;
+  spi_device_copy_to_egress(kMailboxBuffer, &value, sizeof(value));
+  spi_device_flash_status_clear();
+}
+
+rom_error_t rescue_protocol(boot_data_t *bootdata,
+                            const owner_rescue_config_t *config) {
+  dfu_ctx_t ctx = {
+      .bootdata = bootdata,
+      .dfu_state = kDfuStateIdle,
+      .dfu_error = kDfuErrOk,
+  };
+  dbg_printf("SPI-DFU rescue ready\r\n");
+  rescue_state_init(&ctx.state, config);
+  spi_device_init(
+      /*log2_density=*/kRescueDensity, &kRescueSfdpTable,
+      sizeof(kRescueSfdpTable));
+  spi_device_enable_mailbox(kMailboxAddress);
+
+  spi_device_cmd_t cmd;
+  uint32_t length;
+  while (true) {
+    rom_error_t result = spi_device_cmd_get(&cmd);
+    if (result != kErrorOk) {
+      break;
+    }
+    switch (cmd.opcode) {
+      case kSpiDeviceOpcodePageProgram: {
+        if (cmd.address == kMailboxAddress) {
+          usb_setup_data_t *setup = (usb_setup_data_t *)cmd.payload;
+          dfu_protocol_handler(&ctx, 0, kUsbTransferFlagsSetupData, setup);
+        } else {
+          // Our payload buffer is 2K; truncate addresses.
+          uint32_t offset = cmd.address & 0x7FF;
+          if (offset + cmd.payload_byte_count > sizeof(ctx.state.data)) {
+            // If the packet is too big, truncate to the size of the target
+            // buffer.
+            size_t excess =
+                offset + cmd.payload_byte_count - sizeof(ctx.state.data);
+            cmd.payload_byte_count -= excess;
+          }
+          memcpy(ctx.state.data + offset, cmd.payload, cmd.payload_byte_count);
+          length = offset + cmd.payload_byte_count;
+          if (length >= ctx.expected_len) {
+            // Once we've recieved the entire data packet, ask the DFU state
+            // machine to handle it.
+            dfu_protocol_handler(&ctx, 0, kUsbTransferFlagsDone, &length);
+            ctx.expected_len = 0;
+          }
+          spi_device_flash_status_clear();
+        }
+      } break;
+
+      case kSpiDeviceOpcodeReset:
+        rstmgr_reset();
+        break;
+      default:
+        dfu_transport_result(&ctx, kErrorUsbBadSetup);
+    }
+  }
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/rescue/sfdp.c
+++ b/sw/device/silicon_creator/lib/rescue/sfdp.c
@@ -1,0 +1,233 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/rescue/sfdp.h"
+
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+#include "sw/device/silicon_creator/lib/drivers/spi_device_bfpt.h"
+
+enum {
+  /**
+   * Rescue Flash size in bits.  The rescue implementation exposes
+   * 4K of address space: 2K for data transfers and 1K of mailbox (plus
+   * another 1K to be a power of 2).
+   */
+  kFlashBitCount = 1u << (kRescueDensity + 3),
+  /**
+   * 32-bit SFDP signature that indicates the presence of a SFDP table
+   * (JESD216A 6.2.1).
+   */
+  kSfdpSignature = 0x50444653,
+  /**
+   * Number of parameter headers in the SFDP data structure (JESD216A 6.2.2).
+   *
+   * This number is zero-based. The SPI-DFU implementation has 2 parameter
+   * headers: one for the Basic Flash Parameters Table (BFPT) and one for
+   * the proprietary SDFU extension table.
+   */
+  kSfdpParamCount = 1,
+  /**
+   * SFDP major revision number (JESD216A 6.2.2).
+   */
+  kSfdpMajorRevision = 0x01,
+  /**
+   * SFDP minor revision number (JESD216A 6.2.2).
+   */
+  kSfdpMinorRevision = 0x05,
+  /**
+   * Unused value of header word 2 [31:24] (JESD216A 6.2.3).
+   */
+  kSfdpUnused = 0xff,
+  /**
+   * BFPT major revision number (JESD216A 6.4.1).
+   */
+  kBfptMajorRevision = 0x01,
+  /**
+   * BFPT minor revision number (JESD216A 6.4.1).
+   */
+  kBfptMinorRevision = 0x00,
+  /**
+   * LSB of BFPT's parameter ID (JESD216A 6.4.1).
+   */
+  kBfptParamIdLsb = 0x00,
+  /**
+   * MSB of BFPT's parameter ID (JESD216A 6.4.2).
+   */
+  kBfptParamIdMsb = 0xff,
+  /**
+   * Offset of the Basic Flash Parameter Table (BFPT) in the SFDP table.
+   */
+  kBfptTablePointer = offsetof(spi_device_sfdp_table_t, bfpt),
+  /**
+   * Value used for BFPT fields that are not supported.
+   *
+   * Note: A handful of BFPT fields, e.g. Msb of the 14th word of BFPT, use 1
+   * instead. Such fields should be defined according to JESD216A instead of
+   * using this value.
+   */
+  kBfptNotSupported = 0,
+};
+
+static_assert(kBfptTablePointer % sizeof(uint32_t) == 0,
+              "BFPT must be word-aligned");
+
+// Note: Words below are numbered starting from 1 to match JESD216A. Some fields
+// that are not supported by OpenTitan are merged for the sake of conciseness.
+// Unused/reserved fields that should be set to all 1s are ommitted due to the
+// definition of `BFPT_FIELD_VALUE()` above. See JESD216A for more details.
+
+// clang-format off
+/**
+ * BFPT 1st Word
+ * -------------
+ * [31:23]: Unused
+ * [22:19]: (1S-1S-4S) (1S-4S-4S) (1S-2S-2S) DTR Clock (not supported: 0x0)
+ * [18:17]: Address bytes (3-byte only addressing: 0)
+ * [16:16]: (1S-1S-2S) (not supported: 0x0)
+ * [15: 8]: 4 KiB erase instruction (0x20)
+ * [ 7: 5]: Unused
+ * [ 4: 4]: Write enable instruction (use 0x06 for WREN: 0x1)
+ * [ 3: 3]: Volatile block protect bits (solely volatile: 0x1)
+ * [ 2: 2]: Write granularity (buffer >= 64 B: 0x1)
+ * [ 1: 0]: Block/sector erase sizes (uniform 4 KiB erase: 0x1)
+ */
+#define BFPT_WORD_1(X) \
+  X(22, 19, kBfptNotSupported) & \
+  X(18, 17, 0x0) & \
+  X(16, 16, kBfptNotSupported) & \
+  X(15,  8, kSpiDeviceOpcodeSectorErase) & \
+  X( 4,  4, 0x1) & \
+  X( 3,  3, 0x1) & \
+  X( 2,  2, 0x1) & \
+  X( 1,  0, 0x1)
+
+/**
+ * BFPT 2nd Word
+ * -------------
+ * [31:31]: Density greater than 2 Gib (0x0)
+ * [30: 0]: Flash memory density in bits, zero-based.
+ */
+#define BFPT_WORD_2(X) \
+  X(31, 31, 0) & \
+  X(30,  0, kFlashBitCount - 1)
+
+/**
+ * BFPT 3rd Word
+ * -------------
+ * [31: 0]: Fast read (1S-4S-4S) (1S-1S-4S) (not supported, 0x0)
+ */
+#define BFPT_WORD_3(X) \
+  X(31,  0, kBfptNotSupported)
+
+/**
+ * BFPT 4th Word
+ * -------------
+ * [31: 0]: Fast read (1S-1S-2S) (1S-2S-2S) (not supported, 0x0)
+ */
+#define BFPT_WORD_4(X) \
+  X(31,  0, kBfptNotSupported)
+
+/**
+ * BFPT 5th Word
+ * -------------
+ * [31: 5]: Reserved
+ * [ 4: 4]: Fast read (4S-4S-4S) support (not supported, 0x0)
+ * [ 3: 1]: Reserved
+ * [ 0: 0]: Fast read (2S-2S-2S) support (not supported, 0x0)
+ */
+#define BFPT_WORD_5(X) \
+  X( 4,  4, kBfptNotSupported) & \
+  X( 0,  0, kBfptNotSupported)
+
+/**
+ * BFPT 6th Word
+ * -------------
+ * [31:16]: Fast read (2S-2S-2S) (not supported, 0x0)
+ * [15: 0]: Reserved
+ */
+#define BFPT_WORD_6(X) \
+  X(31, 16, kBfptNotSupported)
+
+/**
+ * BFPT 7th Word
+ * -------------
+ * [31:16]: Fast read (4S-4S-4S) (not supported, 0x0)
+ * [15: 0]: Reserved
+ */
+#define BFPT_WORD_7(X) \
+  X(31, 16, kBfptNotSupported)
+
+/**
+ * BFPT 8th Word
+ * -------------
+ * [31:16]: Erase type 2 instruction and size (not supported, 0x0)
+ * [15: 8]: Erase type 1 instruction (0x20)
+ * [ 7: 0]: Erase type 1 size (4 KiB, 2^N bytes, N = 0x0c)
+ */
+#define BFPT_WORD_8(X) \
+  X(31, 16, kBfptNotSupported) & \
+  X(15,  8, kSpiDeviceOpcodeSectorErase) & \
+  X( 7,  0, 0x0c)
+
+/**
+ * BFPT 9th Word
+ * -------------
+ * [31: 0]: Erase type 4 and 3 (not supported, 0x0)
+ */
+#define BFPT_WORD_9(X) \
+  X(31,  0, kBfptNotSupported)
+// clang-format on
+
+const rescue_sfdp_table_t kRescueSfdpTable = {
+    .header =
+        {
+            .signature = kSfdpSignature,
+            .minor_revision = kSfdpMinorRevision,
+            .major_revision = kSfdpMajorRevision,
+            .param_count = kSfdpParamCount,
+            .access_protocol = kSfdpUnused,
+        },
+    .phdr =
+        {
+            {
+                .param_id_lsb = kBfptParamIdLsb,
+                .minor_revision = kBfptMinorRevision,
+                .major_revision = kBfptMajorRevision,
+                .table_word_count = kRescueBfptSizeInWords,
+                .table_pointer = {offsetof(rescue_sfdp_table_t, bfpt)},
+                .param_id_msb = kBfptParamIdMsb,
+            },
+            {
+                .param_id_lsb = 0xEF,  // lowRISC
+                .minor_revision = 0,
+                .major_revision = 1,
+                .table_word_count = sizeof(sdfu_table_t) / sizeof(uint32_t),
+                .table_pointer = {offsetof(rescue_sfdp_table_t, sdfu)},
+                .param_id_msb =
+                    12,  // page_number-1; The lowRISC JEDEC ID is on page 13.
+            },
+        },
+    .bfpt =
+        {
+            BFPT_WORD_1(BFPT_FIELD_VALUE),
+            BFPT_WORD_2(BFPT_FIELD_VALUE),
+            BFPT_WORD_3(BFPT_FIELD_VALUE),
+            BFPT_WORD_4(BFPT_FIELD_VALUE),
+            BFPT_WORD_5(BFPT_FIELD_VALUE),
+            BFPT_WORD_6(BFPT_FIELD_VALUE),
+            BFPT_WORD_7(BFPT_FIELD_VALUE),
+            BFPT_WORD_8(BFPT_FIELD_VALUE),
+            BFPT_WORD_9(BFPT_FIELD_VALUE),
+        },
+    .sdfu =
+        {
+            .tag = kRescueSDFU,
+            .length = sizeof(sdfu_table_t),
+            .major = 1,
+            .minor = 0,
+            .mailbox_address = 0x800,
+            .mailbox_size = 0x400,
+            .dfu_size = 0x800,
+        },
+};

--- a/sw/device/silicon_creator/lib/rescue/sfdp.h
+++ b/sw/device/silicon_creator/lib/rescue/sfdp.h
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_RESCUE_SFDP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_RESCUE_SFDP_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  /**
+   * Rescue flash density: log2(4K bytes).  The rescue implementation exposes
+   * 4K of address space: 2K for data transfers and 1K of mailbox (plus another
+   * 1K to be a power of 2).
+   */
+  kRescueDensity = 12,
+  /**
+   * Size of rescue's BFPT in words.
+   */
+  kRescueBfptSizeInWords = 9,
+  /**
+   * The SDFU tag: ASCII `SDFU`.
+   */
+  kRescueSDFU = 0x55464453,
+};
+
+/**
+ * The SDFU extension describes SPI-DFU in the SFDP table.
+ */
+typedef struct sdfu_table {
+  /** tag: `SDFU`. */
+  uint32_t tag;
+  /** length: 16 bytes. */
+  uint16_t length;
+  /** Major version. */
+  uint8_t major;
+  /** Minor version. */
+  uint8_t minor;
+  /** The SDFU mailbox address. */
+  uint32_t mailbox_address;
+  /** The SDFU mailbox size. */
+  uint16_t mailbox_size;
+  /** The DFU transfer size. */
+  uint16_t dfu_size;
+} sdfu_table_t;
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, tag, 0);
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, length, 4);
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, major, 6);
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, minor, 7);
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, mailbox_address, 8);
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, mailbox_size, 12);
+OT_ASSERT_MEMBER_OFFSET(sdfu_table_t, dfu_size, 14);
+OT_ASSERT_SIZE(sdfu_table_t, 16);
+
+/**
+ * The Rescue SFDP table describes the flash interface for rescue mode.
+ */
+typedef struct rescue_sfdp_table {
+  spi_device_sfdp_header_t header;
+  spi_device_param_header_t phdr[2];
+  uint32_t bfpt[kRescueBfptSizeInWords];
+  sdfu_table_t sdfu;
+} rescue_sfdp_table_t;
+OT_ASSERT_MEMBER_OFFSET(rescue_sfdp_table_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(rescue_sfdp_table_t, phdr, 8);
+OT_ASSERT_MEMBER_OFFSET(rescue_sfdp_table_t, bfpt, 24);
+OT_ASSERT_MEMBER_OFFSET(rescue_sfdp_table_t, sdfu, 60);
+OT_ASSERT_SIZE(rescue_sfdp_table_t, 76);
+
+extern const rescue_sfdp_table_t kRescueSfdpTable;
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_RESCUE_SFDP_H_

--- a/sw/device/silicon_creator/rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/rom/bootstrap_unittest.cc
@@ -31,6 +31,7 @@ using bootstrap_unittest_util::PageProgramCmd;
 using bootstrap_unittest_util::ResetCmd;
 using bootstrap_unittest_util::SectorEraseCmd;
 
+using ::testing::_;
 using ::testing::NotNull;
 using ::testing::Return;
 
@@ -64,7 +65,7 @@ TEST_F(BootstrapTest, RequestedEnabled) {
 
 TEST_F(BootstrapTest, PayloadOverflowErase) {
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   EXPECT_CALL(spi_device_, CmdGet(NotNull()))
       .WillOnce(Return(kErrorSpiDevicePayloadOverflow));
 
@@ -74,7 +75,7 @@ TEST_F(BootstrapTest, PayloadOverflowErase) {
 TEST_F(BootstrapTest, PayloadOverflowProgram) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -91,7 +92,7 @@ TEST_F(BootstrapTest, PayloadOverflowProgram) {
 TEST_F(BootstrapTest, BootstrapSimple) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -122,7 +123,7 @@ TEST_F(BootstrapTest, BootstrapSimple) {
 TEST_F(BootstrapTest, BootstrapOddPayload) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -156,7 +157,7 @@ TEST_F(BootstrapTest, BootstrapOddPayload) {
 TEST_F(BootstrapTest, BootstrapMisalignedAddrLongPayload) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -190,7 +191,7 @@ TEST_F(BootstrapTest, BootstrapMisalignedAddrLongPayload) {
 TEST_F(BootstrapTest, BootstrapMisalignedAddrShortPayload) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -221,7 +222,7 @@ TEST_F(BootstrapTest, BootstrapMisalignedAddrShortPayload) {
 TEST_F(BootstrapTest, BootstrapStartWithSectorErase) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(SectorEraseCmd(0));
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -254,7 +255,7 @@ TEST_F(BootstrapTest, BootstrapStartWithSectorErase) {
 TEST_F(BootstrapTest, BootstrapProgramWithErase) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -298,7 +299,7 @@ TEST_F(BootstrapTest, BootstrapProgramWithErase) {
 TEST_F(BootstrapTest, MisalignedEraseAddress) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -330,7 +331,7 @@ TEST_F(BootstrapTest, MisalignedEraseAddress) {
 TEST_F(BootstrapTest, IgnoredCommands) {
   // Phase 1: Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());  // Ignored, missing WREN.
   ExpectSpiFlashStatusGet(false);
   ExpectSpiCmd(ResetCmd());  // Ignored, not supported.
@@ -358,7 +359,7 @@ TEST_F(BootstrapTest, IgnoredCommands) {
 
 TEST_F(BootstrapTest, EraseBank0Error) {
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorUnknown, kErrorOk);
@@ -368,7 +369,7 @@ TEST_F(BootstrapTest, EraseBank0Error) {
 
 TEST_F(BootstrapTest, EraseBank1Error) {
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorUnknown);
@@ -379,7 +380,7 @@ TEST_F(BootstrapTest, EraseBank1Error) {
 TEST_F(BootstrapTest, EraseVerifyBank0Error) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -392,7 +393,7 @@ TEST_F(BootstrapTest, EraseVerifyBank0Error) {
 TEST_F(BootstrapTest, EraseVerifyBank1Error) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -405,7 +406,7 @@ TEST_F(BootstrapTest, EraseVerifyBank1Error) {
 TEST_F(BootstrapTest, DataWriteError) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -433,7 +434,7 @@ TEST_F(BootstrapTest, DataWriteError) {
 TEST_F(BootstrapTest, DataWriteErrorMisalignedAddr) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -459,7 +460,7 @@ TEST_F(BootstrapTest, DataWriteErrorMisalignedAddr) {
 TEST_F(BootstrapTest, BadProgramAddress) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
@@ -477,7 +478,7 @@ TEST_F(BootstrapTest, BadProgramAddress) {
 TEST_F(BootstrapTest, BadEraseAddress) {
   // Erase
   ExpectBootstrapRequestCheck(true);
-  EXPECT_CALL(spi_device_, Init());
+  EXPECT_CALL(spi_device_, InitBootstrap());
   ExpectSpiCmd(ChipEraseCmd());
   ExpectSpiFlashStatusGet(true);
   ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);


### PR DESCRIPTION
1. Use the `spi_device` driver to configure the SPI peripheral.  Turn on
   the mailbox and spi egress buffer to facilitate send and recv of
   command packets (mailbox) and data packets (egress buffer).
2. Initialize an SFPD table that communicates the SPI-DFU capability in
   a parameter table.
3. Process SPI opcodes captured by the SPI device to implement the DFU
   protocol.

This PR depends on #26622, #26638 and #26647.  You need only review the last 2 commits.