### PR TITLE
[perso] Disable WD and clear reset status.

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -319,6 +319,8 @@ manifest(d = {
             "//sw/device/silicon_creator/lib/drivers:hmac",
             "//sw/device/silicon_creator/lib/drivers:keymgr",
             "//sw/device/silicon_creator/lib/drivers:kmac",
+            "//sw/device/silicon_creator/lib/drivers:rstmgr",
+            "//sw/device/silicon_creator/lib/drivers:watchdog",
             "//sw/device/silicon_creator/lib/ownership:owner_block",
             "//sw/device/silicon_creator/lib/ownership:ownership_key",
             "//sw/device/silicon_creator/manuf/lib:flash_info_fields",

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -38,6 +38,8 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
@@ -962,11 +964,28 @@ static status_t configure_ate_gpio_indicators(void) {
 }
 
 bool test_main(void) {
+  // Unconditionally disable the watchdog timer.
+  // This is needed to avoid a watchdog reset if enabled in the ROM.
+  watchdog_disable();
+
   CHECK_STATUS_OK(peripheral_handles_init());
   pinmux_testutils_init(&pinmux);
   CHECK_STATUS_OK(configure_ate_gpio_indicators());
   ujson_t uj = ujson_ottf_console();
+
   log_self_hash();
+
+  // Read the reset reason directly from the RSTMGR.
+  // This is needed to clear the reset reason before the first call to
+  // `personalize_otp_and_flash_secrets()`, which will reset the device.
+  uint32_t reason = rstmgr_reason_get();
+  if (reason != 0) {
+    rstmgr_reason_clear(reason);
+  }
+
+  // Read the reset reason from SRAM.
+  LOG_INFO("Reset reason: %08x", rstmgr_testutils_reason_get());
+
   CHECK_STATUS_OK(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
   CHECK_STATUS_OK(personalize_otp_and_flash_secrets(&uj));
   CHECK_STATUS_OK(personalize_gen_dice_certificates(&uj));

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -518,6 +518,7 @@ pub fn run_ft_personalize(
     // Bootstrap personalization + ROM_EXT + Owner FW binaries into flash, since
     // flash scrambling seeds were provisioned in the previous step.
     let t0 = Instant::now();
+    let _ = UartConsole::wait_for(spi_console, r"Reset reason.*", timeout)?;
     let _ = UartConsole::wait_for(spi_console, r"Bootstrap requested.", timeout)?;
     response.stats.log_elapsed_time("first-bootstrap-done", t0);
 


### PR DESCRIPTION
The OTP configuration may instruct the ROM to turn on the Watchdog and preserve the reset reason in the `rstmgr`. This change makes implements the following:

1. Unconditionally disable the watchdog in ft_personalize. This is to avoid having to pet the watchdog during long running operations (e.g. TBS certificate round trip).
2. Clear the reset reason in the `rstmgr`. This is to avoid accumulation of reset events during the perso flow.