### PR TITLE
[rom_ext] Fix type errors of drivers used in the immutable section.

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -767,7 +767,7 @@ static status_t entropy_src_check(const entropy_src_config_t *config) {
       config->alert_threshold);
   exp_reg = bitfield_field32_write(
       exp_reg, ENTROPY_SRC_ALERT_THRESHOLD_ALERT_THRESHOLD_INV_FIELD,
-      ~config->alert_threshold);
+      ~(uint32_t)config->alert_threshold);
   if (exp_reg != abs_mmio_read32(kBaseEntropySrc +
                                  ENTROPY_SRC_ALERT_THRESHOLD_REG_OFFSET)) {
     return OTCRYPTO_RECOV_ERR;

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -34,8 +34,8 @@ enum {
  * Increments the `sec_mmio_ctx.last_index`.
  */
 static void upsert_register(uint32_t addr, uint32_t value) {
-  const size_t last_index = sec_mmio_ctx.last_index;
-  size_t i = 0, j = last_index - 1;
+  const uint32_t last_index = sec_mmio_ctx.last_index;
+  uint32_t i = 0, j = last_index - 1;
   for (; launder32(i) < last_index && launder32(j) < last_index; ++i, --j) {
     if (launder32(sec_mmio_ctx.addrs[i]) == addr) {
       sec_mmio_ctx.values[i] = value;
@@ -43,7 +43,7 @@ static void upsert_register(uint32_t addr, uint32_t value) {
     }
   }
   if (launder32(i) == last_index && launder32(i) < kSecMmioRegFileSize) {
-    HARDENED_CHECK_EQ(j, SIZE_MAX);
+    HARDENED_CHECK_EQ(j, UINT32_MAX);
     sec_mmio_ctx.addrs[i] = addr;
     sec_mmio_ctx.values[i] = value;
     ++sec_mmio_ctx.last_index;
@@ -58,13 +58,13 @@ void sec_mmio_init(void) {
   sec_mmio_ctx.write_count = launder32(0);
   sec_mmio_ctx.check_count = launder32(0);
   sec_mmio_ctx.expected_write_count = launder32(0);
-  size_t i = 0, r = kEntryCount - 1;
+  uint32_t i = 0, r = kEntryCount - 1;
   for (; launder32(i) < kEntryCount && launder32(r) < kEntryCount; ++i, --r) {
     sec_mmio_ctx.addrs[i] = UINT32_MAX;
     sec_mmio_ctx.values[i] = UINT32_MAX;
   }
   HARDENED_CHECK_EQ(i, kEntryCount);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+  HARDENED_CHECK_EQ(r, UINT32_MAX);
   uint32_t check = kSecMmioValZero ^ sec_mmio_ctx.last_index;
   check ^= sec_mmio_ctx.write_count;
   check ^= sec_mmio_ctx.check_count;
@@ -74,14 +74,14 @@ void sec_mmio_init(void) {
 
 void sec_mmio_next_stage_init(void) {
   sec_mmio_ctx.check_count = launder32(0);
-  size_t i = sec_mmio_ctx.last_index,
-         r = kEntryCount - sec_mmio_ctx.last_index - 1;
+  uint32_t i = sec_mmio_ctx.last_index,
+           r = kEntryCount - sec_mmio_ctx.last_index - 1;
   for (; launder32(i) < kEntryCount && launder32(r) < kEntryCount; ++i, --r) {
     sec_mmio_ctx.addrs[i] = UINT32_MAX;
     sec_mmio_ctx.values[i] = UINT32_MAX;
   }
   HARDENED_CHECK_EQ(i, kEntryCount);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+  HARDENED_CHECK_EQ(r, UINT32_MAX);
   HARDENED_CHECK_EQ(sec_mmio_ctx.check_count, 0);
 }
 
@@ -123,7 +123,7 @@ void sec_mmio_check_values(uint32_t rnd_offset) {
   // Pick a random starting offset.
   uint32_t offset = ((uint64_t)rnd_offset * (uint64_t)last_index) >> 32;
   enum { kStep = 1 };
-  size_t i = 0, r = last_index - 1;
+  uint32_t i = 0, r = last_index - 1;
   for (; launder32(i) < last_index && launder32(r) < last_index; ++i, --r) {
     uint32_t read_value = abs_mmio_read32(sec_mmio_ctx.addrs[offset]);
     HARDENED_CHECK_EQ(read_value ^ kSecMmioMaskVal,
@@ -135,7 +135,7 @@ void sec_mmio_check_values(uint32_t rnd_offset) {
   }
   // Check for loop completion.
   HARDENED_CHECK_EQ(i, last_index);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+  HARDENED_CHECK_EQ(r, UINT32_MAX);
   ++sec_mmio_ctx.check_count;
 }
 
@@ -144,7 +144,7 @@ void sec_mmio_check_values_except_otp(uint32_t rnd_offset, uint32_t otp_base) {
   // Pick a random starting offset.
   uint32_t offset = ((uint64_t)rnd_offset * (uint64_t)last_index) >> 32;
   enum { kStep = 1 };
-  size_t i = 0, r = last_index - 1;
+  uint32_t i = 0, r = last_index - 1;
   // Make sure the otp_base is 64K aligned and not zero.
   HARDENED_CHECK_EQ(otp_base & 0x0000FFFF, 0);
   HARDENED_CHECK_NE(otp_base & 0xFFFF0000, 0);
@@ -165,7 +165,7 @@ void sec_mmio_check_values_except_otp(uint32_t rnd_offset, uint32_t otp_base) {
   }
   // Check for loop completion.
   HARDENED_CHECK_EQ(i, last_index);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+  HARDENED_CHECK_EQ(r, UINT32_MAX);
   ++sec_mmio_ctx.check_count;
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -79,9 +79,9 @@ rom_error_t sc_otbn_busy_wait_for_done(void) {
 static void sc_otbn_write(uint32_t dest_addr, const uint32_t *src,
                           size_t num_words) {
   // Start from a random index less than `num_words`.
-  size_t i = ((uint64_t)rnd_uint32() * (uint64_t)num_words) >> 32;
+  uint32_t i = ((uint64_t)rnd_uint32() * (uint64_t)num_words) >> 32;
   enum { kStep = 1 };
-  size_t iter_cnt = 0, r_iter_cnt = num_words - 1;
+  uint32_t iter_cnt = 0, r_iter_cnt = num_words - 1;
   for (; launder32(iter_cnt) < num_words && launder32(r_iter_cnt) < num_words;
        ++iter_cnt, --r_iter_cnt) {
     abs_mmio_write32(dest_addr + i * sizeof(uint32_t), src[i]);
@@ -92,7 +92,7 @@ static void sc_otbn_write(uint32_t dest_addr, const uint32_t *src,
     HARDENED_CHECK_LT(i, num_words);
   }
   HARDENED_CHECK_EQ(iter_cnt, num_words);
-  HARDENED_CHECK_EQ(r_iter_cnt, SIZE_MAX);
+  HARDENED_CHECK_EQ(r_iter_cnt, UINT32_MAX);
 }
 
 OT_WARN_UNUSED_RESULT
@@ -116,13 +116,13 @@ rom_error_t sc_otbn_dmem_read(size_t num_words, sc_otbn_addr_t src,
                               uint32_t *dest) {
   HARDENED_RETURN_IF_ERROR(
       check_offset_len(src, num_words, OTBN_DMEM_SIZE_BYTES));
-  size_t i = 0, r = num_words - 1;
+  uint32_t i = 0, r = num_words - 1;
   for (; launder32(i) < num_words && launder32(r) < num_words; ++i, --r) {
     dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + src +
                               i * sizeof(uint32_t));
   }
   HARDENED_CHECK_EQ(i, num_words);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+  HARDENED_CHECK_EQ(r, UINT32_MAX);
   return kErrorOk;
 }
 


### PR DESCRIPTION
1. In `sec_mmio` and `otbn`, some variables of type `size_t` were being passed to `launder32` which accepts `uint32_t`.
2. In `entropy`, the `config->alert_threshold` is `uint16_t` type. It will be promoted to `int32_t` by the `~` operator. However, `bitfield_field32_write` accepts `uint32_t` type. This commit converts the `config->alert_threshold` to `uint32_t` first.
