### PR TITLE
[opentitanlib] Derive clap::ValueEnum for LcCtrlReg

### DIFF
--- a/sw/host/opentitanlib/src/dif/lc_ctrl.rs
+++ b/sw/host/opentitanlib/src/dif/lc_ctrl.rs
@@ -340,7 +340,7 @@ impl DifLcCtrlToken {
     }
 }
 
-#[derive(Clone, Copy, Debug, strum::EnumString)]
+#[derive(clap::ValueEnum, Clone, Copy, Debug, strum::EnumString)]
 #[strum(serialize_all = "snake_case")]
 #[repr(u32)]
 pub enum LcCtrlReg {


### PR DESCRIPTION
Without this, it's impossible to know the list of valid values when trying to read a register via `life-cycle read-reg` which makes the command read hard to use.

There are probably other instances of this in opentitanlib.