### PR TITLE
[boot_svc, rescue] Allow app-requested rescue

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/BUILD
+++ b/sw/device/silicon_creator/lib/rescue/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:pinmux",

--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
@@ -18,6 +19,8 @@
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 
 #include "flash_ctrl_regs.h"
+
+static hardened_bool_t rescue_requested;
 
 const uint32_t kFlashPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE;
 const uint32_t kFlashBankSize =
@@ -281,7 +284,16 @@ void rescue_state_init(rescue_state_t *state,
   }
 }
 
+rom_error_t rescue_enter_handler(boot_svc_msg_t *msg) {
+  rescue_requested = kHardenedBoolTrue;
+  boot_svc_enter_rescue_res_init(kErrorOk, &msg->enter_rescue_res);
+  return kErrorOk;
+}
+
 hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config) {
+  if (rescue_requested == kHardenedBoolTrue) {
+    return kHardenedBoolTrue;
+  }
   rescue_detect_t detect = kRescueDetectBreak;
   uint32_t index = 0;
   uint32_t gpio_val = 0;

--- a/sw/device/silicon_creator/lib/rescue/rescue.h
+++ b/sw/device/silicon_creator/lib/rescue/rescue.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
@@ -126,6 +127,14 @@ rom_error_t rescue_validate_mode(uint32_t mode, rescue_state_t *state,
  */
 void rescue_state_init(rescue_state_t *state,
                        const owner_rescue_config_t *config);
+
+/**
+ * Handle the boot services RescueEnter request.
+ *
+ * @param msg The boot services message.
+ * @return kErrorOk if the command was processed correctly.
+ */
+rom_error_t rescue_enter_handler(boot_svc_msg_t *msg);
 
 /**
  * Perform the rescue protocol.

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -60,6 +60,31 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "boot_svc_enter_rescue_test",
+    srcs = ["boot_svc_enter_rescue_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
+        exit_failure = "BFV|PASS|FAIL",
+        exit_success = "mode: RESQ\r\n",
+    ),
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    deps = [
+        ":boot_svc_test_lib",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_enter_rescue",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)
+
+opentitan_test(
     name = "boot_svc_wakeup_test",
     srcs = ["boot_svc_wakeup_test.c"],
     exec_env = {

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_enter_rescue_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_enter_rescue_test.c
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
+  boot_svc_msg_t msg = {0};
+  boot_svc_enter_rescue_req_init(&msg.enter_rescue_req);
+  retram->creator.boot_svc_msg = msg;
+  state->state = kBootSvcTestStateEnterRescue;
+  rstmgr_reset();
+  return INTERNAL();
+}
+
+static status_t enter_rescue_message_test(void) {
+  retention_sram_t *retram = retention_sram_get();
+  TRY(boot_svc_test_init(retram, kBootSvcTestEmpty));
+  boot_svc_retram_t *state = (boot_svc_retram_t *)&retram->owner;
+
+  for (;;) {
+    LOG_INFO("Test state = %d", state->state);
+    switch (state->state) {
+      case kBootSvcTestStateInit:
+        TRY(initialize(retram, state));
+        break;
+      default:
+        // We never expect to come back because the test's exit_success is to
+        // observe the rescue entry message.
+        LOG_INFO("Unexpected State: %d", state->state);
+        return UNKNOWN();
+    }
+  }
+}
+
+bool test_main(void) {
+  status_t sts = enter_rescue_message_test();
+  if (status_err(sts)) {
+    LOG_ERROR("enter_rescue_message_test: %r", sts);
+  }
+  return status_ok(sts);
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
@@ -24,6 +24,7 @@ typedef enum boot_svc_test_state {
   kBootSvcTestStateMinSecAdvance,
   kBootSvcTestStateMinSecTooFar,
   kBootSvcTestStateMinSecGoBack,
+  kBootSvcTestStateEnterRescue,
   kBootSvcTestStateFinal,
 } boot_svc_test_state_t;
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -533,6 +533,9 @@ static rom_error_t handle_boot_svc(boot_data_t *boot_data,
         HARDENED_CHECK_EQ(msg_type, kBootSvcEmptyReqType);
         boot_svc_empty_res_init(&boot_svc_msg->empty);
         break;
+      case kBootSvcEnterRescueReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcEnterRescueReqType);
+        return rescue_enter_handler(boot_svc_msg);
       case kBootSvcNextBl0SlotReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcNextBl0SlotReqType);
         return boot_svc_next_boot_bl0_slot_handler(boot_svc_msg, boot_data,
@@ -547,6 +550,7 @@ static rom_error_t handle_boot_svc(boot_data_t *boot_data,
         HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipActivateReqType);
         return ownership_activate_handler(boot_svc_msg, boot_data);
       case kBootSvcEmptyResType:
+      case kBootSvcEnterRescueResType:
       case kBootSvcNextBl0SlotResType:
       case kBootSvcMinBl0SecVerResType:
       case kBootSvcOwnershipUnlockResType:


### PR DESCRIPTION
Allow the owner application to request entry into rescue mode on the next boot.  This will enable applications to implement the app-state portion of the DFU state machine and request DFU mode to process firmware updates.

1. Add a handler for boot_svc `EnterRescue` command.
2. Add tests.