### PR TITLE
[perso] fix bug in boot data flash info page config

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -275,14 +275,7 @@ void flash_ctrl_init(void) {
   };
   flash_ctrl_data_default_cfg_set(data_default_cfg);
   // Configure scrambling, ECC, and HE for `boot_data` pages.
-  otp_val =
-      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET);
-  flash_ctrl_cfg_t boot_data_cfg = {
-      .scrambling =
-          bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_SCRAMBLING),
-      .ecc = bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_ECC),
-      .he = bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_HE),
-  };
+  flash_ctrl_cfg_t boot_data_cfg = flash_ctrl_boot_data_cfg_get();
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData0, boot_data_cfg);
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData1, boot_data_cfg);
 }
@@ -520,6 +513,17 @@ flash_ctrl_cfg_t flash_ctrl_data_default_cfg_get(void) {
                                    FLASH_CTRL_DEFAULT_REGION_ECC_EN_FIELD),
       .he = bitfield_field32_read(default_region,
                                   FLASH_CTRL_DEFAULT_REGION_HE_EN_FIELD),
+  };
+}
+
+flash_ctrl_cfg_t flash_ctrl_boot_data_cfg_get(void) {
+  uint32_t otp_val =
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG_OFFSET);
+  return (flash_ctrl_cfg_t){
+      .scrambling =
+          bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_SCRAMBLING),
+      .ecc = bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_ECC),
+      .he = bitfield_field32_read(otp_val, FLASH_CTRL_OTP_FIELD_HE),
   };
 }
 

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -540,6 +540,13 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg);
 flash_ctrl_cfg_t flash_ctrl_data_default_cfg_get(void);
 
 /**
+ * Reads the boot data info page configuration settings from OTP.
+ *
+ * @return Current OTP configuration settings.
+ */
+flash_ctrl_cfg_t flash_ctrl_boot_data_cfg_get(void);
+
+/**
  * A type for flash_ctrl memory protection region indices.
  */
 typedef uint32_t flash_ctrl_region_index_t;

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -597,7 +597,7 @@ static status_t boot_data_cfg_initialize(void) {
   }
 
   // Loads the boot data configuration from OTP.
-  flash_ctrl_cfg_t cfg = flash_ctrl_data_default_cfg_get();
+  flash_ctrl_cfg_t boot_data_cfg = flash_ctrl_boot_data_cfg_get();
 
   flash_ctrl_perms_t perm = {
       .read = kMultiBitBool4False,
@@ -610,8 +610,8 @@ static status_t boot_data_cfg_initialize(void) {
   // next boot.
   flash_ctrl_info_perms_set(&kFlashCtrlInfoPageBootData0, perm);
   flash_ctrl_info_perms_set(&kFlashCtrlInfoPageBootData1, perm);
-  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData0, cfg);
-  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData1, cfg);
+  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData0, boot_data_cfg);
+  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageBootData1, boot_data_cfg);
 
   TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageBootData0,
                             kFlashCtrlEraseTypePage));
@@ -643,8 +643,8 @@ static status_t install_owner(void) {
   flash_ctrl_info_perms_set(&kFlashCtrlInfoPageOwnerSlot1, perm);
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageOwnerSlot1, cfg);
 
-  //  Initializes the boot data flash configuration in OTP, and
-  //  erases the boot data pages to avoid integrity errors in the next boot.
+  // Initializes the boot data flash configuration in OTP, and erases the boot
+  // data pages to avoid integrity errors in the next boot.
   // `sku_creator_owner_init` will write the owner block to the flash.
   TRY(boot_data_cfg_initialize());
 


### PR DESCRIPTION
This fixes a bug in the boot-data flash info page configuration. We need to read the configuration of the boot-data flash info page from OTP before configuring the page, not the default data page configuration as there are two different sets of configuration settings.