### PR TITLE
[racl_ctrl,rtl] Re-order racl_policy_t to match the register

### DIFF
--- a/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_racl_pkg.sv
@@ -41,8 +41,8 @@ package top_racl_pkg;
 
   // RACL policy containing a read and write permission
   typedef struct packed {
-    racl_role_vec_t read_perm;
-    racl_role_vec_t write_perm;
+    racl_role_vec_t write_perm;    // Write permission (upper bits)
+    racl_role_vec_t read_perm;     // Read permission (lower bits)
   } racl_policy_t;
 
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP

--- a/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_racl_pkg.sv
@@ -41,8 +41,8 @@ package top_racl_pkg;
 
   // RACL policy containing a read and write permission
   typedef struct packed {
-    racl_role_vec_t read_perm;
-    racl_role_vec_t write_perm;
+    racl_role_vec_t write_perm;    // Write permission (upper bits)
+    racl_role_vec_t read_perm;     // Read permission (lower bits)
   } racl_policy_t;
 
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP

--- a/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_racl_pkg.sv
@@ -41,8 +41,8 @@ package top_racl_pkg;
 
   // RACL policy containing a read and write permission
   typedef struct packed {
-    racl_role_vec_t read_perm;
-    racl_role_vec_t write_perm;
+    racl_role_vec_t write_perm;    // Write permission (upper bits)
+    racl_role_vec_t read_perm;     // Read permission (lower bits)
   } racl_policy_t;
 
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP

--- a/util/topgen/templates/top_racl_pkg.sv.tpl
+++ b/util/topgen/templates/top_racl_pkg.sv.tpl
@@ -35,8 +35,8 @@ package top_racl_pkg;
 
   // RACL policy containing a read and write permission
   typedef struct packed {
-    racl_role_vec_t read_perm;
-    racl_role_vec_t write_perm;
+    racl_role_vec_t write_perm;    // Write permission (upper bits)
+    racl_role_vec_t read_perm;     // Read permission (lower bits)
   } racl_policy_t;
 
   // RACL policy vector for distributing RACL policies from the RACL widget to the subscribing IP


### PR DESCRIPTION
Since SystemVerilog structs go from msb to lsb, this layout didn't match the register definitions. We *could* teach everything to do the reversal, but it's confusing for a reader. Switch things round now.