### PR TITLE
[sram_ctrl] Update sram_ctrl_smoketest for Darjeeling using DT

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4376,9 +4376,10 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/sram_ctrl_smoketest.c
+++ b/sw/device/tests/sram_ctrl_smoketest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_sram_ctrl.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
@@ -11,11 +12,16 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
-// define a number of reads and writes to perform,
-// for our purposes a small number will be sufficient.
+// Define a number of reads and writes to perform; for our purposes a small
+// number will be sufficient.
 #define SRAM_CTRL_TEST_DATA_SIZE_WORDS 16
+
+static_assert(kDtSramCtrlCount >= 1,
+              "This test requires at least one RAM Control instance");
+static_assert(kDtSramCtrlCount < 100,
+              "The reported SRAM_CTRL instance number may be incorrect");
+
+#define SRAM_CTRL_NAME(x) #x
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -28,68 +34,94 @@ static const uint32_t kRandomData[SRAM_CTRL_TEST_DATA_SIZE_WORDS] = {
     0x5c95e716, 0xe887aab1, 0x307f6ef9, 0x6f5c0464, 0x5882279d, 0x44c19574,
     0x1bd20079, 0xf8250ead, 0x4bf362a4, 0xad41437d};
 
+// Properties of each of the SRAM_CTRL blocks to be tested.
+static struct {
+  /**
+   * Interface to SRAM_CTRL.
+   */
+  dif_sram_ctrl_t dif;
+  /**
+   * Base address of test buffer within SRAM_CTRL instance.
+   */
+  uintptr_t buf;
+  /**
+   * MMIO access to test buffer.
+   */
+  mmio_region_t region;
+  /**
+   * Name of SRAM_CTRL instance.
+   */
+  const char *name;
+  /**
+   * Name buffer, for those instances which are identified numerically.
+   */
+  char nameBuf[12];
+} sram_ctrl[kDtSramCtrlCount];
+
 // Buffer to allow the compiler to allocate a safe area in Main SRAM where
 // we can do the write/read test without the risk of clobbering data
 // used by the program.
 OT_SECTION(".data")
 static volatile uint32_t sram_main_buffer[SRAM_CTRL_TEST_DATA_SIZE_WORDS];
 
-// Write / Read small chunks of data to SRAM to test
-// basic functionality of sram_ctrl
-static void write_read_check(mmio_region_t base_addr_region,
-                             const char *sram_name) {
-  uint32_t rw_data_32;
+// Write and read small chunks of data to each SRAM_CTRL to test basic
+// functionality; exercise all of the controllers in an interleaved fashion
+// just to increase the chance of catching any crosstalk issues/interactions
+// between the instances.
+static void write_read_check(void) {
   for (int i = 0; i < SRAM_CTRL_TEST_DATA_SIZE_WORDS; ++i) {
-    mmio_region_write32(base_addr_region, i * (ptrdiff_t)sizeof(uint32_t),
-                        kRandomData[i]);
-    rw_data_32 =
-        mmio_region_read32(base_addr_region, i * (ptrdiff_t)sizeof(uint32_t));
-    CHECK(rw_data_32 == kRandomData[i],
-          "Memory Write/Read Mismatch for %s, index %d, data read = %08x "
-          "data_expected = %08x.",
-          sram_name, i, rw_data_32, kRandomData[i]);
+    for (dt_sram_ctrl_t sc = (dt_sram_ctrl_t)0; sc < kDtSramCtrlCount; ++sc) {
+      mmio_region_write32(sram_ctrl[sc].region, i * (ptrdiff_t)sizeof(uint32_t),
+                          kRandomData[i]);
+      uint32_t rw_data_32 = mmio_region_read32(sram_ctrl[sc].region,
+                                               i * (ptrdiff_t)sizeof(uint32_t));
+      CHECK(rw_data_32 == kRandomData[i],
+            "Memory Write/Read Mismatch for %s, index %d, data read = %08x "
+            "data_expected = %08x.",
+            sram_ctrl[sc].name, i, rw_data_32, kRandomData[i]);
+    }
   }
 }
 
 bool test_main(void) {
-  // Initialize SRAM_CTRL hardware.
-  dif_sram_ctrl_t sram_ctrl_main;
-  dif_sram_ctrl_t sram_ctrl_ret;
-  CHECK_DIF_OK(dif_sram_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
-      &sram_ctrl_main));
-  CHECK_DIF_OK(dif_sram_ctrl_init(
-      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR),
-      &sram_ctrl_ret));
+  // Initialize SRAM_CTRL blocks.
+  for (dt_sram_ctrl_t sc = (dt_sram_ctrl_t)0; sc < kDtSramCtrlCount; ++sc) {
+    CHECK_DIF_OK(dif_sram_ctrl_init_from_dt(sc, &sram_ctrl[sc].dif));
 
-  dif_sram_ctrl_status_bitfield_t status_main;
-  dif_sram_ctrl_status_bitfield_t status_ret;
+    // Decide upon the buffer address to be used for this SRAM controller.
+    switch (sc) {
+      // Main SRAM will use the address of the buffer that has been allocated.
+      case kDtSramCtrlMain:
+        sram_ctrl[sc].buf = (uintptr_t)sram_main_buffer;
+        sram_ctrl[sc].name = SRAM_CTRL_NAME(kDtSramCtrlMain);
+        break;
+
+      default:
+        // Ret SRAM can start at the beginning of the owner section.
+        sram_ctrl[sc].buf =
+            (uintptr_t)dt_sram_ctrl_reg_block(sc, kDtSramCtrlRegBlockRam);
+        // Assume that no target device has more than 100 SRAM_CTRL instances.
+        unsigned dig = (unsigned)sc / 10;
+        sram_ctrl[sc].nameBuf[0] = (char)('0' + dig);
+        sram_ctrl[sc].nameBuf[1] = (char)('0' + ((unsigned)sc - dig * 10));
+        sram_ctrl[sc].name = sram_ctrl[sc].nameBuf;
+        break;
+    }
+    // Obtain access to the buffer.
+    sram_ctrl[sc].region = mmio_region_from_addr(sram_ctrl[sc].buf);
+  }
 
   // Check Status registers
-  CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram_ctrl_ret, &status_ret));
-  CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram_ctrl_main, &status_main));
+  for (dt_sram_ctrl_t sc = (dt_sram_ctrl_t)0; sc < kDtSramCtrlCount; ++sc) {
+    dif_sram_ctrl_status_bitfield_t status;
+    CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram_ctrl[sc].dif, &status));
+    CHECK((status & kStatusRegMask) == 0x0,
+          "SRAM %s status error bits set, status = %08x.", sram_ctrl[sc].name,
+          status);
+  }
 
-  CHECK((status_main & kStatusRegMask) == 0x0,
-        "SRAM main status error bits set, status = %08x.", status_main);
-  CHECK((status_ret & kStatusRegMask) == 0x0,
-        "SRAM ret status error bits set, status = %08x.", status_ret);
-
-  // Read and Write to/from SRAMs. Main SRAM will use the address of the
-  // buffer that has been allocated. Ret SRAM can start at the beginning
-  // of the owner section.
-  uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
-  uintptr_t sram_ret_buffer_addr =
-      TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
-      offsetof(retention_sram_t, owner);
-
-  mmio_region_t sram_region_main_addr =
-      mmio_region_from_addr(sram_main_buffer_addr);
-  mmio_region_t sram_region_ret_addr =
-      mmio_region_from_addr(sram_ret_buffer_addr);
-
-  // write / read checks
-  write_read_check(sram_region_ret_addr, "SRAM_RET");
-  write_read_check(sram_region_main_addr, "SRAM_MAIN");
+  // Write/read to/from SRAMs.
+  write_read_check();
 
   return true;
 }


### PR DESCRIPTION
Port the sram_ctrl_smoketest to use DT and perform bring up on Darjeeling.

Generalize the code to support a variable number of SRAM Controller instances. kDtSramCtrlMain still needs to be treated as special to avoid corrupting the main SRAM content.

Overlap the testing of the individual SRAM Controller instances to increase the chance of catching an interactions/crosstalk.

Test thus now exercises the mailbox SRAM controller on Darjeeling.