### PR TITLE
[dt] Expose IP hardware features in DT headers

### DIFF
--- a/util/dtgen/dt_ip.h.tpl
+++ b/util/dtgen/dt_ip.h.tpl
@@ -100,6 +100,13 @@ ${helper.periph_io_enum.render()}
 ${helper.wakeup_enum.render()}
 
 % endif
+% if helper.has_features():
+/**
+ * List of supported hardware features.
+ */
+${helper.feature_defines.render()}
+
+% endif
 
 /**
  * Get the ${device_name} instance from an instance ID

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -59,6 +59,12 @@ py_library(
 )
 
 py_library(
+    name = "feature",
+    srcs = ["feature.py"],
+    deps = [":lib"],
+)
+
+py_library(
     name = "enum_entry",
     srcs = ["enum_entry.py"],
     deps = [":lib"],
@@ -106,6 +112,7 @@ py_library(
         ":bus_interfaces",
         ":clocking",
         ":countermeasure",
+        ":feature",
         ":inter_signal",
         ":interrupt",
         ":lib",

--- a/util/reggen/feature.py
+++ b/util/reggen/feature.py
@@ -1,0 +1,69 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, List
+
+from reggen.lib import check_keys, check_str, check_list, check_name
+
+
+class Feature:
+    """Object holding details for one feature within an IP block."""
+
+    def __init__(self, instance: str, name: str, desc: str):
+        self.instance = instance
+        self.name = name
+        self.desc = desc
+
+    @staticmethod
+    def from_raw(what: str, raw: object) -> 'Feature':
+        """
+        Create a Feature object from a dict.
+
+        The 'raw' dict must have the keys 'name' and 'desc', where 'name' has
+        to follow the canonical feature naming convention.
+        """
+        rd = check_keys(raw, what, ['name', 'desc'], [])
+
+        name = check_str(rd['name'], f'name field of {what}')
+        desc = check_str(rd['desc'], f'desc field of {what}')
+
+        try:
+            # the format is [INST_NAME].<feature>
+            # i.e., the IP instance name is optional.
+            fields = name.split('.', 1)
+            if len(fields) == 1:
+                instance = ""
+                name = fields[0]
+            elif len(fields) == 2:
+                instance, name = fields
+        except ValueError:
+            raise ValueError(
+                f'Invalid feature ID format: {name} ({what}).')
+
+        name = name.replace('.', '_').replace('-', '_')
+        name = check_name(name, f'name of {what}')
+
+        return Feature(instance, name, desc)
+
+    @staticmethod
+    def from_raw_list(what: str, raw: object) -> List['Feature']:
+        """
+        Create a list of Feature objects from a list of dicts.
+
+        The dicts in 'raw' must have the keys 'name' and 'desc', where 'name'
+        has to follow the canonical feature naming convention.
+        """
+        ret = []
+        for idx, entry in enumerate(check_list(raw, what)):
+            entry_what = f'entry {idx} of {what}'
+            cm = Feature.from_raw(entry_what, entry)
+            ret.append(cm)
+        return ret
+
+    def _asdict(self) -> Dict[str, object]:
+        """Returns a dict with 'name' and 'desc' fields"""
+        return {'name': str(self), 'desc': self.desc}
+
+    def __str__(self) -> str:
+        return f'{self.instance}.{self.name}' if self.instance else self.name

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -11,6 +11,7 @@ from reggen.alert import Alert
 from reggen.bus_interfaces import BusInterfaces
 from reggen.clocking import Clocking, ClockingItem
 from reggen.countermeasure import CounterMeasure
+from reggen.feature import Feature
 from reggen.inter_signal import InterSignal
 from reggen.interrupt import Interrupt
 from reggen.lib import (check_bool, check_int, check_keys, check_list,
@@ -184,6 +185,7 @@ class IpBlock:
                  scan_reset: bool,
                  scan_en: bool,
                  countermeasures: List[CounterMeasure],
+                 features: List[Feature],
                  node: str = ''):
         assert reg_blocks
 
@@ -226,6 +228,7 @@ class IpBlock:
         self.scan_reset = scan_reset
         self.scan_en = scan_en
         self.countermeasures = countermeasures
+        self.features = features
 
     @staticmethod
     def from_raw(param_defaults: List[Tuple[str, str]],
@@ -269,6 +272,9 @@ class IpBlock:
 
         countermeasures = CounterMeasure.from_raw_list(
             'countermeasure list for block {}'.format(name), raw_cms)
+
+        features = Feature.from_raw_list(
+            'feature list for block {}'.format(name), rd.get('features', []))
 
         # Ensure that the countermeasures are unique
         for x in countermeasures:
@@ -396,7 +402,7 @@ class IpBlock:
                        None, interrupts, no_auto_intr, alerts, no_auto_alert,
                        scan, inter_signals, bus_interfaces, clocking, xputs,
                        wakeups, rst_reqs, expose_reg_if, scan_reset, scan_en,
-                       countermeasures, node)
+                       countermeasures, features, node)
 
     @staticmethod
     def from_text(txt: str,


### PR DESCRIPTION
These can be used to enable/disable code when two tops have the same IP but with different features and helps avoid hard-coding top names.

None of our current tests need this, but I think it will be useful if e.g. AES gains GCM or I2C gains multi-host.
Maybe `keymgr` and `keymgr_dpe` could share more code and use a `DPE` feature? I'm not sure how similar they are.

`#define`s were chosen over function(s) to avoid having to `#include` unsupported testutils.

Example output:

```c
/**
 * List of supported hardware features.
 */
#define OPENTITAN_UART_HAS_PARITY 1
#define OPENTITAN_UART_HAS_LINE_LOOPBACK 1
#define OPENTITAN_UART_HAS_SYSTEM_LOOPBACK 1
#define OPENTITAN_UART_HAS_BAUD_RATE_CONTROL 1
#define OPENTITAN_UART_HAS_LINE_BREAK 1
#define OPENTITAN_UART_HAS_FIFO_INTERRUPTS 1
```