### PR TITLE
[rom_ext,dice] Fix incorrect static assertion criteria

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -55,7 +55,7 @@ enum payload_entry_sizes {
   // 64 byte should be enough for 2 entries
   kConfigDescBuffSize = 64,
 };
-static_assert(kIssuerSubjectNameLength < (1u << kIssuerSubjectKeyIdLength),
+static_assert(kIssuerSubjectNameLength <= kIssuerSubjectKeyIdLength * 2,
               "Insufficient SubjectNameLength");
 
 enum cwt_cert_expectations {


### PR DESCRIPTION
The issuer/subject names come from the key ID.

This check should ensure the name (hex string) does not exceed the double of the key id's length.