### PR TITLE
[uart] Fix uart_tx_rx_alt_clk/rand_baudrate in DV sim

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -46,10 +46,10 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
 
   virtual task cpu_init();
     // sw_symbol_backdoor_overwrite takes an array as the input
-    bit [7:0] uart_freq_arr[8] = {<<byte{cfg.uart_baud_rate}};
+    bit [7:0] uart_freq_arr[8] = {<<byte{64'(cfg.uart_baud_rate)}};
 
     super.cpu_init();
-    sw_symbol_backdoor_overwrite("kUartBaudrate", uart_freq_arr);
+    sw_symbol_backdoor_overwrite("kUartBaudrateDV", uart_freq_arr);
     `uvm_info(`gfn, $sformatf(
               "Backdoor_overwrite: configure uart core clk %0d khz, baud_rate: %s",
               uart_clk_freq_khz,
@@ -59,11 +59,11 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
     if (cfg.chip_clock_source != ChipClockSourceInternal) begin
       bit [7:0] use_extclk_arr[] = {cfg.chip_clock_source != ChipClockSourceInternal};
       bit [7:0] low_speed_sel_arr[] = {cfg.chip_clock_source == ChipClockSourceExternal48Mhz};
-      bit [7:0] uart_clk_freq_arr[8] = {<<byte{uart_clk_freq_khz * 1000}};
+      bit [7:0] uart_clk_freq_arr[8] = {<<byte{64'(uart_clk_freq_khz * 1000)}};
 
       sw_symbol_backdoor_overwrite("kUseExtClk", use_extclk_arr);
       sw_symbol_backdoor_overwrite("kUseLowSpeedSel", low_speed_sel_arr);
-      sw_symbol_backdoor_overwrite("kClockFreqPeripheralHz", uart_clk_freq_arr);
+      sw_symbol_backdoor_overwrite("kUartClockFreqHzDV", uart_clk_freq_arr);
     end
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -46,10 +46,10 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
 
   virtual task cpu_init();
     // sw_symbol_backdoor_overwrite takes an array as the input
-    bit [7:0] uart_freq_arr[8] = {<<byte{cfg.uart_baud_rate}};
+    bit [7:0] uart_freq_arr[8] = {<<byte{64'(cfg.uart_baud_rate)}};
 
     super.cpu_init();
-    sw_symbol_backdoor_overwrite("kUartBaudrate", uart_freq_arr);
+    sw_symbol_backdoor_overwrite("kUartBaudrateDV", uart_freq_arr);
     `uvm_info(`gfn, $sformatf(
               "Backdoor_overwrite: configure uart core clk %0d khz, baud_rate: %s",
               uart_clk_freq_khz,
@@ -59,11 +59,11 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
     if (cfg.chip_clock_source != ChipClockSourceInternal) begin
       bit [7:0] use_extclk_arr[] = {cfg.chip_clock_source != ChipClockSourceInternal};
       bit [7:0] low_speed_sel_arr[] = {cfg.chip_clock_source == ChipClockSourceExternal48Mhz};
-      bit [7:0] uart_clk_freq_arr[8] = {<<byte{uart_clk_freq_khz * 1000}};
+      bit [7:0] uart_clk_freq_arr[8] = {<<byte{64'(uart_clk_freq_khz * 1000)}};
 
       sw_symbol_backdoor_overwrite("kUseExtClk", use_extclk_arr);
       sw_symbol_backdoor_overwrite("kUseLowSpeedSel", low_speed_sel_arr);
-      sw_symbol_backdoor_overwrite("kClockFreqPeripheralHz", uart_clk_freq_arr);
+      sw_symbol_backdoor_overwrite("kUartClockFreqHzDV", uart_clk_freq_arr);
     end
   endtask
 

--- a/sw/device/lib/testing/test_framework/ottf_utils.h
+++ b/sw/device/lib/testing/test_framework/ottf_utils.h
@@ -22,7 +22,7 @@
  *
  * In DV, this function will simply spin since the DV environment can do
  * backdoor writes to make the condition true. On real device, this will wait
- * for host to send ujson message. The condition is check after each command.
+ * for host to send ujson message. The condition is checked after each command.
  */
 #define OTTF_WAIT_FOR(cond, timeout_usec)                                     \
   do {                                                                        \


### PR DESCRIPTION
This PR fixes the following failing Earl Grey DV top-level tests:
- chip_sw_uart_tx_rx_alt_clk_freq
- chip_sw_uart_tx_rx_alt_clk_freq_low_speed
- chip_sw_uart_rand_baudrate

The `sim_dv` targets expect to be able to override the clock frequency and target baud rate of the UART peripheral under test in order to cover a wider range of sampling ratios and phases (= NCO values).

Explicitly widen the parameters to 64 bits before using the streaming operators because otherwise one simulator replicates the MS byte whilst another zeroes the additional bytes. This is done in both the Earl Grey and Darjeeling test environments but presently the software has not been ported to Darjeeling.