### PR TITLE
[dv] A few build fixes for sim_dv targets

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1047,7 +1047,7 @@
     {
       name: chip_sw_alert_handler_escalation
       uvm_test_seq: chip_sw_alert_handler_escalation_vseq
-      sw_images: ["//sw/device/tests/sim_dv:alert_handler_escalation_test:6:new_rules"]
+      sw_images: ["//sw/device/tests:alert_handler_escalation_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       // Disable scoreboard to avoid incorrect alert prediction from the alert_monitor. Due to the
       // cross-domain alert senders and receivers, the monitor from the chip level did not support
@@ -1561,7 +1561,7 @@
     {
       name: chip_sw_rv_dm_access_after_escalation_reset
       uvm_test_seq: "chip_sw_rv_dm_access_after_escalation_reset_vseq"
-      sw_images: ["//sw/device/tests/sim_dv:alert_handler_escalation_test:6:new_rules"]
+      sw_images: ["//sw/device/tests:alert_handler_escalation_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_jtag_dmi=1"]
     }

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1957,7 +1957,7 @@
     {
       name: chip_sw_rv_dm_access_after_escalation_reset
       uvm_test_seq: "chip_sw_rv_dm_access_after_escalation_reset_vseq"
-      sw_images: ["//sw/device/tests/sim_dv:alert_handler_escalation_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:alert_handler_escalation_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_jtag_dmi=1"]
     }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1609,6 +1609,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
     ),
     deps = [
         "//sw/device/lib/runtime:log",
@@ -1663,6 +1664,7 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
+        "//hw/top_darjeeling:sim_dv": None,
     },
     # This test is designed to run and complete entirely in the ROM boot stage.
     # Setting the `test_in_rom` flag makes the `opentitan_test` rule aware


### PR DESCRIPTION
Update some of the configuration files for both Earl Grey and Darjeeling to reflect altered test locations.
Make `example_...` tests build for Darjeeling by adding it as a valid target.