### PR TITLE
[hw,ac_range_check,rtl] Make error response paramtrizable

### DIFF
--- a/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
@@ -33,6 +33,17 @@ import math
       default: "8",
       local:   "true"
     },
+    { name:    "RangeCheckErrorRsp",
+      desc:    '''
+        Error behavior on blocked requests:
+        1: A denied request returns a TLUL error (.d_error = 1 on the response)
+        0: Writes are dropped and reads return all-zero, without a TLUL error
+        ''',
+      type:    "bit",
+      default: "1",
+      local:   "false"
+      expose:  "true"
+    },
   ],
   inter_signal_list: [
     { name:    "range_check_overwrite"

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -7,6 +7,7 @@ module ${module_instance_name}
   import ${module_instance_name}_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             RangeCheckErrorRsp        = 1'b1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
@@ -234,7 +235,9 @@ module ${module_instance_name}
   // TLUL Loopback for failing accesses
   //////////////////////////////////////////////////////////////////////////////
 
-  tlul_request_loopback u_req_loopback (
+  tlul_request_loopback #(
+    .ErrorRsp( RangeCheckErrorRsp )
+  ) u_req_loopback (
     .clk_i         ( clk_i                 ),
     .rst_ni        ( rst_ni                ),
     .squash_req_i  ( range_check_fail      ),

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -10004,7 +10004,24 @@
         clk_i: clkmgr_aon_clocks.clk_main_secure
       }
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: RangeCheckErrorRsp
+          desc:
+            '''
+            Error behavior on blocked requests:
+            1: A denied request returns a TLUL error (.d_error = 1 on the response)
+            0: Writes are dropped and reads return all-zero, without a TLUL error
+            '''
+          type: bit
+          default: "1"
+          local: "false"
+          expose: "true"
+          name_top: AcRangeCheckRangeCheckErrorRsp
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
@@ -30,6 +30,17 @@
       default: "8",
       local:   "true"
     },
+    { name:    "RangeCheckErrorRsp",
+      desc:    '''
+        Error behavior on blocked requests:
+        1: A denied request returns a TLUL error (.d_error = 1 on the response)
+        0: Writes are dropped and reads return all-zero, without a TLUL error
+        ''',
+      type:    "bit",
+      default: "1",
+      local:   "false"
+      expose:  "true"
+    },
   ],
   inter_signal_list: [
     { name:    "range_check_overwrite"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -7,6 +7,7 @@ module ac_range_check
   import ac_range_check_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0]           AlertAsyncOn              = {NumAlerts{1'b1}},
+  parameter bit                             RangeCheckErrorRsp        = 1'b1,
   parameter bit                             EnableRacl                = 1'b0,
   parameter bit                             RaclErrorRsp              = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[NumRegs] = '{NumRegs{0}}
@@ -234,7 +235,9 @@ module ac_range_check
   // TLUL Loopback for failing accesses
   //////////////////////////////////////////////////////////////////////////////
 
-  tlul_request_loopback u_req_loopback (
+  tlul_request_loopback #(
+    .ErrorRsp( RangeCheckErrorRsp )
+  ) u_req_loopback (
     .clk_i         ( clk_i                 ),
     .rst_ni        ( rst_ni                ),
     .squash_req_i  ( range_check_fail      ),

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -129,6 +129,7 @@ module top_darjeeling #(
   // parameters for racl_ctrl
   parameter int RaclCtrlNumExternalSubscribingIps = 1,
   // parameters for ac_range_check
+  parameter bit AcRangeCheckRangeCheckErrorRsp = 1,
   // parameters for rv_core_ibex
   parameter bit RvCoreIbexPMPEnable = 1,
   parameter int unsigned RvCoreIbexPMPGranularity = 0,
@@ -2643,7 +2644,8 @@ module top_darjeeling #(
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
     .RaclPolicySelVec(RACL_POLICY_SEL_VEC_AC_RANGE_CHECK),
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[98:97])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[98:97]),
+    .RangeCheckErrorRsp(AcRangeCheckRangeCheckErrorRsp)
   ) u_ac_range_check (
 
       // Interrupt


### PR DESCRIPTION
Expose the option of the underlying loopback primitive to make the design more configurable for other use cases.