### PR TITLE
[earlgrey,pwm] Fix up top-level pwm sleep test

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -585,7 +585,8 @@ interface chip_if;
                   .clk  (`CLKMGR_HIER.clocks_o.clk_aon_powerup),
                   .rst_n(`RSTMGR_HIER.resets_o.rst_lc_aon_n[0]),
 `endif
-                  .pwm  (mios[AssignedPwmIos[i]]));
+                  .start_cntr (`PWM_HIER.u_pwm_core.clr_phase_cntr),
+                  .pwm        (mios[AssignedPwmIos[i]]));
 
     initial begin
       uvm_config_db#(virtual pwm_if)::set(null, $sformatf("*.env.m_pwm_monitor%0d*", i), "vif",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwm_pulses_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_pwm_pulses_vseq.sv
@@ -38,7 +38,10 @@ class chip_sw_pwm_pulses_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, $sformatf("PWMSEQ : duty_cycle = %p",duty_cycle), UVM_MEDIUM)
     `DV_WAIT(cfg.sw_logger_vif.printed_log == "pinmux_init end")
     `uvm_info(`gfn, $sformatf("set mon active 1"), UVM_MEDIUM)
+    // Supply each of the monitors with the phase counter configuration.
     foreach (cfg.m_pwm_monitor_cfg[i]) begin
+      cfg.m_pwm_monitor_cfg[i].clk_div = CLOCK_DIV;
+      cfg.m_pwm_monitor_cfg[i].resolution = $clog2(BEATS_PER_PULSE_CYCLE) - 1;
       cfg.m_pwm_monitor_cfg[i].active = 1;
     end
     fork


### PR DESCRIPTION
The impact upon this top-level test was overlooked during the recent PWM DV work, and some changes are required to support the alterations to the `pwm_monitor.`