### PR TITLE
[lc_ctrl] Darjeeling has just one RmaAck signal

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
@@ -1068,12 +1068,10 @@ class lc_ctrl_errors_vseq extends lc_ctrl_smoke_vseq;
     if (err_inj.clk_byp_rsp_mubi_err) `DV_ASSERT_CTRL_REQ("FsmClkBypAckSync", 0)
     else `DV_ASSERT_CTRL_REQ("FsmClkBypAckSync", 1)
     if (err_inj.flash_rma_rsp_mubi_err) begin
-      `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckSync0", 0)
-      `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckSync1", 0)
+      `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckSync", 0)
       `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckBuf", 0)
     end else begin
-      `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckSync0", 1)
-      `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckSync1", 1)
+      `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckSync", 1)
       `DV_ASSERT_CTRL_REQ("FsmClkFlashRmaAckBuf", 1)
     end
     if (err_inj.otp_test_tokens_valid_mubi_err) `DV_ASSERT_CTRL_REQ("FsmOtpTestTokensValidSync", 0)

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -311,10 +311,10 @@ module tb;
                   kmac_app_if.req_data_if.H_DataStableWhenValidAndNotReady_A)
   `DV_ASSERT_CTRL("KmacIfSyncReqAckAckNeedsReq", kmac_app_if.req_data_if.ValidHighUntilReady_A)
   `DV_ASSERT_CTRL("FsmClkBypAckSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_clk_byp_ack)
-  `DV_ASSERT_CTRL("FsmClkFlashRmaAckSync0",
-                  dut.u_lc_ctrl_fsm.gen_syncs[0].u_prim_lc_sync_flash_rma_ack)
-  `DV_ASSERT_CTRL("FsmClkFlashRmaAckSync1",
-                  dut.u_lc_ctrl_fsm.gen_syncs[1].u_prim_lc_sync_flash_rma_ack)
+  for (genvar k = 0; k < NUM_RMA_ACK_SIGS; k++) begin : gen_sync_asserts
+    `DV_ASSERT_CTRL("FsmClkFlashRmaAckSync",
+                    dut.u_lc_ctrl_fsm.gen_syncs[k].u_prim_lc_sync_flash_rma_ack)
+  end
   `DV_ASSERT_CTRL("FsmClkFlashRmaAckBuf", dut.u_lc_ctrl_fsm.u_prim_lc_sync_flash_rma_ack_buf)
   `DV_ASSERT_CTRL("FsmOtpTestTokensValidSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_test_token_valid)
   `DV_ASSERT_CTRL("FsmOtpRmaTokenValidSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_rma_token_valid)


### PR DESCRIPTION
Support a variable number of assertion checkers on the RmaAck signals within lc_ctrl.