### PR TITLE
[fusesoc,otp_ctrl] Change otp_ctrl_prim_reg_top core to template

### DIFF
--- a/hw/ip/prim_generic/prim_generic_otp.core
+++ b/hw/ip/prim_generic/prim_generic_otp.core
@@ -15,7 +15,7 @@ filesets:
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - lowrisc:prim:otp_pkg
       - lowrisc:prim_generic:otp_cfg_pkg
-      - lowrisc:ip:otp_ctrl_prim_reg_top
+      - lowrisc:virtual_ip:otp_ctrl_prim_reg_top
     files:
       - rtl/prim_generic_otp.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/otp_ctrl/otp_ctrl_prim_reg_top.core.tpl
+++ b/hw/ip_templates/otp_ctrl/otp_ctrl_prim_reg_top.core.tpl
@@ -2,15 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ip:otp_ctrl_prim_reg_top:1.0"
+name: ${instance_vlnv("lowrisc:ip:otp_ctrl_prim_reg_top:1.0")}
 description: "Generic register top for the OTP wrapper"
+virtual:
+  - lowrisc:virtual_ip:otp_ctrl_prim_reg_top
+
 filesets:
   files_rtl:
     depend:
       # otp_ctrl_prim_reg_top.sv should depend on generic items for now.
       # This may change and will require reworking the flow to generate
       # the otp prim.
-      - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
+      - ${instance_vlnv("lowrisc:ip:otp_ctrl_top_specific_pkg")}
     files:
       - rtl/otp_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
@@ -2,15 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ip:otp_ctrl_prim_reg_top:1.0"
+name: lowrisc:darjeeling_ip:otp_ctrl_prim_reg_top:1.0
 description: "Generic register top for the OTP wrapper"
+virtual:
+  - lowrisc:virtual_ip:otp_ctrl_prim_reg_top
+
 filesets:
   files_rtl:
     depend:
       # otp_ctrl_prim_reg_top.sv should depend on generic items for now.
       # This may change and will require reworking the flow to generate
       # the otp prim.
-      - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
+      - lowrisc:darjeeling_ip:otp_ctrl_top_specific_pkg
     files:
       - rtl/otp_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/otp_ctrl_prim_reg_top.core
@@ -2,15 +2,18 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ip:otp_ctrl_prim_reg_top:1.0"
+name: lowrisc:earlgrey_ip:otp_ctrl_prim_reg_top:1.0
 description: "Generic register top for the OTP wrapper"
+virtual:
+  - lowrisc:virtual_ip:otp_ctrl_prim_reg_top
+
 filesets:
   files_rtl:
     depend:
       # otp_ctrl_prim_reg_top.sv should depend on generic items for now.
       # This may change and will require reworking the flow to generate
       # the otp prim.
-      - lowrisc:virtual_ip:otp_ctrl_top_specific_pkg
+      - lowrisc:earlgrey_ip:otp_ctrl_top_specific_pkg
     files:
       - rtl/otp_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This moves the generic to top-specific dependency down to prim_generic_otp core, which is an area that will need changes anyway.