### PR TITLE
[signing] Improve automation

### DIFF
--- a/rules/scripts/copy_files.template.sh
+++ b/rules/scripts/copy_files.template.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+DEST="__DEST__"
+FILES=(__FILES__)
+
+if [[ ! -z "${__WORKSPACE__+is_set}" ]]; then
+    cd ${__WORKSPACE__} || exit 1
+else
+    echo "__WORKSPACE__ was not set."
+    exit 1
+fi
+
+for f in "${FILES[@]}"; do
+  cp --no-preserve=mode "$f" "$DEST"
+done

--- a/sw/device/silicon_creator/manuf/base/binaries/BUILD
+++ b/sw/device/silicon_creator/manuf/base/binaries/BUILD
@@ -3,8 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/opentitan:cc.bzl", "exec_env_filegroup")
+load("//rules:files.bzl", "copy_files")
 
 package(default_visibility = ["//visibility:public"])
+
+copy_files(
+    name = "copy_signed",
+    testonly = True,
+    srcs = [
+        "//sw/device/silicon_creator/manuf/base:signed",
+    ],
+    filter = [
+        "ft_personalize_sival",
+    ],
+    relative_to = ":BUILD",
+    tags = ["manual"],
+)
 
 exec_env_filegroup(
     name = "ft_personalize_sival",

--- a/sw/device/silicon_creator/rom_ext/sival/binaries/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/binaries/BUILD
@@ -3,8 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/opentitan:cc.bzl", "exec_env_filegroup")
+load("//rules:files.bzl", "copy_files")
 
 package(default_visibility = ["//visibility:public"])
+
+copy_files(
+    name = "copy_signed",
+    testonly = True,
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext/sival:signed",
+    ],
+    relative_to = ":BUILD",
+    tags = ["manual"],
+)
 
 exec_env_filegroup(
     name = "rom_ext_dice_x509_prod",


### PR DESCRIPTION
During the signing ceremony, after re-attaching signatures, it is necessary to copy the signed binaries from the `bazel-out` directory to their desired location within the project.  This copying is tedious and error prone.

To ease toil, provide a rule which can copy the files produced by the post_signing_attach rule to their desired destination.
```
bazel run //sw/device/silicon_creator/rom_ext/sival:copy_signed
```