### PR TITLE
[hw,pwm,rtl] Fix PWM hjson template

### DIFF
--- a/hw/ip_templates/pwm/data/pwm.hjson.tpl
+++ b/hw/ip_templates/pwm/data/pwm.hjson.tpl
@@ -46,7 +46,7 @@
       desc:  '''Pulse output.  Note that though this output is always enabled, there is a formal
                 set of enable pins (pwm_en_o) which are required for top-level integration of
                 comportable IPs.'''
-      width: "6"
+      width: "${nr_output_channels}"
     }
   ]
   alert_list: [


### PR DESCRIPTION
The available number of outputs need to be templatized with the ipgen parameter. No change for Earlgrey, since the default is 6 anyways.