### PR TITLE
[usbdev] DPI model spends a little over 1ms in Bus Reset

### DIFF
--- a/sw/device/tests/usbdev_setuprx_test.c
+++ b/sw/device/tests/usbdev_setuprx_test.c
@@ -127,7 +127,8 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   // In simulation the DPI model connects VBUS shortly after reset and
   // prolonged delays when asserting or deasserting pull ups are wasteful.
-  uint32_t timeout_micros = 1000u;
+  // It spends a little over a bus frame (1ms) in the Bus Reset state.
+  uint32_t timeout_micros = 1500u;
   uint32_t delay_micros = 1u;
   bool prompt = false;
 


### PR DESCRIPTION
The DPI model spends slightly over one bus frame in the Bus Reset state after detecting a device connection. This is now 1ms since the duration of the bus frame was originally shortened artificially to reduce simulation times. It was subsequently extended to model the real USB.

With a 1ms timeout the test `usbdev_setuprx` has been observed to fail sometimes because the software gives up just as the transmission of the first SOF packet commences. Increase the timeout to 1.5 USB bus frames.