### PR TITLE
[darjeeling] Port a number of the simple smoketests to Darjeeling DV

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -91,6 +91,7 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:sim_dv",
             "//hw/top_earlgrey:sim_verilator",
+            "//hw/top_darjeeling:sim_dv",
         ],
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
         deps = [
@@ -128,6 +129,7 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:sim_dv",
             "//hw/top_earlgrey:sim_verilator",
+            "//hw/top_darjeeling:sim_dv",
         ],
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
         deps = [
@@ -151,6 +153,7 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
+            "//hw/top_darjeeling:sim_dv": None,
         },
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
         # We need to specify the manifest because the simulation environments do not
@@ -199,7 +202,7 @@ opentitan_test(
 ]
 
 # Corrupt binaries
-# Note: the naming of the files is important for dvsim. The code expects fiel to be named:
+# Note: the naming of the files is important for dvsim. The code expects file to be named:
 # - binary: <something>.<key_name>.signed.bin
 # - vmem: <something>.<key_name>.signed.64.vmem
 # - flash vmem: <something>.<key_name>.signed.64.scr.vmem

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2131,9 +2131,10 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
+        DARJEELING_TEST_ENVS,
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:hmac",
@@ -2201,9 +2202,10 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
+        DARJEELING_TEST_ENVS,
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:hmac",
@@ -7574,9 +7576,7 @@ opentitan_test(
 opentitan_test(
     name = "mbx_smoketest",
     srcs = ["mbx_smoketest.c"],
-    exec_env = {
-        "//hw/top_darjeeling:sim_dv": None,
-    },
+    exec_env = DARJEELING_TEST_ENVS,
     deps = [
         "//hw/top_darjeeling/sw/autogen:top_darjeeling",
         "//sw/device/lib/dif:mbx",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2986,12 +2986,13 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
+        "//hw/top_darjeeling:sim_dv": None,
     },
     fpga = fpga_params(
         changes_otp = True,
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1197,12 +1197,14 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
     silicon = silicon_params(tags = ["broken"]),
     deps = [
+        "//hw/top:dt",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:csrng",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2723,13 +2723,14 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:kmac",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2905,6 +2905,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
@@ -2912,7 +2913,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/dif:otbn",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_csrng.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
@@ -10,7 +11,10 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static_assert(kDtCsrngCount >= 1,
+              "This test requires at least one CSRNG instance");
+
+static const dt_csrng_t kTestCsrng = (dt_csrng_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -53,8 +57,7 @@ status_t test_ctr_drbg_ctr0_smoke(const dif_csrng_t *csrng) {
 
 bool test_main(void) {
   dif_csrng_t csrng;
-  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR);
-  CHECK_DIF_OK(dif_csrng_init(base_addr, &csrng));
+  CHECK_DIF_OK(dif_csrng_init_from_dt(kTestCsrng, &csrng));
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
   CHECK_STATUS_OK(test_ctr_drbg_ctr0_smoke(&csrng));
   return true;

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_hmac.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_hmac.h"
@@ -10,7 +11,10 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static_assert(kDtHmacCount >= 1,
+              "This test requires at least one HMAC instance");
+
+static dt_hmac_t kTestHmac = (dt_hmac_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -101,7 +105,7 @@ bool test_main(void) {
   LOG_INFO("Running HMAC DIF test...");
 
   dif_hmac_t hmac;
-  test_setup(mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR), &hmac);
+  CHECK_DIF_OK(dif_hmac_init_from_dt(kTestHmac, &hmac));
 
   LOG_INFO("Running test SHA256 pass 1...");
   run_test(&hmac, kData, sizeof(kData), NULL, &kExpectedShaDigest);

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_kmac.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_kmac.h"
@@ -9,8 +10,12 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "kmac_regs.h"  // Generated.
+
+static_assert(kDtKmacCount >= 1,
+              "This test requires at least one KMAC instance");
+
+static dt_kmac_t kTestKmac = (dt_kmac_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -291,8 +296,7 @@ bool test_main(void) {
 
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kTestKmac, &kmac));
 
   // Configure KMAC hardware using software entropy. The seed has been randomnly
   // chosen and is genrated using enerated using

--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_otbn.h"
 #include "sw/device/lib/dif/dif_otbn.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
@@ -9,8 +10,6 @@
 #include "sw/device/lib/testing/otbn_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTBN_DECLARE_APP_SYMBOLS(barrett384);
 OTBN_DECLARE_SYMBOL_ADDR(barrett384, inp_a);
@@ -29,6 +28,11 @@ static const otbn_addr_t kOupC = OTBN_ADDR_T_INIT(barrett384, oup_c);
 OTBN_DECLARE_APP_SYMBOLS(err_test);
 
 static const otbn_app_t kAppErrTest = OTBN_APP_T_INIT(err_test);
+
+static_assert(kDtOtbnCount >= 1,
+              "This test requires at least one OTBN instance");
+
+static dt_otbn_t kTestOtbn = (dt_otbn_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -152,8 +156,7 @@ bool test_main(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
 
   dif_otbn_t otbn;
-  CHECK_DIF_OK(
-      dif_otbn_init(mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR), &otbn));
+  CHECK_DIF_OK(dif_otbn_init_from_dt(kTestOtbn, &otbn));
 
   test_barrett384(&otbn);
   test_sec_wipe(&otbn);

--- a/sw/device/tests/otp_ctrl_smoketest.c
+++ b/sw/device/tests/otp_ctrl_smoketest.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <stdbool.h>
 
+#include "dt/dt_otp_ctrl.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
@@ -14,13 +15,16 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 static dif_otp_ctrl_t otp;
 
 static const char kTestData[] = "abcdefghijklmno";
 static_assert(ARRAYSIZE(kTestData) % sizeof(uint32_t) == 0,
               "kTestData must be a word array");
+
+static_assert(kDtOtpCtrlCount >= 1,
+              "This test requires at least one OTP Control instance");
+
+static dt_otp_ctrl_t kTestOtpCtrl = (dt_otp_ctrl_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -29,8 +33,7 @@ OTTF_DEFINE_TEST_CONFIG();
  * value can then be read out exactly through the blocking read interface.
  */
 bool test_main(void) {
-  CHECK_DIF_OK(dif_otp_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_init_from_dt(kTestOtpCtrl, &otp));
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,


### PR DESCRIPTION
This PR just updates a number of the very simple smoke tests of internal blocks to work on Darjeeling as well as Earl Grey, using DT.

HMAC smoketest is ported first, and then the other tests follow on accordingly, making changes in the same manner, so hopefully only the first two commits really need any appreciable attention.
Modifications have been tested in both Earl Grey and Darjeeling top-level DV simulations.