### PR TITLE
[ci] Add note about triggering CI for backports (`earlgrey_1.0.0`)

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -38,6 +38,11 @@ jobs:
           pull_description: |
             This is an automatic cherry-pick of #${pull_number} to branch `${target_branch}`.
 
+            > [!IMPORTANT]
+            > This automated pull request cannot trigger CI tests itself.
+            >
+            > Please add the `CI:Rerun` label to trigger them manually before merging.
+
       - name: Apply label for manually cherry picking
         if: ${{ steps.backport.outputs.was_successful == 'false' }}
         env:


### PR DESCRIPTION
Manual backport of https://github.com/lowRISC/opentitan/pull/26768