### PR TITLE
[util] Add filename and line numbers to logging messages

### DIFF
--- a/util/dttool.py
+++ b/util/dttool.py
@@ -85,7 +85,8 @@ def render_template(template_path: Path, rendered_path: Path,
 
 
 def main():
-    logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+    logging.basicConfig(format="%(filename)s:%(lineno)d: %(levelname)s: %(message)s",
+                        level=logging.WARNING)
 
     parser = argparse.ArgumentParser(prog="dtgen")
     parser.add_argument(

--- a/util/ipgen.py
+++ b/util/ipgen.py
@@ -15,11 +15,11 @@ from ipgen import (IpBlockRenderer, IpConfig, IpTemplate, TemplateParseError,
 
 def init_logging(verbose: bool) -> None:
     """ Initialize the logging system """
+    log_format = "%(filename)s:%(lineno)d: %(levelname)s: %(message)s"
     if verbose:
-        logging.basicConfig(format="%(levelname)s: %(message)s",
-                            level=logging.DEBUG)
+        logging.basicConfig(format=log_format, level=logging.DEBUG)
     else:
-        logging.basicConfig(format="%(levelname)s: %(message)s")
+        logging.basicConfig(format=log_format)
 
 
 def action_generate(ip_template: IpTemplate, args: argparse.Namespace) -> None:

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -150,13 +150,14 @@ def main():
     if args.version:
         version.show_and_exit(__file__, ["Hjson", "Mako"])
 
+    log_format = "%(filename)s:%(lineno)d: %(levelname)s: %(message)s"
     verbose = args.verbose
     if verbose:
-        log.basicConfig(format="%(levelname)s: %(message)s", level=log.DEBUG)
+        log.basicConfig(format=log_format, level=log.DEBUG)
     elif args.quiet:
-        log.basicConfig(format="%(levelname)s: %(message)s", level=log.ERROR)
+        log.basicConfig(format=log_format, level=log.ERROR)
     else:
-        log.basicConfig(format="%(levelname)s: %(message)s")
+        log.basicConfig(format=log_format)
 
     # Entries are triples of the form (arg, (fmt, dirspec)).
     #

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1499,7 +1499,8 @@ def main():
     log_level = (log.ERROR if args.get_blocks or args.check_cm else
                  log.DEBUG if args.verbose else None)
 
-    log.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
+    log.basicConfig(format="%(filename)s:%(lineno)d: %(levelname)s: %(message)s",
+                    level=log_level)
 
     if not args.outdir:
         outdir = Path(args.topcfg).parents[1]


### PR DESCRIPTION
Addresses #26754, with hat tip to @matutem and @milesdai for their guidance. I changed the log format in tools I run into most frequently, but there are other util/ scripts that call `logging.basicConfig()`, such as tlgen.py, otbn_build.py, and generate_compilation_db.py. Should these be changed, too?