### PR TITLE
[rust] move to edition 2024

### DIFF
--- a/sw/host/hsmtool/acorn/acorn.rs
+++ b/sw/host/hsmtool/acorn/acorn.rs
@@ -16,11 +16,18 @@ pub enum AcornError {
 }
 
 /// Converts a C-string into a rust string.
+///
+/// # Safety
+///
+/// `ptr` should either be a null pointer or a valid pointer to a C NUL-terminated string.
 unsafe fn rust_string(ptr: *const std::ffi::c_char) -> String {
     if ptr.is_null() {
         "nullptr for string!".into()
     } else {
-        CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        // SAFETY: `ptr` is a valid pointer to a C string.
+        unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned()
     }
 }
 

--- a/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
+++ b/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
@@ -118,7 +118,7 @@ fn dispatch_variant(name: &Ident, variant: &Variant) -> Result<TokenStream> {
         ));
     }
     Ok(quote! {
-        #name::#ident(ref __field) =>
+        #name::#ident(__field) =>
             opentitanlib::app::command::CommandDispatch::run(__field, context, backend)
     })
 }
@@ -141,7 +141,7 @@ fn exclusive_variant(name: &Ident, variant: &Variant) -> Result<TokenStream> {
         ));
     }
     Ok(quote! {
-        #name::#ident(ref __field) =>
+        #name::#ident(__field) =>
             opentitanlib::app::command::CommandDispatch::exclusive_use_of_transport(__field)
     })
 }

--- a/sw/host/opentitanlib/src/transport/dediprog/spi.rs
+++ b/sw/host/opentitanlib/src/transport/dediprog/spi.rs
@@ -266,7 +266,7 @@ impl DediprogSpi {
                     transactions = rest;
                     self.run_transaction(&mut [Transfer::Write(cmd.to_bytes()?)])?
                 }
-                [Read(cmd, ref mut rbuf), rest @ ..] => {
+                [Read(cmd, rbuf), rest @ ..] => {
                     transactions = rest;
                     self.eeprom_read_transaction(cmd, rbuf)?;
                 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -1004,7 +1004,7 @@ impl Target for HyperdebugSpiTarget {
                         self.eeprom_transmit(None, cmd, &[], &mut [], false, stream_state)?;
                     transactions = rest;
                 }
-                [eeprom::Transaction::Read(cmd, ref mut rbuf), rest @ ..] => {
+                [eeprom::Transaction::Read(cmd, rbuf), rest @ ..] => {
                     stream_state =
                         self.eeprom_transmit(None, cmd, &[], rbuf, false, stream_state)?;
                     transactions = rest;

--- a/sw/host/opentitantool/src/command/bfv.rs
+++ b/sw/host/opentitantool/src/command/bfv.rs
@@ -17,7 +17,7 @@ pub struct BfvCommand {
     bfv: Vec<String>,
 }
 
-extern "C" {
+unsafe extern "C" {
     fn bfv_decoder(bfv: u32, buf: *mut u8, buf_size: usize) -> usize;
 }
 

--- a/sw/host/ot_certs/src/asn1/builder.rs
+++ b/sw/host/ot_certs/src/asn1/builder.rs
@@ -72,7 +72,7 @@ pub trait Builder {
         &mut self,
         name_hint: Option<String>,
         tag: &Tag,
-        gen: impl FnOnce(&mut Self) -> Result<()>,
+        build: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()>;
 
     /// Push a tagged octet string into the ASN1 output. The closure can use any available function of the builder
@@ -80,9 +80,9 @@ pub trait Builder {
     fn push_octet_string(
         &mut self,
         name_hint: Option<String>,
-        gen: impl FnOnce(&mut Self) -> Result<()>,
+        build: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()> {
-        self.push_tag(name_hint, &Tag::OctetString, |builder| gen(builder))
+        self.push_tag(name_hint, &Tag::OctetString, |builder| build(builder))
     }
 
     /// Push a sequence into the ASN1 output. The closure can use any available function of the builder
@@ -90,9 +90,9 @@ pub trait Builder {
     fn push_seq(
         &mut self,
         name_hint: Option<String>,
-        gen: impl FnOnce(&mut Self) -> Result<()>,
+        build: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()> {
-        self.push_tag(name_hint, &Tag::Sequence, gen)
+        self.push_tag(name_hint, &Tag::Sequence, build)
     }
 
     /// Push a sequence into the ASN1 output. The closure can use any available function of the builder
@@ -100,9 +100,9 @@ pub trait Builder {
     fn push_set(
         &mut self,
         name_hint: Option<String>,
-        gen: impl FnOnce(&mut Self) -> Result<()>,
+        build: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()> {
-        self.push_tag(name_hint, &Tag::Set, gen)
+        self.push_tag(name_hint, &Tag::Set, build)
     }
 
     /// Push tagged content into the ASN1 output as a bitstring. The closure can use any available function of the builder
@@ -112,7 +112,7 @@ pub trait Builder {
         name_hint: Option<String>,
         tag: &Tag,
         unused_bits: usize,
-        gen: impl FnOnce(&mut Self) -> Result<()>,
+        build: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()> {
         self.push_tag(name_hint, tag, |builder| {
             ensure!(
@@ -120,7 +120,7 @@ pub trait Builder {
                 "unused bits value must be in the range 0 to 7"
             );
             builder.push_byte(unused_bits as u8)?;
-            gen(builder)
+            build(builder)
         })
     }
 

--- a/sw/host/ot_certs/src/asn1/der.rs
+++ b/sw/host/ot_certs/src/asn1/der.rs
@@ -57,9 +57,9 @@ impl Der {
         Der { output: Vec::new() }
     }
 
-    pub fn generate(gen: impl FnOnce(&mut Self) -> Result<()>) -> Result<Vec<u8>> {
+    pub fn generate(build: impl FnOnce(&mut Self) -> Result<()>) -> Result<Vec<u8>> {
         let mut der = Der::new();
-        gen(&mut der)?;
+        build(&mut der)?;
         Ok(der.output)
     }
 
@@ -205,10 +205,10 @@ impl Builder for Der {
         &mut self,
         _name_hint: Option<String>,
         tag: &Tag,
-        gen: impl FnOnce(&mut Self) -> Result<()>,
+        build: impl FnOnce(&mut Self) -> Result<()>,
     ) -> Result<()> {
         let mut content = Der::new();
-        gen(&mut content)?;
+        build(&mut content)?;
         // Push identifier octets.
         self.push_bytes(&tag.to_der()?)?;
         // Push length, see X.690 section 8.1.3.

--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -360,7 +360,7 @@ impl X509 {
         builder: &mut B,
         oid: &Oid,
         critical: bool,
-        gen: impl FnOnce(&mut B) -> Result<()>,
+        build: impl FnOnce(&mut B) -> Result<()>,
     ) -> Result<()> {
         // From https://datatracker.ietf.org/doc/html/rfc5280#section-4.1:
         // Extension  ::=  SEQUENCE  {
@@ -374,7 +374,7 @@ impl X509 {
         builder.push_seq(concat_suffix(&Some(oid.to_string()), "ext"), |builder| {
             builder.push_oid(oid)?;
             builder.push_boolean(&Tag::Boolean, &Value::Literal(critical))?;
-            builder.push_octet_string(concat_suffix(&Some(oid.to_string()), "ext_value"), gen)
+            builder.push_octet_string(concat_suffix(&Some(oid.to_string()), "ext_value"), build)
         })
     }
 

--- a/sw/host/ot_certs/src/codegen.rs
+++ b/sw/host/ot_certs/src/codegen.rs
@@ -421,7 +421,7 @@ fn generate_builder(
     fn_name: &str,
     fn_params_str: &str,
     variables: &IndexMap<String, VariableType>,
-    gen: impl FnOnce(&mut codegen::Codegen) -> Result<()>,
+    build: impl FnOnce(&mut codegen::Codegen) -> Result<()>,
 ) -> Result<(String, CodegenOutput)> {
     let get_var_info = |var_name: &str| -> Result<VariableInfo> {
         let var_type = variables
@@ -455,7 +455,7 @@ fn generate_builder(
             /* buf_name */ "out_buf",
             /* buf_size_name */ "inout_size",
             &get_var_info,
-            gen,
+            build,
         )?;
     } else {
         generate_fn_def = indoc::formatdoc! { r#"
@@ -479,7 +479,7 @@ fn generate_builder(
             /* buf_name */ "out_buf",
             /* buf_size_name */ "inout_size",
             &get_var_info,
-            gen,
+            build,
         )?;
     }
 

--- a/sw/host/tests/chip/pattgen/pattgen_ios.rs
+++ b/sw/host/tests/chip/pattgen/pattgen_ios.rs
@@ -112,8 +112,8 @@ impl PattGenChannelParams {
             patt_inactive_level_pda: rng.gen_range(0..=1),
             patt_inactive_level_pcl: rng.gen_range(0..=1),
             patt_div: rng.gen_range(PATTGEN_MIN_DIV..=PATTGEN_MAX_DIV),
-            patt_lower: rng.gen(),
-            patt_upper: rng.gen(),
+            patt_lower: rng.r#gen(),
+            patt_upper: rng.r#gen(),
             patt_len: rng.gen_range(1..=64),
             patt_rep: rng.gen_range(1..=PATTGEN_MAX_REP),
         }

--- a/sw/host/tests/chip/rv_dm/src/csr_rw.rs
+++ b/sw/host/tests/chip/rv_dm/src/csr_rw.rs
@@ -54,7 +54,7 @@ fn test(jtag: &mut dyn Jtag, base: usize, offset: u32) -> Result<()> {
 }
 
 fn test_csr_rw(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let seed = opts.seed.unwrap_or_else(|| thread_rng().gen());
+    let seed = opts.seed.unwrap_or_else(|| thread_rng().r#gen());
     log::info!("Random number generator seed is {:x}", seed);
     let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(seed);
 

--- a/sw/host/tests/chip/rv_dm/src/mem_access.rs
+++ b/sw/host/tests/chip/rv_dm/src/mem_access.rs
@@ -46,7 +46,7 @@ const NUM_ACCESSES_PER_REGION: usize = 32;
 const ROM_ACCESSIBLE_BYTES: usize = top_earlgrey::ROM_SIZE_BYTES - 32;
 
 fn test_mem_access(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let seed = opts.seed.unwrap_or_else(|| thread_rng().gen());
+    let seed = opts.seed.unwrap_or_else(|| thread_rng().r#gen());
     log::info!("Random number generator seed is {:x}", seed);
     let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(seed);
 
@@ -104,7 +104,7 @@ fn test_mem_access(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
                 .step_by(4)
                 .choose_multiple(&mut rng, NUM_ACCESSES_PER_REGION)
                 .into_iter()
-                .map(|offset| (name, base, offset, rng.gen::<u32>())),
+                .map(|offset| (name, base, offset, rng.r#gen::<u32>())),
         );
     }
 

--- a/sw/host/tests/xmodem/xmodem.rs
+++ b/sw/host/tests/xmodem/xmodem.rs
@@ -125,7 +125,7 @@ impl XmodemFirmware {
 ///
 /// * `iohandle` must be a valid reference to a `dyn Uart` trait object.
 /// * `data` must be valid for `len` bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn xmodem_read(
     iohandle: *mut c_void,
     data: *mut u8,
@@ -155,7 +155,7 @@ unsafe extern "C" fn xmodem_read(
 ///
 /// * `iohandle` must be a valid reference to a `dyn Uart` trait object.
 /// * `data` must be valid for `len` bytes.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn xmodem_write(iohandle: *mut c_void, data: *const u8, len: usize) {
     // SAFETY:
     // We know that the `iohandle` pointer is a valid reference to a `Uart`

--- a/third_party/rust/rust.MODULE.bazel
+++ b/third_party/rust/rust.MODULE.bazel
@@ -30,7 +30,7 @@ single_version_override(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.repository_set(
     name = "rust_host",
-    edition = "2021",
+    edition = "2024",
     exec_triple = "x86_64-unknown-linux-gnu",
     target_compatible_with = [
         "@platforms//cpu:x86_64",


### PR DESCRIPTION
This includes all fixes necessary to move to Rust 2024:
* `gen` becomes a reserved keyword
* `unsafe` is now required even the function is `unsafe`
* `ref` can no longer be added if the scrutinee is already ref
* `no_mangle` and `extern` now require `unsafe`

Some changes that require no fixing:
* if-let drop order changes; I've reviewed all sites and they seem fine (they're all false positives, see https://github.com/rust-lang/rust/issues/137376)
* expr in macro accepts more expressions, our use of them are all fine.
* tail expression drop order changes; I've reviewed all sites and they seem fine.