### PR TITLE
[ac_range_check,dv] Fix smoke to reveal RTL bug

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
@@ -7,6 +7,7 @@ class ac_range_check_smoke_vseq extends ac_range_check_base_vseq;
 
   // Local variables
   rand bit zero_delays;
+  rand protected bit [NUM_RANGES-1:0] config_range_mask;  // Which ranges should be constrained
 
   // Constraints
   extern constraint num_trans_c;
@@ -34,12 +35,15 @@ constraint ac_range_check_smoke_vseq::tmp_c {
 }
 
 constraint ac_range_check_smoke_vseq::range_c {
+  solve config_range_mask before dut_cfg.range_base;
   solve dut_cfg.range_base before dut_cfg.range_limit;
   foreach (dut_cfg.range_limit[i]) {
     // Limit always greater than base
     dut_cfg.range_limit[i] > dut_cfg.range_base[i];
-    // Range size in 32-bit words, it shouldn't be too large and let it be 1 word size
-    ((dut_cfg.range_limit[i] - dut_cfg.range_base[i]) >> 2) inside {[1:49]};
+    if (config_range_mask[i]) {
+      // Range size in 32-bit words, it shouldn't be too large and let it be 1 word size
+      ((dut_cfg.range_limit[i] - dut_cfg.range_base[i]) >> 2) inside {[1:49]};
+    }
   }
 }
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
@@ -7,6 +7,7 @@ class ac_range_check_smoke_vseq extends ac_range_check_base_vseq;
 
   // Local variables
   rand bit zero_delays;
+  rand protected bit [NUM_RANGES-1:0] config_range_mask;  // Which ranges should be constrained
 
   // Constraints
   extern constraint num_trans_c;
@@ -34,12 +35,15 @@ constraint ac_range_check_smoke_vseq::tmp_c {
 }
 
 constraint ac_range_check_smoke_vseq::range_c {
+  solve config_range_mask before dut_cfg.range_base;
   solve dut_cfg.range_base before dut_cfg.range_limit;
   foreach (dut_cfg.range_limit[i]) {
     // Limit always greater than base
     dut_cfg.range_limit[i] > dut_cfg.range_base[i];
-    // Range size in 32-bit words, it shouldn't be too large and let it be 1 word size
-    ((dut_cfg.range_limit[i] - dut_cfg.range_base[i]) >> 2) inside {[1:49]};
+    if (config_range_mask[i]) {
+      // Range size in 32-bit words, it shouldn't be too large and let it be 1 word size
+      ((dut_cfg.range_limit[i] - dut_cfg.range_base[i]) >> 2) inside {[1:49]};
+    }
   }
 }
 


### PR DESCRIPTION
Limit the range_base/limit constraints to only some ranges. This has the effect of revealing the RTL bug raised in issue #26588 and fixed in PR #26589.