### PR TITLE
[hw,aon_timer] Fix typo in documentation

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -53,7 +53,7 @@
   ],
   reset_request_list: [
     { name: "aon_timer_rst_req",
-      desc: "watchdog reset requestt"
+      desc: "watchdog reset request"
     },
   ],
   inter_signal_list: [

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -476,7 +476,7 @@
         name: aon_timer_rst_req
         width: "1"
         module: aon_timer_aon
-        desc: watchdog reset requestt
+        desc: watchdog reset request
       }
       {
         name: rst_req_external

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
@@ -59,7 +59,7 @@
           name: aon_timer_rst_req
           width: "1"
           module: aon_timer_aon
-          desc: watchdog reset requestt
+          desc: watchdog reset request
         }
         {
           name: rst_req_external

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/rstmgr.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/rstmgr.hjson
@@ -327,7 +327,7 @@
           desc: '''
             Indicates when a device has reset due to a hardware requested reset.
             The bit mapping is as follows:
-            b3: aon_timer_aon: watchdog reset requestt
+            b3: aon_timer_aon: watchdog reset request
             b4: soc_proxy: External reset request
             b5: pwrmgr_aon: main power glitch reset request
             b6: alert_handler: escalation reset request

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -43,7 +43,7 @@
           name: aon_timer_rst_req
           width: "1"
           module: aon_timer_aon
-          desc: watchdog reset requestt
+          desc: watchdog reset request
         }
         {
           name: rst_req_external

--- a/hw/top_darjeeling/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/doc/registers.md
@@ -82,7 +82,7 @@ Device reset reason.
 ### RESET_INFO . HW_REQ
 Indicates when a device has reset due to a hardware requested reset.
 The bit mapping is as follows:
-b3: aon_timer_aon: watchdog reset requestt
+b3: aon_timer_aon: watchdog reset request
 b4: soc_proxy: External reset request
 b5: pwrmgr_aon: main power glitch reset request
 b6: alert_handler: escalation reset request

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -554,7 +554,7 @@
         name: aon_timer_rst_req
         width: "1"
         module: aon_timer_aon
-        desc: watchdog reset requestt
+        desc: watchdog reset request
       }
     ]
   }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -75,7 +75,7 @@
           name: aon_timer_rst_req
           width: "1"
           module: aon_timer_aon
-          desc: watchdog reset requestt
+          desc: watchdog reset request
         }
       ]
     }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr.hjson
@@ -358,7 +358,7 @@
             Indicates when a device has reset due to a hardware requested reset.
             The bit mapping is as follows:
             b3: sysrst_ctrl_aon: OpenTitan reset request to `rstmgr` (running on AON clock).
-            b4: aon_timer_aon: watchdog reset requestt
+            b4: aon_timer_aon: watchdog reset request
             b5: pwrmgr_aon: main power glitch reset request
             b6: alert_handler: escalation reset request
             b7: rv_dm: non-debug-module reset request

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -49,7 +49,7 @@
           name: aon_timer_rst_req
           width: "1"
           module: aon_timer_aon
-          desc: watchdog reset requestt
+          desc: watchdog reset request
         }
       ]
     }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.md
@@ -93,7 +93,7 @@ Device reset reason.
 Indicates when a device has reset due to a hardware requested reset.
 The bit mapping is as follows:
 b3: sysrst_ctrl_aon: OpenTitan reset request to `rstmgr` (running on AON clock).
-b4: aon_timer_aon: watchdog reset requestt
+b4: aon_timer_aon: watchdog reset request
 b5: pwrmgr_aon: main power glitch reset request
 b6: alert_handler: escalation reset request
 b7: rv_dm: non-debug-module reset request

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -437,7 +437,7 @@
         name: aon_timer_rst_req
         width: "1"
         module: aon_timer_aon
-        desc: watchdog reset requestt
+        desc: watchdog reset request
       }
     ]
   }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
@@ -54,7 +54,7 @@
           name: aon_timer_rst_req
           width: "1"
           module: aon_timer_aon
-          desc: watchdog reset requestt
+          desc: watchdog reset request
         }
       ]
     }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/rstmgr.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/rstmgr.hjson
@@ -327,7 +327,7 @@
           desc: '''
             Indicates when a device has reset due to a hardware requested reset.
             The bit mapping is as follows:
-            b3: aon_timer_aon: watchdog reset requestt
+            b3: aon_timer_aon: watchdog reset request
             b4: pwrmgr_aon: main power glitch reset request
             b5: alert_handler: escalation reset request
             b6: rv_dm: non-debug-module reset request

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -43,7 +43,7 @@
           name: aon_timer_rst_req
           width: "1"
           module: aon_timer_aon
-          desc: watchdog reset requestt
+          desc: watchdog reset request
         }
       ]
     }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/doc/registers.md
@@ -82,7 +82,7 @@ Device reset reason.
 ### RESET_INFO . HW_REQ
 Indicates when a device has reset due to a hardware requested reset.
 The bit mapping is as follows:
-b3: aon_timer_aon: watchdog reset requestt
+b3: aon_timer_aon: watchdog reset request
 b4: pwrmgr_aon: main power glitch reset request
 b5: alert_handler: escalation reset request
 b6: rv_dm: non-debug-module reset request


### PR DESCRIPTION
No RTL change, but the changes propagates through topgen to several hjson files and register documentation.