### PR TITLE
[rescue] Implement a SPI-DFU client 

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -296,6 +296,35 @@ cc_library(
 )
 
 cc_library(
+    name = "test_owner_spidfu",
+    testonly = True,
+    srcs = ["test_owner.c"],
+    defines = [
+        # 0x53 is 'S'pi.
+        "WITH_RESCUE_PROTOCOL=0x53",
+        # Trigger 3 is GPIO pin.
+        "WITH_RESCUE_TRIGGER=3",
+        # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+        # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+        "WITH_RESCUE_INDEX=2",
+        # GPIO param 3 means enable the internal pull resistor and trigger
+        # rescue when the GPIO is high.
+        "WITH_RESCUE_GPIO_PARAM=3",
+    ],
+    deps = [
+        ":datatypes",
+        ":owner_block",
+        ":ownership",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
+        "//sw/device/silicon_creator/lib/rescue",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
     name = "owner_verify",
     srcs = ["owner_verify.c"],
     hdrs = ["owner_verify.h"],

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -71,8 +71,8 @@
   (owner_keydata_t) { .ecdsa = UNLOCK_ECDSA_P256 }
 #endif
 
-#ifndef WITH_RESCUE_GPIO
-#define WITH_RESCUE_GPIO 0
+#ifndef WITH_RESCUE_GPIO_PARAM
+#define WITH_RESCUE_GPIO_PARAM 0
 #endif
 #ifndef WITH_RESCUE_TRIGGER
 #define WITH_RESCUE_TRIGGER 1 /* default to UartBreak */
@@ -224,7 +224,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
               .length = sizeof(owner_rescue_config_t),
           },
       .protocol = WITH_RESCUE_PROTOCOL,
-      .gpio = WITH_RESCUE_GPIO,
+      .gpio = WITH_RESCUE_GPIO_PARAM,
       .detect = (WITH_RESCUE_TRIGGER << 6) | WITH_RESCUE_INDEX,
       .start = 32,
       .size = 224,

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -292,6 +292,31 @@ opentitan_binary(
     ],
 )
 
+# This binary is a test-only ROM_EXT that has rescue configured for USB-DFU.
+opentitan_binary(
+    name = "rom_ext_spidfu",
+    testonly = True,
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+    ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
+    linker_script = ":ld_slot_a",
+    manifest = ":manifest",
+    deps = [
+        ":rom_ext_dice_x509",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership:test_owner_spidfu",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake",
+        "//sw/device/silicon_creator/lib/rescue:rescue_spidfu",
+        "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
+    ],
+)
+
 manifest(d = {
     "name": "manifest_bad_address_translation",
     "address_translation": "0",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -1,6 +1,9 @@
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules/opentitan:defs.bzl",
     "DEFAULT_TEST_FAILURE_MSG",
@@ -11,8 +14,6 @@ load(
     "opentitan_binary",
     "opentitan_test",
 )
-load("//rules:const.bzl", "CONST", "hex")
-load("//rules:manifest.bzl", "manifest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,12 +32,21 @@ _CONFIGS = {
     "xmodem": {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "params": "",
+        "setup": "",
         "tags": [],
     },
     "usbdfu": {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_usbdfu",
         "params": "-p usb-dfu -t strap -v 3",
+        "setup": "",
         "tags": ["broken"],
+    },
+    "spidfu": {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu",
+        # Use spi-dfu, trigger with GPIO IOA2 high.
+        "params": "-p spi-dfu -t gpio -v +Ioa2",
+        "setup": "--exec=\"gpio set --mode OpenDrain Ioa2\"",
+        "tags": [],
     },
 }
 
@@ -74,12 +84,14 @@ _CONFIGS = {
             },
             params = config["params"],
             rom_ext = config["rom_ext"],
+            setup = config["setup"],
             slot = position["slot"],
             tags = config["tags"],
             test_cmd = """
                 --exec="transport init"
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
+                {setup}
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
                 --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
@@ -109,12 +121,14 @@ _CONFIGS = {
             },
             params = config["params"],
             rom_ext = config["rom_ext"],
+            setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
                 --exec="transport init"
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {firmware}"
+                {setup}
                 --exec="no-op --info='##### Set next slot via the rescue protocol'"
                 --exec="rescue {params} boot-svc set-next-bl0-slot --next=SlotB --get-response=false"
                 --exec="no-op --info='##### Check for firmware execution in slot B'"
@@ -145,12 +159,14 @@ _CONFIGS = {
             },
             params = config["params"],
             rom_ext = config["rom_ext"],
+            setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
                 --exec="transport init"
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {firmware}"
+                {setup}
                 --exec="no-op --info='##### Set primary slot via the rescue protocol'"
                 --exec="rescue {params} boot-svc set-next-bl0-slot --primary=SlotB"
                 --exec="no-op --info='##### Check for firmware execution in slot B'"

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -143,6 +143,7 @@ rust_library(
         "src/rescue/dfu.rs",
         "src/rescue/mod.rs",
         "src/rescue/serial.rs",
+        "src/rescue/spidfu.rs",
         "src/rescue/usbdfu.rs",
         "src/rescue/xmodem.rs",
         "src/spiflash/flash.rs",

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -14,7 +14,7 @@ use crate::app::TransportWrapper;
 use crate::impl_serializable_error;
 use crate::util::voltage::Voltage;
 
-#[derive(Clone, Debug, Args, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, Args, Serialize, Deserialize)]
 pub struct SpiParams {
     /// SPI instance.
     #[arg(long)]

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -69,21 +69,25 @@ pub struct OwnerRescueConfig {
     #[serde(alias = "rescue_type")]
     pub protocol: RescueProtocol,
     /// The rescue triggering mechanism (UartBreak, Strapping or Gpio).
+    #[serde(default)]
     pub trigger: RescueTrigger,
     /// The index of the trigger (e.g. Strapping combo or GPIO pin number).
+    #[serde(default)]
     pub trigger_index: u8,
     /// Whether or not to enable the GPIO pull resistor (only if trigger is GPIO).
+    #[serde(default)]
     pub gpio_pull_en: bool,
     /// The GPIO trigger value (only if trigger is GPIO).
+    #[serde(default)]
     pub gpio_value: bool,
     /// Enter rescue mode if boot fails (not implemented yet).
-    #[serde(skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub _enter_on_failure: bool,
     /// Enable a timeout (rescue exits after a period of no activity; not implemented yet).
-    #[serde(skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub _timeout_enable: bool,
     /// The timeout in seconds (not implemented yet).
-    #[serde(skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub _timeout: u8,
     /// The start of the rescue flash region (in pages).
     pub start: u16,

--- a/sw/host/opentitanlib/src/rescue/dfu.rs
+++ b/sw/host/opentitanlib/src/rescue/dfu.rs
@@ -61,8 +61,9 @@ with_unknown! {
 #[derive(Clone, Copy)]
 #[repr(u8)]
 pub enum DfuRequestType {
-    Out = 0x21, // direction=out, type=class, recipient=interface.
-    In = 0xA1,  // direction=in, type=class, recipient=interface.
+    Out = 0x21,    // direction=out, type=class, recipient=interface.
+    In = 0xA1,     // direction=in, type=class, recipient=interface.
+    Vendor = 0x40, // direction=out, type=vendor, recipient=device.
 }
 
 impl From<DfuRequestType> for u8 {

--- a/sw/host/opentitanlib/src/rescue/mod.rs
+++ b/sw/host/opentitanlib/src/rescue/mod.rs
@@ -11,16 +11,19 @@ use crate::chip::boot_log::BootLog;
 use crate::chip::boot_svc::{BootSlot, BootSvc, OwnershipActivateRequest, OwnershipUnlockRequest};
 use crate::chip::device_id::DeviceId;
 use crate::io::gpio::PinMode;
+use crate::io::spi::SpiParams;
 use crate::io::uart::UartParams;
 use crate::util::parse_int::ParseInt;
 use crate::with_unknown;
 
 pub mod dfu;
 pub mod serial;
+pub mod spidfu;
 pub mod usbdfu;
 pub mod xmodem;
 
 pub use serial::RescueSerial;
+pub use spidfu::SpiDfu;
 pub use usbdfu::UsbDfu;
 
 #[derive(Debug, Error)]
@@ -31,6 +34,8 @@ pub enum RescueError {
     Configuration(String),
     #[error("bad protocol: {0}")]
     BadProtocol(String),
+    #[error("not found: {0}")]
+    NotFound(String),
 }
 
 #[derive(ValueEnum, Default, Debug, Clone, Copy, PartialEq)]
@@ -58,6 +63,8 @@ pub struct RescueParams {
     pub trigger: RescueTrigger,
     #[arg(short, long, default_value = "")]
     pub value: String,
+    #[command(flatten)]
+    spi: SpiParams,
     #[command(flatten)]
     uart: UartParams,
     #[arg(long)]
@@ -114,8 +121,22 @@ impl RescueParams {
         Ok(Box::new(UsbDfu::new(self.clone())))
     }
 
-    fn create_spidfu(&self, _transport: &TransportWrapper) -> Result<Box<dyn Rescue>> {
-        unimplemented!()
+    fn create_spidfu(&self, transport: &TransportWrapper) -> Result<Box<dyn Rescue>> {
+        ensure!(
+            self.trigger != RescueTrigger::SerialBreak,
+            RescueError::Configuration(format!(
+                "Usb-DFU does not support trigger {:?}",
+                self.trigger
+            ))
+        );
+        ensure!(
+            !self.value.is_empty(),
+            RescueError::Configuration("Usb-DFU requires a trigger value".into())
+        );
+        Ok(Box::new(SpiDfu::new(
+            self.spi.create(transport, "BOOTSTRAP")?,
+            self.clone(),
+        )))
     }
 
     fn set_strap(&self, transport: &TransportWrapper, trigger: bool) -> Result<()> {

--- a/sw/host/opentitanlib/src/rescue/spidfu.rs
+++ b/sw/host/opentitanlib/src/rescue/spidfu.rs
@@ -1,0 +1,266 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+use zerocopy::AsBytes;
+
+use crate::app::TransportWrapper;
+use crate::chip::rom_error::RomError;
+use crate::io::spi::Target;
+use crate::rescue::dfu::*;
+use crate::rescue::{EntryMode, Rescue, RescueError, RescueMode, RescueParams};
+use crate::spiflash::sfdp::Sdfu;
+use crate::spiflash::SpiFlash;
+
+#[repr(C)]
+#[derive(Default, Debug, AsBytes)]
+struct SetupData {
+    request_type: u8,
+    request: u8,
+    value: u16,
+    index: u16,
+    length: u16,
+}
+
+pub struct SpiDfu {
+    spi: Rc<dyn Target>,
+    flash: RefCell<SpiFlash>,
+    sdfu: RefCell<Sdfu>,
+    params: RescueParams,
+    reset_delay: Duration,
+    enter_delay: Duration,
+}
+
+impl SpiDfu {
+    const SET_INTERFACE: u8 = 0x0b;
+
+    pub fn new(spi: Rc<dyn Target>, params: RescueParams) -> Self {
+        SpiDfu {
+            spi,
+            flash: RefCell::default(),
+            sdfu: RefCell::default(),
+            params,
+            reset_delay: Duration::from_millis(50),
+            enter_delay: Duration::from_secs(5),
+        }
+    }
+
+    fn wait_for_device(spi: &dyn Target, timeout: Duration) -> Result<SpiFlash> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match SpiFlash::from_spi(spi) {
+                Ok(flash) => return Ok(flash),
+                Err(e) => {
+                    if Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(100));
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Rescue for SpiDfu {
+    fn enter(&self, transport: &TransportWrapper, mode: EntryMode) -> Result<()> {
+        log::info!(
+            "Setting {:?}({}) to trigger rescue mode.",
+            self.params.trigger,
+            self.params.value
+        );
+        self.params.set_trigger(transport, true)?;
+        match mode {
+            EntryMode::Reset => {
+                transport.reset_target(self.reset_delay, /*clear_uart=*/ false)?
+            }
+            EntryMode::Reboot => {
+                self.reboot()?;
+                // Give the chip a chance to reset before attempting to re-read
+                // the SFDP from the SPI device.
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            EntryMode::None => {}
+        }
+
+        let flash = Self::wait_for_device(&*self.spi, self.enter_delay);
+        log::info!("Rescue triggered; clearing trigger condition.");
+        self.params.set_trigger(transport, false)?;
+        let mut flash = flash?;
+        log::info!("Flash = {:?}", flash.sfdp);
+        if let Some(sdfu) = flash.sfdp.as_ref().and_then(|sfdp| sfdp.sdfu.as_ref()) {
+            self.sdfu.replace(sdfu.clone());
+        } else {
+            return Err(RescueError::NotFound(
+                "Could not find SDFU parameters in the SDFP table".into(),
+            )
+            .into());
+        }
+        flash.set_address_mode_auto(&*self.spi)?;
+        self.flash.replace(flash);
+        Ok(())
+    }
+
+    fn set_mode(&self, mode: RescueMode) -> Result<()> {
+        let setting = match mode {
+            // FIXME: Remap "send" modes to their corresponding "recv" mode.
+            // The firmware will stage the recv data, then enter the send mode.
+            RescueMode::Rescue => RescueMode::Rescue,
+            RescueMode::RescueB => RescueMode::RescueB,
+            RescueMode::DeviceId => RescueMode::DeviceId,
+            RescueMode::BootLog => RescueMode::BootLog,
+            RescueMode::BootSvcReq => RescueMode::BootSvcRsp,
+            RescueMode::BootSvcRsp => RescueMode::BootSvcRsp,
+            RescueMode::OwnerBlock => RescueMode::GetOwnerPage0,
+            RescueMode::GetOwnerPage0 => RescueMode::GetOwnerPage0,
+            _ => bail!(RescueError::BadMode(format!(
+                "mode {mode:?} not supported by DFU"
+            ))),
+        };
+
+        log::info!("Mode {mode} is AltSetting {setting}");
+        let setting = u32::from(setting);
+        // This is a proprietary version of the standard USB SetInterface command.
+        self.write_control(
+            DfuRequestType::Vendor.into(),
+            Self::SET_INTERFACE,
+            (setting >> 16) as u16,
+            setting as u16,
+            &[],
+        )?;
+        Ok(())
+    }
+
+    fn set_speed(&self, _speed: u32) -> Result<u32> {
+        log::warn!("set_speed is not implemented for DFU");
+        Ok(0)
+    }
+
+    fn reboot(&self) -> Result<()> {
+        SpiFlash::chip_reset(&*self.spi)?;
+        Ok(())
+    }
+
+    fn send(&self, data: &[u8]) -> Result<()> {
+        let sdfu = self.sdfu.borrow();
+        for chunk in data.chunks(sdfu.dfu_size as usize) {
+            let _ = self.download(chunk)?;
+            let status = loop {
+                let status = self.get_status()?;
+                match status.state() {
+                    DfuState::DnLoadIdle | DfuState::Error => {
+                        break status;
+                    }
+                    _ => {
+                        std::thread::sleep(Duration::from_millis(status.poll_timeout() as u64));
+                    }
+                }
+            };
+            status.status()?;
+        }
+        // Send a zero-length chunk to signal the end.
+        let _ = self.download(&[])?;
+        let status = self.get_status()?;
+        log::warn!("State after DFU download: {}", status.state());
+        Ok(())
+    }
+
+    fn recv(&self) -> Result<Vec<u8>> {
+        let sdfu = self.sdfu.borrow();
+        let mut data = vec![0u8; sdfu.dfu_size as usize];
+        /*
+         * FIXME: what am I supposed to do here?
+         * The spec seems to indicate that I should keep performing `upload` until I get back a
+         * short or zero length packet.
+        let mut offset = 0;
+        loop {
+            log::info!("upload at {offset}");
+            let length = self.upload(&mut data[offset..])?;
+            if length == 0 || length < data.len() - offset {
+                break;
+            }
+            offset += length;
+        }
+        */
+        self.upload(&mut data)?;
+        let status = self.get_status()?;
+        log::warn!("State after DFU upload: {}", status.state());
+        Ok(data)
+    }
+}
+
+impl DfuOperations for SpiDfu {
+    fn get_interface(&self) -> u8 {
+        0
+    }
+
+    // Implement a USB-like control write transaction using OpenTitan's SPI interface.
+    // - Prepare an 8-byte SetupData structure and write it to the Mailbox.
+    //   Note: `flash.program` polls the SPI status BUSY bit for completion.
+    // - Read the Setup status back from the mailbox.  The status will be a
+    //   single 4-byte word of type `RomError`.
+    // - Write the data phase of the control transaction to SPI addresss 0.
+    fn write_control(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: &[u8],
+    ) -> Result<usize> {
+        let setup = SetupData {
+            request_type,
+            request,
+            value,
+            index,
+            length: data.len().try_into()?,
+        };
+        let flash = self.flash.borrow();
+        let sdfu = self.sdfu.borrow();
+        flash.program(&*self.spi, sdfu.mailbox_address, setup.as_bytes())?;
+
+        let mut result = [0u8; 4];
+        flash.read(&*self.spi, sdfu.mailbox_address, &mut result)?;
+        Result::<(), RomError>::from(RomError(u32::from_le_bytes(result)))?;
+
+        flash.program(&*self.spi, 0, data)?;
+        Ok(data.len())
+    }
+
+    // Implement a USB-like control read transaction using OpenTitan's SPI interface.
+    // - Prepare an 8-byte SetupData structure and write it to the Mailbox.
+    //   Note: `flash.program` polls the SPI status BUSY bit for completion.
+    // - Read the Setup status back from the mailbox.  The status will be a
+    //   single 4-byte word of type `RomError`.
+    // - Read the data phase from SPI address 0.
+    fn read_control(
+        &self,
+        request_type: u8,
+        request: u8,
+        value: u16,
+        index: u16,
+        data: &mut [u8],
+    ) -> Result<usize> {
+        let setup = SetupData {
+            request_type,
+            request,
+            value,
+            index,
+            length: data.len().try_into()?,
+        };
+        let flash = self.flash.borrow();
+        let sdfu = self.sdfu.borrow();
+        flash.program(&*self.spi, sdfu.mailbox_address, setup.as_bytes())?;
+
+        let mut result = [0u8; 4];
+        flash.read(&*self.spi, sdfu.mailbox_address, &mut result)?;
+        Result::<(), RomError>::from(RomError(u32::from_le_bytes(result)))?;
+
+        flash.read(&*self.spi, 0, data)?;
+        Ok(data.len())
+    }
+}

--- a/sw/host/opentitanlib/src/spiflash/sfdp.rs
+++ b/sw/host/opentitanlib/src/spiflash/sfdp.rs
@@ -869,6 +869,40 @@ impl TryFrom<&[u8]> for JedecParams {
     }
 }
 
+#[derive(Default, Debug, Clone, Serialize)]
+pub struct Sdfu {
+    pub tag: u32,
+    pub length: u16,
+    pub major: u8,
+    pub minor: u8,
+    pub mailbox_address: u32,
+    pub mailbox_size: u16,
+    pub dfu_size: u16,
+}
+
+impl TryFrom<&[u8]> for Sdfu {
+    type Error = Error;
+    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
+        const SDFU_TAG: u32 = 0x55464453;
+        log::info!("sdfu from {buf:x?}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let header = Sdfu {
+            tag: reader.read_u32::<LittleEndian>()?,
+            length: reader.read_u16::<LittleEndian>()?,
+            major: reader.read_u8()?,
+            minor: reader.read_u8()?,
+            mailbox_address: reader.read_u32::<LittleEndian>()?,
+            mailbox_size: reader.read_u16::<LittleEndian>()?,
+            dfu_size: reader.read_u16::<LittleEndian>()?,
+        };
+        match header.tag {
+            SDFU_TAG => Ok(header),
+            v => Err(Error::WrongHeaderSignature(v)),
+        }
+    }
+}
+
 /// An `UnknownParams` structure represents SFDP parameter tables for which
 /// we don't have a specialized parser.
 #[derive(Debug, Serialize)]
@@ -892,10 +926,13 @@ pub struct Sfdp {
     pub header: SfdpHeader,
     pub phdr: Vec<SfdpPhdr>,
     pub jedec: JedecParams,
+    pub sdfu: Option<Sdfu>,
     pub params: Vec<UnknownParams>,
 }
 
 impl Sfdp {
+    const LOWRISC_JEDEC_ID: u8 = 0xEF;
+
     /// Given an initial SFDP buffer calculate the number of bytes needed for
     /// the entire SFDP.
     pub fn length_required(buf: &[u8]) -> Result<usize, Error> {
@@ -944,19 +981,26 @@ impl TryFrom<&[u8]> for Sfdp {
         let jedec =
             JedecParams::try_from(buf.get(start..end).ok_or(Error::SliceRange(start, end))?)?;
 
+        let mut sdfu: Option<Sdfu> = None;
         let mut params = Vec::new();
         for ph in phdr.iter().take((header.nph as usize) + 1).skip(1) {
             let start = ph.offset as usize;
             let end = start + ph.dwords as usize * 4;
-            params.push(UnknownParams::try_from(
-                buf.get(start..end).ok_or(Error::SliceRange(start, end))?,
-            )?);
+            let data = buf.get(start..end).ok_or(Error::SliceRange(start, end))?;
+            if ph.id == Self::LOWRISC_JEDEC_ID {
+                if let Ok(s) = Sdfu::try_from(data) {
+                    sdfu = Some(s);
+                    continue;
+                }
+            }
+            params.push(UnknownParams::try_from(data)?);
         }
 
         Ok(Sfdp {
             header,
             phdr,
             jedec,
+            sdfu,
             params,
         })
     }


### PR DESCRIPTION
1. Detect the SPI-DFU capability with an SFDP extension.
2. Implement USB-like control transactions over SPI using the SPI mailbox and SPI egress buffers.
3. Add spi-dfu to to the rescue e2e tests.

This PR depends on #26622, #26638, #26647 and #26669.  You need only review the last 2 commits.