### PR TITLE
[ci] Add note about triggering CI for backports

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -44,6 +44,11 @@ jobs:
           pull_description: |
             This is an automatic cherry-pick of #${pull_number} to branch `${target_branch}`.
 
+            > [!IMPORTANT]
+            > This automated pull request cannot trigger CI tests itself.
+            >
+            > Please add the `CI:Rerun` label to trigger them manually before merging.
+
       - name: Apply label for manually cherry picking
         if: ${{ steps.backport.outputs.was_successful == 'false' }}
         env:


### PR DESCRIPTION
The note will look like this:

> [!IMPORTANT]
> This automated pull request cannot trigger CI tests itself.
>
> Please add the `CI:Rerun` label to trigger them manually before merging.