### PR TITLE
[rv_plic, fpv] Assertions added for rsp and data intg

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/tb/rv_plic_bind_fpv.sv.tpl
+++ b/hw/ip_templates/rv_plic/fpv/tb/rv_plic_bind_fpv.sv.tpl
@@ -26,7 +26,8 @@ module ${module_instance_name}_bind_fpv;
     .complete,
     .prio,
     .threshold,
-    .fatal_alert_i (alerts[0])
+    .fatal_alert_i (alerts[0]),
+    .tl_o
   );
 
   bind ${module_instance_name} tlul_assert #(

--- a/hw/ip_templates/rv_plic/fpv/vip/rv_plic_assert_fpv.sv.tpl
+++ b/hw/ip_templates/rv_plic/fpv/vip/rv_plic_assert_fpv.sv.tpl
@@ -25,7 +25,8 @@ module ${module_instance_name}_assert_fpv #(parameter int NumSrc = 1,
   input [NumSrc-1:0] complete,
   input [NumSrc-1:0][PRIOW-1:0] prio,
   input [PRIOW-1:0]  threshold [NumTarget],
-  input logic        fatal_alert_i
+  input logic        fatal_alert_i,
+  input tlul_pkg::tl_d2h_t tl_o
 );
 
   localparam int SrcIdxWidth = NumSrc > 1 ? $clog2(NumSrc - 1) : 1;
@@ -108,4 +109,14 @@ module ${module_instance_name}_assert_fpv #(parameter int NumSrc = 1,
 
   // When fatal alert happens then only reset can clear it.
   `ASSERT(FatalAlertNeverdrops_A, !$fell(fatal_alert_i))
+
+  // If a response is coming back from the device, then check if it contains the correct integrity
+  // bits.
+  `ASSERT(DataIntg_A,
+          tl_o.d_valid -> (tlul_pkg::get_data_intg(tl_o.d_data) == tl_o.d_user.data_intg))
+
+  `ASSERT(RspIntg_A,
+          tl_o.d_valid ->
+          (prim_secded_pkg::prim_secded_inv_64_57_enc({51'b0, tlul_pkg::extract_d2h_rsp_intg(tl_o)})
+          >> (64-tlul_pkg::D2HRspIntgWidth)) == tl_o.d_user.rsp_intg)
 endmodule : ${module_instance_name}_assert_fpv

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
@@ -26,7 +26,8 @@ module rv_plic_bind_fpv;
     .complete,
     .prio,
     .threshold,
-    .fatal_alert_i (alerts[0])
+    .fatal_alert_i (alerts[0]),
+    .tl_o
   );
 
   bind rv_plic tlul_assert #(

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
@@ -25,7 +25,8 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
   input [NumSrc-1:0] complete,
   input [NumSrc-1:0][PRIOW-1:0] prio,
   input [PRIOW-1:0]  threshold [NumTarget],
-  input logic        fatal_alert_i
+  input logic        fatal_alert_i,
+  input tlul_pkg::tl_d2h_t tl_o
 );
 
   localparam int SrcIdxWidth = NumSrc > 1 ? $clog2(NumSrc - 1) : 1;
@@ -108,4 +109,14 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
 
   // When fatal alert happens then only reset can clear it.
   `ASSERT(FatalAlertNeverdrops_A, !$fell(fatal_alert_i))
+
+  // If a response is coming back from the device, then check if it contains the correct integrity
+  // bits.
+  `ASSERT(DataIntg_A,
+          tl_o.d_valid -> (tlul_pkg::get_data_intg(tl_o.d_data) == tl_o.d_user.data_intg))
+
+  `ASSERT(RspIntg_A,
+          tl_o.d_valid ->
+          (prim_secded_pkg::prim_secded_inv_64_57_enc({51'b0, tlul_pkg::extract_d2h_rsp_intg(tl_o)})
+          >> (64-tlul_pkg::D2HRspIntgWidth)) == tl_o.d_user.rsp_intg)
 endmodule : rv_plic_assert_fpv

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
@@ -26,7 +26,8 @@ module rv_plic_bind_fpv;
     .complete,
     .prio,
     .threshold,
-    .fatal_alert_i (alerts[0])
+    .fatal_alert_i (alerts[0]),
+    .tl_o
   );
 
   bind rv_plic tlul_assert #(

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
@@ -25,7 +25,8 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
   input [NumSrc-1:0] complete,
   input [NumSrc-1:0][PRIOW-1:0] prio,
   input [PRIOW-1:0]  threshold [NumTarget],
-  input logic        fatal_alert_i
+  input logic        fatal_alert_i,
+  input tlul_pkg::tl_d2h_t tl_o
 );
 
   localparam int SrcIdxWidth = NumSrc > 1 ? $clog2(NumSrc - 1) : 1;
@@ -108,4 +109,14 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
 
   // When fatal alert happens then only reset can clear it.
   `ASSERT(FatalAlertNeverdrops_A, !$fell(fatal_alert_i))
+
+  // If a response is coming back from the device, then check if it contains the correct integrity
+  // bits.
+  `ASSERT(DataIntg_A,
+          tl_o.d_valid -> (tlul_pkg::get_data_intg(tl_o.d_data) == tl_o.d_user.data_intg))
+
+  `ASSERT(RspIntg_A,
+          tl_o.d_valid ->
+          (prim_secded_pkg::prim_secded_inv_64_57_enc({51'b0, tlul_pkg::extract_d2h_rsp_intg(tl_o)})
+          >> (64-tlul_pkg::D2HRspIntgWidth)) == tl_o.d_user.rsp_intg)
 endmodule : rv_plic_assert_fpv

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
@@ -26,7 +26,8 @@ module rv_plic_bind_fpv;
     .complete,
     .prio,
     .threshold,
-    .fatal_alert_i (alerts[0])
+    .fatal_alert_i (alerts[0]),
+    .tl_o
   );
 
   bind rv_plic tlul_assert #(

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
@@ -25,7 +25,8 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
   input [NumSrc-1:0] complete,
   input [NumSrc-1:0][PRIOW-1:0] prio,
   input [PRIOW-1:0]  threshold [NumTarget],
-  input logic        fatal_alert_i
+  input logic        fatal_alert_i,
+  input tlul_pkg::tl_d2h_t tl_o
 );
 
   localparam int SrcIdxWidth = NumSrc > 1 ? $clog2(NumSrc - 1) : 1;
@@ -108,4 +109,14 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
 
   // When fatal alert happens then only reset can clear it.
   `ASSERT(FatalAlertNeverdrops_A, !$fell(fatal_alert_i))
+
+  // If a response is coming back from the device, then check if it contains the correct integrity
+  // bits.
+  `ASSERT(DataIntg_A,
+          tl_o.d_valid -> (tlul_pkg::get_data_intg(tl_o.d_data) == tl_o.d_user.data_intg))
+
+  `ASSERT(RspIntg_A,
+          tl_o.d_valid ->
+          (prim_secded_pkg::prim_secded_inv_64_57_enc({51'b0, tlul_pkg::extract_d2h_rsp_intg(tl_o)})
+          >> (64-tlul_pkg::D2HRspIntgWidth)) == tl_o.d_user.rsp_intg)
 endmodule : rv_plic_assert_fpv


### PR DESCRIPTION
The intention was to get rid of undetectable coverage. u_rsp_intg_gen in rv_plic_reg_top that generates both data and rsp intg through some prim_secded_inv_xx_xx_enc. All the continuous assignments to data_o for the generation of integrity bits were marked as undetectable by jasper.
The assertions added in this PR simply says that if I have a response coming from the device, then it must have correct integrity bits.