### PR TITLE
[dv] Re-enable Darjeeling configs

### DIFF
--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -51,6 +51,7 @@
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
@@ -64,7 +65,6 @@
              //"{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
              //"{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
              //"{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
-             //"{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              //"{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
             ]
 }

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -31,6 +31,8 @@
              "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
              "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
              "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
              "{proj_root}/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
@@ -61,8 +63,6 @@
              // Top level.
              "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson",
              // TODO(#26733): the smoketests here must be fixed before enabling.
-             //"{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_disabled_sim_cfg.hjson",
-             //"{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_dmi_volatile_unlock_enabled_sim_cfg.hjson",
              //"{proj_root}/hw/ip/rv_dm/dv/rv_dm_use_dmi_interface_sim_cfg.hjson",
              //"{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
              //"{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",


### PR DESCRIPTION
The OTP config was disabled by mistake. The LC_CTRL tests should work since https://github.com/lowRISC/opentitan/pull/26778.

The others should also not really have been disabled, but their smoke regressions fail CI so I'll need to disable that tomorrow before they can re-enabled.