### PR TITLE
[RACL] Allow non-napot and non-parameter racl ranges

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -85,16 +85,20 @@ module spi_device
   localparam int unsigned TpmRdFifoWidth  = spi_device_reg_pkg::TpmRdFifoWidth;
 
   // Derived parameters
-  localparam top_racl_pkg::racl_range_t RaclPolicySelRangesEgressbuffer[1] = '{
-    '{base: {top_pkg::TL_AW{1'b0}},
-      mask: {top_pkg::TL_AW{1'b1}},
-      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinEgressbuffer)
+  localparam top_racl_pkg::racl_range_t [0:0] RaclPolicySelRangesEgressbuffer = '{
+    '{
+      base:  {top_pkg::TL_AW{1'b0}},
+      limit: {top_pkg::TL_AW{1'b1}},
+      policy_sel: RaclPolicySelWinEgressbuffer,
+      enable: 1'b1
     }
   };
-  localparam top_racl_pkg::racl_range_t RaclPolicySelRangesIngressbuffer[1] = '{
-    '{base: {top_pkg::TL_AW{1'b0}},
-      mask: {top_pkg::TL_AW{1'b1}},
-      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinIngressbuffer)
+  localparam top_racl_pkg::racl_range_t  [0:0] RaclPolicySelRangesIngressbuffer = '{
+    '{
+      base:  {top_pkg::TL_AW{1'b0}},
+      limit: {top_pkg::TL_AW{1'b1}},
+      policy_sel: RaclPolicySelWinIngressbuffer,
+      enable: 1'b1
     }
   };
 
@@ -1703,8 +1707,7 @@ module spi_device
     .ByteAccess       (0),
     .EnableRacl       (EnableRacl),
     .RaclErrorRsp     (RaclErrorRsp),
-    .RaclPolicySelNumRanges(1),
-    .RaclPolicySelRanges(RaclPolicySelRangesEgressbuffer)
+    .RaclPolicySelNumRanges(1)
   ) u_tlul2sram_egress (
     .clk_i,
     .rst_ni,
@@ -1730,7 +1733,8 @@ module spi_device
     .wr_collision_i             (1'b0),
     .write_pending_i            (1'b0),
     .racl_policies_i            (racl_policies_i),
-    .racl_error_o               (racl_error[1])
+    .racl_error_o               (racl_error[1]),
+    .racl_policy_sel_ranges     (RaclPolicySelRangesEgressbuffer)
   );
 
   tlul_adapter_sram_racl #(
@@ -1741,8 +1745,7 @@ module spi_device
     .ByteAccess       (0),
     .EnableRacl       (EnableRacl),
     .RaclErrorRsp     (RaclErrorRsp),
-    .RaclPolicySelNumRanges(1),
-    .RaclPolicySelRanges(RaclPolicySelRangesIngressbuffer)
+    .RaclPolicySelNumRanges(1)
   ) u_tlul2sram_ingress (
     .clk_i,
     .rst_ni,
@@ -1768,7 +1771,8 @@ module spi_device
     .wr_collision_i             (1'b0),
     .write_pending_i            (1'b0),
     .racl_policies_i            (racl_policies_i),
-    .racl_error_o               (racl_error[2])
+    .racl_error_o               (racl_error[2]),
+    .racl_policy_sel_ranges     (RaclPolicySelRangesIngressbuffer)
   );
   assign sys_sram_l2m[SysSramFwEgress].wstrb =
     sram_mask2strb(sys_sram_l2m_fw_wmask[SPI_DEVICE_EGRESS_BUFFER_IDX]);

--- a/hw/ip/spi_host/rtl/spi_host_window.sv
+++ b/hw/ip/spi_host/rtl/spi_host_window.sv
@@ -32,11 +32,12 @@ module spi_host_window
   localparam int AW = spi_host_reg_pkg::BlockAw;
   localparam int DW = 32;
   localparam int ByteMaskW = DW / 8;
-  localparam top_racl_pkg::racl_range_t RaclPolicySelRangesTXDATA[1] = '{
+  localparam top_racl_pkg::racl_range_t [0:0] RaclPolicySelRangesTXDATA = '{
     '{
-      base: {top_pkg::TL_AW{1'b0}},
-      mask: {top_pkg::TL_AW{1'b1}},
-      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinTXDATA)
+      base:  {top_pkg::TL_AW{1'b0}},
+      limit: {top_pkg::TL_AW{1'b1}},
+      policy_sel: top_racl_pkg::racl_policy_sel_t'(RaclPolicySelWinTXDATA),
+      enable: 1'b1
     }
   };
 
@@ -92,8 +93,7 @@ module spi_host_window
     .ErrOnRead(1),
     .EnableRacl(EnableRacl),
     .RaclErrorRsp(RaclErrorRsp),
-    .RaclPolicySelNumRanges(1),
-    .RaclPolicySelRanges(RaclPolicySelRangesTXDATA)
+    .RaclPolicySelNumRanges(1)
   ) u_adapter_tx (
     .clk_i,
     .rst_ni,
@@ -118,7 +118,8 @@ module spi_host_window
     .wr_collision_i(1'b0),
     .write_pending_i(1'b0),
     .racl_policies_i  (racl_policies_i),
-    .racl_error_o     (racl_error_tx_o)
+    .racl_error_o     (racl_error_tx_o),
+    .racl_policy_sel_ranges(RaclPolicySelRangesTXDATA)
   );
 
 endmodule : spi_host_window

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -114,6 +114,13 @@
       expose:    "true",
       default:   "2"
     },
+    { name:      "RaclPolicySelRangesRamNum",
+      desc:      "Number of Racl Policy Selection Ranges for the Ram interface",
+      type:      "int",
+      local:     "false",
+      expose:    "true",
+      default:   "1"
+    },
   ]
 
   features: [
@@ -228,6 +235,16 @@
       package: "top_racl_pkg",
       desc:    '''
         RACL error log information of this module.
+      '''
+    },
+    { struct:  "racl_range_t",
+      type:    "uni",
+      name:    "racl_policy_sel_ranges_ram",
+      act:     "rcv",
+      width:   "RaclPolicySelRangesRamNum"
+      package: "top_racl_pkg",
+      desc:    '''
+        Incoming array of RACL policy ranges.
       '''
     }
   ]

--- a/hw/ip/sram_ctrl/doc/interfaces.md
+++ b/hw/ip/sram_ctrl/doc/interfaces.md
@@ -27,18 +27,19 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name          | Package::Struct                 | Type    | Act   | Width      | Description                                                                                                                          |
-|:-------------------|:--------------------------------|:--------|:------|:-----------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| sram_otp_key       | otp_ctrl_pkg::sram_otp_key      | req_rsp | req   | 1          |                                                                                                                                      |
-| cfg                | prim_ram_1p_pkg::ram_1p_cfg     | uni     | rcv   | NumRamInst |                                                                                                                                      |
-| cfg_rsp            | prim_ram_1p_pkg::ram_1p_cfg_rsp | uni     | req   | NumRamInst |                                                                                                                                      |
-| lc_escalate_en     | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1          |                                                                                                                                      |
-| lc_hw_debug_en     | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1          |                                                                                                                                      |
-| otp_en_sram_ifetch | prim_mubi_pkg::mubi8            | uni     | rcv   | 1          |                                                                                                                                      |
-| racl_policies      | top_racl_pkg::racl_policy_vec   | uni     | rcv   | 1          | Incoming RACL policy vector from a racl_ctrl instance. The policy selection vector (parameter) selects the policy for each register. |
-| racl_error         | top_racl_pkg::racl_error_log    | uni     | req   | 1          | RACL error log information of this module.                                                                                           |
-| regs_tl            | tlul_pkg::tl                    | req_rsp | rsp   | 1          |                                                                                                                                      |
-| ram_tl             | tlul_pkg::tl                    | req_rsp | rsp   | 1          |                                                                                                                                      |
+| Port Name                  | Package::Struct                 | Type    | Act   | Width                     | Description                                                                                                                          |
+|:---------------------------|:--------------------------------|:--------|:------|:--------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| sram_otp_key               | otp_ctrl_pkg::sram_otp_key      | req_rsp | req   | 1                         |                                                                                                                                      |
+| cfg                        | prim_ram_1p_pkg::ram_1p_cfg     | uni     | rcv   | NumRamInst                |                                                                                                                                      |
+| cfg_rsp                    | prim_ram_1p_pkg::ram_1p_cfg_rsp | uni     | req   | NumRamInst                |                                                                                                                                      |
+| lc_escalate_en             | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1                         |                                                                                                                                      |
+| lc_hw_debug_en             | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1                         |                                                                                                                                      |
+| otp_en_sram_ifetch         | prim_mubi_pkg::mubi8            | uni     | rcv   | 1                         |                                                                                                                                      |
+| racl_policies              | top_racl_pkg::racl_policy_vec   | uni     | rcv   | 1                         | Incoming RACL policy vector from a racl_ctrl instance. The policy selection vector (parameter) selects the policy for each register. |
+| racl_error                 | top_racl_pkg::racl_error_log    | uni     | req   | 1                         | RACL error log information of this module.                                                                                           |
+| racl_policy_sel_ranges_ram | top_racl_pkg::racl_range_t      | uni     | rcv   | RaclPolicySelRangesRamNum | Incoming array of RACL policy ranges.                                                                                                |
+| regs_tl                    | tlul_pkg::tl                    | req_rsp | rsp   | 1                         |                                                                                                                                      |
+| ram_tl                     | tlul_pkg::tl                    | req_rsp | rsp   | 1                         |                                                                                                                                      |
 
 ## Security Alerts
 

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -34,8 +34,7 @@ module sram_ctrl
   parameter bit                         EnableRacl       = 1'b0,
   parameter bit                         RaclErrorRsp     = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecRegs[NumRegsRegs] = '{NumRegsRegs{0}},
-  parameter int unsigned RaclPolicySelRangesRamNum = 1,
-  parameter top_racl_pkg::racl_range_t RaclPolicySelRangesRam[RaclPolicySelRangesRamNum] = '{'0}
+  parameter int unsigned RaclPolicySelRangesRamNum = 1
 ) (
   // SRAM Clock
   input  logic                                               clk_i,
@@ -55,6 +54,7 @@ module sram_ctrl
   // RACL interface
   input  top_racl_pkg::racl_policy_vec_t                     racl_policies_i,
   output top_racl_pkg::racl_error_log_t                      racl_error_o,
+  input  top_racl_pkg::racl_range_t [RaclPolicySelRangesRamNum-1:0] racl_policy_sel_ranges_ram_i,
   // Life-cycle escalation input (scraps the scrambling keys)
   // SEC_CM: LC_ESCALATE_EN.INTERSIG.MUBI
   input  lc_ctrl_pkg::lc_tx_t                                lc_escalate_en_i,
@@ -530,8 +530,7 @@ module sram_ctrl
     .EnableReadback  (1), // SEC_CM: MEM.READBACK
     .EnableRacl(EnableRacl),
     .RaclErrorRsp(RaclErrorRsp),
-    .RaclPolicySelNumRanges(RaclPolicySelRangesRamNum),
-    .RaclPolicySelRanges(RaclPolicySelRangesRam)
+    .RaclPolicySelNumRanges(RaclPolicySelRangesRamNum)
   ) u_tlul_adapter_sram_racl (
     .clk_i,
     .rst_ni,
@@ -558,7 +557,8 @@ module sram_ctrl
     .write_pending_i            (sram_wpending),
     // RACL interface
     .racl_policies_i            (racl_policies_i),
-    .racl_error_o               (racl_error[1])
+    .racl_error_o               (racl_error[1]),
+    .racl_policy_sel_ranges     (racl_policy_sel_ranges_ram_i)
   );
 
   logic key_valid;

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4355,6 +4355,15 @@
           expose: "true"
           name_top: SramCtrlRetAonOutstanding
         }
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          type: int
+          default: 1
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
+        }
       ]
       inter_signal_list:
       [
@@ -4475,6 +4484,27 @@
           type: uni
           act: req
           width: 1
+          inst_name: sram_ctrl_ret_aon
+          index: -1
+        }
+        {
+          name: racl_policy_sel_ranges_ram
+          desc: Incoming array of RACL policy ranges.
+          struct: racl_range_t
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width:
+          {
+            name: RaclPolicySelRangesRamNum
+            desc: Number of Racl Policy Selection Ranges for the Ram interface
+            param_type: int
+            unpacked_dimensions: null
+            default: 1
+            local: false
+            expose: true
+            name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
+          }
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -6640,6 +6670,15 @@
           expose: "true"
           name_top: SramCtrlMainOutstanding
         }
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          type: int
+          default: 1
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMainRaclPolicySelRangesRamNum
+        }
       ]
       inter_signal_list:
       [
@@ -6762,6 +6801,27 @@
           type: uni
           act: req
           width: 1
+          inst_name: sram_ctrl_main
+          index: -1
+        }
+        {
+          name: racl_policy_sel_ranges_ram
+          desc: Incoming array of RACL policy ranges.
+          struct: racl_range_t
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width:
+          {
+            name: RaclPolicySelRangesRamNum
+            desc: Number of Racl Policy Selection Ranges for the Ram interface
+            param_type: int
+            unpacked_dimensions: null
+            default: 1
+            local: false
+            expose: true
+            name_top: SramCtrlMainRaclPolicySelRangesRamNum
+          }
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -6947,6 +7007,15 @@
           expose: "true"
           name_top: SramCtrlMboxOutstanding
         }
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          type: int
+          default: 1
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMboxRaclPolicySelRangesRamNum
+        }
       ]
       inter_signal_list:
       [
@@ -7067,6 +7136,27 @@
           type: uni
           act: req
           width: 1
+          inst_name: sram_ctrl_mbox
+          index: -1
+        }
+        {
+          name: racl_policy_sel_ranges_ram
+          desc: Incoming array of RACL policy ranges.
+          struct: racl_range_t
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width:
+          {
+            name: RaclPolicySelRangesRamNum
+            desc: Number of Racl Policy Selection Ranges for the Ram interface
+            param_type: int
+            unpacked_dimensions: null
+            default: 1
+            local: false
+            expose: true
+            name_top: SramCtrlMboxRaclPolicySelRangesRamNum
+          }
           inst_name: sram_ctrl_mbox
           index: -1
         }
@@ -22574,6 +22664,27 @@
         index: -1
       }
       {
+        name: racl_policy_sel_ranges_ram
+        desc: Incoming array of RACL policy ranges.
+        struct: racl_range_t
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width:
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
+        }
+        inst_name: sram_ctrl_ret_aon
+        index: -1
+      }
+      {
         name: regs_tl
         struct: tl
         package: tlul_pkg
@@ -23724,6 +23835,27 @@
         index: -1
       }
       {
+        name: racl_policy_sel_ranges_ram
+        desc: Incoming array of RACL policy ranges.
+        struct: racl_range_t
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width:
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlMainRaclPolicySelRangesRamNum
+        }
+        inst_name: sram_ctrl_main
+        index: -1
+      }
+      {
         name: regs_tl
         struct: tl
         package: tlul_pkg
@@ -23866,6 +23998,27 @@
         type: uni
         act: req
         width: 1
+        inst_name: sram_ctrl_mbox
+        index: -1
+      }
+      {
+        name: racl_policy_sel_ranges_ram
+        desc: Incoming array of RACL policy ranges.
+        struct: racl_range_t
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width:
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlMboxRaclPolicySelRangesRamNum
+        }
         inst_name: sram_ctrl_mbox
         index: -1
       }

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -50,6 +50,7 @@ module top_darjeeling #(
   parameter int SramCtrlRetAonNumRamInst = 1,
   parameter bit SramCtrlRetAonInstrExec = 0,
   parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlRetAonRaclPolicySelRangesRamNum = 1,
   // parameters for rv_dm
   parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
   parameter bit RvDmUseDmiInterface = 1,
@@ -90,11 +91,13 @@ module top_darjeeling #(
   parameter int SramCtrlMainNumRamInst = 1,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for sram_ctrl_mbox
   parameter int SramCtrlMboxInstSize = 4096,
   parameter int SramCtrlMboxNumRamInst = 1,
   parameter bit SramCtrlMboxInstrExec = 0,
   parameter int SramCtrlMboxNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlMboxRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl0
   parameter RomCtrl0BootRomInitFile = "",
   parameter bit SecRomCtrl0DisableScrambling = 1'b0,
@@ -1691,7 +1694,8 @@ module top_darjeeling #(
     .NumRamInst(SramCtrlRetAonNumRamInst),
     .InstrExec(SramCtrlRetAonInstrExec),
     .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf),
-    .Outstanding(SramCtrlRetAonOutstanding)
+    .Outstanding(SramCtrlRetAonOutstanding),
+    .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_ret_aon (
       // [50]: fatal_error
       .alert_tx_o  ( alert_tx[50:50] ),
@@ -1707,6 +1711,7 @@ module top_darjeeling #(
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
+      .racl_policy_sel_ranges_ram_i({SramCtrlRetAonRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_ret_aon_ram_tl_req),
@@ -2062,7 +2067,8 @@ module top_darjeeling #(
     .NumRamInst(SramCtrlMainNumRamInst),
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
-    .Outstanding(SramCtrlMainOutstanding)
+    .Outstanding(SramCtrlMainOutstanding),
+    .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
       // [68]: fatal_error
       .alert_tx_o  ( alert_tx[68:68] ),
@@ -2078,6 +2084,7 @@ module top_darjeeling #(
       .otp_en_sram_ifetch_i(sram_ctrl_main_otp_en_sram_ifetch),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
+      .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_main_ram_tl_req),
@@ -2100,7 +2107,8 @@ module top_darjeeling #(
     .NumRamInst(SramCtrlMboxNumRamInst),
     .InstrExec(SramCtrlMboxInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMboxNumPrinceRoundsHalf),
-    .Outstanding(SramCtrlMboxOutstanding)
+    .Outstanding(SramCtrlMboxOutstanding),
+    .RaclPolicySelRangesRamNum(SramCtrlMboxRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_mbox (
       // [69]: fatal_error
       .alert_tx_o  ( alert_tx[69:69] ),
@@ -2116,6 +2124,7 @@ module top_darjeeling #(
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
+      .racl_policy_sel_ranges_ram_i({SramCtrlMboxRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .regs_tl_i(sram_ctrl_mbox_regs_tl_req),
       .regs_tl_o(sram_ctrl_mbox_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_mbox_ram_tl_req),

--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -45,11 +45,22 @@ package top_racl_pkg;
     racl_role_vec_t write_perm;
   } racl_policy_t;
 
+  // RACL range used to protect a range of addresses with a RACL policy (e.g., for sram).
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;       // Start address of range
+    logic [top_pkg::TL_AW-1:0] limit;      // End address of range (inclusive)
+    racl_policy_sel_t          policy_sel; // Policy selector
+    logic                      enable;     // 0: Range is disabled, 1: Range is enabled
+  } racl_range_t;
+
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP
   typedef racl_policy_t [NrRaclPolicies-1:0] racl_policy_vec_t;
 
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
+
+  // Default policy selection range for unconnected RACL IPs
+  parameter racl_range_t RACL_RANGE_T_DEFAULT = '0;
 
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = 16'h1;
@@ -66,13 +77,6 @@ package top_racl_pkg;
     logic                      read_access;  // 0: Write access, 1: Read access
     logic [top_pkg::TL_AW-1:0] request_address;
   } racl_error_log_t;
-
-  // Range definition for RACL protected SRAM adapter
-  typedef struct packed {
-    logic [top_pkg::TL_AW-1:0] base;
-    logic [top_pkg::TL_AW-1:0] mask;
-    racl_policy_sel_t          policy_sel;
-  } racl_range_t;
 
   // Extract RACL role bits from the TLUL reserved user bits
   function automatic racl_role_t tlul_extract_racl_role_bits(logic [tlul_pkg::RsvdWidth-1:0] rsvd);

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5730,6 +5730,15 @@
           expose: "true"
           name_top: SramCtrlRetAonOutstanding
         }
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          type: int
+          default: 1
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
+        }
       ]
       inter_signal_list:
       [
@@ -5847,6 +5856,27 @@
           type: uni
           act: req
           width: 1
+          inst_name: sram_ctrl_ret_aon
+          index: -1
+        }
+        {
+          name: racl_policy_sel_ranges_ram
+          desc: Incoming array of RACL policy ranges.
+          struct: racl_range_t
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width:
+          {
+            name: RaclPolicySelRangesRamNum
+            desc: Number of Racl Policy Selection Ranges for the Ram interface
+            param_type: int
+            unpacked_dimensions: null
+            default: 1
+            local: false
+            expose: true
+            name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
+          }
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -8671,6 +8701,15 @@
           expose: "true"
           name_top: SramCtrlMainOutstanding
         }
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          type: int
+          default: 1
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMainRaclPolicySelRangesRamNum
+        }
       ]
       inter_signal_list:
       [
@@ -8790,6 +8829,27 @@
           type: uni
           act: req
           width: 1
+          inst_name: sram_ctrl_main
+          index: -1
+        }
+        {
+          name: racl_policy_sel_ranges_ram
+          desc: Incoming array of RACL policy ranges.
+          struct: racl_range_t
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width:
+          {
+            name: RaclPolicySelRangesRamNum
+            desc: Number of Racl Policy Selection Ranges for the Ram interface
+            param_type: int
+            unpacked_dimensions: null
+            default: 1
+            local: false
+            expose: true
+            name_top: SramCtrlMainRaclPolicySelRangesRamNum
+          }
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -21414,6 +21474,27 @@
         index: -1
       }
       {
+        name: racl_policy_sel_ranges_ram
+        desc: Incoming array of RACL policy ranges.
+        struct: racl_range_t
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width:
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
+        }
+        inst_name: sram_ctrl_ret_aon
+        index: -1
+      }
+      {
         name: regs_tl
         struct: tl
         package: tlul_pkg
@@ -22948,6 +23029,27 @@
         type: uni
         act: req
         width: 1
+        inst_name: sram_ctrl_main
+        index: -1
+      }
+      {
+        name: racl_policy_sel_ranges_ram
+        desc: Incoming array of RACL policy ranges.
+        struct: racl_range_t
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width:
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlMainRaclPolicySelRangesRamNum
+        }
         inst_name: sram_ctrl_main
         index: -1
       }

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -70,3 +70,6 @@ waive -rules SAME_NAME_TYPE -location {tlul_socket_m1.sv otbn_pkg.sv} -regexp {'
       -comment {This is acceptable, since these are used in different hierarchies.}
 waive -rules SAME_NAME_TYPE -location {prim_trivium.sv prim_xoshiro256pp.sv} -regexp {'state_update' is used as a (reg|function) here, and as a (function|reg) at} \
       -comment {This is acceptable, since these are used in different hierarchies.}
+
+waive -rules {LINE_LENGTH} -location {top_earlgrey.sv} -regexp {Line length of [0-9]+ exceeds 100 character limit} \
+      -comment "top_darjeeling is auto-generated and adhering to the line length limit is not always feasible for auto-generated code"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -64,6 +64,7 @@ module top_earlgrey #(
   parameter int SramCtrlRetAonNumRamInst = 1,
   parameter bit SramCtrlRetAonInstrExec = 0,
   parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlRetAonRaclPolicySelRangesRamNum = 1,
   // parameters for flash_ctrl
   parameter bit SecFlashCtrlScrambleEn = 1,
   parameter int FlashCtrlProgFifoDepth = 4,
@@ -110,6 +111,7 @@ module top_earlgrey #(
   parameter int SramCtrlMainNumRamInst = 1,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 2,
+  parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b0,
@@ -2167,7 +2169,8 @@ module top_earlgrey #(
     .NumRamInst(SramCtrlRetAonNumRamInst),
     .InstrExec(SramCtrlRetAonInstrExec),
     .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf),
-    .Outstanding(SramCtrlRetAonOutstanding)
+    .Outstanding(SramCtrlRetAonOutstanding),
+    .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_ret_aon (
       // [34]: fatal_error
       .alert_tx_o  ( alert_tx[34:34] ),
@@ -2183,6 +2186,7 @@ module top_earlgrey #(
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
+      .racl_policy_sel_ranges_ram_i({SramCtrlRetAonRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_ret_aon_ram_tl_req),
@@ -2655,7 +2659,8 @@ module top_earlgrey #(
     .NumRamInst(SramCtrlMainNumRamInst),
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
-    .Outstanding(SramCtrlMainOutstanding)
+    .Outstanding(SramCtrlMainOutstanding),
+    .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
       // [59]: fatal_error
       .alert_tx_o  ( alert_tx[59:59] ),
@@ -2671,6 +2676,7 @@ module top_earlgrey #(
       .otp_en_sram_ifetch_i(sram_ctrl_main_otp_en_sram_ifetch),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
+      .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_main_ram_tl_req),

--- a/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
@@ -45,11 +45,22 @@ package top_racl_pkg;
     racl_role_vec_t write_perm;
   } racl_policy_t;
 
+  // RACL range used to protect a range of addresses with a RACL policy (e.g., for sram).
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;       // Start address of range
+    logic [top_pkg::TL_AW-1:0] limit;      // End address of range (inclusive)
+    racl_policy_sel_t          policy_sel; // Policy selector
+    logic                      enable;     // 0: Range is disabled, 1: Range is enabled
+  } racl_range_t;
+
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP
   typedef racl_policy_t [NrRaclPolicies-1:0] racl_policy_vec_t;
 
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
+
+  // Default policy selection range for unconnected RACL IPs
+  parameter racl_range_t RACL_RANGE_T_DEFAULT = '0;
 
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = 2'h0;
@@ -66,13 +77,6 @@ package top_racl_pkg;
     logic                      read_access;  // 0: Write access, 1: Read access
     logic [top_pkg::TL_AW-1:0] request_address;
   } racl_error_log_t;
-
-  // Range definition for RACL protected SRAM adapter
-  typedef struct packed {
-    logic [top_pkg::TL_AW-1:0] base;
-    logic [top_pkg::TL_AW-1:0] mask;
-    racl_policy_sel_t          policy_sel;
-  } racl_range_t;
 
   // Extract RACL role bits from the TLUL reserved user bits
   function automatic racl_role_t tlul_extract_racl_role_bits(logic [tlul_pkg::RsvdWidth-1:0] rsvd);

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3851,6 +3851,15 @@
           expose: "true"
           name_top: SramCtrlMainOutstanding
         }
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          type: int
+          default: 1
+          local: "false"
+          expose: "true"
+          name_top: SramCtrlMainRaclPolicySelRangesRamNum
+        }
       ]
       inter_signal_list:
       [
@@ -3963,6 +3972,27 @@
           type: uni
           act: req
           width: 1
+          inst_name: sram_ctrl_main
+          index: -1
+        }
+        {
+          name: racl_policy_sel_ranges_ram
+          desc: Incoming array of RACL policy ranges.
+          struct: racl_range_t
+          package: top_racl_pkg
+          type: uni
+          act: rcv
+          width:
+          {
+            name: RaclPolicySelRangesRamNum
+            desc: Number of Racl Policy Selection Ranges for the Ram interface
+            param_type: int
+            unpacked_dimensions: null
+            default: 1
+            local: false
+            expose: true
+            name_top: SramCtrlMainRaclPolicySelRangesRamNum
+          }
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -11118,6 +11148,27 @@
         type: uni
         act: req
         width: 1
+        inst_name: sram_ctrl_main
+        index: -1
+      }
+      {
+        name: racl_policy_sel_ranges_ram
+        desc: Incoming array of RACL policy ranges.
+        struct: racl_range_t
+        package: top_racl_pkg
+        type: uni
+        act: rcv
+        width:
+        {
+          name: RaclPolicySelRangesRamNum
+          desc: Number of Racl Policy Selection Ranges for the Ram interface
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlMainRaclPolicySelRangesRamNum
+        }
         inst_name: sram_ctrl_main
         index: -1
       }

--- a/hw/top_englishbreakfast/lint/top_englishbreakfast.vbl
+++ b/hw/top_englishbreakfast/lint/top_englishbreakfast.vbl
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# These lines are too long due to templating
+waive --rule=line-length --location=".*top_englishbreakfast.*"

--- a/hw/top_englishbreakfast/lint/top_englishbreakfast.waiver
+++ b/hw/top_englishbreakfast/lint/top_englishbreakfast.waiver
@@ -17,3 +17,6 @@ waive -rules RESET_MUX -location {top_englishbreakfast.sv} -regexp {Asynchronous
 #      -comment "upper bits of a_source are shifted off when going through M:1 sockets"
 #waive -rules LINE_LENGTH -location {xbar_main.sv} -regexp {Line length of .* exceeds 100 character limit} \
 #      -comment "This is a generated file and it is hence permissible to have line lengths that exceed this limit"
+
+waive -rules {LINE_LENGTH} -location {top_englishbreakfast.sv} -regexp {Line length of [0-9]+ exceeds 100 character limit} \
+      -comment "top_darjeeling is auto-generated and adhering to the line length limit is not always feasible for auto-generated code"

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -51,6 +51,7 @@ module top_englishbreakfast #(
   parameter int SramCtrlMainNumRamInst = 1,
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b1,
@@ -1193,7 +1194,8 @@ module top_englishbreakfast #(
     .NumRamInst(SramCtrlMainNumRamInst),
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
-    .Outstanding(SramCtrlMainOutstanding)
+    .Outstanding(SramCtrlMainOutstanding),
+    .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
       // [22]: fatal_error
       .alert_tx_o  ( alert_tx[22:22] ),
@@ -1209,6 +1211,7 @@ module top_englishbreakfast #(
       .otp_en_sram_ifetch_i(sram_ctrl_main_otp_en_sram_ifetch),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
+      .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_main_ram_tl_req),

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -45,11 +45,22 @@ package top_racl_pkg;
     racl_role_vec_t write_perm;
   } racl_policy_t;
 
+  // RACL range used to protect a range of addresses with a RACL policy (e.g., for sram).
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;       // Start address of range
+    logic [top_pkg::TL_AW-1:0] limit;      // End address of range (inclusive)
+    racl_policy_sel_t          policy_sel; // Policy selector
+    logic                      enable;     // 0: Range is disabled, 1: Range is enabled
+  } racl_range_t;
+
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP
   typedef racl_policy_t [NrRaclPolicies-1:0] racl_policy_vec_t;
 
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
+
+  // Default policy selection range for unconnected RACL IPs
+  parameter racl_range_t RACL_RANGE_T_DEFAULT = '0;
 
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = 2'h0;
@@ -66,13 +77,6 @@ package top_racl_pkg;
     logic                      read_access;  // 0: Write access, 1: Read access
     logic [top_pkg::TL_AW-1:0] request_address;
   } racl_error_log_t;
-
-  // Range definition for RACL protected SRAM adapter
-  typedef struct packed {
-    logic [top_pkg::TL_AW-1:0] base;
-    logic [top_pkg::TL_AW-1:0] mask;
-    racl_policy_sel_t          policy_sel;
-  } racl_range_t;
 
   // Extract RACL role bits from the TLUL reserved user bits
   function automatic racl_role_t tlul_extract_racl_role_bits(logic [tlul_pkg::RsvdWidth-1:0] rsvd);

--- a/hw/top_englishbreakfast/top_englishbreakfast.core
+++ b/hw/top_englishbreakfast/top_englishbreakfast.core
@@ -71,6 +71,9 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
+    files:
+      - lint/top_englishbreakfast.vbl
+    file_type: veribleLintWaiver
 
 
 parameters:

--- a/util/raclgen/lib.py
+++ b/util/raclgen/lib.py
@@ -230,24 +230,23 @@ def parse_racl_mapping(
         try:
             base = int(range['base'], 0)
             size = int(range['size'], 0)
-            mask = size - 1
-            if size <= 0 or size.bit_count() != 1 or base & mask:
-                raise ValueError
-        except ValueError:
-            raise SystemExit(f'Invalid RACL range mapping ({range}) in {mapping_path}')
+            if size <= 0 or base < 0:
+                raise ValueError("Base must not be negative and size must be > 0.")
+            limit = base + size - 1
+        except ValueError as error:
+            raise SystemExit(f'Invalid RACL range mapping ({range}) in {mapping_path}: {error}')
 
         # ensure disjunct ranges:
         for range_mapping in parsed_range_mapping:
-            start = range_mapping['base']
-            end = range_mapping['base'] + range_mapping['size'] - 1
-            if max(base, start) <= min(base + size - 1, end):
+            other_base = range_mapping['base']
+            other_limit = range_mapping['limit']
+            if max(base, other_base) <= min(limit, other_limit):
                 raise SystemExit(f'Overlapping RACL range ({range}) in {mapping_path}')
 
         parsed_range_mapping.append(
             {
                 'base': base,
-                'size': size,
-                'mask': mask,
+                'limit': limit,
                 'policy': policy_name_to_idx(range['policy'])
             }
         )

--- a/util/topgen/templates/top_racl_pkg.sv.tpl
+++ b/util/topgen/templates/top_racl_pkg.sv.tpl
@@ -39,11 +39,22 @@ package top_racl_pkg;
     racl_role_vec_t write_perm;
   } racl_policy_t;
 
+  // RACL range used to protect a range of addresses with a RACL policy (e.g., for sram).
+  typedef struct packed {
+    logic [top_pkg::TL_AW-1:0] base;       // Start address of range
+    logic [top_pkg::TL_AW-1:0] limit;      // End address of range (inclusive)
+    racl_policy_sel_t          policy_sel; // Policy selector
+    logic                      enable;     // 0: Range is disabled, 1: Range is enabled
+  } racl_range_t;
+
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP
   typedef racl_policy_t [NrRaclPolicies-1:0] racl_policy_vec_t;
 
   // Default policy vector for unconnected RACL IPs
   parameter racl_policy_vec_t RACL_POLICY_VEC_DEFAULT = '0;
+
+  // Default policy selection range for unconnected RACL IPs
+  parameter racl_range_t RACL_RANGE_T_DEFAULT = '0;
 
   // Default ROT Private read policy value
   parameter racl_role_vec_t RACL_POLICY_ROT_PRIVATE_RD = ${racl_role_vec_len}'h${f"{racl_config['rot_private_policy_rd']:x}"};
@@ -60,13 +71,6 @@ package top_racl_pkg;
     logic                      read_access;  // 0: Write access, 1: Read access
     logic [top_pkg::TL_AW-1:0] request_address;
   } racl_error_log_t;
-
-  // Range definition for RACL protected SRAM adapter
-  typedef struct packed {
-    logic [top_pkg::TL_AW-1:0] base;
-    logic [top_pkg::TL_AW-1:0] mask;
-    racl_policy_sel_t          policy_sel;
-  } racl_range_t;
 
   // Extract RACL role bits from the TLUL reserved user bits
   function automatic racl_role_t tlul_extract_racl_role_bits(logic [tlul_pkg::RsvdWidth-1:0] rsvd);

--- a/util/topgen/templates/toplevel_racl_pkg_parameters.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg_parameters.tpl
@@ -66,11 +66,11 @@ policy: ${policy_names[range['policy']]} (Idx ${f"{range['policy']}".rjust(polic
 % endfor
 % if len(range_mapping) > 0:
   parameter racl_policy_sel_t RACL_POLICY_SEL_NUM_RANGES_${policy_sel_name} = ${len(range_mapping)};
-<% fmt_range = "'{{base:'h{base:04x},mask:'h{mask:04x},policy:{policy:{policy_sel_len}}}}" %>\
-  parameter racl_range_t RACL_POLICY_SEL_RANGES_${policy_sel_name} [${len(range_mapping)}] = '{
+<% fmt_range = "'{{base:'h{base:04x},limit:'h{limit:04x},policy:{policy:{policy_sel_len}},enable:1'b1}}" %>\
+  parameter racl_range_t [${len(range_mapping)-1}:0] RACL_POLICY_SEL_RANGES_${policy_sel_name} = '{
 % for range in range_mapping:
 <%
-    value = fmt_range.format(base=range['base'],mask=range['mask'],policy=policy_names[range['policy']],policy_sel_len=policy_sel_len)
+    value = fmt_range.format(base=range['base'],limit=range['limit'],policy=policy_names[range['policy']],policy_sel_len=policy_sel_len)
     value += ' ' if loop.last else ','
     comment = " // Policy Idx " + f"{range['policy']}".rjust(policy_idx_len)
 %>\


### PR DESCRIPTION
This PR makes RACL ranges more flexible by using signals instead of parameters for the ranges and removing the power-of-two constraint.

Since RACL is still disabled for sram_ctrl (on darjeeling, earlgrey, englishbreakfast) it has no effects.