### PR TITLE
[epmp] Check the PMP address for NAPOT decode.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/epmp.c
+++ b/sw/device/silicon_creator/lib/drivers/epmp.c
@@ -76,7 +76,8 @@ uint32_t epmp_encode_napot(epmp_region_t region) {
 }
 
 epmp_region_t epmp_decode_napot(uint32_t pmpaddr) {
-  uint32_t size = 1 << bitfield_count_trailing_zeroes32(~pmpaddr);
+  HARDENED_CHECK_NE(pmpaddr, UINT32_MAX);
+  uint32_t size = 1u << bitfield_count_trailing_zeroes32(~pmpaddr);
   pmpaddr = (pmpaddr & ~(size - 1)) << 2;
   size <<= 3;
   return (epmp_region_t){.start = pmpaddr, .end = pmpaddr + size};

--- a/sw/device/silicon_creator/lib/drivers/epmp.h
+++ b/sw/device/silicon_creator/lib/drivers/epmp.h
@@ -51,7 +51,7 @@ void epmp_clear_lock_bits(void);
 /**
  * Encode a start/end address pair to NAPOT address.
  *
- * The region start must have an alignment consistend with the region size.  The
+ * The region start must have an alignment consistent with the region size.  The
  * region size must be a power of two.  If either of these conditions is not
  * met, this function will fault.
  *
@@ -71,7 +71,7 @@ epmp_region_t epmp_decode_napot(uint32_t pmpaddr);
 /**
  * Configures an ePMP entry for a NAPOT or NA4 region.
  *
- * The region start must have an alignment consistend with the region size.  The
+ * The region start must have an alignment consistent with the region size.  The
  * region size must be a power of two.  If either of these conditions is not
  * met, this function will fault.
  *


### PR DESCRIPTION
The `pmpaddr` should not be UINT32_MAX as the input for decoding napot.

1. Add a HARDENED_CHECK_NE for `pmpaddr`, as `1u << 32` is an undefined behavior.
2. Mitigate the signed integer conversion by replacing `1` to `1u`.