### PR TITLE
[rv_dm] Fix rv_dm_smoke when using the DMI interface

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -111,7 +111,6 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     forever begin
       // Read seq_item_port to get items to drive
       seq_item_port.get_next_item(req);
-
       $cast(rsp, req.clone());
       rsp.set_id_info(req);
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_if.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_if.sv
@@ -8,9 +8,13 @@ interface rv_dm_if(input logic clk, input logic rst_n);
 
   // "Enable" inputs
   lc_ctrl_pkg::lc_tx_t    lc_hw_debug_en;
+  lc_ctrl_pkg::lc_tx_t    lc_check_byp_en;
+  lc_ctrl_pkg::lc_tx_t    lc_escalate_en;
   lc_ctrl_pkg::lc_tx_t    pinmux_hw_debug_en;
   lc_ctrl_pkg::lc_tx_t    lc_dft_en;
   prim_mubi_pkg::mubi8_t  otp_dis_rv_dm_late_debug;
+  logic                   strap_en;
+  logic                   strap_en_override;
 
   // Other DUT inputs.
   prim_mubi_pkg::mubi4_t  scanmode;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -32,7 +32,6 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     // Check immediately that the write has been reflected in the debug_req_o output. There's no
     // need to wait because the write goes through a jtag_dmi_agent, which follows the write
     // operation with a read operation (polling) to check that it was applied.
-
     if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, data)
   endtask
 

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -68,9 +68,15 @@ module tb;
     // value as given as a default for next_dm_addr in rv_dm.hjson.
     .next_dm_addr_i            ('0),
 
+    // the strapping behavior of lc_hw_debug_en_i will be tested at the top-level.
     .lc_hw_debug_en_i          (rv_dm_if.lc_hw_debug_en           ),
     .pinmux_hw_debug_en_i      (rv_dm_if.pinmux_hw_debug_en       ),
     .lc_dft_en_i               (rv_dm_if.lc_dft_en                ),
+    .lc_check_byp_en_i         (rv_dm_if.lc_check_byp_en          ),
+    .lc_escalate_en_i          (rv_dm_if.lc_escalate_en           ),
+    .strap_en_i                (rv_dm_if.strap_en                 ),
+    .strap_en_override_i       (rv_dm_if.strap_en_override        ),
+
     .otp_dis_rv_dm_late_debug_i(rv_dm_if.otp_dis_rv_dm_late_debug ),
 
     .scanmode_i                (rv_dm_if.scanmode      ),
@@ -104,10 +110,13 @@ module tb;
     .dbg_tl_d_o                (dbg_tl_d2h)
   );
 
+  jtag_mon_if mon_jtag_if ();
+`ifdef USE_DMI_INTERFACE
+  // TODO: In this case, what should the monitor see? Perhaps there should be no JTAG signaling
+  // and thus no monitor, but presently the vseqs depend upon the monitor directly.
+`else
   // Apply the muxing that we get in rv_dm, where the JTAG interface that actually connects to the
   // debug module has direct clock/reset in scan mode, and is disabled if debug is not enabled.
-  jtag_mon_if mon_jtag_if ();
-`ifndef USE_DMI_INTERFACE
   assign mon_jtag_if.tck    = dut.gen_jtag_gating.dap.tck_i;
   assign mon_jtag_if.trst_n = dut.gen_jtag_gating.dap.trst_ni;
   assign mon_jtag_if.tms    = dut.gen_jtag_gating.dap.tms_i;


### PR DESCRIPTION
When using the DMI interface we must not wait on the monitor because it does not see the internal JTAG signaling, and we must be sure to enable the straps because otherwise the internal DMI gate will block the DMI traffic from reaching the debug logic.