### PR TITLE
[ipgen,alert_handler] Expose esc_prim_receiver parameters

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -218,6 +218,20 @@
       local: "true",
       expose: "true"
     },
+    {
+      name: "EscNumSeverities"
+      desc: "Number of escalation severities"
+      type: "int"
+      default: "4"
+      local: "false"
+    },
+    {
+      name: "EscPingCountWidth"
+      desc: "Width of ping count for the escalation receiver"
+      type: "int"
+      default: "16"
+      local: "false"
+    },
   ]
 
   /////////////////////////////

--- a/hw/ip/lc_ctrl/lc_ctrl.core
+++ b/hw/ip/lc_ctrl/lc_ctrl.core
@@ -21,7 +21,6 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:kmac_pkg
       - lowrisc:ip:rv_dm
-      - lowrisc:virtual_ip:alert_handler_pkg
     files:
       - rtl/lc_ctrl_regs_reg_top.sv
       - rtl/lc_ctrl_dmi_reg_top.sv

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -29,7 +29,9 @@ module lc_ctrl
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction   = LcKeymgrDivWidth'(3),
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivRma          = LcKeymgrDivWidth'(4),
   parameter lc_token_mux_t  RndCnstInvalidTokens           = {TokenMuxBits{1'b1}},
-  parameter bit             SecVolatileRawUnlockEn         = 0
+  parameter bit             SecVolatileRawUnlockEn         = 0,
+  parameter int             EscNumSeverities               = 4,
+  parameter int             EscPingCountWidth              = 16
 ) (
   // Life cycle controller clock
   input                                              clk_i,
@@ -668,8 +670,8 @@ module lc_ctrl
   // and asserts the lc_escalate_en life cycle control signal.
   logic esc_scrap_state0;
   prim_esc_receiver #(
-    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
-    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+    .N_ESC_SEV   (EscNumSeverities),
+    .PING_CNT_DW (EscPingCountWidth)
   ) u_prim_esc_receiver0 (
     .clk_i,
     .rst_ni,
@@ -682,8 +684,8 @@ module lc_ctrl
   // state into a temporary "SCRAP" state named "ESCALATE".
   logic esc_scrap_state1;
   prim_esc_receiver #(
-    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
-    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+    .N_ESC_SEV   (EscNumSeverities),
+    .PING_CNT_DW (EscPingCountWidth)
   ) u_prim_esc_receiver1 (
     .clk_i,
     .rst_ni,

--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -34,6 +34,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
   ],
   regwidth: "32",
 ##############################################################################
+  # The number of escalation severities and ping count width parameters
+  # have a local and non-local varieties instantiated with the same value.
+  # This is to work around the restriction in CSR generation to only allow
+  # local parameters, or the value may become inconsistent when the
+  # parameter gets an override.
   param_list: [
     // Random netlist constants
     { name:      "RndCnstLfsrSeed",
@@ -122,12 +127,21 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       default: "${n_classes}",
       local: "true"
     },
+    { name: "EscNumSeverities",
+      desc: "Number of escalation severities as regular parameter",
+      type: "int",
+      # NOTE: If this value is to be changed, pass the exposed parameter as
+      # a regular override to all IPs with prim_esc_receiver
+      default: "${n_esc_sev}",
+      expose: "true",
+      local: "false"
+    },
     { name: "N_ESC_SEV",
       desc: "Number of escalation severities",
       type: "int",
       # NOTE: If this value is to be changed, ensure all IPs with
       # prim_esc_receiver get updated as well.
-      default: "4",
+      default: "${n_esc_sev}",
       local: "true"
     },
     { name: "N_PHASES",
@@ -142,12 +156,21 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       default: "7",
       local: "true"
     },
+    { name: "EscPingCountWidth",
+      desc: "Width of ping counter as regular parameter",
+      type: "int",
+      # NOTE: If this value is to be changed, pass the exposed parameter as
+      # a regular override to all IPs with prim_esc_receiver
+      default: "${ping_cnt_dw}",
+      expose: "true",
+      local: "false"
+    },
     { name: "PING_CNT_DW",
       desc: "Width of ping counter",
       type: "int",
       # NOTE: If this value is to be changed, ensure all IPs with
       # prim_esc_receiver get updated as well.
-      default: "16",
+      default: "${ping_cnt_dw}",
       local: "true"
     },
     { name: "PHASE_DW",

--- a/hw/ip_templates/alert_handler/data/alert_handler.tpldesc.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler.tpldesc.hjson
@@ -46,6 +46,18 @@
       default: "4"
     }
     {
+      name: "n_esc_sev"
+      desc: "Number of escalation severities"
+      type: "int"
+      default: "4"
+    }
+    {
+      name: "ping_cnt_dw"
+      desc: "Width of ping timeout counter"
+      type: "int"
+      default: "4"
+    }
+    {
       name: "n_lpg"
       desc: "Number of low-power groups (LPGs)"
       type: "int"

--- a/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler.sv.tpl
@@ -17,6 +17,8 @@ module ${module_instance_name}
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${module_instance_name}_reg_pkg::NumRegs] = 
     '{${module_instance_name}_reg_pkg::NumRegs{0}},
 % endif
+  parameter int EscNumSeverities = ${n_esc_sev},
+  parameter int EscPingCountWidth = ${ping_cnt_dw},
   // Compile time random constants, to be overriden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault
@@ -327,6 +329,9 @@ module ${module_instance_name}
   end
 
   assign loc_alert_trig[3] = |esc_integfail;
+
+  logic unused_params;
+  assign unused_params = ^{EscNumSeverities, EscPingCountWidth};
 
   ////////////////
   // Assertions //

--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -244,16 +244,14 @@
       type:    "int unsigned"
       default: "4"
       desc:    "Number of escalation severities"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "WidthPingCounter"
       type:    "int unsigned"
       default: "16"
       desc:    "Width of the ping counter"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "PMPEnable"

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1673,6 +1673,8 @@
         RevisionId: 8'h 01
         UseDmiInterface: "1"
         NumRmaAckSigs: "1"
+        EscNumSeverities: AlertHandlerEscNumSeverities
+        EscPingCountWidth: AlertHandlerEscPingCountWidth
       }
       clock_connections:
       {
@@ -1814,6 +1816,24 @@
           local: "true"
           expose: "true"
           name_top: LcCtrlNumRmaAckSigs
+        }
+        {
+          name: EscNumSeverities
+          desc: Number of escalation severities
+          type: int
+          default: AlertHandlerEscNumSeverities
+          local: "false"
+          expose: "false"
+          name_top: LcCtrlEscNumSeverities
+        }
+        {
+          name: EscPingCountWidth
+          desc: Width of ping count for the escalation receiver
+          type: int
+          default: AlertHandlerEscPingCountWidth
+          local: "false"
+          expose: "false"
+          name_top: LcCtrlEscPingCountWidth
         }
       ]
       inter_signal_list:
@@ -2302,13 +2322,17 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        EscNumSeverities: "4"
+        EscPingCountWidth: "16"
+      }
       attr: ipgen
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
         clk_edn_i: clkmgr_aon_clocks.clk_main_secure
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -2331,6 +2355,24 @@
           name_top: RndCnstAlertHandlerLfsrPerm
           default: 0x83a2b09fb9d7006b1534f2bf7d8eb2112787b10d
           randwidth: 160
+        }
+        {
+          name: EscNumSeverities
+          desc: Number of escalation severities as regular parameter
+          type: int
+          default: "4"
+          local: "false"
+          expose: "true"
+          name_top: AlertHandlerEscNumSeverities
+        }
+        {
+          name: EscPingCountWidth
+          desc: Width of ping counter as regular parameter
+          type: int
+          default: "16"
+          local: "false"
+          expose: "true"
+          name_top: AlertHandlerEscPingCountWidth
         }
       ]
       inter_signal_list:
@@ -2585,6 +2627,11 @@
         Aon
         "0"
       ]
+      param_decl:
+      {
+        EscNumSeverities: AlertHandlerEscNumSeverities
+        EscPingCountWidth: AlertHandlerEscPingCountWidth
+      }
       attr: ipgen
       clock_connections:
       {
@@ -2593,7 +2640,6 @@
         clk_lc_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_esc_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -2601,7 +2647,7 @@
           name: EscNumSeverities
           desc: Number of escalation severities
           type: int
-          default: "4"
+          default: AlertHandlerEscNumSeverities
           local: "false"
           expose: "false"
           name_top: PwrmgrAonEscNumSeverities
@@ -2610,7 +2656,7 @@
           name: EscPingCountWidth
           desc: Width of ping count for the escalation receiver
           type: int
-          default: "16"
+          default: AlertHandlerEscPingCountWidth
           local: "false"
           expose: "false"
           name_top: PwrmgrAonEscPingCountWidth
@@ -10246,8 +10292,8 @@
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "1"
-        NEscalationSeverities: alert_handler_reg_pkg::N_ESC_SEV
-        WidthPingCounter: alert_handler_reg_pkg::PING_CNT_DW
+        NEscalationSeverities: AlertHandlerEscNumSeverities
+        WidthPingCounter: AlertHandlerEscPingCountWidth
       }
       clock_srcs:
       {
@@ -10342,18 +10388,18 @@
           name: NEscalationSeverities
           desc: Number of escalation severities
           type: int unsigned
-          default: alert_handler_reg_pkg::N_ESC_SEV
-          local: "true"
-          expose: "true"
+          default: AlertHandlerEscNumSeverities
+          local: "false"
+          expose: "false"
           name_top: RvCoreIbexNEscalationSeverities
         }
         {
           name: WidthPingCounter
           desc: Width of the ping counter
           type: int unsigned
-          default: alert_handler_reg_pkg::PING_CNT_DW
-          local: "true"
-          expose: "true"
+          default: AlertHandlerEscPingCountWidth
+          local: "false"
+          expose: "false"
           name_top: RvCoreIbexWidthPingCounter
         }
         {

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -376,6 +376,8 @@
         UseDmiInterface: "1",
         // Only use 1 RMI interface
         NumRmaAckSigs: "1"
+        EscNumSeverities: "AlertHandlerEscNumSeverities",
+        EscPingCountWidth: "AlertHandlerEscPingCountWidth",
       },
     },
     { name: "alert_handler",
@@ -386,6 +388,10 @@
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
       base_addr: {
         hart: "0x30160000",
+      },
+      param_decl: {
+        EscNumSeverities: "4",
+        EscPingCountWidth: "16"
       },
       attr: "ipgen",
     },
@@ -440,6 +446,10 @@
       domain: ["Aon", "0"],
       base_addr: {
         hart: "0x30400000",
+      },
+      param_decl: {
+        EscNumSeverities: "AlertHandlerEscNumSeverities",
+        EscPingCountWidth: "AlertHandlerEscPingCountWidth",
       },
       attr: "ipgen",
 
@@ -1089,8 +1099,8 @@
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
                    PipeLine: "1",
-                   NEscalationSeverities: "alert_handler_reg_pkg::N_ESC_SEV",
-                   WidthPingCounter: "alert_handler_reg_pkg::PING_CNT_DW"
+                   NEscalationSeverities: "AlertHandlerEscNumSeverities",
+                   WidthPingCounter: "AlertHandlerEscPingCountWidth",
                   },
       clock_srcs: {
         clk_i: "main",

--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -26,6 +26,11 @@
     { protocol: "tlul", direction: "device", hier_path: "u_reg_wrap.u_reg" }
   ],
   regwidth: "32",
+  # The number of escalation severities and ping count width parameters
+  # have a local and non-local varieties instantiated with the same value.
+  # This is to work around the restriction in CSR generation to only allow
+  # local parameters, or the value may become inconsistent when the
+  # parameter gets an override.
   param_list: [
     // Random netlist constants
     { name:      "RndCnstLfsrSeed",
@@ -306,6 +311,15 @@
       default: "4",
       local: "true"
     },
+    { name: "EscNumSeverities",
+      desc: "Number of escalation severities as regular parameter",
+      type: "int",
+      # NOTE: If this value is to be changed, pass the exposed parameter as
+      # a regular override to all IPs with prim_esc_receiver
+      default: "4",
+      expose: "true",
+      local: "false"
+    },
     { name: "N_ESC_SEV",
       desc: "Number of escalation severities",
       type: "int",
@@ -325,6 +339,15 @@
       type: "int",
       default: "7",
       local: "true"
+    },
+    { name: "EscPingCountWidth",
+      desc: "Width of ping counter as regular parameter",
+      type: "int",
+      # NOTE: If this value is to be changed, pass the exposed parameter as
+      # a regular override to all IPs with prim_esc_receiver
+      default: "16",
+      expose: "true",
+      local: "false"
     },
     { name: "PING_CNT_DW",
       desc: "Width of ping counter",

--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
@@ -116,6 +116,8 @@
       1'b1
     ]
     n_classes: 4
+    n_esc_sev: 4
+    ping_cnt_dw: 16
     n_lpg: 18
     lpg_map:
     [

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -11,6 +11,8 @@ module alert_handler
   import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 #(
+  parameter int EscNumSeverities = 4,
+  parameter int EscPingCountWidth = 16,
   // Compile time random constants, to be overriden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault
@@ -304,6 +306,9 @@ module alert_handler
   end
 
   assign loc_alert_trig[3] = |esc_integfail;
+
+  logic unused_params;
+  assign unused_params = ^{EscNumSeverities, EscPingCountWidth};
 
   ////////////////
   // Assertions //

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -244,16 +244,14 @@
       type:    "int unsigned"
       default: "4"
       desc:    "Number of escalation severities"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "WidthPingCounter"
       type:    "int unsigned"
       default: "16"
       desc:    "Width of the ping counter"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "PMPEnable"

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -35,6 +35,8 @@ module top_darjeeling #(
   parameter logic [7:0] LcCtrlRevisionId = 8'h 01,
   parameter logic [31:0] LcCtrlIdcodeValue = 32'h00000001,
   // parameters for alert_handler
+  parameter int AlertHandlerEscNumSeverities = 4,
+  parameter int AlertHandlerEscPingCountWidth = 16,
   // parameters for spi_host0
   // parameters for pwrmgr_aon
   // parameters for rstmgr_aon
@@ -327,9 +329,6 @@ module top_darjeeling #(
   localparam int SramCtrlMboxOutstanding = 2;
   // local parameters for racl_ctrl
   localparam int RaclCtrlNumSubscribingIps = 9;
-  // local parameters for rv_core_ibex
-  localparam int unsigned RvCoreIbexNEscalationSeverities = alert_handler_reg_pkg::N_ESC_SEV;
-  localparam int unsigned RvCoreIbexWidthPingCounter = alert_handler_reg_pkg::PING_CNT_DW;
 
   // Signals
   logic [3:0] mio_p2d;
@@ -1265,7 +1264,9 @@ module top_darjeeling #(
     .ProductId(LcCtrlProductId),
     .RevisionId(LcCtrlRevisionId),
     .IdcodeValue(LcCtrlIdcodeValue),
-    .NumRmaAckSigs(LcCtrlNumRmaAckSigs)
+    .NumRmaAckSigs(LcCtrlNumRmaAckSigs),
+    .EscNumSeverities(AlertHandlerEscNumSeverities),
+    .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_lc_ctrl (
       // [10]: fatal_prog_error
       // [11]: fatal_state_error
@@ -1327,7 +1328,9 @@ module top_darjeeling #(
   );
   alert_handler #(
     .RndCnstLfsrSeed(RndCnstAlertHandlerLfsrSeed),
-    .RndCnstLfsrPerm(RndCnstAlertHandlerLfsrPerm)
+    .RndCnstLfsrPerm(RndCnstAlertHandlerLfsrPerm),
+    .EscNumSeverities(AlertHandlerEscNumSeverities),
+    .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_alert_handler (
 
       // Interrupt
@@ -1397,8 +1400,8 @@ module top_darjeeling #(
   );
   pwrmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[14:14]),
-    .EscNumSeverities(4),
-    .EscPingCountWidth(16)
+    .EscNumSeverities(AlertHandlerEscNumSeverities),
+    .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_pwrmgr_aon (
 
       // Interrupt
@@ -2659,8 +2662,8 @@ module top_darjeeling #(
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),
     .RndCnstIbexNonceDefault(RndCnstRvCoreIbexIbexNonceDefault),
-    .NEscalationSeverities(RvCoreIbexNEscalationSeverities),
-    .WidthPingCounter(RvCoreIbexWidthPingCounter),
+    .NEscalationSeverities(AlertHandlerEscNumSeverities),
+    .WidthPingCounter(AlertHandlerEscPingCountWidth),
     .PMPEnable(RvCoreIbexPMPEnable),
     .PMPGranularity(RvCoreIbexPMPGranularity),
     .PMPNumRegions(RvCoreIbexPMPNumRegions),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2276,6 +2276,8 @@
         ProductId: 16'h 0002
         RevisionId: 8'h 01
         IdcodeValue: jtag_id_pkg::LC_CTRL_JTAG_IDCODE
+        EscNumSeverities: AlertHandlerEscNumSeverities
+        EscPingCountWidth: AlertHandlerEscPingCountWidth
       }
       clock_connections:
       {
@@ -2417,6 +2419,24 @@
           local: "true"
           expose: "true"
           name_top: LcCtrlNumRmaAckSigs
+        }
+        {
+          name: EscNumSeverities
+          desc: Number of escalation severities
+          type: int
+          default: AlertHandlerEscNumSeverities
+          local: "false"
+          expose: "false"
+          name_top: LcCtrlEscNumSeverities
+        }
+        {
+          name: EscPingCountWidth
+          desc: Width of ping count for the escalation receiver
+          type: int
+          default: AlertHandlerEscPingCountWidth
+          local: "false"
+          expose: "false"
+          name_top: LcCtrlEscPingCountWidth
         }
       ]
       inter_signal_list:
@@ -2913,13 +2933,17 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        EscNumSeverities: "4"
+        EscPingCountWidth: "16"
+      }
       attr: ipgen
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
         clk_edn_i: clkmgr_aon_clocks.clk_main_secure
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -2942,6 +2966,24 @@
           name_top: RndCnstAlertHandlerLfsrPerm
           default: 0x83a2b09fb9d7006b1534f2bf7d8eb2112787b10d
           randwidth: 160
+        }
+        {
+          name: EscNumSeverities
+          desc: Number of escalation severities as regular parameter
+          type: int
+          default: "4"
+          local: "false"
+          expose: "true"
+          name_top: AlertHandlerEscNumSeverities
+        }
+        {
+          name: EscPingCountWidth
+          desc: Width of ping counter as regular parameter
+          type: int
+          default: "16"
+          local: "false"
+          expose: "true"
+          name_top: AlertHandlerEscPingCountWidth
         }
       ]
       inter_signal_list:
@@ -3631,6 +3673,11 @@
         Aon
         "0"
       ]
+      param_decl:
+      {
+        EscNumSeverities: AlertHandlerEscNumSeverities
+        EscPingCountWidth: AlertHandlerEscPingCountWidth
+      }
       attr: ipgen
       clock_connections:
       {
@@ -3639,7 +3686,6 @@
         clk_lc_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_esc_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -3647,7 +3693,7 @@
           name: EscNumSeverities
           desc: Number of escalation severities
           type: int
-          default: "4"
+          default: AlertHandlerEscNumSeverities
           local: "false"
           expose: "false"
           name_top: PwrmgrAonEscNumSeverities
@@ -3656,7 +3702,7 @@
           name: EscPingCountWidth
           desc: Width of ping count for the escalation receiver
           type: int
-          default: "16"
+          default: AlertHandlerEscPingCountWidth
           local: "false"
           expose: "false"
           name_top: PwrmgrAonEscPingCountWidth
@@ -9111,8 +9157,8 @@
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "0"
-        NEscalationSeverities: alert_handler_reg_pkg::N_ESC_SEV
-        WidthPingCounter: alert_handler_reg_pkg::PING_CNT_DW
+        NEscalationSeverities: AlertHandlerEscNumSeverities
+        WidthPingCounter: AlertHandlerEscPingCountWidth
       }
       clock_srcs:
       {
@@ -9207,18 +9253,18 @@
           name: NEscalationSeverities
           desc: Number of escalation severities
           type: int unsigned
-          default: alert_handler_reg_pkg::N_ESC_SEV
-          local: "true"
-          expose: "true"
+          default: AlertHandlerEscNumSeverities
+          local: "false"
+          expose: "false"
           name_top: RvCoreIbexNEscalationSeverities
         }
         {
           name: WidthPingCounter
           desc: Width of the ping counter
           type: int unsigned
-          default: alert_handler_reg_pkg::PING_CNT_DW
-          local: "true"
-          expose: "true"
+          default: AlertHandlerEscPingCountWidth
+          local: "false"
+          expose: "false"
           name_top: RvCoreIbexWidthPingCounter
         }
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -448,6 +448,8 @@
         ProductId: "16'h 0002", // Earlgrey PROD
         RevisionId: "8'h 01",   // First tapeout
         IdcodeValue: "jtag_id_pkg::LC_CTRL_JTAG_IDCODE",
+        EscNumSeverities: "AlertHandlerEscNumSeverities",
+        EscPingCountWidth: "AlertHandlerEscPingCountWidth",
       },
     },
     { name: "alert_handler",
@@ -458,6 +460,10 @@
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
       base_addr: {
         hart: "0x40150000",
+      },
+      param_decl: {
+        EscNumSeverities: "4",
+        EscPingCountWidth: "16"
       },
       attr: "ipgen",
     },
@@ -529,6 +535,10 @@
       domain: ["Aon", "0"],
       base_addr: {
         hart: "0x40400000",
+      },
+      param_decl: {
+        EscNumSeverities: "AlertHandlerEscNumSeverities",
+        EscPingCountWidth: "AlertHandlerEscPingCountWidth",
       },
       attr: "ipgen",
     },
@@ -1006,8 +1016,8 @@
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
                    PipeLine: "0",
-                   NEscalationSeverities: "alert_handler_reg_pkg::N_ESC_SEV",
-                   WidthPingCounter: "alert_handler_reg_pkg::PING_CNT_DW"
+                   NEscalationSeverities: "AlertHandlerEscNumSeverities",
+                   WidthPingCounter: "AlertHandlerEscPingCountWidth",
                   },
       clock_srcs: {
         clk_i: "main",

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -26,6 +26,11 @@
     { protocol: "tlul", direction: "device", hier_path: "u_reg_wrap.u_reg" }
   ],
   regwidth: "32",
+  # The number of escalation severities and ping count width parameters
+  # have a local and non-local varieties instantiated with the same value.
+  # This is to work around the restriction in CSR generation to only allow
+  # local parameters, or the value may become inconsistent when the
+  # parameter gets an override.
   param_list: [
     // Random netlist constants
     { name:      "RndCnstLfsrSeed",
@@ -230,6 +235,15 @@
       default: "4",
       local: "true"
     },
+    { name: "EscNumSeverities",
+      desc: "Number of escalation severities as regular parameter",
+      type: "int",
+      # NOTE: If this value is to be changed, pass the exposed parameter as
+      # a regular override to all IPs with prim_esc_receiver
+      default: "4",
+      expose: "true",
+      local: "false"
+    },
     { name: "N_ESC_SEV",
       desc: "Number of escalation severities",
       type: "int",
@@ -249,6 +263,15 @@
       type: "int",
       default: "7",
       local: "true"
+    },
+    { name: "EscPingCountWidth",
+      desc: "Width of ping counter as regular parameter",
+      type: "int",
+      # NOTE: If this value is to be changed, pass the exposed parameter as
+      # a regular override to all IPs with prim_esc_receiver
+      default: "16",
+      expose: "true",
+      local: "false"
     },
     { name: "PING_CNT_DW",
       desc: "Width of ping counter",

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
@@ -78,6 +78,8 @@
       1'b1
     ]
     n_classes: 4
+    n_esc_sev: 4
+    ping_cnt_dw: 16
     n_lpg: 24
     lpg_map:
     [

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler.sv
@@ -11,6 +11,8 @@ module alert_handler
   import prim_alert_pkg::*;
   import prim_esc_pkg::*;
 #(
+  parameter int EscNumSeverities = 4,
+  parameter int EscPingCountWidth = 16,
   // Compile time random constants, to be overriden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault
@@ -304,6 +306,9 @@ module alert_handler
   end
 
   assign loc_alert_trig[3] = |esc_integfail;
+
+  logic unused_params;
+  assign unused_params = ^{EscNumSeverities, EscPingCountWidth};
 
   ////////////////
   // Assertions //

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -244,16 +244,14 @@
       type:    "int unsigned"
       default: "4"
       desc:    "Number of escalation severities"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "WidthPingCounter"
       type:    "int unsigned"
       default: "16"
       desc:    "Width of the ping counter"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "PMPEnable"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -41,6 +41,8 @@ module top_earlgrey #(
   parameter logic [7:0] LcCtrlRevisionId = 8'h 01,
   parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::LC_CTRL_JTAG_IDCODE,
   // parameters for alert_handler
+  parameter int AlertHandlerEscNumSeverities = 4,
+  parameter int AlertHandlerEscPingCountWidth = 16,
   // parameters for spi_host0
   // parameters for spi_host1
   // parameters for usbdev
@@ -254,9 +256,6 @@ module top_earlgrey #(
   localparam int SramCtrlRetAonOutstanding = 2;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
-  // local parameters for rv_core_ibex
-  localparam int unsigned RvCoreIbexNEscalationSeverities = alert_handler_reg_pkg::N_ESC_SEV;
-  localparam int unsigned RvCoreIbexWidthPingCounter = alert_handler_reg_pkg::PING_CNT_DW;
 
   // Signals
   logic [56:0] mio_p2d;
@@ -1563,7 +1562,9 @@ module top_earlgrey #(
     .ProductId(LcCtrlProductId),
     .RevisionId(LcCtrlRevisionId),
     .IdcodeValue(LcCtrlIdcodeValue),
-    .NumRmaAckSigs(LcCtrlNumRmaAckSigs)
+    .NumRmaAckSigs(LcCtrlNumRmaAckSigs),
+    .EscNumSeverities(AlertHandlerEscNumSeverities),
+    .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_lc_ctrl (
       // [16]: fatal_prog_error
       // [17]: fatal_state_error
@@ -1625,7 +1626,9 @@ module top_earlgrey #(
   );
   alert_handler #(
     .RndCnstLfsrSeed(RndCnstAlertHandlerLfsrSeed),
-    .RndCnstLfsrPerm(RndCnstAlertHandlerLfsrPerm)
+    .RndCnstLfsrPerm(RndCnstAlertHandlerLfsrPerm),
+    .EscNumSeverities(AlertHandlerEscNumSeverities),
+    .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_alert_handler (
 
       // Interrupt
@@ -1798,8 +1801,8 @@ module top_earlgrey #(
   );
   pwrmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[22:22]),
-    .EscNumSeverities(4),
-    .EscPingCountWidth(16)
+    .EscNumSeverities(AlertHandlerEscNumSeverities),
+    .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_pwrmgr_aon (
 
       // Interrupt
@@ -2721,8 +2724,8 @@ module top_earlgrey #(
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),
     .RndCnstIbexNonceDefault(RndCnstRvCoreIbexIbexNonceDefault),
-    .NEscalationSeverities(RvCoreIbexNEscalationSeverities),
-    .WidthPingCounter(RvCoreIbexWidthPingCounter),
+    .NEscalationSeverities(AlertHandlerEscNumSeverities),
+    .WidthPingCounter(AlertHandlerEscPingCountWidth),
     .PMPEnable(RvCoreIbexPMPEnable),
     .PMPGranularity(RvCoreIbexPMPGranularity),
     .PMPNumRegions(RvCoreIbexPMPNumRegions),

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4321,8 +4321,8 @@
           desc: Number of escalation severities
           type: int unsigned
           default: "4"
-          local: "true"
-          expose: "true"
+          local: "false"
+          expose: "false"
           name_top: RvCoreIbexNEscalationSeverities
         }
         {
@@ -4330,8 +4330,8 @@
           desc: Width of the ping counter
           type: int unsigned
           default: "16"
-          local: "true"
-          expose: "true"
+          local: "false"
+          expose: "false"
           name_top: RvCoreIbexWidthPingCounter
         }
         {

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -244,16 +244,14 @@
       type:    "int unsigned"
       default: "4"
       desc:    "Number of escalation severities"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "WidthPingCounter"
       type:    "int unsigned"
       default: "16"
       desc:    "Width of the ping counter"
-      local:   "true"
-      expose:  "true"
+      local:   "false"
     },
 
     { name:    "PMPEnable"

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -166,9 +166,6 @@ module top_englishbreakfast #(
   localparam int SpiHost0NumCS = 1;
   // local parameters for sram_ctrl_main
   localparam int SramCtrlMainOutstanding = 2;
-  // local parameters for rv_core_ibex
-  localparam int unsigned RvCoreIbexNEscalationSeverities = 4;
-  localparam int unsigned RvCoreIbexWidthPingCounter = 16;
 
   // Signals
   logic [37:0] mio_p2d;
@@ -1256,8 +1253,8 @@ module top_englishbreakfast #(
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),
     .RndCnstIbexNonceDefault(RndCnstRvCoreIbexIbexNonceDefault),
-    .NEscalationSeverities(RvCoreIbexNEscalationSeverities),
-    .WidthPingCounter(RvCoreIbexWidthPingCounter),
+    .NEscalationSeverities(4),
+    .WidthPingCounter(16),
     .PMPEnable(RvCoreIbexPMPEnable),
     .PMPGranularity(RvCoreIbexPMPGranularity),
     .PMPNumRegions(RvCoreIbexPMPNumRegions),

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -324,6 +324,9 @@ def _get_alert_handler_params(top: ConfigT) -> ParamsT:
     module = lib.find_module(top["module"], "alert_handler")
     uniquified_modules.add_module(module["template_type"], module["type"])
 
+    n_esc_sev = module["param_decl"]["EscNumSeverities"]
+    ping_cnt_dw = module["param_decl"]["EscPingCountWidth"]
+
     return {
         "module_instance_name": module["type"],
         "n_alerts": n_alerts,
@@ -331,6 +334,8 @@ def _get_alert_handler_params(top: ConfigT) -> ParamsT:
         "accu_cnt_dw": accu_cnt_dw,
         "async_on": async_on,
         "n_classes": n_classes,
+        "n_esc_sev": n_esc_sev,
+        "ping_cnt_dw": ping_cnt_dw,
         "n_lpg": n_lpgs,
         "lpg_map": lpg_map,
         "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",


### PR DESCRIPTION
All ips that instantiate prim_esc_receiver need to get a couple parameters from alert_handler. Pass them to these ips via regular parameter overrides.

Reggen only allows local params to determine CSR sizes. This means we need to create both a regular and a local parameter in alert_handler set to the same value.