### PR TITLE
[fusesoc,instance_vlnv] Add missing uses of instance_vlnv

### DIFF
--- a/hw/dv/sv/bus_params_pkg/bus_params_pkg.core
+++ b/hw/dv/sv/bus_params_pkg/bus_params_pkg.core
@@ -8,7 +8,7 @@ description: "Package holding common bus parameters such as widths."
 filesets:
   files_dv:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
     files:
       - bus_params_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/adc_ctrl/adc_ctrl.core
+++ b/hw/ip/adc_ctrl/adc_ctrl.core
@@ -7,7 +7,7 @@ description: "USB-C debug cable detection (CC1/CC2 voltage sensing)"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:ip:tlul
       - "fileset_partner  ? (partner:systems:ast_pkg)"

--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -7,7 +7,7 @@ description: "csrng"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:count
       - lowrisc:prim:edge_detector

--- a/hw/ip/edn/edn.core
+++ b/hw/ip/edn/edn.core
@@ -7,7 +7,7 @@ description: "edn"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:count
       - lowrisc:prim:edge_detector

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -7,7 +7,7 @@ description: "entropy_src"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:count
       - lowrisc:prim:edge_detector

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -7,7 +7,7 @@ description: "i2c"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:ram_1p_pkg
       - lowrisc:prim:ram_1p_adv

--- a/hw/ip/keymgr/keymgr_pkg.core
+++ b/hw/ip/keymgr/keymgr_pkg.core
@@ -8,7 +8,7 @@ description: "Flash Package"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:ip:edn_pkg
     files:
       - rtl/keymgr_reg_pkg.sv

--- a/hw/ip/keymgr_dpe/keymgr_dpe_pkg.core
+++ b/hw/ip/keymgr_dpe/keymgr_dpe_pkg.core
@@ -8,7 +8,7 @@ description: "Keymgr DPE Package"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:ip:keymgr_pkg
     files:

--- a/hw/ip/kmac/kmac_pkg.core
+++ b/hw/ip/kmac/kmac_pkg.core
@@ -8,7 +8,7 @@ description: "KMAC Package"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:ip:sha3
     files:
       - rtl/kmac_pkg.sv

--- a/hw/ip/spi_host/spi_host.core
+++ b/hw/ip/spi_host/spi_host.core
@@ -8,7 +8,7 @@ description: "SPI_HOST DV"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:prim:flop_en
       - lowrisc:prim:racl_error_arb

--- a/hw/ip/sysrst_ctrl/sysrst_ctrl.core
+++ b/hw/ip/sysrst_ctrl/sysrst_ctrl.core
@@ -7,7 +7,7 @@ description: "sysrst_ctrl"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:ip:tlul
     files:

--- a/hw/ip/tlul/adapter_host.core
+++ b/hw/ip/tlul/adapter_host.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:tlul:common
       - lowrisc:tlul:trans_intg
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
     files:
       - rtl/tlul_adapter_host.sv
     file_type: systemVerilogSource

--- a/hw/ip/tlul/headers.core
+++ b/hw/ip/tlul/headers.core
@@ -8,7 +8,7 @@ description: "TL-UL headers"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:secded
       - lowrisc:prim:mubi_pkg
     files:

--- a/hw/ip/uart/uart.core
+++ b/hw/ip/uart/uart.core
@@ -7,7 +7,7 @@ description: "uart"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_pkg
+      - lowrisc:virtual_constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:ip:tlul
       - lowrisc:systems:top_racl_pkg

--- a/hw/ip_templates/alert_handler/data/alert_handler.tpldesc.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler.tpldesc.hjson
@@ -70,12 +70,6 @@
       default: []
     }
     {
-      name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this alert_handler"
-      type: "string"
-      default: "lowrisc:constants:top_pkg"
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple alert_handler instances"
       type: "string"

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core.tpl
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - ${instance_vlnv(f"lowrisc:ip:{module_instance_name}_pkg:0.1")}
       - lowrisc:prim:mubi_pkg
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
     files:
       - ${module_instance_name}_env_pkg.sv
       - ${module_instance_name}_if.sv

--- a/hw/ip_templates/clkmgr/data/clkmgr.tpldesc.hjson
+++ b/hw/ip_templates/clkmgr/data/clkmgr.tpldesc.hjson
@@ -99,12 +99,6 @@
       default: "1"
     }
     {
-      name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this clkmgr"
-      type: "string"
-      default: "lowrisc:constants:top_pkg"
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple clkmgr instances. Not yet implemented."
       type: "string"

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env.core.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env.core.tpl
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - ${instance_vlnv("lowrisc:ip:clkmgr_pkg")}
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
     files:
       - clkmgr_csrs_if.sv
       - clkmgr_env_pkg.sv

--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.tpldesc.hjson
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.tpldesc.hjson
@@ -94,12 +94,6 @@
       default: "1048576"
     }
     {
-      name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this clkmgr"
-      type: "string"
-      default: "lowrisc:constants:top_pkg"
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple flash_ctrl instances. Not yet implemented."
       type: "string"

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.core.tpl
@@ -15,7 +15,7 @@ filesets:
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
       - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
     files:
       - flash_ctrl_eflash_ral_pkg.sv
       - flash_ctrl_env_pkg.sv

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_sim.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_sim.core.tpl
@@ -8,7 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
       - ${instance_vlnv("lowrisc:ip:flash_ctrl:0.1")}
     file_type: systemVerilogSource
 

--- a/hw/ip_templates/flash_ctrl/flash_ctrl.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl.core.tpl
@@ -22,7 +22,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
       - ${instance_vlnv("lowrisc:ip:flash_ctrl_reg")}
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
       - lowrisc:ip:jtag_pkg
     files:
       - rtl/flash_ctrl.sv

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_pkg.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_pkg.core.tpl
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}

--- a/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
@@ -76,12 +76,6 @@
       default: "1"
     }
     {
-      name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this pinmux"
-      type: "string"
-      default: "lowrisc:constants:top_pkg"
-    }
-    {
       name: "scan_role_pkg_vlnv"
       desc: "Provides the VLNV for the scan_role_pkg used by this pinmux"
       type: "string"

--- a/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
@@ -76,12 +76,6 @@
       default: "1"
     }
     {
-      name: "scan_role_pkg_vlnv"
-      desc: "Provides the VLNV for the scan_role_pkg used by this pinmux"
-      type: "string"
-      default: "lowrisc:systems:scan_role_pkg"
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple pinmux instances. Not yet implemented."
       type: "string"

--- a/hw/ip_templates/pinmux/fpv/pinmux_chip_fpv.core.tpl
+++ b/hw/ip_templates/pinmux/fpv/pinmux_chip_fpv.core.tpl
@@ -17,7 +17,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - ${instance_vlnv("lowrisc:fpv:pinmux_common_fpv:0.1")}
       - ${instance_vlnv("lowrisc:constants:top_pkg")}
-      - ${scan_role_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:systems:scan_role_pkg")}
     files:
       - tb/pinmux_chip_tb.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/pinmux/fpv/pinmux_chip_fpv.core.tpl
+++ b/hw/ip_templates/pinmux/fpv/pinmux_chip_fpv.core.tpl
@@ -16,7 +16,7 @@ filesets:
       - ${instance_vlnv("lowrisc:ip:pinmux:0.1")}
       - lowrisc:fpv:csr_assert_gen
       - ${instance_vlnv("lowrisc:fpv:pinmux_common_fpv:0.1")}
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
       - ${scan_role_pkg_vlnv}
     files:
       - tb/pinmux_chip_tb.sv

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
@@ -71,12 +71,6 @@
       default: "1"
     }
     {
-      name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this clkmgr"
-      type: "string"
-      default: "lowrisc:constants:top_pkg"
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple pwrmgr instances. Not yet implemented."
       type: "string"

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env.core.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_env.core.tpl
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
     files:
       - pwrmgr_env_pkg.sv
       - pwrmgr_env_cfg.sv: {is_include_file: true}

--- a/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
@@ -124,12 +124,6 @@
       default: "1"
     }
     {
-      name: "alert_handler_vlnv"
-      desc: "Provides the vlnv for alert_handler_pkt used by this rstmgr"
-      type: "string"
-      default: ""
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple rstmgr instances. Not yet implemented."
       type: "string"

--- a/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr.tpldesc.hjson
@@ -130,12 +130,6 @@
       default: ""
     }
     {
-      name: "top_pkg_vlnv"
-      desc: "Provides the VLNV for the top_pkg used by this rstmgr"
-      type: "string"
-      default: "lowrisc:constants:top_pkg"
-    }
-    {
       name: "module_instance_name"
       desc: "instance name in case there are multiple rstmgr instances. Not yet implemented."
       type: "string"

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_env.core.tpl
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_env.core.tpl
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - ${instance_vlnv("lowrisc:ip:rstmgr_pkg")}
-      - ${top_pkg_vlnv}
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
 
     files:
       - rstmgr_env_pkg.sv

--- a/hw/ip_templates/rstmgr/rstmgr.core.tpl
+++ b/hw/ip_templates/rstmgr/rstmgr.core.tpl
@@ -8,8 +8,8 @@ description: "Reset manager RTL"
 filesets:
   files_rtl:
     depend:
-% if alert_handler_vlnv:
-      - ${alert_handler_vlnv}
+% if with_alert_handler:
+      - ${instance_vlnv("lowrisc:ip:alert_handler_pkg")}
 % endif
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul

--- a/hw/top_darjeeling/chip_darjeeling_asic.core
+++ b/hw/top_darjeeling/chip_darjeeling_asic.core
@@ -13,7 +13,7 @@ filesets:
       - "fileset_partner ? (partner:systems:top_darjeeling_ast)"
       - "fileset_partner ? (partner:systems:top_darjeeling_scan_role_pkg)"
       - "!fileset_partner ? (lowrisc:systems:top_darjeeling_ast)"
-      - "!fileset_partner ? (lowrisc:systems:top_darjeeling_scan_role_pkg)"
+      - "!fileset_partner ? (lowrisc:darjeeling_systems:scan_role_pkg)"
     files:
       - rtl/autogen/chip_darjeeling_asic.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip/ast/ast_pkg.core
+++ b/hw/top_darjeeling/ip/ast/ast_pkg.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
       - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/ast_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
@@ -225,7 +225,6 @@
       5'd10
       5'd10
     ]
-    top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
     uniquified_modules: {}
   }

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:darjeeling_ip:alert_handler_pkg:0.1
       - lowrisc:prim:mubi_pkg
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
     files:
       - alert_handler_env_pkg.sv
       - alert_handler_if.sv

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
@@ -244,7 +244,6 @@
     exported_clks: {}
     number_of_clock_groups: 7
     with_alert_handler: true
-    top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
     uniquified_modules: {}
   }

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:darjeeling_ip:pwrmgr_pkg
       - lowrisc:darjeeling_ip:clkmgr_pkg
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
     files:
       - clkmgr_csrs_if.sv
       - clkmgr_env_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
@@ -15,7 +15,6 @@
     n_dio_periph_out: 57
     enable_usb_wakeup: false
     enable_strap_sampling: false
-    scan_role_pkg_vlnv: lowrisc:systems:top_darjeeling_scan_role_pkg
     topname: darjeeling
     uniquified_modules: {}
   }

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
@@ -15,7 +15,6 @@
     n_dio_periph_out: 57
     enable_usb_wakeup: false
     enable_strap_sampling: false
-    top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_darjeeling_scan_role_pkg
     topname: darjeeling
     uniquified_modules: {}

--- a/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -17,7 +17,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:darjeeling_fpv:pinmux_common_fpv:0.1
       - lowrisc:darjeeling_constants:top_pkg
-      - lowrisc:systems:top_darjeeling_scan_role_pkg
+      - lowrisc:darjeeling_systems:scan_role_pkg
     files:
       - tb/pinmux_chip_tb.sv
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -16,7 +16,7 @@ filesets:
       - lowrisc:darjeeling_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:darjeeling_fpv:pinmux_common_fpv:0.1
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
       - lowrisc:systems:top_darjeeling_scan_role_pkg
     files:
       - tb/pinmux_chip_tb.sv

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
@@ -71,7 +71,6 @@
     }
     wait_for_external_reset: true
     NumRomInputs: 3
-    top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
     uniquified_modules: {}
   }

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:darjeeling_ip:pwrmgr_pkg
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
     files:
       - pwrmgr_env_pkg.sv
       - pwrmgr_env_cfg.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -543,7 +543,6 @@
     ]
     rst_ni: lc_io_div4
     export_rsts: {}
-    alert_handler_vlnv: lowrisc:darjeeling_ip:alert_handler_pkg
     with_alert_handler: true
     topname: darjeeling
     uniquified_modules: {}

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -545,7 +545,6 @@
     export_rsts: {}
     alert_handler_vlnv: lowrisc:darjeeling_ip:alert_handler_pkg
     with_alert_handler: true
-    top_pkg_vlnv: lowrisc:constants:top_darjeeling_top_pkg
     topname: darjeeling
     uniquified_modules: {}
   }

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:darjeeling_ip:rstmgr_pkg
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
 
     files:
       - rstmgr_env_pkg.sv

--- a/hw/top_darjeeling/top_darjeeling.core
+++ b/hw/top_darjeeling/top_darjeeling.core
@@ -30,7 +30,7 @@ filesets:
       - lowrisc:prim:ram_1p_scr
       - lowrisc:ip:sram_ctrl
       - lowrisc:ip:keymgr_dpe
-      - lowrisc:constants:top_darjeeling_top_pkg
+      - lowrisc:darjeeling_constants:top_pkg
       - lowrisc:constants:top_darjeeling_jtag_id_pkg
       - lowrisc:constants:top_darjeeling_ibex_pmp_reset_pkg
       - lowrisc:ip:lc_ctrl

--- a/hw/top_darjeeling/top_darjeeling_scan_role_pkg.core
+++ b/hw/top_darjeeling/top_darjeeling_scan_role_pkg.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:systems:top_darjeeling_scan_role_pkg:0.1"
+name: "lowrisc:darjeeling_systems:scan_role_pkg:0.1"
 description: "Open-source place-holder for scanrole parameters for Darjeeling"
-virtual:
-  - lowrisc:systems:scan_role_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_darjeeling/top_pkg.core
+++ b/hw/top_darjeeling/top_pkg.core
@@ -3,13 +3,10 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# XXX: This name is currently required as global identifier until we have
-# support for "interfaces" or a similar concept.
-# Tracked in https://github.com/olofk/fusesoc/issues/235
-name: "lowrisc:constants:top_darjeeling_top_pkg"
+name: "lowrisc:darjeeling_constants:top_pkg"
 description: "Toplevel-wide constants for Darjeeling"
 virtual:
-  - lowrisc:constants:top_pkg
+  - lowrisc:virtual_constants:top_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -13,7 +13,7 @@ filesets:
       - "fileset_partner ? (partner:systems:top_earlgrey_ast)"
       - "fileset_partner ? (partner:systems:top_earlgrey_scan_role_pkg)"
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast)"
-      - "!fileset_partner ? (lowrisc:systems:top_earlgrey_scan_role_pkg)"
+      - "!fileset_partner ? (lowrisc:earlgrey_systems:scan_role_pkg)"
     files:
       - rtl/autogen/chip_earlgrey_asic.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:top_earlgrey_ast
       - lowrisc:systems:top_earlgrey_padring
-      - lowrisc:systems:top_earlgrey_scan_role_pkg
+      - lowrisc:earlgrey_systems:scan_role_pkg
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:top_earlgrey_ast
       - lowrisc:systems:top_earlgrey_padring
-      - lowrisc:systems:top_earlgrey_scan_role_pkg
+      - lowrisc:earlgrey_systems:scan_role_pkg
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_earlgrey/chip_earlgrey_cw340.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw340.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:top_earlgrey_ast
       - lowrisc:systems:top_earlgrey_padring
-      - lowrisc:systems:top_earlgrey_scan_role_pkg
+      - lowrisc:earlgrey_systems:scan_role_pkg
     files:
       - rtl/clkgen_xil_ultrascale.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:ibex:ibex_tracer
       - lowrisc:prim:clock_div
       - lowrisc:systems:top_earlgrey_ast
-      - lowrisc:systems:top_earlgrey_scan_role_pkg
+      - lowrisc:earlgrey_systems:scan_role_pkg
 
     files:
       - rtl/chip_earlgrey_verilator.sv: { file_type: systemVerilogSource }

--- a/hw/top_earlgrey/ip/ast/ast_pkg.core
+++ b/hw/top_earlgrey/ip/ast/ast_pkg.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/ast_pkg.sv

--- a/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
+++ b/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
@@ -8,7 +8,7 @@ description: "Sensor Control Package"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
       - "fileset_partner ? (partner:systems:top_earlgrey_ast_pkg)"
       - lowrisc:systems:top_earlgrey_sensor_ctrl_reg

--- a/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_reg.core
+++ b/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_reg.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
     files:
       - rtl/sensor_ctrl_reg_pkg.sv
       - rtl/sensor_ctrl_reg_top.sv

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
@@ -149,7 +149,6 @@
       5'd17
       5'd17
     ]
-    top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
     uniquified_modules: {}
   }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:earlgrey_ip:alert_handler_pkg:0.1
       - lowrisc:prim:mubi_pkg
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
     files:
       - alert_handler_env_pkg.sv
       - alert_handler_if.sv

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
@@ -259,7 +259,6 @@
     exported_clks: {}
     number_of_clock_groups: 7
     with_alert_handler: true
-    top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
     uniquified_modules: {}
   }

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:earlgrey_ip:clkmgr_pkg
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
     files:
       - clkmgr_csrs_if.sv
       - clkmgr_env_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
@@ -23,7 +23,6 @@
     bytes_per_page: 2048
     bytes_per_bank: 524288
     size: 1048576
-    top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
     uniquified_modules: {}
   }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -15,7 +15,7 @@ filesets:
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:earlgrey_ip:flash_ctrl_pkg
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
     files:
       - flash_ctrl_eflash_ral_pkg.sv
       - flash_ctrl_env_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
@@ -8,7 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:earlgrey_ip:flash_ctrl:0.1
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl.core
@@ -22,7 +22,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:earlgrey_ip:flash_ctrl_pkg
       - lowrisc:earlgrey_ip:flash_ctrl_reg
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:ip:jtag_pkg
     files:
       - rtl/flash_ctrl.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:earlgrey_ip:pwrmgr_pkg

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
@@ -15,7 +15,6 @@
     n_dio_periph_out: 14
     enable_usb_wakeup: true
     enable_strap_sampling: true
-    top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_earlgrey_scan_role_pkg
     topname: earlgrey
     uniquified_modules: {}

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
@@ -15,7 +15,6 @@
     n_dio_periph_out: 14
     enable_usb_wakeup: true
     enable_strap_sampling: true
-    scan_role_pkg_vlnv: lowrisc:systems:top_earlgrey_scan_role_pkg
     topname: earlgrey
     uniquified_modules: {}
   }

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -16,7 +16,7 @@ filesets:
       - lowrisc:earlgrey_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:earlgrey_fpv:pinmux_common_fpv:0.1
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:systems:top_earlgrey_scan_role_pkg
     files:
       - tb/pinmux_chip_tb.sv

--- a/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -17,7 +17,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:earlgrey_fpv:pinmux_common_fpv:0.1
       - lowrisc:earlgrey_constants:top_pkg
-      - lowrisc:systems:top_earlgrey_scan_role_pkg
+      - lowrisc:earlgrey_systems:scan_role_pkg
     files:
       - tb/pinmux_chip_tb.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -81,7 +81,6 @@
     }
     wait_for_external_reset: false
     NumRomInputs: 1
-    top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
     uniquified_modules: {}
   }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:earlgrey_ip:pwrmgr_pkg
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
     files:
       - pwrmgr_env_pkg.sv
       - pwrmgr_env_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -692,7 +692,6 @@
     export_rsts: {}
     alert_handler_vlnv: lowrisc:earlgrey_ip:alert_handler_pkg
     with_alert_handler: true
-    top_pkg_vlnv: lowrisc:constants:top_earlgrey_top_pkg
     topname: earlgrey
     uniquified_modules: {}
   }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -690,7 +690,6 @@
     ]
     rst_ni: lc_io_div4
     export_rsts: {}
-    alert_handler_vlnv: lowrisc:earlgrey_ip:alert_handler_pkg
     with_alert_handler: true
     topname: earlgrey
     uniquified_modules: {}

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:earlgrey_ip:rstmgr_pkg
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
 
     files:
       - rstmgr_env_pkg.sv

--- a/hw/top_earlgrey/scan_role_pkg.core
+++ b/hw/top_earlgrey/scan_role_pkg.core
@@ -2,10 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:systems:top_earlgrey_scan_role_pkg:0.1"
+name: "lowrisc:earlgrey_systems:scan_role_pkg:0.1"
 description: "Open-source place-holder for scanrole parameters"
-virtual:
-  - lowrisc:systems:scan_role_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -30,7 +30,7 @@ filesets:
       - lowrisc:prim:flash
       - lowrisc:ip:sram_ctrl
       - lowrisc:ip:keymgr
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:constants:top_earlgrey_jtag_id_pkg
       - lowrisc:constants:top_earlgrey_ibex_pmp_reset_pkg
       - lowrisc:ip:lc_ctrl

--- a/hw/top_earlgrey/top_pkg.core
+++ b/hw/top_earlgrey/top_pkg.core
@@ -3,13 +3,10 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# XXX: This name is currently required as global identifier until we have
-# support for "interfaces" or a similar concept.
-# Tracked in https://github.com/olofk/fusesoc/issues/235
-name: "lowrisc:constants:top_earlgrey_top_pkg"
+name: "lowrisc:earlgrey_constants:top_pkg"
 description: "Toplevel-wide constants for Earl Grey"
 virtual:
-  - lowrisc:constants:top_pkg
+  - lowrisc:virtual_constants:top_pkg
 
 filesets:
   files_rtl:

--- a/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:systems:top_englishbreakfast_pkg
       - lowrisc:systems:top_englishbreakfast_ast
       - lowrisc:systems:top_earlgrey_padring
-      - lowrisc:systems:top_earlgrey_scan_role_pkg
+      - lowrisc:earlgrey_systems:scan_role_pkg
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_englishbreakfast/ip/ast/ast_pkg.core
+++ b/hw/top_englishbreakfast/ip/ast/ast_pkg.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/ast_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
@@ -236,7 +236,6 @@
     exported_clks: {}
     number_of_clock_groups: 8
     with_alert_handler: false
-    top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
     uniquified_modules: {}
   }

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:englishbreakfast_ip:pwrmgr_pkg
       - lowrisc:englishbreakfast_ip:clkmgr_pkg
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
     files:
       - clkmgr_csrs_if.sv
       - clkmgr_env_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
@@ -23,7 +23,6 @@
     bytes_per_page: 2048
     bytes_per_bank: 32768
     size: 65536
-    top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
     uniquified_modules: {}
   }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -15,7 +15,7 @@ filesets:
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
     files:
       - flash_ctrl_eflash_ral_pkg.sv
       - flash_ctrl_env_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_sim.core
@@ -8,7 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:englishbreakfast_ip:flash_ctrl:0.1
     file_type: systemVerilogSource
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl.core
@@ -22,7 +22,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
       - lowrisc:englishbreakfast_ip:flash_ctrl_reg
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:ip:jtag_pkg
     files:
       - rtl/flash_ctrl.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_pkg.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:englishbreakfast_ip:pwrmgr_pkg

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
@@ -15,7 +15,6 @@
     n_dio_periph_out: 12
     enable_usb_wakeup: true
     enable_strap_sampling: true
-    scan_role_pkg_vlnv: lowrisc:systems:top_englishbreakfast_scan_role_pkg
     topname: englishbreakfast
     uniquified_modules: {}
   }

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
@@ -15,7 +15,6 @@
     n_dio_periph_out: 12
     enable_usb_wakeup: true
     enable_strap_sampling: true
-    top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     scan_role_pkg_vlnv: lowrisc:systems:top_englishbreakfast_scan_role_pkg
     topname: englishbreakfast
     uniquified_modules: {}

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -16,7 +16,7 @@ filesets:
       - lowrisc:englishbreakfast_ip:pinmux:0.1
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:englishbreakfast_fpv:pinmux_common_fpv:0.1
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:systems:top_englishbreakfast_scan_role_pkg
     files:
       - tb/pinmux_chip_tb.sv

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/fpv/pinmux_chip_fpv.core
@@ -17,7 +17,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:englishbreakfast_fpv:pinmux_common_fpv:0.1
       - lowrisc:englishbreakfast_constants:top_pkg
-      - lowrisc:systems:top_englishbreakfast_scan_role_pkg
+      - lowrisc:englishbreakfast_systems:scan_role_pkg
     files:
       - tb/pinmux_chip_tb.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
@@ -60,7 +60,6 @@
     }
     wait_for_external_reset: false
     NumRomInputs: 1
-    top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
     uniquified_modules: {}
   }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_env.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:englishbreakfast_ip:pwrmgr_pkg
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
     files:
       - pwrmgr_env_pkg.sv
       - pwrmgr_env_cfg.sv: {is_include_file: true}

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -450,7 +450,6 @@
     ]
     rst_ni: lc_io_div4
     export_rsts: {}
-    alert_handler_vlnv: lowrisc:earlgrey_ip:alert_handler_pkg
     with_alert_handler: false
     topname: englishbreakfast
     uniquified_modules: {}

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -452,7 +452,6 @@
     export_rsts: {}
     alert_handler_vlnv: lowrisc:earlgrey_ip:alert_handler_pkg
     with_alert_handler: false
-    top_pkg_vlnv: lowrisc:constants:top_englishbreakfast_top_pkg
     topname: englishbreakfast
     uniquified_modules: {}
   }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_env.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:englishbreakfast_ip:rstmgr_pkg
-      - lowrisc:constants:top_englishbreakfast_top_pkg
+      - lowrisc:englishbreakfast_constants:top_pkg
 
     files:
       - rstmgr_env_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr.core
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rstmgr.core
@@ -8,7 +8,6 @@ description: "Reset manager RTL"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:earlgrey_ip:alert_handler_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:clock_mux2

--- a/hw/top_englishbreakfast/top_englishbreakfast_scan_role_pkg.core
+++ b/hw/top_englishbreakfast/top_englishbreakfast_scan_role_pkg.core
@@ -1,0 +1,16 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:englishbreakfast_systems:scan_role_pkg:0.1"
+description: "Open-source place-holder for scanrole parameters"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:earlgrey_systems:scan_role_pkg
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl

--- a/hw/top_englishbreakfast/top_pkg.core
+++ b/hw/top_englishbreakfast/top_pkg.core
@@ -3,13 +3,13 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:constants:top_englishbreakfast_top_pkg"
+name: "lowrisc:englishbreakfast_constants:top_pkg"
 description: "Toplevel-wide constants for English Breakfast"
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:constants:top_earlgrey_top_pkg
+      - lowrisc:earlgrey_constants:top_pkg
     file_type: systemVerilogSource
 
 targets:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -338,7 +338,6 @@ def _get_alert_handler_params(top: ConfigT) -> ParamsT:
         "ping_cnt_dw": ping_cnt_dw,
         "n_lpg": n_lpgs,
         "lpg_map": lpg_map,
-        "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
     }
 
 
@@ -484,7 +483,6 @@ def _get_pinmux_params(top: ConfigT) -> ParamsT:
         "n_dio_periph_out": n_dio_periph_out,
         "enable_usb_wakeup": pinmux['enable_usb_wakeup'],
         "enable_strap_sampling": pinmux['enable_strap_sampling'],
-        "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
         "scan_role_pkg_vlnv": f"lowrisc:systems:top_{topname}_scan_role_pkg",
     }
 
@@ -540,8 +538,6 @@ def _get_clkmgr_params(top: ConfigT) -> ParamsT:
         len(clocks.groups),
         "with_alert_handler":
         with_alert_handler,
-        "top_pkg_vlnv":
-        f"lowrisc:constants:top_{topname}_top_pkg",
     }
 
 
@@ -590,7 +586,6 @@ def _get_pwrmgr_params(top: ConfigT) -> ParamsT:
         "rst_reqs": top["reset_requests"],
         "wait_for_external_reset": top['power']['wait_for_external_reset'],
         "NumRomInputs": n_rom_ctrl,
-        "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
     }
 
 
@@ -656,7 +651,6 @@ def _get_rstmgr_params(top: ConfigT) -> ParamsT:
         "export_rsts": top["exported_rsts"],
         "alert_handler_vlnv": alert_handler_vlnv,
         "with_alert_handler": with_alert_handler,
-        "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
     }
 
 
@@ -686,7 +680,6 @@ def _get_flash_ctrl_params(top: ConfigT) -> ParamsT:
         "metadata_width": 12,
         "info_types": 3,
         "infos_per_bank": [10, 1, 2],
-        "top_pkg_vlnv": f"lowrisc:constants:top_{topname}_top_pkg",
     })
 
     params.pop('base_addrs', None)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -270,7 +270,6 @@ def generate_ipgen(top: ConfigT, module: ConfigT, params: ParamsT,
 
 def _get_alert_handler_params(top: ConfigT) -> ParamsT:
     """Returns parameters for alert_hander ipgen from top config."""
-    topname = top["name"]
     # default values
     esc_cnt_dw = 32
     accu_cnt_dw = 16
@@ -418,7 +417,6 @@ def _get_pinmux_params(top: ConfigT) -> ParamsT:
     assert "pinmux" in top
     assert "pinout" in top
 
-    topname = top["name"]
     pinmux = top["pinmux"]
 
     # Get number of wakeup detectors
@@ -483,7 +481,6 @@ def _get_pinmux_params(top: ConfigT) -> ParamsT:
         "n_dio_periph_out": n_dio_periph_out,
         "enable_usb_wakeup": pinmux['enable_usb_wakeup'],
         "enable_strap_sampling": pinmux['enable_strap_sampling'],
-        "scan_role_pkg_vlnv": f"lowrisc:systems:top_{topname}_scan_role_pkg",
     }
 
 
@@ -516,7 +513,6 @@ def _get_clkmgr_params(top: ConfigT) -> ParamsT:
     with_alert_handler = lib.find_module(top['module'],
                                          'alert_handler') is not None
 
-    topname = top["name"]
     return {
         "src_clks":
         OrderedDict({name: vars(obj)
@@ -553,7 +549,6 @@ def generate_clkmgr(top: ConfigT, module: ConfigT, out_path: Path) -> None:
 
 def _get_pwrmgr_params(top: ConfigT) -> ParamsT:
     """Extracts parameters for pwrmgr ipgen."""
-    topname = top["name"]
     # Count number of wakeups
     n_wkups = len(top["wakeups"])
     log.info("Found {} wakeup signals".format(n_wkups))
@@ -602,7 +597,6 @@ def get_rst_ni(top: ConfigT) -> object:
 
 def _get_rstmgr_params(top: ConfigT) -> ParamsT:
     """Extracts parameters for rstmgr ipgen."""
-    topname = top["name"]
     # Parameters needed for generation
     reset_obj = top["resets"]
 
@@ -664,7 +658,6 @@ def _get_flash_ctrl_params(top: ConfigT) -> ParamsT:
         raise ValueError(
             "In _get_flash_ctrl_params for design with no flash_ctrl")
 
-    topname = top["name"]
     params = vars(flash_mems[0]["memory"]["mem"]["config"])
     # Additional parameters not provided in the top config.
     params.update({

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -630,14 +630,6 @@ def _get_rstmgr_params(top: ConfigT) -> ParamsT:
     # Will connect to alert_handler
     with_alert_handler = lib.find_module(top['module'],
                                          'alert_handler') is not None
-    if with_alert_handler:
-        alert_handler_vlnv = f"lowrisc:{topname}_ip:alert_handler_pkg"
-    elif topname == "englishbreakfast":
-        # TODO: Clean templates to not require alert_handler. English Breakfast
-        # does not have one, so it uses types and constants from Earl Grey.
-        alert_handler_vlnv = "lowrisc:earlgrey_ip:alert_handler_pkg"
-    else:
-        alert_handler_vlnv = ""
 
     return {
         "clks": clks,
@@ -649,7 +641,6 @@ def _get_rstmgr_params(top: ConfigT) -> ParamsT:
         "leaf_rsts": leaf_rsts,
         "rst_ni": rst_ni['rst_ni']['name'],
         "export_rsts": top["exported_rsts"],
-        "alert_handler_vlnv": alert_handler_vlnv,
         "with_alert_handler": with_alert_handler,
     }
 


### PR DESCRIPTION
This has three commits that use instance_vlnv to handle
- All dependencies on top_pkg
- The rstmgr dependency on alert_handler_pkg
- The pinmux fpv dependency on scan_role_pkg

Each commit removes ipgen parameters that become unnecessary.