### PR TITLE
[bazel/otp] Add ordered_params to ot_alert_classification.

### DIFF
--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -426,7 +426,7 @@ def _parse_str_list(s):
     """
     return s.replace(" ", "").split(",")
 
-def otp_alert_classification(alert_list, default = None, **kwargs):
+def otp_alert_classification(alert_list, default = None, ordered_params = {}, **kwargs):
     """Create an array specifying the alert classifications.
 
     This function creates an array of bytestrings that specifies the alert
@@ -438,6 +438,14 @@ def otp_alert_classification(alert_list, default = None, **kwargs):
         default: default classification for all alerts that are not specified
             in kwargs. If kwargs does not include all alerts, a value must be
             specified for default.
+        ordered_params: a mapping of the format '{"alert_name": alert_class_string}'.
+            alert_name is an alert in the alert_list argument.
+            alert_class_string is a comma-delimited string that can contain
+            spaces and is intended to be parsed by the _parse_str_list macro.
+            This string must indicate exactly 4 alert classes for the prod,
+            prod_end, dev, and rma LC states in that order.
+            Use this argument instead of kwargs to ensure the order of the
+            alert classes is maintained in the bazel build file.
         kwargs: a mapping of the format 'alert_name = alert_class_string'.
             alert_name is an alert in the alert_list argument.
             alert_class_string is a comma-delimited string that can contain
@@ -468,6 +476,9 @@ def otp_alert_classification(alert_list, default = None, **kwargs):
 
     provided_alerts = dict()
     for alert, class_str in kwargs.items():
+        provided_alerts[alert] = _parse_alert_class_string(class_str)
+
+    for alert, class_str in ordered_params.items():
         provided_alerts[alert] = _parse_alert_class_string(class_str)
 
     alert_set = sets.make(alert_list)


### PR DESCRIPTION
This is to be able to maintained an ordered list of alert parameters matching the layout of the alert_handler configuration. Otherwise buildifier will want to sort the parameters if set via `kwargs`.