### PR TITLE
[dv] Exclude currently failing tests from Darjeeling smoke set

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -222,6 +222,9 @@
     //   build_opts: ["-cm_constfile {top_dv_path}/cov/constfile.txt"]
     //   is_sim_mode: 1
     // }
+    {
+      name: cover_reg_top
+    }
   ]
 
   // Add options needed to compile against otbn_memutil, otbn_tracer,

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -48,7 +48,9 @@
                 // Enable C compilation of AES model for DPI-C
                 "{proj_root}/hw/ip/aes/model/aes_model_sim_opts.hjson",
 
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+                // TODO(#26733): fix these smoke tests for Darjeeling.
+                //"{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+
                 // TODO #5484, comment these 2 lines out because spi host memory is dummy
                 // "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 // xbar tests
@@ -1718,17 +1720,20 @@
     }
     {
       name: smoke
-      tests: ["xbar_smoke",
-              "chip_sw_uart_tx_rx",
-              "chip_sw_spi_host_tx_rx",
-              "chip_sw_spi_device_pass_through",
-              "chip_sw_i2c_host_tx_rx",
-              "chip_sw_i2c_device_tx_rx",
-              "chip_plic_all_irqs",
-              "chip_sw_example_rom",
-              "chip_sw_example_manufacturer",
-              "chip_sw_example_concurrency"]
-              // TODO: add this test after enabling HW verification: "rom_e2e_smoke"]
+      tests: ["chip_sw_spi_device_pass_through",
+              "chip_sw_example_concurrency",
+              // TODO(#26733): fix these tests for Darjeeling or select more appropriate ones.
+              //"xbar_smoke",
+              //"chip_sw_uart_tx_rx",
+              //"chip_sw_spi_host_tx_rx",
+              //"chip_sw_i2c_host_tx_rx",
+              //"chip_sw_i2c_device_tx_rx",
+              //"chip_plic_all_irqs",
+              //"chip_sw_example_rom",
+              //"chip_sw_example_manufacturer",
+              // TODO: add this test after enabling HW verification:
+              //"rom_e2e_smoke",
+             ]
     }
     {
       name: jitter
@@ -1753,21 +1758,22 @@
     }
     {
       name: xcelium_ci_0
-      tests: ["chip_plic_all_irqs",
-              "chip_rv_dm_lc_disabled",
-              "chip_sw_kmac_app_rom",
+      tests: ["chip_rv_dm_lc_disabled",
               "chip_sw_rstmgr_sw_rst",
               "chip_sw_hmac_enc",
               "chip_sw_clkmgr_jitter",
               "chip_sw_rom_ctrl_integrity_check",
-              "chip_sw_aes_entropy",
               "chip_sw_kmac_idle",
-              "chip_sw_kmac_mode_cshake",
-              "chip_sw_kmac_mode_kmac",
-              "chip_sw_kmac_mode_kmac_jitter_en",
               "chip_sw_lc_ctrl_rand_to_scrap"
               "chip_sw_sleep_pin_mio_dio_val",
-              "chip_sw_power_virus",
+              // TODO(#26733): uncomment when these run for Darjeeling.
+              // "chip_plic_all_irqs",
+              // "chip_sw_kmac_app_rom",
+              // "chip_sw_aes_entropy",
+              // "chip_sw_kmac_mode_cshake",
+              // "chip_sw_kmac_mode_kmac",
+              // "chip_sw_kmac_mode_kmac_jitter_en",
+              // "chip_sw_power_virus",
               // TODO: uncomment when these run with Xcelium.
               // "chip_sw_lc_walkthrough_dev",
               // "chip_sw_lc_walkthrough_prod",
@@ -1783,22 +1789,22 @@
               "chip_sw_spi_device_pass_through",
               "chip_sw_plic_sw_irq",
               "chip_sw_aes_enc",
-              "chip_sw_aes_enc_jitter_en",
-              "chip_sw_sram_ctrl_scrambled_access",
-              "chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_all_escalation_resets",
-              "chip_rv_dm_ndm_reset_req",
               "chip_sw_csrng_kat_test",
-              "chip_sw_sensor_ctrl_status",
-              "chip_sw_rstmgr_sw_req",
+              // TODO(#26733): uncomment when these run for Darjeeling.
+              // "chip_sw_aes_enc_jitter_en",
+              // "chip_sw_sram_ctrl_scrambled_access",
+              // "chip_rv_dm_ndm_reset_req",
+              // "chip_sw_sensor_ctrl_status",
+              // "chip_sw_rstmgr_sw_req",
+              // "chip_sw_pwrmgr_sleep_disabled",
+              // "base_rom_e2e_smoke",
               "chip_sw_aes_idle",
               // TODO: uncomment when these run with Xcelium.
               // "chip_sw_pwrmgr_main_power_glitch_reset",
               // "chip_sw_pwrmgr_deep_sleep_power_glitch_reset",
               // "chip_sw_pwrmgr_sleep_power_glitch_reset",
-              "chip_sw_pwrmgr_sleep_disabled",
               "chip_sw_csrng_kat_test",
-              "base_rom_e2e_smoke",
               // TODO(opentitan-integrated/#332): enable this test again once ROM has been
               // refactored to work without embedded flash.
               // "rom_e2e_smoke"

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -31,8 +31,6 @@
              "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
-             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
-             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
              "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
              "{proj_root}/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
@@ -42,28 +40,31 @@
              "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
              "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
              "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson",
-             "{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
-            //  "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
+             // "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
              "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
              // Top level IPs.
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson",
-            //  // Top level.
-             "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson"
-             ]
+             // Top level.
+             "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson",
+             // TODO(#26733): the smoketests here must be fixed before enabling.
+             //"{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
+             //"{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
+             //"{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
+             //"{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
+             //"{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
+             //"{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
+            ]
 }

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -227,6 +227,9 @@
     //   build_opts: ["-cm_constfile {top_dv_path}/cov/constfile.txt"]
     //   is_sim_mode: 1
     // }
+    {
+      name: cover_reg_top
+    }
   ]
 
   // Add options needed to compile against otbn_memutil, otbn_tracer,


### PR DESCRIPTION
See #26733 which tracks either fixing or selecting another set of smoke tests for Darjeeling.

This will allow us to enable Darjeeling DV CI for pull requests, though it will only run the three tests shown here for now.