### PR TITLE
[rom_ext] Order the ePMP as expected by customers

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -87,3 +87,45 @@ test_suite(
     name = "faults",
     tests = ["fault_{}".format(name) for name in _FAULT_TEST_CASES],
 )
+
+opentitan_test(
+    name = "epmp_test",
+    srcs = ["epmp_print.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        # Note: the application stage may have a dependency on the ePMP
+        # configuration.  If you are making changes to the ePMP layout,
+        # you need to check that your changes won't negatively affect
+        # the handoff to the application.
+        exit_success = "\r\n".join([
+            "0: 00000000 ----- ---- sz=00000000",
+            "1: 00000000 ----- ---- sz=00000000",
+            "2: a....... ----- ---- sz=00000000",  # Application code start.
+            "3: a.......   TOR -X-R sz=........",  # Application code end.
+            "4: a0000000 NAPOT ---R sz=00080000",  # Application rodata region.
+            "5: 00000000 ----- ---- sz=00000000",
+            "6: 00000000 ----- ---- sz=00000000",
+            "7: 00000000 ----- ---- sz=00000000",
+            "8: 2....... ----- ---- sz=00000000",  # ROM_EXT code start.
+            "9: 2.......   TOR -X-R sz=........",  # ROM_EXT code end.
+            "10: 00000000 ----- ---- sz=00000000",
+            "11: 1001c000   NA4 ---- sz=00000004",  # Stack guard.
+            "12: 20000000 NAPOT ---R sz=00100000",  # Entire flash region.
+            "13: 00010000 NAPOT -XWR sz=00001000",  # RvDM regionn
+            "14: 40000000 NAPOT --WR sz=10000000",  # MMIO for peripherals.
+            "15: 10000000 NAPOT --WR sz=00020000",  # All of RAM.
+            "mseccfg = 00000002",
+            ".*",
+            ".*PASS!",
+            "",
+        ]),
+    ),
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:dbg_print",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/epmp_print.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/epmp_print.c
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  dbg_print_epmp();
+  return true;
+}

--- a/sw/device/silicon_creator/rom_ext/imm_section/imm_section_epmp.c
+++ b/sw/device/silicon_creator/rom_ext/imm_section/imm_section_epmp.c
@@ -55,18 +55,17 @@ rom_error_t imm_section_epmp_reconfigure(void) {
   // This stack guard was in ePMP region 14.
   epmp_set_napot(11, kStackGuard, kEpmpPermLockedNoAccess);
 
-  // ePMP region 12 allows RvDM access.
-  // This RvDM region was in ePMP region 13.
+  // ePMP region 12 gives read access to all of flash for both M and U modes.
+  // This flash region was in ePMP region 5.
+  epmp_set_napot(12, kFlashRegion, kEpmpPermLockedReadOnly);
+
+  // ePMP region 13 allows RvDM access.
   if (lifecycle_is_prod() == kHardenedBoolTrue) {
     // No RvDM access in Prod states, so we can clear the entry.
-    epmp_clear(12);
+    epmp_clear(13);
   } else {
-    epmp_set_napot(12, kRvDmRegion, kEpmpPermLockedReadWriteExecute);
+    epmp_set_napot(13, kRvDmRegion, kEpmpPermLockedReadWriteExecute);
   }
-
-  // ePMP region 13 gives read access to all of flash for both M and U modes.
-  // This flash region was in ePMP region 5.
-  epmp_set_napot(13, kFlashRegion, kEpmpPermLockedReadOnly);
 
   // Move the ROM_EXT virtual region from entry 6 to 10.
   uint32_t virtual_napot;


### PR DESCRIPTION
Traditionally, we placed the RvDm region in ePMP entry 13 and the memory-mapped flash in region 12.

This was reversed because it would allow for one more ToR region when RvDM is not in use, however downstream customers applications may depend on a specific ePMP configuration when their firmware starts.

The customer is free to re-arrange ePMP as they wish, so a configuration with an extra ToR entry is still possible as long as the customer programs the proper ePMP arragement.