### PR TITLE
[manuf] remove ECC from flash info page 0

### DIFF
--- a/sw/device/silicon_creator/manuf/base/flash_info_permissions.h
+++ b/sw/device/silicon_creator/manuf/base/flash_info_permissions.h
@@ -9,9 +9,12 @@
 
 /**
  * Access permissions for flash info page 0 (holds device_id and manuf_state).
+ *
+ * We keep ECC disabled on this page as the ATE cannot use ECC when writing this
+ * page earlier during the provisioning process.
  */
 dif_flash_ctrl_region_properties_t kFlashInfoPage0Permissions = {
-    .ecc_en = kMultiBitBool4True,
+    .ecc_en = kMultiBitBool4False,
     .high_endurance_en = kMultiBitBool4False,
     .erase_en = kMultiBitBool4True,
     .prog_en = kMultiBitBool4True,

--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision_functest.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision_functest.c
@@ -116,6 +116,10 @@ bool test_main(void) {
     uint32_t cp_device_id[kFlashInfoFieldCpDeviceIdSizeIn32BitWords] = {0};
     static_assert(kFlashInfoFieldCpDeviceIdSizeIn32BitWords == 4,
                   "CP device ID should fit in four 32bit words.");
+    CHECK_STATUS_OK(flash_ctrl_testutils_info_region_setup_properties(
+        &flash_ctrl_state, kFlashInfoFieldCpDeviceId.page,
+        kFlashInfoFieldCpDeviceId.bank, kFlashInfoFieldCpDeviceId.partition,
+        kFlashInfoPage0Permissions, /*offset=*/NULL));
     CHECK_STATUS_OK(manuf_flash_info_field_read(
         &flash_ctrl_state, kFlashInfoFieldCpDeviceId, cp_device_id,
         kFlashInfoFieldCpDeviceIdSizeIn32BitWords));


### PR DESCRIPTION
Early in manufacturing, the ATE cannot write to flash info page 0 with ECC enabled. This removes ECC from this page.