### PR TITLE
[individualize] only check AST patch if it is set

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -99,16 +99,16 @@ static status_t patch_ast_config_value(void) {
       &flash_ctrl_state, kFlashInfoFieldAstIndividPatchVal, &ast_patch_value,
       kFlashInfoFieldAstIndividPatchValSizeIn32BitWords));
 
-  // Check the address is within range before programming.
-  if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) {
-    TRY_CHECK(ast_patch_addr_offset <= AST_REGAL_REG_OFFSET);
-  }
-
   // Only patch AST if the patch value is present.
   if (ast_patch_value != 0 && ast_patch_value != UINT32_MAX) {
     LOG_INFO("Patching AST with:");
     LOG_INFO("AST patch address offset = 0x%08x", ast_patch_addr_offset);
     LOG_INFO("AST patch address value  = 0x%08x", ast_patch_value);
+
+    // Check the address is within range before programming.
+    if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) {
+      TRY_CHECK(ast_patch_addr_offset <= AST_REGAL_REG_OFFSET);
+    }
 
     // Write patch value.
     abs_mmio_write32(


### PR DESCRIPTION
This was checking the AST patch address regardless if it was set or not.