### PR TITLE
[reggen] Allow a multireg with count <= 0

### DIFF
--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -47,6 +47,17 @@ OPTIONAL_FIELDS.update({
 })
 
 
+class EmptyMultiRegException(Exception):
+    '''A MultiRegister was requested without a positive count.'''
+    def __init__(self, name: str, count: int):
+        self.name = name
+        self.count = count
+
+    def __str__(self) -> str:
+        return (f"Multireg {self.name} has a count of {self.count}, "
+                "which isn't positive.")
+
+
 class MultiRegister(RegBase):
 
     def __init__(self, offset: int, addrsep: int, reg_width: int,
@@ -122,9 +133,7 @@ class MultiRegister(RegBase):
         self.count = params.expand(count_str,
                                    'count field of multireg ' + self.reg.name)
         if self.count <= 0:
-            raise ValueError(
-                f"Multireg {self.reg.name} has a count of {self.count}, "
-                "which isn't positive.")
+            raise EmptyMultiRegException(self.reg.name, self.count)
 
         # Generate the registers that this multireg expands into. Here, a
         # "creg" is a "compacted register", which might contain multiple actual

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -14,7 +14,7 @@ from reggen.field import Field
 from reggen.interrupt import Interrupt, IntrType
 from reggen.signal import Signal
 from reggen.lib import check_int, check_list, check_str_dict, check_str
-from reggen.multi_register import MultiRegister
+from reggen.multi_register import MultiRegister, EmptyMultiRegException
 from reggen.params import ReggenParams
 from reggen.register import Register
 from reggen.window import Window
@@ -275,8 +275,18 @@ class RegBlock:
 
     def _handle_multireg(self, where: str, body: object, clocks: Clocking,
                          is_alias: bool) -> None:
-        mr = MultiRegister(self.offset, self._addrsep, self._reg_width,
-                           self._params, body, clocks, is_alias)
+        '''Update the register block by adding a multiregister as requested.
+
+        If the multiregister has a count that is not positive, it will be
+        ignored and the register block will not gain any element.
+
+        '''
+
+        try:
+            mr = MultiRegister(self.offset, self._addrsep, self._reg_width,
+                               self._params, body, clocks, is_alias)
+        except EmptyMultiRegException:
+            return
 
         # validate async schemes
         self._validate_async(mr.async_name, mr.async_clk)


### PR DESCRIPTION
Honestly, this is slightly overengineered (the only place we can generate this exception catches it and throws it away!). But I thought it might make sense to store the information properly in case we care in the future.

Fixes #26545.