### PR TITLE
Undetectable statement coverage and exclusion of a non-required waiver and supporting assertion

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
@@ -18,3 +18,11 @@ check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance\
 # The intention to add this assertion is to make sure that while doing FPV there is not a
 # possibility to inject parasitic state to the state register of alert sender FSM.
 assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance\
+ {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance\
+ {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}

--- a/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# The statement is a deadcode as le_i is always level triggered.
-check_cov -waiver -add -start_line 34 -end_line 34 -type {branch} -instance {dut.u_gateway} -comment {le_i is tied to a parameter which is 0}
-
-# All the interrupts are level triggered thus le_i is always 0. The reason to add this assertion is
-# to support the waiver for the statement above. The statement is a ternary assignment and the
-# conditional part of it is le_i which is always false.
-assert -name InterruptsAreLevelTriggered {!$rose(dut.u_gateway.le_i)}
-
 # This line is a default case statement which could be executed if a parasitic state has been
 # injected to the state register of u_prim_alert_sender.
 check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance\

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# The statement is a deadcode as le_i is always level triggered.
-check_cov -waiver -add -start_line 34 -end_line 34 -type {branch} -instance {dut.u_gateway} -comment {le_i is tied to a parameter which is 0}
-
-# All the interrupts are level triggered thus le_i is always 0. The reason to add this assertion is
-# to support the waiver for the statement above. The statement is a ternary assignment and the
-# conditional part of it is le_i which is always false.
-assert -name InterruptsAreLevelTriggered {!$rose(dut.u_gateway.le_i)}
-
 # This line is a default case statement which could be executed if a parasitic state has been
 # injected to the state register of u_prim_alert_sender.
 check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance {dut.gen_alert_tx[0].u_prim_alert_sender} -comment {No parasitic state injection while doing FPV}

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -17,3 +17,9 @@ check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance {d
 # The intention to add this assertion is to make sure that while doing FPV there is not a
 # possibility to inject parasitic state to the state register of alert sender FSM.
 assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# The statement is a deadcode as le_i is always level triggered.
-check_cov -waiver -add -start_line 34 -end_line 34 -type {branch} -instance {dut.u_gateway} -comment {le_i is tied to a parameter which is 0}
-
-# All the interrupts are level triggered thus le_i is always 0. The reason to add this assertion is
-# to support the waiver for the statement above. The statement is a ternary assignment and the
-# conditional part of it is le_i which is always false.
-assert -name InterruptsAreLevelTriggered {!$rose(dut.u_gateway.le_i)}
-
 # This line is a default case statement which could be executed if a parasitic state has been
 # injected to the state register of u_prim_alert_sender.
 check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance {dut.gen_alert_tx[0].u_prim_alert_sender} -comment {No parasitic state injection while doing FPV}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -17,3 +17,9 @@ check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance {d
 # The intention to add this assertion is to make sure that while doing FPV there is not a
 # possibility to inject parasitic state to the state register of alert sender FSM.
 assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# The statement is a deadcode as le_i is always level triggered.
-check_cov -waiver -add -start_line 34 -end_line 34 -type {branch} -instance {dut.u_gateway} -comment {le_i is tied to a parameter which is 0}
-
-# All the interrupts are level triggered thus le_i is always 0. The reason to add this assertion is
-# to support the waiver for the statement above. The statement is a ternary assignment and the
-# conditional part of it is le_i which is always false.
-assert -name InterruptsAreLevelTriggered {!$rose(dut.u_gateway.le_i)}
-
 # This line is a default case statement which could be executed if a parasitic state has been
 # injected to the state register of u_prim_alert_sender.
 check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance {dut.gen_alert_tx[0].u_prim_alert_sender} -comment {No parasitic state injection while doing FPV}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -17,3 +17,9 @@ check_cov -waiver -add -start_line 249 -end_line 249 -type {branch} -instance {d
 # The intention to add this assertion is to make sure that while doing FPV there is not a
 # possibility to inject parasitic state to the state register of alert sender FSM.
 assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
+
+# The port data_o in u_data_chk is untied and used nowhere.
+check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}


### PR DESCRIPTION
This PR:
1) Adds waivers for the undetectable statement coverage.
2) Removes the chunk of code in coverage_waivers.tcl which is no longer required. [#26559](https://github.com/lowRISC/opentitan/pull/26559)