### PR TITLE
[dv, tlul] Reverting change to cip_tl_host_single_seq.sv

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -11,12 +11,9 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
   `uvm_object_utils(cip_tl_host_single_seq)
   `uvm_object_new
 
-  rand mubi4_t  instr_type;
+  mubi4_t  instr_type;
   tl_intg_err_e tl_intg_err_type = TlIntgErrNone;
 
-  constraint instr_type_c {
-    soft instr_type == MuBi4False;
-  }
 
   virtual function void randomize_req(REQ req, int idx);
     super.randomize_req(req, idx);


### PR DESCRIPTION
The change in [commit](https://github.com/lowRISC/opentitan/commit/910717e67ed492c0f20df35b4464ce91501e87e3#r1993824080):
910717e67ed492c0f20df35b4464ce91501e87e3

Breaks tests for several blocks with signatures:
`uvm_test_top.env.scoreboard [uvm_test_top.env.scoreboard]: Access unexpected addr 0xb8e4db8c`


Perhaps we can define a child class for cip_tl_host_single_seq: maybe something like `cip_tl_host_single_inst_mubifalse_seq`?
Then we could override it for those specific sequences where we want the constraint to be valid. Or just use it directly in those sequences  if those sequences are custom to a block?