### PR TITLE
[rtl] Avoid Addr/Data channel misnaming

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -160,13 +160,13 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       forever begin
         dir_fifo.get(dir);
         case (dir)
-          AddrChannel: begin
+          AChannel: begin
             `DV_CHECK_FATAL(a_chan_fifo.try_get(item),
                             "dir_fifo pointed at A channel, but a_chan_fifo empty")
             process_tl_a_item(ral_name, item);
           end
 
-          DataChannel: begin
+          DChannel: begin
             `DV_CHECK_FATAL(d_chan_fifo.try_get(item),
                             "dir_fifo pointed at D channel, but d_chan_fifo empty")
             process_tl_d_item(ral_name, item);
@@ -182,11 +182,11 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     `uvm_info(`gfn, $sformatf("received tl a_chan item: %0s", item.convert2string()), UVM_HIGH)
 
     if (cfg.en_scb_tl_err_chk) begin
-      if (predict_tl_err(item, AddrChannel, ral_name)) return;
+      if (predict_tl_err(item, AChannel, ral_name)) return;
     end
     if (!cfg.en_scb) return;
 
-    process_tl_access(item, AddrChannel, ral_name);
+    process_tl_access(item, AChannel, ral_name);
   endtask
 
   task process_tl_d_item(string ral_name, tl_seq_item item);
@@ -199,7 +199,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
                    $sformatf("a_source: 0x%0h & d_source: 0x%0h mismatch",
                              item.a_source, item.d_source))
       end
-      if (predict_tl_err(item, DataChannel, ral_name)) return;
+      if (predict_tl_err(item, DChannel, ral_name)) return;
     end
     if (cfg.en_scb_mem_chk && is_mem_addr(item, ral_name)) begin
       if (item.is_write()) begin
@@ -219,7 +219,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         do_read_check(dv_reg, item);
       end
     end
-    process_tl_access(item, DataChannel, ral_name);
+    process_tl_access(item, DChannel, ral_name);
   endtask
 
   // This function implements the generic read checks, any TB can override this method to
@@ -523,7 +523,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
                      write_w_instr_type_err | instr_type_err | cfg.tl_mem_access_gated |
                      csr_read_err;
 
-    if (channel == DataChannel) begin
+    if (channel == DChannel) begin
       // integrity at d_user is from DUT, which should be always correct, except data integrity for
       // passthru memory
       void'(item.is_d_chan_intg_ok(
@@ -545,7 +545,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       end
     end
 
-    if (channel == DataChannel) begin
+    if (channel == DChannel) begin
       `DV_CHECK_EQ(item.d_error, exp_d_error,
           $sformatf({"On interface %0s, TL item: %0s, unmapped_err: %0d, mem_access_err: %0d, ",
                     "bus_intg_err: %0d, byte_wr_err: %0d, csr_size_err: %0d, tl_item_err: %0d, ",

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -449,9 +449,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   // Checks if the TL access is valid.
   //
-  // On the Addr channel, returns 1 if the item should cause a TL error.
+  // On the A channel, returns 1 if the item should cause a TL error.
   //
-  // On the Data channel, this also asserts that the item's D channel integrity is correct (because
+  // On the D channel, this also asserts that the item's D channel integrity is correct (because
   // the DUT should never inject errors) and that item.d_error matches the prediction (to check that
   // the DUT correctly spots TL errors on the A channel). If TL integrity generation is enabled,
   // this also calls update_tl_alert_field_prediction() to update the mirrored value of any "I've

--- a/hw/dv/sv/tl_agent/tl_agent_pkg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_pkg.sv
@@ -40,8 +40,8 @@ package tl_agent_pkg;
   } tl_level_e;
 
   typedef enum {
-    AddrChannel,
-    DataChannel
+    AChannel,
+    DChannel
   } tl_channels_e;
 
   function automatic void enable_logging(string file_name="tl_agent.log");

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -126,7 +126,7 @@ class tl_monitor extends dv_base_monitor#(
       end
       if (a_chan_req_item != null) begin
         a_chan_port.write(a_chan_req_item);
-        if (cfg.synchronise_ports) channel_dir_port.write(AddrChannel);
+        if (cfg.synchronise_ports) channel_dir_port.write(AChannel);
         a_chan_req_item = null;
       end
 
@@ -236,7 +236,7 @@ class tl_monitor extends dv_base_monitor#(
       `uvm_info(`gfn, $sformatf("[%0s][d_chan] : %0s", agent_name, rsp.convert2string()), UVM_HIGH)
 
       d_chan_port.write(rsp);
-      if (cfg.synchronise_ports) channel_dir_port.write(DataChannel);
+      if (cfg.synchronise_ports) channel_dir_port.write(DChannel);
 
       if (cfg.en_cov) cov.sample(rsp);
     end

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -202,10 +202,10 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
     uvm_reg_data_t write_data;
 
     // if access was to a valid csr, get the csr handle

--- a/hw/ip/aes/dv/README.md
+++ b/hw/ip/aes/dv/README.md
@@ -114,10 +114,10 @@ The functional coverage plan can be found here [coverage_plan](#testplan)
 #### Scoreboard
 The `aes_scoreboard` is primarily used for end to end checking.
 It creates the following analysis FIFOs to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
-These 2 FIFOs provide transaction items at the end of the address channel and data channel respectively.
+These 2 FIFOs provide transaction items at the end of the A and D channel, respectively.
 Each FIFO is monitored and incoming transactions are stored.
 Whenever a transaction is finished the sequence item is handed over to a reference model that will generate the expected response.
 At the same time the scoreboard is waiting for the result of the AES module to compute.

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -187,7 +187,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   // Handle a write to a named CSR on the A channel
-  function void on_addr_channel_write(string csr_name, logic [31:0] wdata);
+  function void on_a_channel_write(string csr_name, logic [31:0] wdata);
     alert_test_t alert_test;
     // add individual case item for each csr
     case (1)
@@ -257,7 +257,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       // if incoming access is a write to a valid csr, then make updates right away
       if (write) begin
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
-        on_addr_channel_write(csr_name, item.a_data);
+        on_a_channel_write(csr_name, item.a_data);
       end
 
       ///////////////////////////////////////

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -250,7 +250,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       string csr_name = csr.get_name();
       `uvm_info(`gfn, $sformatf("\n\t ----| ITEM received reg name : %s",csr.get_name()), UVM_FULL)
 
@@ -350,7 +350,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
     //////////////////////////////////////////////////////////////////////////////
 
     `uvm_info(`gfn, $sformatf("\n\t ---| channel  %h", channel), UVM_DEBUG)
-    if (!write && channel == DataChannel) begin
+    if (!write && channel == DChannel) begin
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
                      $sformatf("reg name: %0s", csr.get_full_name()))

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -672,10 +672,10 @@ task aon_timer_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e cha
   bit     write           = item.is_write();
   uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-  bit addr_phase_read   = (!write && channel == AddrChannel);
-  bit addr_phase_write  = (write && channel == AddrChannel);
-  bit data_phase_read   = (!write && channel == DataChannel);
-  bit data_phase_write  = (write && channel == DataChannel);
+  bit addr_phase_read   = (!write && channel == AChannel);
+  bit addr_phase_write  = (write && channel == AChannel);
+  bit data_phase_read   = (!write && channel == DChannel);
+  bit data_phase_write  = (write && channel == DChannel);
 
   // if access was to a valid csr, get the csr handle
   if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip/csrng/dv/README.md
+++ b/hw/ip/csrng/dv/README.md
@@ -77,7 +77,7 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `csrng_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo, tl_d_chan_fifo:  These 2 FIFOs provide transaction items at the end of Tilelink address channel and data channel respectively
+* tl_a_chan_fifo, tl_d_chan_fifo:  These 2 FIFOs provide transaction items at the end of Tilelink A and D channel, respectively
 * entropy_src_fifo, genbits_fifo:  The entropy_src_fifo provides transaction items from the predictor and the genbits_fifo provide actual post-entropy_src transaction items to compare
 
 

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -132,10 +132,10 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     bit last_word;
     bit genbits_valid;
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip/dma/dv/env/dma_env.sv
+++ b/hw/ip/dma/dv/env/dma_env.sv
@@ -30,7 +30,7 @@ class dma_env extends cip_base_env #(
     cfg.tl_agent_dma_ctn_cfg.synchronise_ports = 1'b1;
     cfg.tl_agent_dma_sys_cfg.synchronise_ports  = 1'b1;
 
-    // The SoC System bus does not have a TL-style 'ready' signal on the address channel.
+    // The SoC System bus does not have a TL-style 'ready' signal on the A channel.
     cfg.tl_agent_dma_sys_cfg.a_ready_delay_min = 0;
     cfg.tl_agent_dma_sys_cfg.a_ready_delay_max = 0;
 

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -291,7 +291,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
 
       // Push addr item to source queue
       src_queue.push_back(item);
-      `uvm_info(`gfn, $sformatf("Addr channel checks done for source item"), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("A channel checks done for source item"), UVM_HIGH)
 
       // Update the count of bytes read from the source.
       // Note that this is complicated by the fact that the TL-UL host adapter always fetches
@@ -315,7 +315,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       intr_source = intr_addr_lookup(a_addr);
       // Push addr item to destination queue
       dst_queue.push_back(item);
-      `uvm_info(`gfn, $sformatf("Addr channel checks done for destination item"), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("A channel checks done for destination item"), UVM_HIGH)
 
       // The range of memory addresses that should be touched by the DMA controller depends upon
       // whether chunks overlap.
@@ -466,7 +466,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       // Check if data item opcode is as expected
       `DV_CHECK(d_opcode inside {AccessAckData},
                 $sformatf("Invalid opcode %s for source data item", d_opcode))
-      // Delete after all checks related to data channel are done
+      // Delete after all checks related to D channel are done
       `uvm_info(`gfn, $sformatf("Deleting element at %d index in source queue", queue_idx),
                 UVM_HIGH)
       src_queue.delete(queue_idx);
@@ -487,7 +487,7 @@ class dma_scoreboard extends cip_base_scoreboard #(
       // Check if data item opcode is as expected
       `DV_CHECK(d_opcode inside {AccessAck},
                 $sformatf("Invalid opcode %s for destination data item", d_opcode))
-      // Delete after all checks related to data channel are done
+      // Delete after all checks related to D channel are done
       `uvm_info(`gfn, $sformatf("Deleting element at %d index in destination queue", queue_idx),
                 UVM_HIGH)
       dst_queue.delete(queue_idx);
@@ -507,8 +507,8 @@ class dma_scoreboard extends cip_base_scoreboard #(
     end else if (got_dest_item) begin
       // Is this the final destination write?
       //
-      // Note: we must perform this on the data channel (write response) because an error may occur
-      //       on the very final write transaction, in which case DONE should not be seen.
+      // Note: we must perform this on the D channel (write response) because an error may occur on
+      //       the very final write transaction, in which case DONE should not be seen.
       if (num_bytes_transferred >= exp_bytes_transferred) begin
         // Whether an interrupt is expected also depends upon whether it is enabled.
         // Have we yet completed the entire transfer?

--- a/hw/ip/dma/dv/env/dma_sys_tl_if.sv
+++ b/hw/ip/dma/dv/env/dma_sys_tl_if.sv
@@ -78,7 +78,7 @@ interface dma_sys_tl_if
                         !addr_matches;
 
   assign tl_h2d = '{
-    // Host->device address channel
+    // Host->device A channel
     a_valid:   h2d_a_valid,
     a_opcode:  h2d_opcode,
     a_param:   3'b0,

--- a/hw/ip/edn/dv/README.md
+++ b/hw/ip/edn/dv/README.md
@@ -78,7 +78,7 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `edn_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo, tl_d_chan_fifo:           These 2 fifos provide transaction items at the end of Tilelink address channel and data channel respectively
+* `tl_a_chan_fifo`, `tl_d_chan_fifo`: These 2 fifos provide transaction items at the end of Tilelink A and D channel, respectively
 <!-- * analysis port1:
 * analysis port2:
 explain inputs monitored, flow of data and outputs checked -->

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -125,10 +125,10 @@ class edn_scoreboard extends cip_base_scoreboard #(
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // bools to determine whether sm is done and FIFOs need to be reset
     bit auto_req_mode_turned_off;

--- a/hw/ip/entropy_src/dv/README.md
+++ b/hw/ip/entropy_src/dv/README.md
@@ -85,7 +85,7 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `entropy_src_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo, tl_d_chan_fifo:  These 2 FIFOs provide transaction items at the end of Tilelink address channel and data channel respectively
+* `tl_a_chan_fifo`, `tl_d_chan_fifo`: These 2 FIFOs provide transaction items at the end of Tilelink A and D channel, respectively
 * rng_fifo, csrng_fifo:   The rng_fifo provides transaction items from the predictor and the csrng_fifo provide actual post-entropy_src transaction items to compare
 
 #### Assertions

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1579,7 +1579,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       "fw_ov_sha3_start": begin
       end
       "fw_ov_rd_data": begin
-        if (!write && channel == AddrChannel) begin
+        if (!write && channel == AChannel) begin
           // Signal that a read is incoming.
           // The actual comparison in the scoreboard happens with a delay. In the DUT the
           // observe FIFO would have been already popped in this cycle. We model this
@@ -1600,7 +1600,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       "fw_ov_wr_data": begin
       end
       "fw_ov_wr_fifo_full": begin
-        if (!write && channel == AddrChannel) begin
+        if (!write && channel == AChannel) begin
           fork
             begin
               bit es_fw_ov_insert_mode, es_bypass_mode, module_enable;
@@ -1633,7 +1633,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       "observe_fifo_depth": begin
         // If a word is being pushed into the observe FIFO while reading observe_fifo_depth, the
         // prediction will be off by one word. We need to take this into account for predictions.
-        if (!write && channel == AddrChannel) begin
+        if (!write && channel == AChannel) begin
           observe_push_busy_addr_phase = observe_push_busy;
         end
       end
@@ -1653,7 +1653,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       end
     endcase
 
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away
       if (write) begin
         if (csr.get_name() == "module_enable") begin
@@ -2009,7 +2009,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     end
 
     // On reads, if do_read_check is set, then check mirrored_value against item.d_data
-    if (!write && channel == DataChannel) begin
+    if (!write && channel == DChannel) begin
       case (csr.get_name())
         "intr_state": begin
           // Though we do not predict the interrupt state we do stop here to process any

--- a/hw/ip/hmac/dv/README.md
+++ b/hw/ip/hmac/dv/README.md
@@ -104,20 +104,20 @@ that the test intent has been adequately met:
 The `hmac_scoreboard` is primarily used for end to end checking. It creates the
 following analysis ports to retrieve the data monitored by corresponding
 interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 Hmac scoreboard monitors all hmac valid CSR registers, hmac msg_fifo (addr:
 'h800 to 'hfff), and interrupt pins.
 
-For a write transaction, during the address channel, CSR values are updated in
+For a write transaction, during the A channel, CSR values are updated in
 RAL. Msg_fifo values are updated to an internal msg queue. Once the data
 finishes streaming, hmac scoreboard will input the msg queue to the C model and
 calculate the expected output, then update the corresponding RAL registers.
 
-For a read transaction, during the address channel, for status related CSRs
+For a read transaction, during the A channel, for status related CSRs
 (such as fifo_full, fifo_empty, etc), hmac will predict its value according to
-the cycle accurate model. During the data channel, hmac scoreboard will compare
+the cycle accurate model. At the D channel response, `hmac_scoreboard` will compare
 the read data with expected data in RAL.
 
 ##### Scoreboard cycle accurate checking model

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -135,7 +135,7 @@ task hmac_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e channel,
   end
 
   // if incoming access is a write to a valid csr or mem, then update right away on addr channel
-  if (write && channel == AddrChannel) begin
+  if (write && channel == AChannel) begin
     // push the msg into msg_fifo
     if ((item.a_addr & addr_mask) inside {[HMAC_MSG_FIFO_BASE : HMAC_MSG_FIFO_LAST_ADDR]}) begin
       // Only push message into the FIFO when intended, as in case of S&R triggered with another
@@ -374,7 +374,7 @@ task hmac_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e channel,
   end
 
   // predict status based on csr read addr channel
-  if (!write && channel != DataChannel) begin
+  if (!write && channel != DChannel) begin
     // Update expected status register
     if (csr_name == "status") begin
       hmac_status_data = (hmac_idle       << HmacStaIdle)         |

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -134,7 +134,7 @@ task hmac_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e channel,
     `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
   end
 
-  // if incoming access is a write to a valid csr or mem, then update right away on addr channel
+  // if incoming access is a write to a valid csr or mem, then update right away on A channel
   if (write && channel == AChannel) begin
     // push the msg into msg_fifo
     if ((item.a_addr & addr_mask) inside {[HMAC_MSG_FIFO_BASE : HMAC_MSG_FIFO_LAST_ADDR]}) begin
@@ -373,7 +373,7 @@ task hmac_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e channel,
     end
   end
 
-  // predict status based on csr read addr channel
+  // predict status based on csr read A channel
   if (!write && channel != DChannel) begin
     // Update expected status register
     if (csr_name == "status") begin

--- a/hw/ip/i2c/dv/env/i2c_reference_model.sv
+++ b/hw/ip/i2c/dv/env/i2c_reference_model.sv
@@ -198,10 +198,10 @@ class i2c_reference_model extends uvm_component;
     bit do_read_check = 1'b1;
 
     bit write = item.is_write();
-    bit tl_get           = (!write && channel == AddrChannel);
-    bit tl_putdata       =  (write && channel == AddrChannel); // write
-    bit tl_accessackdata = (!write && channel == DataChannel); // read
-    bit tl_accessack     =  (write && channel == DataChannel);
+    bit tl_get           = (!write && channel == AChannel);
+    bit tl_putdata       =  (write && channel == AChannel); // write
+    bit tl_accessackdata = (!write && channel == DChannel); // read
+    bit tl_accessack     =  (write && channel == DChannel);
 
     if (tl_putdata) begin
       // Incoming access is a write to a valid csr, so update the RAL right away

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -232,10 +232,10 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     uvm_reg csr;
 
     bit write = item.is_write();
-    bit tl_get           = (!write && channel == AddrChannel);
-    bit tl_putdata       =  (write && channel == AddrChannel); // write
-    bit tl_accessackdata = (!write && channel == DataChannel); // read
-    bit tl_accessack     =  (write && channel == DataChannel);
+    bit tl_get           = (!write && channel == AChannel);
+    bit tl_putdata       =  (write && channel == AChannel); // write
+    bit tl_accessackdata = (!write && channel == DChannel); // read
+    bit tl_accessack     =  (write && channel == DChannel);
 
     // If access was not addressed to a valid csr, raise a fatal error
     if (!(csr_addr inside {i2c_ral.csr_addrs})) begin

--- a/hw/ip/keymgr/dv/README.md
+++ b/hw/ip/keymgr/dv/README.md
@@ -83,8 +83,8 @@ The covergroups defined in testplan have been developed to prove that the test i
 #### Scoreboard
 The `keymgr_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: An analysis FIFO to hold transactions from TL address channel.
-* tl_d_chan_fifo: An analysis FIFO to hold transactions from TL data channel.
+* `tl_a_chan_fifo`: An analysis FIFO to hold transactions from TL A channel.
+* `tl_d_chan_fifo`: An analysis FIFO to hold transactions from TL D channel.
 * req_fifo: An analysis FIFO to hold request data sent to KMAC.
 * rsp_fifo: An analysis FIFO to hold response digests received from KMAC.
 * edn_fifo: An analysis FIFO to hold transactions coming from the EDN interface.

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -399,10 +399,10 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -520,7 +520,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
         end
       end
       "intr_test": begin
-        if (write && channel == AddrChannel) begin
+        if (write && channel == AChannel) begin
           bit [TL_DW-1:0] intr_en = `gmv(ral.intr_enable);
           bit [NumKeyMgrIntr-1:0] intr_exp = `gmv(ral.intr_state) | item.a_data;
 

--- a/hw/ip/keymgr_dpe/dv/README.md
+++ b/hw/ip/keymgr_dpe/dv/README.md
@@ -83,8 +83,8 @@ The covergroups defined in testplan have been developed to prove that the test i
 #### Scoreboard
 The `keymgr_dpe_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: An analysis FIFO to hold transactions from TL address channel.
-* tl_d_chan_fifo: An analysis FIFO to hold transactions from TL data channel.
+* `tl_a_chan_fifo`: An analysis FIFO to hold transactions from TileLinkL A channel.
+* `tl_d_chan_fifo`: An analysis FIFO to hold transactions from TileLink D channel.
 * req_fifo: An analysis FIFO to hold request data sent to KMAC.
 * rsp_fifo: An analysis FIFO to hold response digests received from KMAC.
 * edn_fifo: An analysis FIFO to hold transactions coming from the EDN interface.

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -440,10 +440,10 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     keymgr_dpe_pkg::keymgr_dpe_ops_e op = get_operation();
 
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -617,7 +617,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
         end
       end
       "intr_test": begin
-        if (write && channel == AddrChannel) begin
+        if (write && channel == AChannel) begin
           bit [TL_DW-1:0] intr_en = `gmv(ral.intr_enable);
           bit [NumKeyMgrDpeIntr-1:0] intr_exp = `gmv(ral.intr_state) | item.a_data;
 

--- a/hw/ip/kmac/dv/README.md
+++ b/hw/ip/kmac/dv/README.md
@@ -121,8 +121,8 @@ Please refer to the covergroups section under [testplan](#testplan) for coverpoi
 #### Scoreboard
 The `kmac_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: TL address channel
-* tl_d_chan_fifo: TL data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * kmac_app_req_fifo[NUM_APP_INTF]: An array of analysis FIFOs to hold request transactions coming from the various application interfaces
 * kmac_app_rsp_fifo[NUM_APP_INTF]: An array of analysis FIFOs to hold response transactions coming from the various application interfaces
 * edn_fifo: FIFO used to hold transactions coming from the EDN interface

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -631,10 +631,10 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t csr_addr       = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     bit [TL_AW-1:0] csr_addr_mask = ral.get_addr_mask();
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // Indicates that the msgfifo access is now over. Clear it at the beginning of this transaction
     // as this flag is used somewhere else and needs to be actually raised for a non-null simulation

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -223,8 +223,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
         tl_item.d_opcode = (jt_item.op === DmiRead) ? tlul_pkg::Get : tlul_pkg::PutFullData;
 
 
-        process_tl_access(tl_item, AddrChannel, "lc_ctrl_regs_reg_block");
-        process_tl_access(tl_item, DataChannel, "lc_ctrl_regs_reg_block");
+        process_tl_access(tl_item, AChannel, "lc_ctrl_regs_reg_block");
+        process_tl_access(tl_item, DChannel, "lc_ctrl_regs_reg_block");
 
 
       end
@@ -257,10 +257,10 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t  csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     lc_outputs_t    exp = '{default: lc_ctrl_pkg::Off};
     lc_keymgr_div_t exp_div = cfg.parameters_cfg.keymgr_div_invalid;
-    bit             addr_phase_read = (!write && channel == AddrChannel);
-    bit             addr_phase_write = (write && channel == AddrChannel);
-    bit             data_phase_read = (!write && channel == DataChannel);
-    bit             data_phase_write = (write && channel == DataChannel);
+    bit             addr_phase_read = (!write && channel == AChannel);
+    bit             addr_phase_write = (write && channel == AChannel);
+    bit             data_phase_read = (!write && channel == DChannel);
+    bit             data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip/mbx/dv/env/mbx_scoreboard.sv
+++ b/hw/ip/mbx/dv/env/mbx_scoreboard.sv
@@ -96,10 +96,10 @@ class mbx_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     bit [31:0] mask = 'hffff_ffff;
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (ral_name != cfg.mbx_mem_ral_name) begin
@@ -236,10 +236,10 @@ return;
     uvm_reg_addr_t csr_addr = cfg.ral_models[RAL_T::type_name].get_word_aligned_addr(
                               item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     `uvm_info(`gfn, "process_tl_mbx_core_access -- Start", UVM_DEBUG)
     csr = cfg.ral_models[RAL_T::type_name].default_map.get_reg_by_offset(csr_addr);
@@ -325,10 +325,10 @@ return;
     uvm_reg_addr_t csr_addr =
       cfg.ral_models[cfg.mbx_soc_ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     `uvm_info(`gfn, "process_tl_mbx_soc_access -- Start", UVM_DEBUG)
     csr = cfg.ral_models[cfg.mbx_soc_ral_name].default_map.get_reg_by_offset(csr_addr);
@@ -442,10 +442,10 @@ return;
 
   virtual function void process_tl_mbx_mem_access(tl_seq_item item, tl_channels_e channel);
     bit write             = item.is_write();
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     `uvm_info(`gfn, "process_tl_mbx_mem_access -- Start", UVM_DEBUG)
     if(addr_phase_read || addr_phase_write) begin

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -46,9 +46,9 @@ class otbn_scoreboard extends cip_base_scoreboard #(
   // start OTBN. We track this because we derive the "start" signal in the model from an internal
   // DUT signal, so need to make sure it stays in sync with the TL side.
   //
-  // If false, there are no transactions pending. This gets set in process_tl_addr when we see a
-  // write to CMD. This runs on a posedge of the clock. We expect to see the model start on the
-  // following negedge. When we process a change to model status that shows things starting (in
+  // If false, there are no transactions pending. This gets set in process_tl_a when we see a write
+  // to CMD. This runs on a posedge of the clock. We expect to see the model start on the following
+  // negedge. When we process a change to model status that shows things starting (in
   // process_model_fifo), we check that the flag is set and then clear it. When setting the flag, we
   // queue a check to run on the following posedge of the clock to make sure the flag isn't still
   // set.
@@ -130,13 +130,13 @@ class otbn_scoreboard extends cip_base_scoreboard #(
 
   task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     case (channel)
-      AddrChannel: process_tl_addr(item);
-      DataChannel: process_tl_data(item);
+      AChannel: process_tl_a(item);
+      DChannel: process_tl_d(item);
       default: `uvm_fatal(`gfn, $sformatf("Invalid channel: %0h", channel))
     endcase
   endtask
 
-  task process_tl_addr(tl_seq_item item);
+  task process_tl_a(tl_seq_item item);
     uvm_reg              csr;
     uvm_reg_addr_t       masked_addr, aligned_addr;
     operational_state_e  state;
@@ -281,7 +281,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     exp_read_values[item.a_source] = exp_read_data;
   endtask
 
-  task process_tl_data(tl_seq_item item);
+  task process_tl_d(tl_seq_item item);
     uvm_reg              csr;
     uvm_reg_addr_t       csr_addr;
     otbn_exp_read_data_t exp_read_data;

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -286,9 +286,8 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     uvm_reg_addr_t       csr_addr;
     otbn_exp_read_data_t exp_read_data;
 
-    // The data-channel response to a write is just an ack, which isn't particularly interesting.
-    // Check for integrity errors (which should lock the block), but otherwise there's nothing to
-    // do.
+    // The D channel response to a write is just an ack, which isn't particularly interesting. Check
+    // for integrity errors (which should lock the block), but otherwise there's nothing to do.
     if (item.is_write()) begin
       if (item.d_error) locked = 1'b1;
       return;

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -96,8 +96,8 @@ task pattgen_scoreboard::process_tl_access(tl_seq_item   item,
   bit             do_read_check = 1'b1;
   bit             write = item.is_write();
 
-  bit addr_phase_write = (write && channel  == AddrChannel);
-  bit data_phase_read  = (!write && channel == DataChannel);
+  bit addr_phase_write = (write && channel  == AChannel);
+  bit data_phase_read  = (!write && channel == DChannel);
 
   uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
   // if access was to a valid csr, get the csr handle

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -245,10 +245,10 @@ function void rom_ctrl_scoreboard::check_reg_access(tl_seq_item item, tl_channel
   bit     do_read_check   = 1'b1;
   bit     write           = item.is_write();
 
-  bit addr_phase_read   = (!write && channel == AddrChannel);
-  bit addr_phase_write  = (write && channel == AddrChannel);
-  bit data_phase_read   = (!write && channel == DataChannel);
-  bit data_phase_write  = (write && channel == DataChannel);
+  bit addr_phase_read   = (!write && channel == AChannel);
+  bit addr_phase_write  = (write && channel == AChannel);
+  bit data_phase_read   = (!write && channel == DChannel);
+  bit data_phase_write  = (write && channel == DChannel);
 
   // If this is an access to an address that doesn't correspond to a CSR, there is nothing to check:
   // the base classes should already predict an error response.

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -217,7 +217,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
                   "Received an SBA TL item when SBA should have been disabled.")
       end
 
-      process_tl_sba_access(item, AddrChannel);
+      process_tl_sba_access(item, AChannel);
     end
   endtask
 
@@ -236,7 +236,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       if (!item.is_ok()) begin
         // TODO: deal with item not being ok.
       end
-      process_tl_sba_access(item, DataChannel);
+      process_tl_sba_access(item, DChannel);
     end
   endtask
 
@@ -309,10 +309,10 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // Scoreboard only takes csr address, so filter out memory address.
     if (is_mem_addr(item, ral_name)) return;
@@ -440,7 +440,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     end
 
     if ((ral_name == "rv_dm_mem_reg_block") &&
-        (channel == DataChannel) &&
+        (channel == DChannel) &&
         !is_debug_enabled()) begin
 
       `DV_CHECK(item.d_error)

--- a/hw/ip/rv_timer/dv/README.md
+++ b/hw/ip/rv_timer/dv/README.md
@@ -79,19 +79,19 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `rv_timer_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 rv_timer scoreboard monitors all CSR registers and interrupt pins.
 
-For a write transaction, during the address channel, CSR values are updated in RAL and config values (timer enable, step, prescale, timer value, compare value) are updated in internal arrays.
+For a write transaction, during the A channel, CSR values are updated in RAL and config values (timer enable, step, prescale, timer value, compare value) are updated in internal arrays.
 When particular timer is enabled, rv_timer scoreboard calculate timeout clocks and start a thread to wait for timeout, then if any of timer configuration updated on active timer, rv_timer scoreboard recalculate and update the timeout clocks in their running timeout thread.
 If multiple timers are enabled, multiple threads will be initiated. On timeout scoreboard calculate the expected interrupt status and update RAL registers.
 
-For a read transaction, during the address channel for interrupt status CSR rv_timer will predict its value according to the timer timeout threads.
-During the data channel, rv_timer scoreboard will compare the read data with expected data in RAL.
+For a read transaction of the interrupt csr, the `rv_timer` scoreboard will predict its value on the A channel message.
+It will then compare the read data with the expected value when it sees the D channel response.
 
-Interrupt pins are checked against expected at every read/write data channel.
+Interrupt pins are checked against expected at every read/write message on the D channel.
 
 #### Assertions
 * TLUL assertions: The `tb/rv_timer_bind.sv` binds the `tlul_assert` [assertions](../../tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -50,7 +50,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    if (!write && channel == AddrChannel) begin
+    if (!write && channel == AChannel) begin
       if (!uvm_re_match("intr_state*", csr_name)) begin
         for (int i = 0; i < NUM_HARTS; i++) begin
           if (csr_name == $sformatf("intr_state%0d", i)) begin
@@ -69,7 +69,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
     // grab write transactions from address channel; grab completed transactions from data channel
 
     // if incoming access is a write to a valid csr, then make updates right away
-    if (write && channel == AddrChannel) begin
+    if (write && channel == AChannel) begin
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
 
       // process the csr req
@@ -212,8 +212,8 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
       endcase
     end
 
-    if (channel == DataChannel) begin
-      // Check all interrupts in DataChannel of every Read/Write except when ctimecmp updated
+    if (channel == DChannel) begin
+      // Check all interrupts in DChannel of every Read/Write except when ctimecmp updated
       // during timer active. This scenario is checked in base sequence by reading the intr_state.
       // Ignored checking here because sticky intr_pin update has one cycle delay.
       if (!ctimecmp_update_on_fly) check_interrupt_pin();

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -66,7 +66,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
       end
     end
 
-    // grab write transactions from address channel; grab completed transactions from data channel
+    // grab write transactions from A channel; grab completed transactions from D channel
 
     // if incoming access is a write to a valid csr, then make updates right away
     if (write && channel == AChannel) begin
@@ -311,7 +311,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
                 // and wait until the step and/or timecmp/mtime are re-configured
                 if ( !(step[a_i] == 0 && (compare_val[a_i][a_j] - timer_val[a_i]) > 0)) begin
                   `uvm_info(`gfn, $sformatf("Timer expired check for interrupt"), UVM_MEDIUM)
-                  // Update exp val and predict it in read address_channel
+                  // Update exp val and predict it when we see it read on the A channel
                   intr_status_exp[a_i][a_j] = 1'b1;
                   `uvm_info(`gfn,
                             $sformatf("check_interrupt_pin#1 - intr_status_exp = %p",

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
@@ -77,10 +77,10 @@ task soc_dbg_ctrl_scoreboard::process_tl_access(tl_seq_item item,
   uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
   tl_phase_e     tl_phase;
 
-  if (!write && channel == AddrChannel) tl_phase = AddrRead;
-  if ( write && channel == AddrChannel) tl_phase = AddrWrite;
-  if (!write && channel == DataChannel) tl_phase = DataRead;
-  if ( write && channel == DataChannel) tl_phase = DataWrite;
+  if (!write && channel == AChannel) tl_phase = AddrRead;
+  if ( write && channel == AChannel) tl_phase = AddrWrite;
+  if (!write && channel == DChannel) tl_phase = DataRead;
+  if ( write && channel == DChannel) tl_phase = DataWrite;
 
   if (ral_name == ral.get_name()) begin
     process_tl_core_access(item, csr_addr, tl_phase);

--- a/hw/ip/spi_device/dv/README.md
+++ b/hw/ip/spi_device/dv/README.md
@@ -82,8 +82,8 @@ Refer to the testplan covergroups sections for the detail descriptions.
 #### Scoreboard
 The `spi_device_scoreboard` is primarily used for end to end checking.
 It creates the following analysis FIFOs to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo, tl_d_chan_fifo:           These 2 FIFOs provide transaction items at the end of address channel and data channel respectively
-* upstream_spi_host_fifo, upstream_spi_device_fifo: These 2 FIFOs provides TX/RX words of data from spi_monitor
+* `tl_a_chan_fifo`, `tl_d_chan_fifo`: FIFOs that provide sequence items at the end of transactions on the A and D channel respectively
+* `upstream_spi_host_fifo`, `upstream_spi_device_fifo`: FIFOs that provide TX/RX words of data from spi_monitor
 
 #### Assertions
 * TLUL assertions: The `tb/spi_device_bind.sv` binds the `tlul_assert` [assertions](../../tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.

--- a/hw/ip/spi_host/dv/README.md
+++ b/hw/ip/spi_host/dv/README.md
@@ -231,8 +231,8 @@ It creates the following analysis ports to retrieve the data monitored by corres
 
 **TL_UL AGENT**
 
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 **SPI_AGENT**
 

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -491,8 +491,8 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
     spi_segment_item rd_segment;
     spi_segment_item wr_segment;
 
-    bit cmd_phase_write =  (write && channel == AddrChannel);
-    bit data_phase_read = (!write && channel == DataChannel);
+    bit cmd_phase_write =  (write && channel == AChannel);
+    bit data_phase_read = (!write && channel == DChannel);
     // If the access was inside the TXFIFO window...
     if ((csr_addr & csr_addr_mask) inside {[SPI_HOST_TX_FIFO_START :
                                             SPI_HOST_TX_FIFO_END]}) begin

--- a/hw/ip/sram_ctrl/dv/README.md
+++ b/hw/ip/sram_ctrl/dv/README.md
@@ -150,12 +150,12 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `sram_ctrl_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: TL address channel for CSR accesses
-* tl_d_chan_fifo: TL data channel for CSR accesses
+* `tl_a_chan_fifo`: TileLink A channel for CSR accesses
+* `tl_d_chan_fifo`: TileLink D channel for CSR accesses
 * alert_fifos: Alert handshakes
-* sram_tl_a_chan_fifo: TL address channel for memory accesses
-* sram_tl_d_chan_fifo: TL data channel for memory accesses
-* kdi_fifo: For key refresh operations from OTP_CTRL
+* `sram_tl_a_chan_fifo`: TL A channel for memory accesses
+* `sram_tl_d_chan_fifo`: TL D channel for memory accesses
+* `kdi_fifo`: For key refresh operations from OTP_CTRL
 
 All CSR accesses made to the SRAM_CTRL register file are tracked and predicted by the scoreboard.
 

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -155,7 +155,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     end
     if (status_lc_esc == EscFinal) is_tl_err |= 1;
 
-    if (channel == DataChannel && is_tl_err) begin
+    if (channel == DChannel && is_tl_err) begin
       `DV_CHECK_EQ(item.d_error, 1,
           $sformatf({"item_err: %0d, allow_ifetch : %0d, sram_ifetch: %0d, exec: %0d, ",
                      "debug_en: %0d, lc_esc %0d"},
@@ -512,13 +512,13 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     if (ral_name == cfg.sram_ral_name) begin
-      if (channel == AddrChannel) process_sram_tl_a_chan_item(item);
+      if (channel == AChannel) process_sram_tl_a_chan_item(item);
       else                        process_sram_tl_d_chan_item(item);
       return;
     end

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -66,10 +66,10 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip/tlul/doc/dv/README.md
+++ b/hw/ip/tlul/doc/dv/README.md
@@ -98,7 +98,7 @@ Due to this limitation, scoreboard is designed as following:
   Each host has a queue used only for unmapped items. It stores the unmapped item from a_channel, then compare it with the same source ID response received in d_channel.
 
 Following analysis fifos are created to retrieve the data monitored by corresponding interface agents:
-* a_chan_host/device_name, d_chan_host/device_name: These fifos provide transaction items at the end of address channel and data channel respectively from host/device
+* `a_chan_host/device_name`, `d_chan_host/device_name`: These fifos provide transaction items at the end of the A and D channel respectively from host/device
 
 Following item queues are created to store items for check
 * a_chan_device_name: store items from all hosts that are sent to this device

--- a/hw/ip/uart/dv/README.md
+++ b/hw/ip/uart/dv/README.md
@@ -84,9 +84,8 @@ The following covergroups have been developed to prove that the test intent has 
 #### Scoreboard
 The `uart_scoreboard` is primarily used for end to end checking.
 It creates the following analysis FIFOs to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo, tl_d_chan_fifo: These 2 FIFOs provides transaction items at the end of address channel and
-  data channel respectively
-* uart_tx_fifo, uart_rx_fifo:     These 2 FIFOs provides UART TX and RX item when its transfer completes
+* `tl_a_chan_fifo`, `tl_d_chan_fifo`: These provide transaction items at the end of the A and D channel, respectively.
+* uart_tx_fifo, uart_rx_fifo:         These provide UART TX and RX item when its transfer completes.
 
 #### Assertions
 * TLUL assertions: The `tb/uart_bind.sv` binds the `tlul_assert` [assertions](../../tlul/doc/TlulProtocolChecker.md) to the IP to ensure TileLink interface protocol compliance.

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -395,6 +395,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
                     rx_enabled, uart_rx_clk_pulses))
               end
             end
+            default: `uvm_fatal(`gfn, $sformatf("invalid channel: %0p", channel))
           endcase
         end // if (!write)
       end // status
@@ -508,6 +509,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
                 cov.rx_fifo_level_cg.sample(.lvl(rxlvl_act), .rst(0));
               end
             end
+            default: `uvm_fatal(`gfn, $sformatf("invalid channel: %0p", channel))
           endcase
         end
       end

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -611,8 +611,8 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
 
   // These two tasks are overridden because the implementation in the base class performs checks
   // against predictions using its own memory model; instead, we choose to update the BFM packet
-  // buffer memory within 'process_tl_addr' below, and then check the DUT read data against it in
-  // 'process_tl_data' below.
+  // buffer memory within 'process_tl_a' below, and then check the DUT read data against it in
+  // 'process_tl_d' below.
   virtual task process_mem_write(tl_seq_item item, string ral_name);
   endtask
   virtual task process_mem_read(tl_seq_item item, string ral_name);
@@ -657,8 +657,8 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
-  // TL Address Channel transaction.
-  function void process_tl_addr(ref tl_seq_item item, input string ral_name);
+  // TL A channel transaction.
+  function void process_tl_a(ref tl_seq_item item, input string ral_name);
     logic [TL_DW-1:0] wdata = item.a_data;
     int unsigned index;
     uvm_reg csr;
@@ -795,8 +795,8 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     endcase
   endfunction
 
-  // TL Data Channel transaction.
-  function void process_tl_data(ref tl_seq_item item, input string ral_name);
+  // TL D Channel transaction.
+  function void process_tl_d(ref tl_seq_item item, input string ral_name);
     logic [TL_DW-1:0] rdata = item.d_data;
     int unsigned index;
     uvm_reg csr;
@@ -985,8 +985,8 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     case (channel)
-      AddrChannel: process_tl_addr(item, ral_name);
-      DataChannel: process_tl_data(item, ral_name);
+      AChannel: process_tl_a(item, ral_name);
+      DChannel: process_tl_d(item, ral_name);
       default: `uvm_fatal(`gfn, $sformatf("Invalid channel: %0h", channel))
     endcase
   endtask

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -226,8 +226,6 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
   uvm_reg_addr_t csr_addr      = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
   tl_phase_e     tl_phase;
 
-  // Note: AChannel and DChannel don't exist in the TL spec. There is a confusion as TileLink
-  //       defines 5 channels called A, B, C, D and E. But for TLUL version, only A and D are used.
   if (!write && channel == AChannel) tl_phase = AChanRead;
   if ( write && channel == AChannel) tl_phase = AChanWrite;
   if (!write && channel == DChannel) tl_phase = DChanRead;

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -226,12 +226,12 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
   uvm_reg_addr_t csr_addr      = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
   tl_phase_e     tl_phase;
 
-  // Note: AddrChannel and DataChannel don't exist in the TL spec. There is a confusion as TileLink
+  // Note: AChannel and DChannel don't exist in the TL spec. There is a confusion as TileLink
   //       defines 5 channels called A, B, C, D and E. But for TLUL version, only A and D are used.
-  if (!write && channel == AddrChannel) tl_phase = AChanRead;
-  if ( write && channel == AddrChannel) tl_phase = AChanWrite;
-  if (!write && channel == DataChannel) tl_phase = DChanRead;
-  if ( write && channel == DataChannel) tl_phase = DChanWrite;
+  if (!write && channel == AChannel) tl_phase = AChanRead;
+  if ( write && channel == AChannel) tl_phase = AChanWrite;
+  if (!write && channel == DChannel) tl_phase = DChanRead;
+  if ( write && channel == DChannel) tl_phase = DChanWrite;
 
   // If access was to a valid csr, get the csr handle
   if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip_templates/alert_handler/dv/README.md
+++ b/hw/ip_templates/alert_handler/dv/README.md
@@ -86,8 +86,8 @@ The detailed covergroups are documented under alert_handler [testplan](#testplan
 #### Scoreboard
 The `alert_handler_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * alert_fifo:     An array of `alert_fifo` that connects to corresponding alert_monitors
 * esc_fifo:       An array of `esc_fifo` that connects to corresponding esc_monitors
 

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
@@ -363,7 +363,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
       return;
     end
 
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away
       if (write) begin
         string csr_name = csr.get_name();
@@ -463,7 +463,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
 
     if (!write) begin
       // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-      if (channel == DataChannel) begin
+      if (channel == DChannel) begin
         if (cfg.en_cov) begin
           if (csr.get_name() == "intr_state") begin
             bit [TL_DW-1:0] intr_en = ral.intr_enable.get_mirrored_value();

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
@@ -238,13 +238,13 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AddrChannel ? "address" : "data";
+    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
@@ -238,13 +238,12 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AChannel);
-    bit            addr_phase_write = (write && channel == AChannel);
-    bit            data_phase_read = (!write && channel == DChannel);
-    bit            data_phase_write = (write && channel == DChannel);
+    bit            a_chan_read = (!write && channel == AChannel);
+    bit            a_chan_write = (write && channel == AChannel);
+    bit            d_chan_read = (!write && channel == DChannel);
+    bit            d_chan_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -255,25 +254,25 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
     end
 
     // If incoming access is a write to a valid csr, update prediction right away.
-    if (addr_phase_write) begin
+    if (a_chan_write) begin
       `uvm_info(`gfn, $sformatf("Writing 0x%0x to %s", item.a_data, csr.get_name()), UVM_MEDIUM)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
 
     // Process the csr req:
-    // - For write, update local variable and fifo at address phase.
-    // - For read, update prediction at address phase and compare at data phase.
+    // - For write, update local variable and fifo on the A channel.
+    // - For read, update prediction at A channel message and compare at D channel message.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin
         // FIXME
       end
       "extclk_ctrl_regwen": begin
-        if (addr_phase_write) extclk_ctrl_regwen = item.a_data;
+        if (a_chan_write) extclk_ctrl_regwen = item.a_data;
       end
       "extclk_ctrl": begin
         typedef logic [2*$bits(prim_mubi_pkg::mubi4_t) - 1:0] extclk_ctrl_t;
-        if (addr_phase_write && extclk_ctrl_regwen) begin
+        if (a_chan_write && extclk_ctrl_regwen) begin
           `DV_CHECK_EQ(extclk_ctrl_t'(item.a_data), {
                        cfg.clkmgr_vif.extclk_ctrl_csr_step_down, cfg.clkmgr_vif.extclk_ctrl_csr_sel
                        })
@@ -285,18 +284,18 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
       "jitter_regwen": begin
       end
       "jitter_enable": begin
-        if (addr_phase_write && `gmv(ral.jitter_regwen)) begin
+        if (a_chan_write && `gmv(ral.jitter_regwen)) begin
           `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(item.a_data), cfg.clkmgr_vif.jitter_enable_csr)
         end
       end
       "clk_enables": begin
-        if (addr_phase_write) begin
+        if (a_chan_write) begin
           `DV_CHECK_EQ(clk_enables_t'(item.a_data), cfg.clkmgr_vif.clk_enables_csr)
         end
       end
       "clk_hints": begin
         // Clearing a hint sets an expectation for the status to transition to zero.
-        if (addr_phase_write) begin
+        if (a_chan_write) begin
           `DV_CHECK_EQ(clk_hints_t'(item.a_data), cfg.clkmgr_vif.clk_hints_csr)
         end
       end
@@ -306,7 +305,7 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
         do_read_check = 1'b0;
       end
       "measure_ctrl_regwen": begin
-        if (addr_phase_write) measure_ctrl_regwen = item.a_data;
+        if (a_chan_write) measure_ctrl_regwen = item.a_data;
       end
 % for clk in sorted(chain(*[c for c in parent_child_clks.values()])):
       "${clk}_meas_ctrl_en": begin
@@ -328,7 +327,7 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
     endcase
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-    if (data_phase_read) begin
+    if (d_chan_read) begin
       `uvm_info(`gfn, $sformatf("Reading 0x%0x from %s", item.d_data, csr.get_name()), UVM_MEDIUM)
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, $sformatf(

--- a/hw/ip_templates/gpio/dv/README.md.tpl
+++ b/hw/ip_templates/gpio/dv/README.md.tpl
@@ -84,8 +84,8 @@ ${"###"} Self-checking strategy
 ${"####"} Scoreboard
 The `${module_instance_name}_scoreboard` is primarily used for end to end checking.
 It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -78,7 +78,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    // grab completed transactions from data channel; ignore packets from address channel
+    // grab completed transactions from D channel; ignore packets from A channel
     if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;

--- a/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
+++ b/hw/ip_templates/gpio/dv/env/gpio_scoreboard.sv.tpl
@@ -79,7 +79,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
     end
 
     // grab completed transactions from data channel; ignore packets from address channel
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;
       time crnt_time = $time;
@@ -214,7 +214,7 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(.CFG_T ($
         `uvm_info(`gfn, "Calling gpio_predict_and_compare on reg write", UVM_HIGH)
         gpio_predict_and_compare(csr);
       end // if (write)
-    end else begin // if (channel == DataChannel)
+    end else begin // if (channel == DChannel)
       if (write == 0) begin
 % for cnt_idx in range(num_inp_period_counters):
         if (csr.get_name() == "inp_prd_cnt_val_${cnt_idx}") begin

--- a/hw/ip_templates/otp_ctrl/dv/README.md.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/README.md.tpl
@@ -103,8 +103,8 @@ ${"###"} Self-checking strategy
 ${"####"} Scoreboard
 The `otp_ctrl_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * alert_fifos: alert handshakes
 * sram_fifos: sram requests
 * otbn_fifo: otbn request

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -537,10 +537,10 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     uvm_reg_addr_t csr_addr   = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     if (ral_name != "otp_macro_prim_reg_block") begin
       process_core_tl_access(item, csr_addr, ral_name, addr_mask,
@@ -1461,7 +1461,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
   virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     if (ral_name == "otp_macro_prim_reg_block" &&
         cfg.otp_ctrl_vif.lc_dft_en_i != lc_ctrl_pkg::On) begin
-      if (channel == DataChannel) begin
+      if (channel == DChannel) begin
         `DV_CHECK_EQ(item.d_error, 1,
             $sformatf({"On interface %0s, TL item: %0s, access gated by lc_dft_en_i"},
             ral_name, item.sprint(uvm_default_line_printer)))

--- a/hw/ip_templates/pwm/dv/README.md.tpl
+++ b/hw/ip_templates/pwm/dv/README.md.tpl
@@ -118,7 +118,7 @@ ${"####"} Scoreboard
 The `pwm_scoreboard` is primarily used for transaction-by-transaction checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
 * item_fifo[NUM_PWM_CHANNELS]: the FIFO w.r.t channels receives the dut items sent by the pwm_monitor
-* exp_item                   : It is used to store the expected item constructed from tl address and data channels.
+* exp_item                   : It is used to store the expected item constructed from tl A and D channels.
 
 when a channel is configured to start sending pulses the first expected item is generated.
 Because of the way the PWM IP is designed the first and the last pulse might not match the configuration settings.

--- a/hw/ip_templates/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip_templates/pwm/dv/env/pwm_scoreboard.sv
@@ -130,8 +130,8 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
   bit             write = item.is_write();
   uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-  bit             addr_phase_write = (write && channel  == AddrChannel);
-  bit             data_phase_read  = (!write && channel == DataChannel);
+  bit             addr_phase_write = (write && channel  == AChannel);
+  bit             data_phase_read  = (!write && channel == DChannel);
 
   // if access was to a valid csr, get the csr handle
   if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv.tpl
@@ -225,10 +225,10 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/ip_templates/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip_templates/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -136,10 +136,10 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_darjeeling/dv/env/chip_scoreboard.sv
+++ b/hw/top_darjeeling/dv/env/chip_scoreboard.sv
@@ -83,7 +83,7 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
     // if stub_cpu is off, we force connect this DV mem with a sim_sram, accessing the DV mem is to
     // passing info from C to SV, which won't set d_error
     if (mem != null && mem.get_name() == "dv_sim_window" && cfg.chip_vif.stub_cpu) begin
-      if (channel == DataChannel) `DV_CHECK_EQ(item.d_error, 1)
+      if (channel == DChannel) `DV_CHECK_EQ(item.d_error, 1)
       return 1;
     end
     return super.predict_tl_err(item, channel, ral_name);

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -226,8 +226,6 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
   uvm_reg_addr_t csr_addr      = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
   tl_phase_e     tl_phase;
 
-  // Note: AChannel and DChannel don't exist in the TL spec. There is a confusion as TileLink
-  //       defines 5 channels called A, B, C, D and E. But for TLUL version, only A and D are used.
   if (!write && channel == AChannel) tl_phase = AChanRead;
   if ( write && channel == AChannel) tl_phase = AChanWrite;
   if (!write && channel == DChannel) tl_phase = DChanRead;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scoreboard.sv
@@ -226,12 +226,12 @@ task ac_range_check_scoreboard::process_tl_access(tl_seq_item item,
   uvm_reg_addr_t csr_addr      = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
   tl_phase_e     tl_phase;
 
-  // Note: AddrChannel and DataChannel don't exist in the TL spec. There is a confusion as TileLink
+  // Note: AChannel and DChannel don't exist in the TL spec. There is a confusion as TileLink
   //       defines 5 channels called A, B, C, D and E. But for TLUL version, only A and D are used.
-  if (!write && channel == AddrChannel) tl_phase = AChanRead;
-  if ( write && channel == AddrChannel) tl_phase = AChanWrite;
-  if (!write && channel == DataChannel) tl_phase = DChanRead;
-  if ( write && channel == DataChannel) tl_phase = DChanWrite;
+  if (!write && channel == AChannel) tl_phase = AChanRead;
+  if ( write && channel == AChannel) tl_phase = AChanWrite;
+  if (!write && channel == DChannel) tl_phase = DChanRead;
+  if ( write && channel == DChannel) tl_phase = DChanWrite;
 
   // If access was to a valid csr, get the csr handle
   if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/README.md
@@ -86,8 +86,8 @@ The detailed covergroups are documented under alert_handler [testplan](#testplan
 #### Scoreboard
 The `alert_handler_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * alert_fifo:     An array of `alert_fifo` that connects to corresponding alert_monitors
 * esc_fifo:       An array of `esc_fifo` that connects to corresponding esc_monitors
 

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -363,7 +363,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       return;
     end
 
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away
       if (write) begin
         string csr_name = csr.get_name();
@@ -463,7 +463,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
 
     if (!write) begin
       // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-      if (channel == DataChannel) begin
+      if (channel == DChannel) begin
         if (cfg.en_cov) begin
           if (csr.get_name() == "intr_state") begin
             bit [TL_DW-1:0] intr_en = ral.intr_enable.get_mirrored_value();

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -231,13 +231,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AChannel);
-    bit            addr_phase_write = (write && channel == AChannel);
-    bit            data_phase_read = (!write && channel == DChannel);
-    bit            data_phase_write = (write && channel == DChannel);
+    bit            a_chan_read = (!write && channel == AChannel);
+    bit            a_chan_write = (write && channel == AChannel);
+    bit            d_chan_read = (!write && channel == DChannel);
+    bit            d_chan_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -248,25 +247,25 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     end
 
     // If incoming access is a write to a valid csr, update prediction right away.
-    if (addr_phase_write) begin
+    if (a_chan_write) begin
       `uvm_info(`gfn, $sformatf("Writing 0x%0x to %s", item.a_data, csr.get_name()), UVM_MEDIUM)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
 
     // Process the csr req:
-    // - For write, update local variable and fifo at address phase.
-    // - For read, update prediction at address phase and compare at data phase.
+    // - For write, update local variable and fifo on the A channel.
+    // - For read, update prediction at A channel message and compare at D channel message.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin
         // FIXME
       end
       "extclk_ctrl_regwen": begin
-        if (addr_phase_write) extclk_ctrl_regwen = item.a_data;
+        if (a_chan_write) extclk_ctrl_regwen = item.a_data;
       end
       "extclk_ctrl": begin
         typedef logic [2*$bits(prim_mubi_pkg::mubi4_t) - 1:0] extclk_ctrl_t;
-        if (addr_phase_write && extclk_ctrl_regwen) begin
+        if (a_chan_write && extclk_ctrl_regwen) begin
           `DV_CHECK_EQ(extclk_ctrl_t'(item.a_data), {
                        cfg.clkmgr_vif.extclk_ctrl_csr_step_down, cfg.clkmgr_vif.extclk_ctrl_csr_sel
                        })
@@ -278,18 +277,18 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       "jitter_regwen": begin
       end
       "jitter_enable": begin
-        if (addr_phase_write && `gmv(ral.jitter_regwen)) begin
+        if (a_chan_write && `gmv(ral.jitter_regwen)) begin
           `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(item.a_data), cfg.clkmgr_vif.jitter_enable_csr)
         end
       end
       "clk_enables": begin
-        if (addr_phase_write) begin
+        if (a_chan_write) begin
           `DV_CHECK_EQ(clk_enables_t'(item.a_data), cfg.clkmgr_vif.clk_enables_csr)
         end
       end
       "clk_hints": begin
         // Clearing a hint sets an expectation for the status to transition to zero.
-        if (addr_phase_write) begin
+        if (a_chan_write) begin
           `DV_CHECK_EQ(clk_hints_t'(item.a_data), cfg.clkmgr_vif.clk_hints_csr)
         end
       end
@@ -299,7 +298,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       "measure_ctrl_regwen": begin
-        if (addr_phase_write) measure_ctrl_regwen = item.a_data;
+        if (a_chan_write) measure_ctrl_regwen = item.a_data;
       end
       "io_meas_ctrl_en": begin
       end
@@ -329,7 +328,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     endcase
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-    if (data_phase_read) begin
+    if (d_chan_read) begin
       `uvm_info(`gfn, $sformatf("Reading 0x%0x from %s", item.d_data, csr.get_name()), UVM_MEDIUM)
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, $sformatf(

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -231,13 +231,13 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AddrChannel ? "address" : "data";
+    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/README.md
@@ -84,8 +84,8 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 #### Scoreboard
 The `gpio_scoreboard` is primarily used for end to end checking.
 It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -79,7 +79,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
 
     // grab completed transactions from data channel; ignore packets from address channel
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;
       time crnt_time = $time;
@@ -214,7 +214,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         `uvm_info(`gfn, "Calling gpio_predict_and_compare on reg write", UVM_HIGH)
         gpio_predict_and_compare(csr);
       end // if (write)
-    end else begin // if (channel == DataChannel)
+    end else begin // if (channel == DChannel)
       if (write == 0) begin
         if (csr.get_name() == "inp_prd_cnt_val_0") begin
           // TODO(#26544): Check values read from all input period counters.

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -78,7 +78,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    // grab completed transactions from data channel; ignore packets from address channel
+    // grab completed transactions from D channel; ignore packets from A channel
     if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/README.md
@@ -103,8 +103,8 @@ The functional coverage is collected automatically when the sampled signal is ac
 #### Scoreboard
 The `otp_ctrl_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * alert_fifos: alert handshakes
 * sram_fifos: sram requests
 * otbn_fifo: otbn request

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -504,10 +504,10 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     uvm_reg_addr_t csr_addr   = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     if (ral_name != "otp_macro_prim_reg_block") begin
       process_core_tl_access(item, csr_addr, ral_name, addr_mask,
@@ -2030,7 +2030,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
   virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     if (ral_name == "otp_macro_prim_reg_block" &&
         cfg.otp_ctrl_vif.lc_dft_en_i != lc_ctrl_pkg::On) begin
-      if (channel == DataChannel) begin
+      if (channel == DChannel) begin
         `DV_CHECK_EQ(item.d_error, 1,
             $sformatf({"On interface %0s, TL item: %0s, access gated by lc_dft_en_i"},
             ral_name, item.sprint(uvm_default_line_printer)))

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -227,10 +227,10 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -136,10 +136,10 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -83,7 +83,7 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
     // if stub_cpu is off, we force connect this DV mem with a sim_sram, accessing the DV mem is to
     // passing info from C to SV, which won't set d_error
     if (mem != null && mem.get_name() == "dv_sim_window" && cfg.chip_vif.stub_cpu) begin
-      if (channel == DataChannel) `DV_CHECK_EQ(item.d_error, 1)
+      if (channel == DChannel) `DV_CHECK_EQ(item.d_error, 1)
       return 1;
     end
     return super.predict_tl_err(item, channel, ral_name);

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/README.md
@@ -86,8 +86,8 @@ The detailed covergroups are documented under alert_handler [testplan](#testplan
 #### Scoreboard
 The `alert_handler_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * alert_fifo:     An array of `alert_fifo` that connects to corresponding alert_monitors
 * esc_fifo:       An array of `esc_fifo` that connects to corresponding esc_monitors
 

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -363,7 +363,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       return;
     end
 
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // if incoming access is a write to a valid csr, then make updates right away
       if (write) begin
         string csr_name = csr.get_name();
@@ -463,7 +463,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
 
     if (!write) begin
       // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-      if (channel == DataChannel) begin
+      if (channel == DChannel) begin
         if (cfg.en_cov) begin
           if (csr.get_name() == "intr_state") begin
             bit [TL_DW-1:0] intr_en = ral.intr_enable.get_mirrored_value();

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -274,13 +274,13 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AddrChannel ? "address" : "data";
+    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/README.md
@@ -84,8 +84,8 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 #### Scoreboard
 The `gpio_scoreboard` is primarily used for end to end checking.
 It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -79,7 +79,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
 
     // grab completed transactions from data channel; ignore packets from address channel
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;
       time crnt_time = $time;
@@ -214,7 +214,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         `uvm_info(`gfn, "Calling gpio_predict_and_compare on reg write", UVM_HIGH)
         gpio_predict_and_compare(csr);
       end // if (write)
-    end else begin // if (channel == DataChannel)
+    end else begin // if (channel == DChannel)
       if (write == 0) begin
         // If do_read_check, is set, then check mirrored_value against item.d_data
         if (do_read_check) begin

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -78,7 +78,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    // grab completed transactions from data channel; ignore packets from address channel
+    // grab completed transactions from D channel; ignore packets from A channel
     if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/README.md
@@ -103,8 +103,8 @@ The functional coverage is collected automatically when the sampled signal is ac
 #### Scoreboard
 The `otp_ctrl_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 * alert_fifos: alert handshakes
 * sram_fifos: sram requests
 * otbn_fifo: otbn request

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -524,10 +524,10 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     uvm_reg_addr_t csr_addr   = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
     bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     if (ral_name != "otp_macro_prim_reg_block") begin
       process_core_tl_access(item, csr_addr, ral_name, addr_mask,
@@ -1673,7 +1673,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
   virtual function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
     if (ral_name == "otp_macro_prim_reg_block" &&
         cfg.otp_ctrl_vif.lc_dft_en_i != lc_ctrl_pkg::On) begin
-      if (channel == DataChannel) begin
+      if (channel == DChannel) begin
         `DV_CHECK_EQ(item.d_error, 1,
             $sformatf({"On interface %0s, TL item: %0s, access gated by lc_dft_en_i"},
             ral_name, item.sprint(uvm_default_line_printer)))

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/README.md
@@ -118,7 +118,7 @@ The functional coverage plan can be found here: [coverageplan](#testplan)
 The `pwm_scoreboard` is primarily used for transaction-by-transaction checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
 * item_fifo[NUM_PWM_CHANNELS]: the FIFO w.r.t channels receives the dut items sent by the pwm_monitor
-* exp_item                   : It is used to store the expected item constructed from tl address and data channels.
+* exp_item                   : It is used to store the expected item constructed from tl A and D channels.
 
 when a channel is configured to start sending pulses the first expected item is generated.
 Because of the way the PWM IP is designed the first and the last pulse might not match the configuration settings.

--- a/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/dv/env/pwm_scoreboard.sv
@@ -130,8 +130,8 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
   bit             write = item.is_write();
   uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-  bit             addr_phase_write = (write && channel  == AddrChannel);
-  bit             data_phase_read  = (!write && channel == DataChannel);
+  bit             addr_phase_write = (write && channel  == AChannel);
+  bit             data_phase_read  = (!write && channel == DChannel);
 
   // if access was to a valid csr, get the csr handle
   if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -221,10 +221,10 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -136,10 +136,10 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -265,13 +265,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AChannel);
-    bit            addr_phase_write = (write && channel == AChannel);
-    bit            data_phase_read = (!write && channel == DChannel);
-    bit            data_phase_write = (write && channel == DChannel);
+    bit            a_chan_read = (!write && channel == AChannel);
+    bit            a_chan_write = (write && channel == AChannel);
+    bit            d_chan_read = (!write && channel == DChannel);
+    bit            d_chan_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -282,25 +281,25 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     end
 
     // If incoming access is a write to a valid csr, update prediction right away.
-    if (addr_phase_write) begin
+    if (a_chan_write) begin
       `uvm_info(`gfn, $sformatf("Writing 0x%0x to %s", item.a_data, csr.get_name()), UVM_MEDIUM)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
 
     // Process the csr req:
-    // - For write, update local variable and fifo at address phase.
-    // - For read, update prediction at address phase and compare at data phase.
+    // - For write, update local variable and fifo on the A channel.
+    // - For read, update prediction at A channel message and compare at D channel message.
     case (csr.get_name())
       // add individual case item for each csr
       "alert_test": begin
         // FIXME
       end
       "extclk_ctrl_regwen": begin
-        if (addr_phase_write) extclk_ctrl_regwen = item.a_data;
+        if (a_chan_write) extclk_ctrl_regwen = item.a_data;
       end
       "extclk_ctrl": begin
         typedef logic [2*$bits(prim_mubi_pkg::mubi4_t) - 1:0] extclk_ctrl_t;
-        if (addr_phase_write && extclk_ctrl_regwen) begin
+        if (a_chan_write && extclk_ctrl_regwen) begin
           `DV_CHECK_EQ(extclk_ctrl_t'(item.a_data), {
                        cfg.clkmgr_vif.extclk_ctrl_csr_step_down, cfg.clkmgr_vif.extclk_ctrl_csr_sel
                        })
@@ -312,18 +311,18 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       "jitter_regwen": begin
       end
       "jitter_enable": begin
-        if (addr_phase_write && `gmv(ral.jitter_regwen)) begin
+        if (a_chan_write && `gmv(ral.jitter_regwen)) begin
           `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(item.a_data), cfg.clkmgr_vif.jitter_enable_csr)
         end
       end
       "clk_enables": begin
-        if (addr_phase_write) begin
+        if (a_chan_write) begin
           `DV_CHECK_EQ(clk_enables_t'(item.a_data), cfg.clkmgr_vif.clk_enables_csr)
         end
       end
       "clk_hints": begin
         // Clearing a hint sets an expectation for the status to transition to zero.
-        if (addr_phase_write) begin
+        if (a_chan_write) begin
           `DV_CHECK_EQ(clk_hints_t'(item.a_data), cfg.clkmgr_vif.clk_hints_csr)
         end
       end
@@ -333,7 +332,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       "measure_ctrl_regwen": begin
-        if (addr_phase_write) measure_ctrl_regwen = item.a_data;
+        if (a_chan_write) measure_ctrl_regwen = item.a_data;
       end
       "io_meas_ctrl_en": begin
       end
@@ -367,7 +366,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     endcase
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-    if (data_phase_read) begin
+    if (d_chan_read) begin
       `uvm_info(`gfn, $sformatf("Reading 0x%0x from %s", item.d_data, csr.get_name()), UVM_MEDIUM)
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, $sformatf(

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -265,13 +265,13 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     string         access_str = write ? "write" : "read";
-    string         channel_str = channel == AddrChannel ? "address" : "data";
+    string         channel_str = channel == AChannel ? "address" : "data";
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/README.md
@@ -84,8 +84,8 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 #### Scoreboard
 The `gpio_scoreboard` is primarily used for end to end checking.
 It creates the following tlm analysis fifos to retrieve the data monitored by tlul interface agent monitors:
-* tl_a_chan_fifo: tl address channel
-* tl_d_chan_fifo: tl data channel
+* `tl_a_chan_fifo`: TileLink A channel
+* `tl_d_chan_fifo`: TileLink D channel
 
 GPIO scoreboard monitors all valid GPIO CSR register accesses, activity on GPIO IOs, and interrupt pins. For any monitored write transaction, CSR values are updated in RAL. Based on monitored activity, GPIO scoreboard predicts updated values of required CSRs.
 

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -79,7 +79,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     end
 
     // grab completed transactions from data channel; ignore packets from address channel
-    if (channel == AddrChannel) begin
+    if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;
       time crnt_time = $time;
@@ -214,7 +214,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         `uvm_info(`gfn, "Calling gpio_predict_and_compare on reg write", UVM_HIGH)
         gpio_predict_and_compare(csr);
       end // if (write)
-    end else begin // if (channel == DataChannel)
+    end else begin // if (channel == DChannel)
       if (write == 0) begin
         // If do_read_check, is set, then check mirrored_value against item.d_data
         if (do_read_check) begin

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/env/gpio_scoreboard.sv
@@ -78,7 +78,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    // grab completed transactions from data channel; ignore packets from address channel
+    // grab completed transactions from D channel; ignore packets from A channel
     if (channel == AChannel) begin
       // Clock period in nano seconds (timeunit)
       real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -221,10 +221,10 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -136,10 +136,10 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
     bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit            addr_phase_read = (!write && channel == AddrChannel);
-    bit            addr_phase_write = (write && channel == AddrChannel);
-    bit            data_phase_read = (!write && channel == DataChannel);
-    bit            data_phase_write = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AChannel);
+    bit            addr_phase_write = (write && channel == AChannel);
+    bit            data_phase_read = (!write && channel == DChannel);
+    bit            data_phase_write = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -70,10 +70,10 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_read   = (!write && channel == AChannel);
+    bit addr_phase_write  = (write && channel == AChannel);
+    bit data_phase_read   = (!write && channel == DChannel);
+    bit data_phase_write  = (write && channel == DChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin


### PR DESCRIPTION
These names aren't actually right: the channels are called A and D and
these are just indices: TLUL doesn't use channels B and C.

Change the enum names with

    AddrChannel -> AChannel
    DataChannel -> DChannel

Most of the other changes are pretty mechanical, but there were some DV tasks with names like "process_tl_data_txn". Change them to names like "process_tl_d_txn".

Fixes #26519.