### PR TITLE
[manuf] Initialize boot data cfg OTP during perso.

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
@@ -67,6 +67,7 @@ ${fileheader}
     if item['name'] not in [
         'CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN',
         'CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG',
+        'CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG',
         'CREATOR_SW_CFG_MANUF_STATE',
         'OWNER_SW_CFG_ROM_BOOTSTRAP_DIS',
     ]:

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -581,6 +581,40 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   return OK_STATUS();
 }
 
+static status_t boot_data_cfg_initialize(void) {
+  // Configure the boot data OTP word.
+  if (!status_ok(manuf_individualize_device_flash_info_boot_data_cfg_check(
+          &otp_ctrl))) {
+    TRY(manuf_individualize_device_field_cfg(
+        &otp_ctrl,
+        OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET));
+  }
+
+  // Loads the boot data configuration from OTP.
+  flash_ctrl_cfg_t cfg = flash_ctrl_data_default_cfg_get();
+
+  flash_ctrl_perms_t perm = {
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4False,
+      .erase = kMultiBitBool4True,
+  };
+
+  // Erase the BootData pages. This is necessary to ensure that the owner
+  // block is written to a clean page and to avoid ECC errors in the
+  // next boot.
+  flash_ctrl_info_perms_set(&kFlashCtrlInfoPageBootData0, perm);
+  flash_ctrl_info_perms_set(&kFlashCtrlInfoPageBootData1, perm);
+  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData0, cfg);
+  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData1, cfg);
+
+  TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageBootData0,
+                            kFlashCtrlEraseTypePage));
+  TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageBootData1,
+                            kFlashCtrlEraseTypePage));
+
+  return OK_STATUS();
+}
+
 static status_t install_owner(void) {
   // Get the boot_data; installing the owner will write it back with the
   // ownership_state set to LockedOwner.
@@ -603,6 +637,11 @@ static status_t install_owner(void) {
   flash_ctrl_info_perms_set(&kFlashCtrlInfoPageOwnerSlot1, perm);
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageOwnerSlot1, cfg);
 
+  //  Initializes the boot data flash configuration in OTP, and
+  //  erases the boot data pages to avoid integrity errors in the next boot.
+  // `sku_creator_owner_init` will write the owner block to the flash.
+  TRY(boot_data_cfg_initialize());
+
   // Initialize ownership.  This will write the owner block into OwnerSlot0 and
   // set the ownership_state to LockedOwner.  The first boot of the ROM_EXT
   // will create a redundanty copy in OwnerSlot1.
@@ -610,7 +649,6 @@ static status_t install_owner(void) {
   owner_config_default(&config);
   owner_application_keyring_t keyring = {0};
   TRY(sku_creator_owner_init(&boot_data, &config, &keyring));
-
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -71,16 +71,16 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
     // Additionally, we skip the provisioning of the AST configuration data, as
     // this should already be written to a flash info page. We will pull the
     // data directly from there.
-    if (kv[i].offset ==
-            OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET ||
+    // clang-format off
+    if (kv[i].offset == OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET ||
+        kv[i].offset == OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET ||
         kv[i].offset == OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET ||
-        kv[i].offset ==
-            OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET ||
+        kv[i].offset == OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET ||
         kv[i].offset == OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET ||
-        (kv[i].offset >= kValidAstCfgOtpAddrLow &&
-         kv[i].offset < kInvalidAstCfgOtpAddrHigh)) {
+        (kv[i].offset >= kValidAstCfgOtpAddrLow && kv[i].offset < kInvalidAstCfgOtpAddrHigh)) {
       continue;
     }
+    // clang-format on
     uint32_t offset;
     TRY(dif_otp_ctrl_relative_address(partition, kv[i].offset, &offset));
     switch (kv[i].type) {
@@ -228,6 +228,10 @@ status_t manuf_individualize_device_field_cfg(const dif_otp_ctrl_t *otp_ctrl,
       field_value_addr = &kOwnerSwCfgRomBootstrapDisValue;
       partition = kDifOtpCtrlPartitionOwnerSwCfg;
       break;
+    case OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET:
+      field_value_addr = &kCreatorSwCfgFlashInfoBootDataCfgValue;
+      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET:
       field_value_addr = &kCreatorSwCfgFlashDataDefaultCfgValue;
       partition = kDifOtpCtrlPartitionCreatorSwCfg;
@@ -261,6 +265,19 @@ status_t manuf_individualize_device_flash_data_default_cfg_check(
   TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
                                     offset, &val));
   bool is_provisioned = (val == kCreatorSwCfgFlashDataDefaultCfgValue);
+  return is_provisioned ? OK_STATUS() : INTERNAL();
+}
+
+status_t manuf_individualize_device_flash_info_boot_data_cfg_check(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  uint32_t offset;
+  TRY(dif_otp_ctrl_relative_address(
+      kDifOtpCtrlPartitionCreatorSwCfg,
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET, &offset));
+  uint32_t val = 0;
+  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+                                    offset, &val));
+  bool is_provisioned = (val == kCreatorSwCfgFlashInfoBootDataCfgValue);
   return is_provisioned ? OK_STATUS() : INTERNAL();
 }
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -16,6 +16,7 @@
 extern const size_t kOtpKvCreatorSwCfgSize;
 extern const otp_kv_t kOtpKvCreatorSwCfg[];
 extern const uint32_t kCreatorSwCfgFlashDataDefaultCfgValue;
+extern const uint32_t kCreatorSwCfgFlashInfoBootDataCfgValue;
 extern const uint32_t kCreatorSwCfgManufStateValue;
 extern const uint32_t kCreatorSwCfgImmutableRomExtEnValue;
 
@@ -89,6 +90,17 @@ status_t manuf_individualize_device_field_cfg(const dif_otp_ctrl_t *otp_ctrl,
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_individualize_device_flash_data_default_cfg_check(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Checks the FLASH_INFO_BOOT_DATA_CFG field in the CREATOR_SW_CFG OTP
+ * partition.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the FLASH_INFO_BOOT_DATA_CFG field is provisioned.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_flash_info_boot_data_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**


### PR DESCRIPTION
Enabling scrambling and ECC for the boot data info pages during individualization was causing perso bootstrap to fail.

This is because ROM attempts to read the boot data before it has been initialized, causing integrity errors.

The solution is to skip boot data during individualization and apply it during perso, which is when the boot data is written for the first time.