### PR TITLE
[hw,prim_diff_encode,rtl] Add primitive to differentially encode a signal

### DIFF
--- a/hw/ip/prim/prim_alert_to_diff.core
+++ b/hw/ip/prim/prim_alert_to_diff.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:alert_to_diff"
+description: "Translate an alert to a differentially encoded signal"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:diff_encode
+      - lowrisc:prim:alert
+    files:
+      - rtl/prim_alert_to_diff.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/prim_diff_encode.core
+++ b/hw/ip/prim/prim_diff_encode.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:prim:diff_encode"
+description: "prim diff encode"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:flop
+    files:
+      - rtl/prim_diff_encode.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/prim_diff_to_alert.core
+++ b/hw/ip/prim/prim_diff_to_alert.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:diff_to_alert"
+description: "Translate a differentially encoded signal to an alert"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:flop_2sync
+      - lowrisc:prim:buf
+      - lowrisc:prim:alert
+    files:
+      - rtl/prim_diff_to_alert.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_alert_to_diff.sv
+++ b/hw/ip/prim/rtl/prim_alert_to_diff.sv
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// prim_alert_to_diff: This module receives an alert signal (using the alert protocol) and
+// translates it into a differentially encoded signal (without the alert protocol).
+// It also handles integrity errors from the alert receiver, treating them as alerts.
+//
+// IMPORTANT: This primitive is NOT intended to be used in OpenTitan top-level designs.
+// In top-level designs, prim_alert_{sender,receiver} pairs should be used instead.
+// The intended use case of this primitive is to signal an alert through a differential
+// encoding (for minimal integrity protection) to modules that do not support
+// OpenTitan's alert protocol.
+
+module prim_alert_to_diff #(
+  // AsyncOn: Enables additional synchronization logic within the alert receiver.
+  parameter bit AsyncOn = 1'b0
+) (
+  input logic       clk_i,
+  input logic       rst_ni,
+  // Alert pair (interface signals for the alert protocol)
+  output alert_rx_t alert_rx_o,
+  input  alert_tx_t alert_tx_i,
+  // Output diff pair (differentially encoded alert signal)
+  output logic      diff_p_o,
+  output logic      diff_n_o
+);
+
+  logic integ_error;
+  logic alert;
+
+  // u_prim_alert_receiver: Instantiates the alert receiver module.
+  prim_alert_receiver #(
+    .AsyncOn(AsyncOn)
+  ) u_prim_alert_receiver (
+    .clk_i,
+    .rst_ni,
+    .init_trig_i  (prim_mubi_pkg::MuBi4False),
+    .ping_req_i   (1'b0),
+    .ping_ok_o    (),
+    .integ_fail_o (integ_error),
+    .alert_o      (alert),
+    .alert_rx_o,
+    .alert_tx_i
+  );
+
+  // Combines the decoded alert and the integrity error signal.
+  // An alert is triggered if either a valid alert is received or an integrity error occurs.
+  logic combined_alert;
+  assign combined_alert = integ_error | alert;
+
+  // Instantiates the differential encoder module.
+  prim_diff_encode (
+    .clk_i,
+    .rst_ni,
+    .req_i(combined_alert), // Input request signal (combined alert).
+    .diff_p_o,
+    .diff_n_o
+  );
+endmodule

--- a/hw/ip/prim/rtl/prim_diff_encode.sv
+++ b/hw/ip/prim/rtl/prim_diff_encode.sv
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module encodes a single bit signal to a differentially encoded signal.
+//
+// In case the differential pair crosses an asynchronous boundary, it has
+// to be re-synchronized to the local clock.
+
+module prim_diff_encode (
+  input logic  clk_i,
+  input logic  rst_ni,
+  // Single line input signal
+  input logic  req_i,
+  // Output diff pair
+  output logic diff_p_o,
+  output logic diff_n_o
+);
+  // Buff the input signal to avoid any optimization
+  logic req;
+  prim_sec_anchor_buf #(
+    .Width(1)
+  ) u_prim_buf_in_req (
+    .in_i(req_i),
+    .out_o(req)
+  );
+
+  // Differentially encode input
+  logic diff_p, diff_n;
+  assign diff_p = req;
+  assign diff_n = ~req;
+
+  // This prevents further tool optimizations of the differential signal.
+  prim_sec_anchor_buf #(
+    .Width(2)
+  ) u_prim_buf_ack (
+    .in_i({diff_n, diff_p}),
+    .out_o({diff_n_buf, diff_p_buf})
+  );
+
+  // Flop differentially encoded signal at the output
+  prim_flop #(
+    .Width(1),
+    .ResetValue(1'b0)
+  ) u_diff_p (
+    .clk_i,
+    .rst_ni,
+    .d_i   ( diff_p_buf ),
+    .q_o   ( diff_p_o   )
+  );
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue(1'b1)
+  ) u_diff_n (
+    .clk_i,
+    .rst_ni,
+    .d_i   ( diff_n_buf ),
+    .q_o   ( diff_n_o   )
+  );
+endmodule : prim_diff_encode

--- a/hw/ip/prim/rtl/prim_diff_to_alert.sv
+++ b/hw/ip/prim/rtl/prim_diff_to_alert.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// prim_diff_to_alert: This module receives a differentially encoded alert request and translates
+// that to an alert signal with the alert protocol.
+
+module prim_diff_to_alert #(
+  // AsyncOn: Enables additional synchronization logic within the alert receiver.
+  parameter bit AsyncOn = 1'b1,
+  // Alert sender will latch the incoming alert event permanently and
+  // keep on sending alert events until the next reset.
+  parameter bit IsFatal = 1'b1
+) (
+  input logic       clk_i,
+  input logic       rst_ni,
+  // Input diff pair (differentially encoded alert signal)
+  input logic       diff_p_i,
+  input logic       diff_n_i,
+  // Alert pair (interface signals for the alert protocol)
+  input  alert_rx_t alert_rx_i,
+  output alert_tx_t alert_tx_o
+);
+  logic diff_p_sync, diff_n_sync;
+
+  if (AsyncOn) begin : gen_async
+    prim_generic_flop_2sync #(
+      .Width(2),
+      .ResetValue(2'b10)
+    ) u_sync (
+      .clk_i,
+      .rst_ni,
+      .d_i  ( {diff_n_i, diff_p_i}       ),
+      .q_o  ( {diff_n_sync, diff_p_sync} )
+    );
+  end else begin : gen_sync
+    assign diff_p_sync = diff_p_i;
+    assign diff_n_sync = diff_n_i;
+  end
+
+  // This prevents further tool optimizations of the differential signal.
+  logic diff_p_buf, diff_n_buf;
+  prim_sec_anchor_buf #(
+    .Width(2)
+  ) u_prim_buf_ack (
+    .in_i  ( {diff_n_sync, diff_p_sync}  ),
+    .out_o ( {diff_n_buf, diff_p_buf}   )
+  );
+
+  // Treat any positive value on `diff_p_buf` and any negative value on `diff_n_buf` as alert.
+  logic alert_req;
+  assign alert_req = diff_p_buf | ~diff_n_buf
+
+  prim_alert_sender #(
+    .AsyncOn(AsyncOn),
+    .IsFatal(IsFatal)
+  ) u_prim_alert_sender (
+    .clk_i,
+    .rst_ni,
+    .alert_test_i  ( 1'b1      ),
+    .alert_req_i   ( alert_req ),
+    .alert_ack_o   (),
+    .alert_state_o (),
+    .alert_rx_i
+    .alert_tx_o
+  );
+endmodule


### PR DESCRIPTION
A similar module was already in the integrated_dev branch. This adds additional buffers to avoid optimization.

This PR also adds two prims to convert the alert of an IP to a differentially encoded signal and then back to an alert. This is helpful, when you use an IP out-of-tree, in a different design unit, and do not want to distribute clock/rst meta information along the system.

Decoding the differentially encoded signal intentionally does not use prim_diff_decode. Instead, it treats any signal togelling as an alert.