### PR TITLE
[opentitanlib] Respect TPM burstCount

### DIFF
--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -93,28 +93,25 @@ pub trait Driver {
         self.write_register(Register::STS, &TpmStatus::CMD_READY.to_le_bytes())?;
 
         log::debug!("RUN({}) {:02X?}", cmd.len(), cmd);
-        self.poll_for_ready()?;
-        for slice in cmd.chunks(MAX_TRANSACTION_SIZE) {
+        let burst_count = self.poll_for_ready()?.burst_count();
+        for slice in cmd.chunks(burst_count) {
             self.write_register(Register::DATA_FIFO, slice)?;
         }
         self.write_register(Register::STS, &TpmStatus::TPM_GO.to_le_bytes())?;
 
-        let sz = self
-            .poll_for_data_available()?
-            .burst_count()
-            .clamp(RESPONSE_HEADER_SIZE, MAX_TRANSACTION_SIZE);
-        let mut result: Vec<u8> = vec![0; sz];
+        let burst_count = self.poll_for_data_available()?.burst_count();
+        let mut result: Vec<u8> = vec![0; burst_count];
         self.read_register(Register::DATA_FIFO, result.as_mut_slice())?;
         let resp_size: usize = u32::from_be_bytes(result[2..6].try_into().unwrap()) as usize;
         ensure!(
             resp_size < MAX_RESPONSE_SIZE,
             TpmError::UnexpectedResponseSize(resp_size)
         );
-        let mut remaining = resp_size - sz;
+        let mut remaining = resp_size - result.len();
 
         let mut sts = self.read_status()?;
         while sts.is_valid() && sts.data_available() && remaining > 0 {
-            let to_read: usize = remaining.min(MAX_TRANSACTION_SIZE);
+            let to_read: usize = remaining.min(burst_count);
             let mut result2: Vec<u8> = vec![0; to_read];
             self.read_register(Register::DATA_FIFO, result2.as_mut_slice())?;
             result.append(&mut result2);
@@ -273,8 +270,6 @@ const SPI_TPM_WRITE: u32 = 0x40000000;
 const SPI_TPM_DATA_LEN_POS: u8 = 24;
 const SPI_TPM_ADDRESS_OFFSET: u32 = 0x00D40000;
 
-const MAX_TRANSACTION_SIZE: usize = 64;
-const RESPONSE_HEADER_SIZE: usize = 6;
 const MAX_RESPONSE_SIZE: usize = 4096;
 const TIMEOUT: Duration = Duration::from_millis(500);
 


### PR DESCRIPTION
When transmitting large TPM commands, the AP is supposed to inspect the "burstCount" field of the TPM STS register, in order to determine how many bytes the TPM can accept in a single SPI/I2C transfer.

Our code was first hard-coded to 32 bytes, later changed to 64 bytes.  Neither suited every legacy TPM implementation at Google.

In order to be able to handle various TPM implementation, this patch makes the code use whatever is advertised in burstCount.  (It does not re-inspect the STS register between each block of bytes, assuming instead that the TPM has a fixed-size buffer.)
