### PR TITLE
[racl_ctrl] Add interrupt to racl_ctrl

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -19705,6 +19705,16 @@
       incoming: false
     }
     {
+      name: racl_ctrl_racl_error
+      width: 1
+      type: interrupt
+      module_name: racl_ctrl
+      desc: racl_ctrl racl_error interrupt
+      intr_type: IntrType.Status
+      default_val: false
+      incoming: false
+    }
+    {
       name: ac_range_check_deny_cnt_reached
       width: 1
       type: interrupt
@@ -19793,6 +19803,7 @@
     mbx_jtag
     mbx_pcie0
     mbx_pcie1
+    racl_ctrl
     ac_range_check
   ]
   outgoing_alert_module: {}

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -32,9 +32,17 @@
   bus_interfaces: [
     { protocol: "tlul", direction: "device", static_racl_support: true }
   ],
-  // In order to not disturb the racl_ctrl address map, we place the alert test
-  // register manually at a safe offset after the main CSRs.
+  // In order to not disturb the racl_ctrl address map, we place the alert test and interrupt
+  // registers manually at a safe offset after the main CSRs.
+  // TODO(#26748) Add tooling support to avoid manual placement of alert/interrupt registers
+  no_auto_intr_regs: "True",
   no_auto_alert_regs: "True",
+  interrupt_list: [
+    { name: "racl_error",
+      desc: "RACL error has occurred.",
+      type: "status"
+    }
+  ]
   alert_list: [
     { name: "fatal_fault"
       desc: "This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected."
@@ -184,7 +192,47 @@
       ]
     }
     { reserved: "1" }
-    { skipto: "0xF4" }
+    { skipto: "0xE8" }
+    { name: "INTR_STATE",
+      desc: "Interrupt State Register",
+      swaccess: "ro",
+      hwaccess: "hrw",
+      fields: [
+        { bits: "0",
+          name: "racl_error",
+          desc: '''
+                Interrupt status. The interrupt is raised when a RACL error occurs and cleared
+                when error_log is cleared by writing 1 to error_log.valid."
+                '''
+        }
+      ]
+      tags: [// interrupt could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
+    },
+    { name: "INTR_ENABLE",
+        desc: "Interrupt Enable Register",
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
+          { bits: "0",
+            name: "IE",
+            desc: "Interrupt Enable"
+          }
+        ]
+    },
+    { name: "INTR_TEST",
+      desc: "Interrupt Test Register",
+      swaccess: "wo",
+      hwaccess: "hro",
+      hwext: "true",
+      hwqe: "true",
+      fields: [
+        { bits: "0",
+          name: "racl_error",
+          desc: "Write 1 to force racl_error interrupt",
+        }
+      ]
+    },
     { name: "ALERT_TEST",
       desc: '''Alert Test Register.''',
       swaccess: "wo",

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/interfaces.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/interfaces.md
@@ -7,7 +7,6 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 - Bus Device Interfaces (TL-UL): **`tl`**
 - Bus Host Interfaces (TL-UL): *none*
 - Peripheral Pins for Chip IO: *none*
-- Interrupts: *none*
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
@@ -17,6 +16,12 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | racl_error          | top_racl_pkg::racl_error_log  | uni     | rcv   | NumSubscribingIps         | Error log information from all IPs. Only one IP can raise an error at a time.          |
 | racl_error_external | top_racl_pkg::racl_error_log  | uni     | rcv   | NumExternalSubscribingIps | Error log information from all external IPs. Only one IP can raise an error at a time. |
 | tl                  | tlul_pkg::tl                  | req_rsp | rsp   | 1                         |                                                                                        |
+
+## Interrupts
+
+| Interrupt Name   | Type   | Description              |
+|:-----------------|:-------|:-------------------------|
+| racl_error       | Status | RACL error has occurred. |
 
 ## Security Alerts
 

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/registers.md
@@ -8,6 +8,9 @@
 | racl_ctrl.[`POLICY_ALL_RD_WR_SHADOWED`](#policy_all_rd_wr_shadowed)     | 0x0      |        4 | Read and write policy for ALL_RD_WR                      |
 | racl_ctrl.[`POLICY_ROT_PRIVATE_SHADOWED`](#policy_rot_private_shadowed) | 0x8      |        4 | Read and write policy for ROT_PRIVATE                    |
 | racl_ctrl.[`POLICY_SOC_ROT_SHADOWED`](#policy_soc_rot_shadowed)         | 0x10     |        4 | Read and write policy for SOC_ROT                        |
+| racl_ctrl.[`INTR_STATE`](#intr_state)                                   | 0xe8     |        4 | Interrupt State Register                                 |
+| racl_ctrl.[`INTR_ENABLE`](#intr_enable)                                 | 0xec     |        4 | Interrupt Enable Register                                |
+| racl_ctrl.[`INTR_TEST`](#intr_test)                                     | 0xf0     |        4 | Interrupt Test Register                                  |
 | racl_ctrl.[`ALERT_TEST`](#alert_test)                                   | 0xf4     |        4 | Alert Test Register.                                     |
 | racl_ctrl.[`ERROR_LOG`](#error_log)                                     | 0xf8     |        4 | Error logging registers                                  |
 | racl_ctrl.[`ERROR_LOG_ADDRESS`](#error_log_address)                     | 0xfc     |        4 | Contains the address on which a RACL violation occurred. |
@@ -62,6 +65,57 @@ Read and write policy for SOC_ROT
 |:------:|:------:|:-------:|:-----------|:------------------------------------|
 | 31:16  |   rw   |   0x5   | write_perm | Write permission for policy SOC_ROT |
 |  15:0  |   rw   |   0x5   | read_perm  | Read permission for policy SOC_ROT  |
+
+## INTR_STATE
+Interrupt State Register
+- Offset: `0xe8`
+- Reset default: `0x0`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "racl_error", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+```
+
+|  Bits  |  Type  |  Reset  | Name       | Description                                                                                                                                |
+|:------:|:------:|:-------:|:-----------|:-------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:1  |        |         |            | Reserved                                                                                                                                   |
+|   0    |   ro   |   0x0   | racl_error | Interrupt status. The interrupt is raised when a RACL error occurs and cleared when error_log is cleared by writing 1 to error_log.valid." |
+
+## INTR_ENABLE
+Interrupt Enable Register
+- Offset: `0xec`
+- Reset default: `0x0`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "IE", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description      |
+|:------:|:------:|:-------:|:-------|:-----------------|
+|  31:1  |        |         |        | Reserved         |
+|   0    |   rw   |   0x0   | IE     | Interrupt Enable |
+
+## INTR_TEST
+Interrupt Test Register
+- Offset: `0xf0`
+- Reset default: `0x0`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "racl_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+```
+
+|  Bits  |  Type  |  Reset  | Name       | Description                           |
+|:------:|:------:|:-------:|:-----------|:--------------------------------------|
+|  31:1  |        |         |            | Reserved                              |
+|   0    |   wo   |    x    | racl_error | Write 1 to force racl_error interrupt |
 
 ## ALERT_TEST
 Alert Test Register.

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -17,6 +17,8 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   // Alerts
   input  prim_alert_pkg::alert_rx_t [NumAlerts-1:0]                    alert_rx_i,
   output prim_alert_pkg::alert_tx_t [NumAlerts-1:0]                    alert_tx_o,
+  // Interrupt
+  output logic                                                         intr_racl_error_o,
   // Output policy vector for distribution
   output top_racl_pkg::racl_policy_vec_t                               racl_policies_o,
   // RACL violation information.
@@ -181,11 +183,32 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   assign hw2reg.error_log_address.de = first_error | clear_log;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Interrupt handling
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+
+  prim_intr_hw #(
+    .Width ( 1        ),
+    .IntrT ( "Status" )
+  ) u_intr_racl_error (
+    .clk_i                  ( clk_i                    ),
+    .rst_ni                 ( rst_ni                   ),
+    .event_intr_i           ( reg2hw.error_log.valid.q ),
+    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.q     ),
+    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.q       ),
+    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.qe      ),
+    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.q      ),
+    .hw2reg_intr_state_de_o ( hw2reg.intr_state.de     ),
+    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.d      ),
+    .intr_o                 ( intr_racl_error_o        )
+  );
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
   // Assertions
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   // All outputs should be known value after reset
   `ASSERT_KNOWN(AlertsKnown_A, alert_tx_o)
+  `ASSERT_KNOWN(RaclErrorIrqKnown_A, intr_racl_error_o)
 
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready)

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -13,7 +13,7 @@ package racl_ctrl_reg_pkg;
   parameter int BlockAw = 8;
 
   // Number of registers for every interface
-  parameter int NumRegs = 6;
+  parameter int NumRegs = 9;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -47,6 +47,19 @@ package racl_ctrl_reg_pkg;
   } racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t;
 
   typedef struct packed {
+    logic        q;
+  } racl_ctrl_reg2hw_intr_state_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } racl_ctrl_reg2hw_intr_enable_reg_t;
+
+  typedef struct packed {
+    logic        q;
+    logic        qe;
+  } racl_ctrl_reg2hw_intr_test_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
@@ -63,6 +76,11 @@ package racl_ctrl_reg_pkg;
       logic        qe;
     } valid;
   } racl_ctrl_reg2hw_error_log_reg_t;
+
+  typedef struct packed {
+    logic        d;
+    logic        de;
+  } racl_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -94,15 +112,19 @@ package racl_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    racl_ctrl_reg2hw_policy_all_rd_wr_shadowed_reg_t policy_all_rd_wr_shadowed; // [101:70]
-    racl_ctrl_reg2hw_policy_rot_private_shadowed_reg_t policy_rot_private_shadowed; // [69:38]
-    racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t policy_soc_rot_shadowed; // [37:6]
+    racl_ctrl_reg2hw_policy_all_rd_wr_shadowed_reg_t policy_all_rd_wr_shadowed; // [105:74]
+    racl_ctrl_reg2hw_policy_rot_private_shadowed_reg_t policy_rot_private_shadowed; // [73:42]
+    racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t policy_soc_rot_shadowed; // [41:10]
+    racl_ctrl_reg2hw_intr_state_reg_t intr_state; // [9:9]
+    racl_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [8:8]
+    racl_ctrl_reg2hw_intr_test_reg_t intr_test; // [7:6]
     racl_ctrl_reg2hw_alert_test_reg_t alert_test; // [5:2]
     racl_ctrl_reg2hw_error_log_reg_t error_log; // [1:0]
   } racl_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
+    racl_ctrl_hw2reg_intr_state_reg_t intr_state; // [51:50]
     racl_ctrl_hw2reg_error_log_reg_t error_log; // [49:33]
     racl_ctrl_hw2reg_error_log_address_reg_t error_log_address; // [32:0]
   } racl_ctrl_hw2reg_t;
@@ -111,11 +133,15 @@ package racl_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] RACL_CTRL_POLICY_ALL_RD_WR_SHADOWED_OFFSET = 8'h 0;
   parameter logic [BlockAw-1:0] RACL_CTRL_POLICY_ROT_PRIVATE_SHADOWED_OFFSET = 8'h 8;
   parameter logic [BlockAw-1:0] RACL_CTRL_POLICY_SOC_ROT_SHADOWED_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] RACL_CTRL_INTR_STATE_OFFSET = 8'h e8;
+  parameter logic [BlockAw-1:0] RACL_CTRL_INTR_ENABLE_OFFSET = 8'h ec;
+  parameter logic [BlockAw-1:0] RACL_CTRL_INTR_TEST_OFFSET = 8'h f0;
   parameter logic [BlockAw-1:0] RACL_CTRL_ALERT_TEST_OFFSET = 8'h f4;
   parameter logic [BlockAw-1:0] RACL_CTRL_ERROR_LOG_OFFSET = 8'h f8;
   parameter logic [BlockAw-1:0] RACL_CTRL_ERROR_LOG_ADDRESS_OFFSET = 8'h fc;
 
   // Reset values for hwext registers and their fields
+  parameter logic [0:0] RACL_CTRL_INTR_TEST_RESVAL = 1'h 0;
   parameter logic [1:0] RACL_CTRL_ALERT_TEST_RESVAL = 2'h 0;
 
   // Register index
@@ -123,19 +149,25 @@ package racl_ctrl_reg_pkg;
     RACL_CTRL_POLICY_ALL_RD_WR_SHADOWED,
     RACL_CTRL_POLICY_ROT_PRIVATE_SHADOWED,
     RACL_CTRL_POLICY_SOC_ROT_SHADOWED,
+    RACL_CTRL_INTR_STATE,
+    RACL_CTRL_INTR_ENABLE,
+    RACL_CTRL_INTR_TEST,
     RACL_CTRL_ALERT_TEST,
     RACL_CTRL_ERROR_LOG,
     RACL_CTRL_ERROR_LOG_ADDRESS
   } racl_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RACL_CTRL_PERMIT [6] = '{
+  parameter logic [3:0] RACL_CTRL_PERMIT [9] = '{
     4'b 1111, // index[0] RACL_CTRL_POLICY_ALL_RD_WR_SHADOWED
     4'b 1111, // index[1] RACL_CTRL_POLICY_ROT_PRIVATE_SHADOWED
     4'b 1111, // index[2] RACL_CTRL_POLICY_SOC_ROT_SHADOWED
-    4'b 0001, // index[3] RACL_CTRL_ALERT_TEST
-    4'b 0011, // index[4] RACL_CTRL_ERROR_LOG
-    4'b 1111  // index[5] RACL_CTRL_ERROR_LOG_ADDRESS
+    4'b 0001, // index[3] RACL_CTRL_INTR_STATE
+    4'b 0001, // index[4] RACL_CTRL_INTR_ENABLE
+    4'b 0001, // index[5] RACL_CTRL_INTR_TEST
+    4'b 0001, // index[6] RACL_CTRL_ALERT_TEST
+    4'b 0011, // index[7] RACL_CTRL_ERROR_LOG
+    4'b 1111  // index[8] RACL_CTRL_ERROR_LOG_ADDRESS
   };
 
 endpackage

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -44,7 +44,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "159",
+      default: "160",
       local: "true"
     },
     { name: "NumTarget",

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -6,7 +6,7 @@
   param_values:
   {
     module_instance_name: rv_plic
-    src: 159
+    src: 160
     target: 1
     prio: 3
     topname: darjeeling

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -257,11 +257,12 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[156] = reg2hw.prio[156].q;
   assign prio[157] = reg2hw.prio[157].q;
   assign prio[158] = reg2hw.prio[158].q;
+  assign prio[159] = reg2hw.prio[159].q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 159; s++) begin : gen_ie0
+  for (genvar s = 0; s < 160; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -287,7 +288,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 159; s++) begin : gen_ip
+  for (genvar s = 0; s < 160; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 159;
+  parameter int NumSrc = 160;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
   parameter int NumAlerts = 1;
@@ -16,7 +16,7 @@ package rv_plic_reg_pkg;
   parameter int BlockAw = 27;
 
   // Number of registers for every interface
-  parameter int NumRegs = 173;
+  parameter int NumRegs = 174;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -60,8 +60,8 @@ package rv_plic_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    rv_plic_reg2hw_prio_mreg_t [158:0] prio; // [491:174]
-    rv_plic_reg2hw_ie0_mreg_t [158:0] ie0; // [173:15]
+    rv_plic_reg2hw_prio_mreg_t [159:0] prio; // [494:175]
+    rv_plic_reg2hw_ie0_mreg_t [159:0] ie0; // [174:15]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [14:13]
     rv_plic_reg2hw_cc0_reg_t cc0; // [12:3]
     rv_plic_reg2hw_msip0_reg_t msip0; // [2:2]
@@ -70,7 +70,7 @@ package rv_plic_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [158:0] ip; // [325:8]
+    rv_plic_hw2reg_ip_mreg_t [159:0] ip; // [327:8]
     rv_plic_hw2reg_cc0_reg_t cc0; // [7:0]
   } rv_plic_hw2reg_t;
 
@@ -234,6 +234,7 @@ package rv_plic_reg_pkg;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO_156_OFFSET = 27'h 270;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO_157_OFFSET = 27'h 274;
   parameter logic [BlockAw-1:0] RV_PLIC_PRIO_158_OFFSET = 27'h 278;
+  parameter logic [BlockAw-1:0] RV_PLIC_PRIO_159_OFFSET = 27'h 27c;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_0_OFFSET = 27'h 1000;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_1_OFFSET = 27'h 1004;
   parameter logic [BlockAw-1:0] RV_PLIC_IP_2_OFFSET = 27'h 1008;
@@ -414,6 +415,7 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO_156,
     RV_PLIC_PRIO_157,
     RV_PLIC_PRIO_158,
+    RV_PLIC_PRIO_159,
     RV_PLIC_IP_0,
     RV_PLIC_IP_1,
     RV_PLIC_IP_2,
@@ -431,7 +433,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [173] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [174] = '{
     4'b 0001, // index[  0] RV_PLIC_PRIO_0
     4'b 0001, // index[  1] RV_PLIC_PRIO_1
     4'b 0001, // index[  2] RV_PLIC_PRIO_2
@@ -591,20 +593,21 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[156] RV_PLIC_PRIO_156
     4'b 0001, // index[157] RV_PLIC_PRIO_157
     4'b 0001, // index[158] RV_PLIC_PRIO_158
-    4'b 1111, // index[159] RV_PLIC_IP_0
-    4'b 1111, // index[160] RV_PLIC_IP_1
-    4'b 1111, // index[161] RV_PLIC_IP_2
-    4'b 1111, // index[162] RV_PLIC_IP_3
-    4'b 1111, // index[163] RV_PLIC_IP_4
-    4'b 1111, // index[164] RV_PLIC_IE0_0
-    4'b 1111, // index[165] RV_PLIC_IE0_1
-    4'b 1111, // index[166] RV_PLIC_IE0_2
-    4'b 1111, // index[167] RV_PLIC_IE0_3
-    4'b 1111, // index[168] RV_PLIC_IE0_4
-    4'b 0001, // index[169] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[170] RV_PLIC_CC0
-    4'b 0001, // index[171] RV_PLIC_MSIP0
-    4'b 0001  // index[172] RV_PLIC_ALERT_TEST
+    4'b 0001, // index[159] RV_PLIC_PRIO_159
+    4'b 1111, // index[160] RV_PLIC_IP_0
+    4'b 1111, // index[161] RV_PLIC_IP_1
+    4'b 1111, // index[162] RV_PLIC_IP_2
+    4'b 1111, // index[163] RV_PLIC_IP_3
+    4'b 1111, // index[164] RV_PLIC_IP_4
+    4'b 1111, // index[165] RV_PLIC_IE0_0
+    4'b 1111, // index[166] RV_PLIC_IE0_1
+    4'b 1111, // index[167] RV_PLIC_IE0_2
+    4'b 1111, // index[168] RV_PLIC_IE0_3
+    4'b 1111, // index[169] RV_PLIC_IE0_4
+    4'b 0001, // index[170] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[171] RV_PLIC_CC0
+    4'b 0001, // index[172] RV_PLIC_MSIP0
+    4'b 0001  // index[173] RV_PLIC_ALERT_TEST
   };
 
 endpackage

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -52,9 +52,9 @@ module rv_plic_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [172:0] reg_we_check;
+  logic [173:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(173)
+    .OneHotWidth(174)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -598,6 +598,9 @@ module rv_plic_reg_top (
   logic prio_158_we;
   logic [1:0] prio_158_qs;
   logic [1:0] prio_158_wd;
+  logic prio_159_we;
+  logic [1:0] prio_159_qs;
+  logic [1:0] prio_159_wd;
   logic ip_0_p_0_qs;
   logic ip_0_p_1_qs;
   logic ip_0_p_2_qs;
@@ -757,6 +760,7 @@ module rv_plic_reg_top (
   logic ip_4_p_156_qs;
   logic ip_4_p_157_qs;
   logic ip_4_p_158_qs;
+  logic ip_4_p_159_qs;
   logic ie0_0_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
@@ -1080,6 +1084,8 @@ module rv_plic_reg_top (
   logic ie0_4_e_157_wd;
   logic ie0_4_e_158_qs;
   logic ie0_4_e_158_wd;
+  logic ie0_4_e_159_qs;
+  logic ie0_4_e_159_wd;
   logic threshold0_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
@@ -5705,6 +5711,35 @@ module rv_plic_reg_top (
   );
 
 
+  // Subregister 159 of Multireg prio
+  // R[prio_159]: V(False)
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_prio_159 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (prio_159_we),
+    .wd     (prio_159_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio[159].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (prio_159_qs)
+  );
+
+
   // Subregister 0 of Multireg ip
   // R[ip_0]: V(False)
   //   F[p_0]: 0:0
@@ -10010,6 +10045,33 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_4_p_158_qs)
+  );
+
+  //   F[p_159]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ip_4_p_159 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.ip[159].de),
+    .d      (hw2reg.ip[159].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ip_4_p_159_qs)
   );
 
 
@@ -14320,6 +14382,33 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_158_qs)
   );
 
+  //   F[e_159]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ie0_4_e_159 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ie0_4_we),
+    .wd     (ie0_4_e_159_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[159].q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ie0_4_e_159_qs)
+  );
+
 
   // R[threshold0]: V(False)
   prim_subreg #(
@@ -14418,7 +14507,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [172:0] addr_hit;
+  logic [173:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_PLIC_PRIO_0_OFFSET);
@@ -14580,20 +14669,21 @@ module rv_plic_reg_top (
     addr_hit[156] = (reg_addr == RV_PLIC_PRIO_156_OFFSET);
     addr_hit[157] = (reg_addr == RV_PLIC_PRIO_157_OFFSET);
     addr_hit[158] = (reg_addr == RV_PLIC_PRIO_158_OFFSET);
-    addr_hit[159] = (reg_addr == RV_PLIC_IP_0_OFFSET);
-    addr_hit[160] = (reg_addr == RV_PLIC_IP_1_OFFSET);
-    addr_hit[161] = (reg_addr == RV_PLIC_IP_2_OFFSET);
-    addr_hit[162] = (reg_addr == RV_PLIC_IP_3_OFFSET);
-    addr_hit[163] = (reg_addr == RV_PLIC_IP_4_OFFSET);
-    addr_hit[164] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[165] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[166] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[167] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
-    addr_hit[168] = (reg_addr == RV_PLIC_IE0_4_OFFSET);
-    addr_hit[169] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[170] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[171] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
-    addr_hit[172] = (reg_addr == RV_PLIC_ALERT_TEST_OFFSET);
+    addr_hit[159] = (reg_addr == RV_PLIC_PRIO_159_OFFSET);
+    addr_hit[160] = (reg_addr == RV_PLIC_IP_0_OFFSET);
+    addr_hit[161] = (reg_addr == RV_PLIC_IP_1_OFFSET);
+    addr_hit[162] = (reg_addr == RV_PLIC_IP_2_OFFSET);
+    addr_hit[163] = (reg_addr == RV_PLIC_IP_3_OFFSET);
+    addr_hit[164] = (reg_addr == RV_PLIC_IP_4_OFFSET);
+    addr_hit[165] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[166] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[167] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[168] = (reg_addr == RV_PLIC_IE0_3_OFFSET);
+    addr_hit[169] = (reg_addr == RV_PLIC_IE0_4_OFFSET);
+    addr_hit[170] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[171] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[172] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[173] = (reg_addr == RV_PLIC_ALERT_TEST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -14773,7 +14863,8 @@ module rv_plic_reg_top (
                (addr_hit[169] & (|(RV_PLIC_PERMIT[169] & ~reg_be))) |
                (addr_hit[170] & (|(RV_PLIC_PERMIT[170] & ~reg_be))) |
                (addr_hit[171] & (|(RV_PLIC_PERMIT[171] & ~reg_be))) |
-               (addr_hit[172] & (|(RV_PLIC_PERMIT[172] & ~reg_be)))));
+               (addr_hit[172] & (|(RV_PLIC_PERMIT[172] & ~reg_be))) |
+               (addr_hit[173] & (|(RV_PLIC_PERMIT[173] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -15254,7 +15345,10 @@ module rv_plic_reg_top (
   assign prio_158_we = addr_hit[158] & reg_we & !reg_error;
 
   assign prio_158_wd = reg_wdata[1:0];
-  assign ie0_0_we = addr_hit[164] & reg_we & !reg_error;
+  assign prio_159_we = addr_hit[159] & reg_we & !reg_error;
+
+  assign prio_159_wd = reg_wdata[1:0];
+  assign ie0_0_we = addr_hit[165] & reg_we & !reg_error;
 
   assign ie0_0_e_0_wd = reg_wdata[0];
 
@@ -15319,7 +15413,7 @@ module rv_plic_reg_top (
   assign ie0_0_e_30_wd = reg_wdata[30];
 
   assign ie0_0_e_31_wd = reg_wdata[31];
-  assign ie0_1_we = addr_hit[165] & reg_we & !reg_error;
+  assign ie0_1_we = addr_hit[166] & reg_we & !reg_error;
 
   assign ie0_1_e_32_wd = reg_wdata[0];
 
@@ -15384,7 +15478,7 @@ module rv_plic_reg_top (
   assign ie0_1_e_62_wd = reg_wdata[30];
 
   assign ie0_1_e_63_wd = reg_wdata[31];
-  assign ie0_2_we = addr_hit[166] & reg_we & !reg_error;
+  assign ie0_2_we = addr_hit[167] & reg_we & !reg_error;
 
   assign ie0_2_e_64_wd = reg_wdata[0];
 
@@ -15449,7 +15543,7 @@ module rv_plic_reg_top (
   assign ie0_2_e_94_wd = reg_wdata[30];
 
   assign ie0_2_e_95_wd = reg_wdata[31];
-  assign ie0_3_we = addr_hit[167] & reg_we & !reg_error;
+  assign ie0_3_we = addr_hit[168] & reg_we & !reg_error;
 
   assign ie0_3_e_96_wd = reg_wdata[0];
 
@@ -15514,7 +15608,7 @@ module rv_plic_reg_top (
   assign ie0_3_e_126_wd = reg_wdata[30];
 
   assign ie0_3_e_127_wd = reg_wdata[31];
-  assign ie0_4_we = addr_hit[168] & reg_we & !reg_error;
+  assign ie0_4_we = addr_hit[169] & reg_we & !reg_error;
 
   assign ie0_4_e_128_wd = reg_wdata[0];
 
@@ -15577,17 +15671,19 @@ module rv_plic_reg_top (
   assign ie0_4_e_157_wd = reg_wdata[29];
 
   assign ie0_4_e_158_wd = reg_wdata[30];
-  assign threshold0_we = addr_hit[169] & reg_we & !reg_error;
+
+  assign ie0_4_e_159_wd = reg_wdata[31];
+  assign threshold0_we = addr_hit[170] & reg_we & !reg_error;
 
   assign threshold0_wd = reg_wdata[1:0];
-  assign cc0_re = addr_hit[170] & reg_re & !reg_error;
-  assign cc0_we = addr_hit[170] & reg_we & !reg_error;
+  assign cc0_re = addr_hit[171] & reg_re & !reg_error;
+  assign cc0_we = addr_hit[171] & reg_we & !reg_error;
 
   assign cc0_wd = reg_wdata[7:0];
-  assign msip0_we = addr_hit[171] & reg_we & !reg_error;
+  assign msip0_we = addr_hit[172] & reg_we & !reg_error;
 
   assign msip0_wd = reg_wdata[0];
-  assign alert_test_we = addr_hit[172] & reg_we & !reg_error;
+  assign alert_test_we = addr_hit[173] & reg_we & !reg_error;
 
   assign alert_test_wd = reg_wdata[0];
 
@@ -15753,20 +15849,21 @@ module rv_plic_reg_top (
     reg_we_check[156] = prio_156_we;
     reg_we_check[157] = prio_157_we;
     reg_we_check[158] = prio_158_we;
-    reg_we_check[159] = 1'b0;
+    reg_we_check[159] = prio_159_we;
     reg_we_check[160] = 1'b0;
     reg_we_check[161] = 1'b0;
     reg_we_check[162] = 1'b0;
     reg_we_check[163] = 1'b0;
-    reg_we_check[164] = ie0_0_we;
-    reg_we_check[165] = ie0_1_we;
-    reg_we_check[166] = ie0_2_we;
-    reg_we_check[167] = ie0_3_we;
-    reg_we_check[168] = ie0_4_we;
-    reg_we_check[169] = threshold0_we;
-    reg_we_check[170] = cc0_we;
-    reg_we_check[171] = msip0_we;
-    reg_we_check[172] = alert_test_we;
+    reg_we_check[164] = 1'b0;
+    reg_we_check[165] = ie0_0_we;
+    reg_we_check[166] = ie0_1_we;
+    reg_we_check[167] = ie0_2_we;
+    reg_we_check[168] = ie0_3_we;
+    reg_we_check[169] = ie0_4_we;
+    reg_we_check[170] = threshold0_we;
+    reg_we_check[171] = cc0_we;
+    reg_we_check[172] = msip0_we;
+    reg_we_check[173] = alert_test_we;
   end
 
   // Read data return
@@ -16410,6 +16507,10 @@ module rv_plic_reg_top (
       end
 
       addr_hit[159]: begin
+        reg_rdata_next[1:0] = prio_159_qs;
+      end
+
+      addr_hit[160]: begin
         reg_rdata_next[0] = ip_0_p_0_qs;
         reg_rdata_next[1] = ip_0_p_1_qs;
         reg_rdata_next[2] = ip_0_p_2_qs;
@@ -16444,7 +16545,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_0_p_31_qs;
       end
 
-      addr_hit[160]: begin
+      addr_hit[161]: begin
         reg_rdata_next[0] = ip_1_p_32_qs;
         reg_rdata_next[1] = ip_1_p_33_qs;
         reg_rdata_next[2] = ip_1_p_34_qs;
@@ -16479,7 +16580,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_1_p_63_qs;
       end
 
-      addr_hit[161]: begin
+      addr_hit[162]: begin
         reg_rdata_next[0] = ip_2_p_64_qs;
         reg_rdata_next[1] = ip_2_p_65_qs;
         reg_rdata_next[2] = ip_2_p_66_qs;
@@ -16514,7 +16615,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_2_p_95_qs;
       end
 
-      addr_hit[162]: begin
+      addr_hit[163]: begin
         reg_rdata_next[0] = ip_3_p_96_qs;
         reg_rdata_next[1] = ip_3_p_97_qs;
         reg_rdata_next[2] = ip_3_p_98_qs;
@@ -16549,7 +16650,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ip_3_p_127_qs;
       end
 
-      addr_hit[163]: begin
+      addr_hit[164]: begin
         reg_rdata_next[0] = ip_4_p_128_qs;
         reg_rdata_next[1] = ip_4_p_129_qs;
         reg_rdata_next[2] = ip_4_p_130_qs;
@@ -16581,9 +16682,10 @@ module rv_plic_reg_top (
         reg_rdata_next[28] = ip_4_p_156_qs;
         reg_rdata_next[29] = ip_4_p_157_qs;
         reg_rdata_next[30] = ip_4_p_158_qs;
+        reg_rdata_next[31] = ip_4_p_159_qs;
       end
 
-      addr_hit[164]: begin
+      addr_hit[165]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -16618,7 +16720,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[165]: begin
+      addr_hit[166]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -16653,7 +16755,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[166]: begin
+      addr_hit[167]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -16688,7 +16790,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_2_e_95_qs;
       end
 
-      addr_hit[167]: begin
+      addr_hit[168]: begin
         reg_rdata_next[0] = ie0_3_e_96_qs;
         reg_rdata_next[1] = ie0_3_e_97_qs;
         reg_rdata_next[2] = ie0_3_e_98_qs;
@@ -16723,7 +16825,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_3_e_127_qs;
       end
 
-      addr_hit[168]: begin
+      addr_hit[169]: begin
         reg_rdata_next[0] = ie0_4_e_128_qs;
         reg_rdata_next[1] = ie0_4_e_129_qs;
         reg_rdata_next[2] = ie0_4_e_130_qs;
@@ -16755,21 +16857,22 @@ module rv_plic_reg_top (
         reg_rdata_next[28] = ie0_4_e_156_qs;
         reg_rdata_next[29] = ie0_4_e_157_qs;
         reg_rdata_next[30] = ie0_4_e_158_qs;
-      end
-
-      addr_hit[169]: begin
-        reg_rdata_next[1:0] = threshold0_qs;
+        reg_rdata_next[31] = ie0_4_e_159_qs;
       end
 
       addr_hit[170]: begin
-        reg_rdata_next[7:0] = cc0_qs;
+        reg_rdata_next[1:0] = threshold0_qs;
       end
 
       addr_hit[171]: begin
-        reg_rdata_next[0] = msip0_qs;
+        reg_rdata_next[7:0] = cc0_qs;
       end
 
       addr_hit[172]: begin
+        reg_rdata_next[0] = msip0_qs;
+      end
+
+      addr_hit[173]: begin
         reg_rdata_next[0] = '0;
       end
 

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -417,7 +417,7 @@ module top_darjeeling #(
   // rv_core_ibex
 
 
-  logic [158:0]  intr_vector;
+  logic [159:0]  intr_vector;
   // Interrupt source list
   logic intr_uart0_tx_watermark;
   logic intr_uart0_rx_watermark;
@@ -514,6 +514,7 @@ module top_darjeeling #(
   logic intr_mbx_pcie1_mbx_ready;
   logic intr_mbx_pcie1_mbx_abort;
   logic intr_mbx_pcie1_mbx_error;
+  logic intr_racl_ctrl_racl_error;
   logic intr_ac_range_check_deny_cnt_reached;
 
   // Alert list
@@ -2618,6 +2619,9 @@ module top_darjeeling #(
     .NumSubscribingIps(RaclCtrlNumSubscribingIps),
     .NumExternalSubscribingIps(RaclCtrlNumExternalSubscribingIps)
   ) u_racl_ctrl (
+
+      // Interrupt
+      .intr_racl_error_o (intr_racl_ctrl_racl_error),
       // [95]: fatal_fault
       // [96]: recov_ctrl_update_err
       .alert_tx_o  ( alert_tx[96:95] ),
@@ -2756,7 +2760,8 @@ module top_darjeeling #(
 
   // interrupt assignments
   assign intr_vector = {
-      intr_ac_range_check_deny_cnt_reached, // IDs [158 +: 1]
+      intr_ac_range_check_deny_cnt_reached, // IDs [159 +: 1]
+      intr_racl_ctrl_racl_error, // IDs [158 +: 1]
       intr_mbx_pcie1_mbx_error, // IDs [157 +: 1]
       intr_mbx_pcie1_mbx_abort, // IDs [156 +: 1]
       intr_mbx_pcie1_mbx_ready, // IDs [155 +: 1]

--- a/hw/top_darjeeling/sw/autogen/chip/top_darjeeling.rs
+++ b/hw/top_darjeeling/sw/autogen/chip/top_darjeeling.rs
@@ -852,8 +852,10 @@ pub enum PlicPeripheral {
     MbxPcie0 = 28,
     /// mbx_pcie1
     MbxPcie1 = 29,
+    /// racl_ctrl
+    RaclCtrl = 30,
     /// ac_range_check
-    AcRangeCheck = 30,
+    AcRangeCheck = 31,
 }
 
 impl TryFrom<u32> for PlicPeripheral {
@@ -890,7 +892,8 @@ impl TryFrom<u32> for PlicPeripheral {
             27 => Ok(Self::MbxJtag),
             28 => Ok(Self::MbxPcie0),
             29 => Ok(Self::MbxPcie1),
-            30 => Ok(Self::AcRangeCheck),
+            30 => Ok(Self::RaclCtrl),
+            31 => Ok(Self::AcRangeCheck),
             _ => Err(val),
         }
     }
@@ -1219,8 +1222,10 @@ pub enum PlicIrqId {
     MbxPcie1MbxAbort = 156,
     /// mbx_pcie1_mbx_error
     MbxPcie1MbxError = 157,
+    /// racl_ctrl_racl_error
+    RaclCtrlRaclError = 158,
     /// ac_range_check_deny_cnt_reached
-    AcRangeCheckDenyCntReached = 158,
+    AcRangeCheckDenyCntReached = 159,
 }
 
 impl TryFrom<u32> for PlicIrqId {
@@ -1385,7 +1390,8 @@ impl TryFrom<u32> for PlicIrqId {
             155 => Ok(Self::MbxPcie1MbxReady),
             156 => Ok(Self::MbxPcie1MbxAbort),
             157 => Ok(Self::MbxPcie1MbxError),
-            158 => Ok(Self::AcRangeCheckDenyCntReached),
+            158 => Ok(Self::RaclCtrlRaclError),
+            159 => Ok(Self::AcRangeCheckDenyCntReached),
             _ => Err(val),
         }
     }
@@ -1406,7 +1412,7 @@ pub enum PlicTarget {
 ///
 /// This array is a mapping from `PlicIrqId` to
 /// `PlicPeripheral`.
-pub const PLIC_INTERRUPT_FOR_PERIPHERAL: [PlicPeripheral; 159] = [
+pub const PLIC_INTERRUPT_FOR_PERIPHERAL: [PlicPeripheral; 160] = [
     // None -> PlicPeripheral::Unknown
     PlicPeripheral::Unknown,
     // Uart0TxWatermark -> PlicPeripheral::Uart0
@@ -1723,6 +1729,8 @@ pub const PLIC_INTERRUPT_FOR_PERIPHERAL: [PlicPeripheral; 159] = [
     PlicPeripheral::MbxPcie1,
     // MbxPcie1MbxError -> PlicPeripheral::MbxPcie1
     PlicPeripheral::MbxPcie1,
+    // RaclCtrlRaclError -> PlicPeripheral::RaclCtrl
+    PlicPeripheral::RaclCtrl,
     // AcRangeCheckDenyCntReached -> PlicPeripheral::AcRangeCheck
     PlicPeripheral::AcRangeCheck,
 ];

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.c
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.c
@@ -129,7 +129,7 @@ const top_darjeeling_alert_peripheral_t
  * `top_darjeeling_plic_peripheral_t`.
  */
 const top_darjeeling_plic_peripheral_t
-    top_darjeeling_plic_interrupt_for_peripheral[159] = {
+    top_darjeeling_plic_interrupt_for_peripheral[160] = {
   [kTopDarjeelingPlicIrqIdNone] = kTopDarjeelingPlicPeripheralUnknown,
   [kTopDarjeelingPlicIrqIdUart0TxWatermark] = kTopDarjeelingPlicPeripheralUart0,
   [kTopDarjeelingPlicIrqIdUart0RxWatermark] = kTopDarjeelingPlicPeripheralUart0,
@@ -288,5 +288,6 @@ const top_darjeeling_plic_peripheral_t
   [kTopDarjeelingPlicIrqIdMbxPcie1MbxReady] = kTopDarjeelingPlicPeripheralMbxPcie1,
   [kTopDarjeelingPlicIrqIdMbxPcie1MbxAbort] = kTopDarjeelingPlicPeripheralMbxPcie1,
   [kTopDarjeelingPlicIrqIdMbxPcie1MbxError] = kTopDarjeelingPlicPeripheralMbxPcie1,
+  [kTopDarjeelingPlicIrqIdRaclCtrlRaclError] = kTopDarjeelingPlicPeripheralRaclCtrl,
   [kTopDarjeelingPlicIrqIdAcRangeCheckDenyCntReached] = kTopDarjeelingPlicPeripheralAcRangeCheck,
 };

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.h
@@ -1065,8 +1065,9 @@ typedef enum top_darjeeling_plic_peripheral {
   kTopDarjeelingPlicPeripheralMbxJtag = 27, /**< mbx_jtag */
   kTopDarjeelingPlicPeripheralMbxPcie0 = 28, /**< mbx_pcie0 */
   kTopDarjeelingPlicPeripheralMbxPcie1 = 29, /**< mbx_pcie1 */
-  kTopDarjeelingPlicPeripheralAcRangeCheck = 30, /**< ac_range_check */
-  kTopDarjeelingPlicPeripheralLast = 30, /**< \internal Final PLIC peripheral */
+  kTopDarjeelingPlicPeripheralRaclCtrl = 30, /**< racl_ctrl */
+  kTopDarjeelingPlicPeripheralAcRangeCheck = 31, /**< ac_range_check */
+  kTopDarjeelingPlicPeripheralLast = 31, /**< \internal Final PLIC peripheral */
 } top_darjeeling_plic_peripheral_t;
 
 /**
@@ -1234,8 +1235,9 @@ typedef enum top_darjeeling_plic_irq_id {
   kTopDarjeelingPlicIrqIdMbxPcie1MbxReady = 155, /**< mbx_pcie1_mbx_ready */
   kTopDarjeelingPlicIrqIdMbxPcie1MbxAbort = 156, /**< mbx_pcie1_mbx_abort */
   kTopDarjeelingPlicIrqIdMbxPcie1MbxError = 157, /**< mbx_pcie1_mbx_error */
-  kTopDarjeelingPlicIrqIdAcRangeCheckDenyCntReached = 158, /**< ac_range_check_deny_cnt_reached */
-  kTopDarjeelingPlicIrqIdLast = 158, /**< \internal The Last Valid Interrupt ID. */
+  kTopDarjeelingPlicIrqIdRaclCtrlRaclError = 158, /**< racl_ctrl_racl_error */
+  kTopDarjeelingPlicIrqIdAcRangeCheckDenyCntReached = 159, /**< ac_range_check_deny_cnt_reached */
+  kTopDarjeelingPlicIrqIdLast = 159, /**< \internal The Last Valid Interrupt ID. */
 } top_darjeeling_plic_irq_id_t;
 
 /**
@@ -1245,7 +1247,7 @@ typedef enum top_darjeeling_plic_irq_id {
  * `top_darjeeling_plic_peripheral_t`.
  */
 extern const top_darjeeling_plic_peripheral_t
-    top_darjeeling_plic_interrupt_for_peripheral[159];
+    top_darjeeling_plic_interrupt_for_peripheral[160];
 
 /**
  * PLIC Interrupt Target.

--- a/util/make_new_dif/templates/dif_autogen.c.tpl
+++ b/util/make_new_dif/templates/dif_autogen.c.tpl
@@ -185,6 +185,9 @@ dif_result_t dif_${ip.name_snake}_get_dt(
       ## This handles the RV Timer IP.
       % elif ip.name_snake == "rv_timer":
         *index_out = ${ip.name_upper}_INTR_STATE0_IS_${loop.index}_BIT;
+      ## This handles the RACL Controller IP.
+      % elif ip.name_snake == "racl_ctrl":
+        *index_out = ${ip.name_upper}_INTR_STATE_${irq.name_upper}_BIT;
       ## This handles all other IPs that do not have the "no_auto_intr_regs" in
       ## their HJSON files.
       % else:


### PR DESCRIPTION
This PR adds interrupts to racl_ctrl.
The documentation will follow in a later PR (after #26592 is merged) but is tracked in #26720 in the meanwhile.

This PR allows notifying e.g. the ibex core when a RACL error occurred via an interrupt. It is disabled by default but can enabled via software. Interrupts are necessary because the device maintaining the RACL policies also wants to monitor for RACL errors that were triggered by other devices. Interrupts allow to do this more efficiently without having to continuously poll the racl_ctrl registers.
