### PR TITLE
[acrc,dv] Possibility to stress tl_unfilt itfc

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
@@ -35,7 +35,7 @@ class ac_range_check_base_vseq extends cip_base_vseq #(
   extern task cfg_range_limit();
   extern task cfg_range_perm();
   extern task cfg_range_racl_policy();
-  extern task send_single_tl_unfilt_tr();
+  extern task send_single_tl_unfilt_tr(bit zero_delays = 0);
   extern task tl_filt_device_auto_resp(int min_rsp_delay = 0, int max_rsp_delay = 80,
     int rsp_abort_pct = 25, int d_error_pct = 0, int d_chan_intg_err_pct = 0);
 endclass : ac_range_check_base_vseq
@@ -110,9 +110,13 @@ task ac_range_check_base_vseq::cfg_range_racl_policy();
   end
 endtask : cfg_range_racl_policy
 
-task ac_range_check_base_vseq::send_single_tl_unfilt_tr();
+task ac_range_check_base_vseq::send_single_tl_unfilt_tr(bit zero_delays = 0);
   cip_tl_host_single_seq tl_unfilt_host_seq;
   `uvm_create_on(tl_unfilt_host_seq, p_sequencer.tl_unfilt_sqr)
+  if (zero_delays) begin
+    tl_unfilt_host_seq.min_req_delay = 0;
+    tl_unfilt_host_seq.max_req_delay = 0;
+  end
   `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_unfilt_host_seq,
                                  instr_type == mubi4_bool_to_mubi(tl_main_vars.instr_type);
                                  write      == tl_main_vars.write;

--- a/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
@@ -5,6 +5,9 @@
 class ac_range_check_smoke_vseq extends ac_range_check_base_vseq;
   `uvm_object_utils(ac_range_check_smoke_vseq)
 
+  // Local variables
+  rand bit zero_delays;
+
   // Constraints
   extern constraint num_trans_c;
   extern constraint tmp_c;
@@ -75,9 +78,20 @@ task ac_range_check_smoke_vseq::body();
   for (int i=1; i<=num_trans; i++) begin
     `uvm_info(`gfn, $sformatf("Starting seq %0d/%0d", i, num_trans), UVM_LOW)
 
-    `DV_CHECK_RANDOMIZE_FATAL(this)
-    ac_range_check_init();
-    send_single_tl_unfilt_tr();
+    // Randomly keep the same configuration to allow transactions back to back transactions, as no
+    // configuration change will happen in between
+    randcase
+      // 25% of the time, change the config
+      1: begin
+        `DV_CHECK_RANDOMIZE_FATAL(this)
+        ac_range_check_init();
+      end
+      // 75% of the time, keep the same config
+      3: begin
+        `uvm_info(`gfn, $sformatf("Keep the same configuration for seq #%0d", i), UVM_MEDIUM)
+      end
+    endcase
+    send_single_tl_unfilt_tr(zero_delays);  // Send a single TLUL seq with random zero delays
     $display("\n");
   end
 endtask : body

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_base_vseq.sv
@@ -35,7 +35,7 @@ class ac_range_check_base_vseq extends cip_base_vseq #(
   extern task cfg_range_limit();
   extern task cfg_range_perm();
   extern task cfg_range_racl_policy();
-  extern task send_single_tl_unfilt_tr();
+  extern task send_single_tl_unfilt_tr(bit zero_delays = 0);
   extern task tl_filt_device_auto_resp(int min_rsp_delay = 0, int max_rsp_delay = 80,
     int rsp_abort_pct = 25, int d_error_pct = 0, int d_chan_intg_err_pct = 0);
 endclass : ac_range_check_base_vseq
@@ -110,9 +110,13 @@ task ac_range_check_base_vseq::cfg_range_racl_policy();
   end
 endtask : cfg_range_racl_policy
 
-task ac_range_check_base_vseq::send_single_tl_unfilt_tr();
+task ac_range_check_base_vseq::send_single_tl_unfilt_tr(bit zero_delays = 0);
   cip_tl_host_single_seq tl_unfilt_host_seq;
   `uvm_create_on(tl_unfilt_host_seq, p_sequencer.tl_unfilt_sqr)
+  if (zero_delays) begin
+    tl_unfilt_host_seq.min_req_delay = 0;
+    tl_unfilt_host_seq.max_req_delay = 0;
+  end
   `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_unfilt_host_seq,
                                  instr_type == mubi4_bool_to_mubi(tl_main_vars.instr_type);
                                  write      == tl_main_vars.write;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/seq_lib/ac_range_check_smoke_vseq.sv
@@ -5,6 +5,9 @@
 class ac_range_check_smoke_vseq extends ac_range_check_base_vseq;
   `uvm_object_utils(ac_range_check_smoke_vseq)
 
+  // Local variables
+  rand bit zero_delays;
+
   // Constraints
   extern constraint num_trans_c;
   extern constraint tmp_c;
@@ -75,9 +78,20 @@ task ac_range_check_smoke_vseq::body();
   for (int i=1; i<=num_trans; i++) begin
     `uvm_info(`gfn, $sformatf("Starting seq %0d/%0d", i, num_trans), UVM_LOW)
 
-    `DV_CHECK_RANDOMIZE_FATAL(this)
-    ac_range_check_init();
-    send_single_tl_unfilt_tr();
+    // Randomly keep the same configuration to allow transactions back to back transactions, as no
+    // configuration change will happen in between
+    randcase
+      // 25% of the time, change the config
+      1: begin
+        `DV_CHECK_RANDOMIZE_FATAL(this)
+        ac_range_check_init();
+      end
+      // 75% of the time, keep the same config
+      3: begin
+        `uvm_info(`gfn, $sformatf("Keep the same configuration for seq #%0d", i), UVM_MEDIUM)
+      end
+    endcase
+    send_single_tl_unfilt_tr(zero_delays);  // Send a single TLUL seq with random zero delays
     $display("\n");
   end
 endtask : body


### PR DESCRIPTION
- Randomize whether the DUT config should between two transactions. When the config remain the same, this will allow to have back to back TLUL transaction on the unfiltered interface.
- Add possibility to have zero delays on a_valid signal