### PR TITLE
[acrc,dv] Fix Mako formatting in sim_cfg HJSON template

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/dv/ac_range_check_sim_cfg.hjson.tpl
@@ -15,7 +15,7 @@
   tool: xcelium
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: ${instance_vlnv("lowrisc:dv:${module_instance_name}_sim:0.1")}
+  fusesoc_core: ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_sim:0.1")}
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/${module_instance_name}_testplan.hjson"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson
@@ -15,7 +15,7 @@
   tool: xcelium
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:darjeeling_dv:${module_instance_name}_sim:0.1
+  fusesoc_core: lowrisc:darjeeling_dv:ac_range_check_sim:0.1
 
   // Testplan hjson file.
   testplan: "{self_dir}/../data/ac_range_check_testplan.hjson"


### PR DESCRIPTION
Fixes the weekly Darjeeling regression after #26645 and #26688.

This didn't use the correct Python fstring format required to properly format in `module_instance_name`: Mako was escaping the format in the string by default, which was leading to errors in regressions where the ac_range_check sim_cfg HJSON could not be parsed by dvsim due to the unsubstituted `{module_instance_name}` appearing as an unknown, unexpanded wildcard.