### PR TITLE
[gpio,darjeeling] Fixes for gpio_test on Darjeeling

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_gpio_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_gpio_vseq.sv
@@ -73,15 +73,13 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task gpio_input_test();
-    // Wait and check all zs - this indicates it is safe to drive GPIOs as inputs.
-    `DV_SPINWAIT(wait(cfg.chip_vif.gpios_if.pins === {NUM_GPIOS{1'bz}});,
-                 $sformatf("Timed out waiting for GPIOs == %0h", {NUM_GPIOS{1'bz}}),
-                 timeout_ns,
-                `gfn)
+    // Darjeeling does not multiplex the GPIO pins through a pinmux. Instead they are direct IO,
+    // so we rely upon the DUT outputs being in a known state before enabling our drivers.
+    `DV_CHECK_FATAL(cfg.chip_vif.gpios_if.pins === ~gpios_mask, "GPIO pins not in expected state")
 
     // Enable GPIO in input mode.
-    cfg.chip_vif.gpios_if.drive_en(gpios_mask);
     cfg.chip_vif.gpios_if.drive(~gpios_mask);
+    cfg.chip_vif.gpios_if.drive_en(gpios_mask);
 
     `uvm_info(`gfn, "Starting GPIO input test", UVM_LOW)
 

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -128,7 +128,10 @@ opentitan_test(
 opentitan_test(
     name = "gpio_test",
     srcs = ["gpio_test.c"],
-    exec_env = {"//hw/top_earlgrey:sim_dv": None},
+    exec_env = {
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_darjeeling:sim_dv": None,
+    },
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/sim_dv/gpio_test.c
+++ b/sw/device/tests/sim_dv/gpio_test.c
@@ -80,6 +80,11 @@ static void gpio_output_test(const dif_gpio_t *gpio, uint32_t mask) {
     uint32_t gpio_val = 1 << i;
     CHECK_DIF_OK(dif_gpio_write_all(gpio, gpio_val));
 
+    // The GPIO output signals are routed through pinmux back to the GPIO block
+    // and there are synchronizers involved so the inputs may not be available
+    // immediately, and may in fact arrive at different times.
+    busy_spin_micros(1);
+
     // Read GPIO_IN to confirm what we wrote.
     uint32_t read_val;
     CHECK_DIF_OK(dif_gpio_read_all(gpio, &read_val));
@@ -99,6 +104,11 @@ static void gpio_output_test(const dif_gpio_t *gpio, uint32_t mask) {
   for (uint32_t i = 0; i < kDifGpioNumPins; ++i) {
     uint32_t gpio_val = ~(1 << i);
     CHECK_DIF_OK(dif_gpio_write_all(gpio, gpio_val));
+
+    // The GPIO output signals are routed through pinmux back to the GPIO block
+    // and there are synchronizers involved so the inputs may not be available
+    // immediately, and may in fact arrive at different times.
+    busy_spin_micros(1);
 
     // Read GPIO_IN to confirm what we wrote.
     uint32_t read_val;
@@ -226,8 +236,8 @@ void configure_pinmux(void) {
     dt_periph_io_t periph_io =
         dt_gpio_periph_io(kGpioDt, kDtGpioPeriphIoGpio0 + i);
     dt_pad_t pad = kPinmuxTestutilsGpioPads[i];
-    CHECK_DIF_OK(dif_pinmux_mio_select_input(&pinmux, periph_io, pad));
-    CHECK_DIF_OK(dif_pinmux_mio_select_output(&pinmux, pad, periph_io));
+    CHECK_STATUS_OK(
+        pinmux_testutils_connect(&pinmux, periph_io, kDtPeriphIoDirInout, pad));
   }
 }
 


### PR DESCRIPTION
Modifications to bring up `chip_sw_gpio` on Darjeeling T-L. Introduce a delay between writing outputs and reading them back to support different clock frequencies, clock domain crossings, and randomized CDC delays.

Update: required a small modification to the DV sequence to accommodate the DIO pins of Darjeeling.