### PR TITLE
[perso] Update CREATOR SW OTP digest calculation and remove reset logging message.

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -983,9 +983,6 @@ bool test_main(void) {
     rstmgr_reason_clear(reason);
   }
 
-  // Read the reset reason from SRAM.
-  LOG_INFO("Reset reason: %08x", rstmgr_testutils_reason_get());
-
   CHECK_STATUS_OK(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
   CHECK_STATUS_OK(personalize_otp_and_flash_secrets(&uj));
   CHECK_STATUS_OK(personalize_gen_dice_certificates(&uj));

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -121,6 +121,10 @@ static status_t otp_img_expected_value_read(dif_otp_ctrl_partition_t partition,
       memcpy(buffer + relative_addr, &kOwnerSwCfgRomBootstrapDisValue,
              sizeof(uint32_t));
       break;
+    case OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET:
+      memcpy(buffer + relative_addr, &kCreatorSwCfgFlashInfoBootDataCfgValue,
+             sizeof(uint32_t));
+      break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET:
       memcpy(buffer + relative_addr, &kCreatorSwCfgManufStateValue,
              sizeof(uint32_t));
@@ -311,6 +315,10 @@ status_t manuf_individualize_device_partition_expected_read(
           buffer));
       break;
     case kDifOtpCtrlPartitionCreatorSwCfg:
+      TRY(otp_img_expected_value_read(
+          partition,
+          OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET,
+          buffer));
       TRY(otp_img_expected_value_read(
           partition, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET, buffer));
       TRY(otp_img_expected_value_read(

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -518,7 +518,6 @@ pub fn run_ft_personalize(
     // Bootstrap personalization + ROM_EXT + Owner FW binaries into flash, since
     // flash scrambling seeds were provisioned in the previous step.
     let t0 = Instant::now();
-    let _ = UartConsole::wait_for(spi_console, r"Reset reason.*", timeout)?;
     let _ = UartConsole::wait_for(spi_console, r"Bootstrap requested.", timeout)?;
     response.stats.log_elapsed_time("first-bootstrap-done", t0);
 


### PR DESCRIPTION
Changes:

1. Include `OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET`
in `manuf_individualize_device_partition_expected_read()`. This is
required now that the boot data info page configuration is committed
into OTP in the later stages of personalization.

2. Remove logging message to simplify tester integration. The message was
initially added for debugging purposes, but it is no longer needed.