### PR TITLE
[rv_plic, fpv] Removed zero assignment to exclude undetectable checker coverage

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -3973,7 +3973,6 @@ module adc_ctrl_reg_top (
 
   logic [31:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ADC_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == ADC_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == ADC_CTRL_INTR_TEST_OFFSET);
@@ -4174,7 +4173,6 @@ module adc_ctrl_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -1432,7 +1432,6 @@ module aes_reg_top (
 
   logic [33:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == AES_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == AES_KEY_SHARE0_0_OFFSET);
     addr_hit[ 2] = (reg_addr == AES_KEY_SHARE0_1_OFFSET);
@@ -1631,7 +1630,6 @@ module aes_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = key_share0_0_we;
     reg_we_check[2] = key_share0_1_we;

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -1119,7 +1119,6 @@ module aon_timer_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == AON_TIMER_ALERT_TEST_OFFSET);
@@ -1229,7 +1228,6 @@ module aon_timer_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = wkup_ctrl_we;
     reg_we_check[2] = wkup_thold_hi_we;

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -2173,7 +2173,6 @@ module csrng_reg_top (
 
   logic [23:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == CSRNG_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == CSRNG_INTR_TEST_OFFSET);
@@ -2328,7 +2327,6 @@ module csrng_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -3049,7 +3049,6 @@ module dma_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == DMA_INTR_STATE_OFFSET);
@@ -3382,7 +3381,6 @@ module dma_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -1383,7 +1383,6 @@ module edn_reg_top (
 
   logic [17:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == EDN_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == EDN_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == EDN_INTR_TEST_OFFSET);
@@ -1499,7 +1498,6 @@ module edn_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -3398,7 +3398,6 @@ module entropy_src_reg_top (
 
   logic [56:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ENTROPY_SRC_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == ENTROPY_SRC_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == ENTROPY_SRC_INTR_TEST_OFFSET);
@@ -3731,7 +3730,6 @@ module entropy_src_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -1942,7 +1942,6 @@ module hmac_reg_top (
 
   logic [58:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == HMAC_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == HMAC_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == HMAC_INTR_TEST_OFFSET);
@@ -2293,7 +2292,6 @@ module hmac_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -3419,7 +3419,6 @@ module i2c_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == I2C_INTR_STATE_OFFSET);
@@ -3752,7 +3751,6 @@ module i2c_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -2940,7 +2940,6 @@ module keymgr_reg_top (
 
   logic [62:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KEYMGR_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == KEYMGR_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == KEYMGR_INTR_TEST_OFFSET);
@@ -3289,7 +3288,6 @@ module keymgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_top.sv
@@ -2711,7 +2711,6 @@ module keymgr_dpe_reg_top (
 
   logic [52:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KEYMGR_DPE_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == KEYMGR_DPE_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == KEYMGR_DPE_INTR_TEST_OFFSET);
@@ -3020,7 +3019,6 @@ module keymgr_dpe_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -2591,7 +2591,6 @@ module kmac_reg_top (
 
   logic [56:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KMAC_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == KMAC_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == KMAC_INTR_TEST_OFFSET);
@@ -2922,7 +2921,6 @@ module kmac_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_regs_reg_top.sv
@@ -1137,7 +1137,6 @@ module lc_ctrl_regs_reg_top (
 
   logic [34:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == LC_CTRL_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == LC_CTRL_STATUS_OFFSET);
     addr_hit[ 2] = (reg_addr == LC_CTRL_CLAIM_TRANSITION_IF_REGWEN_OFFSET);
@@ -1292,7 +1291,6 @@ module lc_ctrl_regs_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = claim_transition_if_regwen_we;

--- a/hw/ip/mbx/rtl/mbx_core_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_core_reg_top.sv
@@ -896,7 +896,6 @@ module mbx_core_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == MBX_INTR_STATE_OFFSET);
@@ -1034,7 +1033,6 @@ module mbx_core_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -494,7 +494,6 @@ module mbx_soc_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[0] = (reg_addr == MBX_SOC_CONTROL_OFFSET);
@@ -565,7 +564,6 @@ module mbx_soc_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = soc_control_we;
     reg_we_check[1] = soc_status_we;
     reg_we_check[2] = soc_doe_intr_msg_addr_we;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -946,7 +946,6 @@ module otbn_reg_top (
 
   logic [10:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OTBN_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == OTBN_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == OTBN_INTR_TEST_OFFSET);
@@ -1045,7 +1044,6 @@ module otbn_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -854,7 +854,6 @@ module pattgen_reg_top (
 
   logic [11:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PATTGEN_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == PATTGEN_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == PATTGEN_INTR_TEST_OFFSET);
@@ -954,7 +953,6 @@ module pattgen_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -686,7 +686,6 @@ module rom_ctrl_regs_reg_top (
 
   logic [17:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ROM_CTRL_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == ROM_CTRL_FATAL_ALERT_CAUSE_OFFSET);
     addr_hit[ 2] = (reg_addr == ROM_CTRL_DIGEST_0_OFFSET);
@@ -739,7 +738,6 @@ module rom_ctrl_regs_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = 1'b0;

--- a/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_mem_reg_top.sv
@@ -8608,7 +8608,6 @@ module rv_dm_mem_reg_top (
 
   logic [280:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_DM_HALTED_OFFSET);
     addr_hit[  1] = (reg_addr == RV_DM_GOING_OFFSET);
     addr_hit[  2] = (reg_addr == RV_DM_RESUMING_OFFSET);
@@ -9202,7 +9201,6 @@ module rv_dm_mem_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = halted_we;
     reg_we_check[1] = going_we;
     reg_we_check[2] = resuming_we;

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -245,7 +245,6 @@ module rv_dm_regs_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[0] = (reg_addr == RV_DM_ALERT_TEST_OFFSET);
@@ -304,7 +303,6 @@ module rv_dm_regs_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = late_debug_enable_regwen_we;
     reg_we_check[2] = late_debug_enable_gated_we;

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -509,7 +509,6 @@ module rv_timer_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[0] = (reg_addr == RV_TIMER_ALERT_TEST_OFFSET);
@@ -605,7 +604,6 @@ module rv_timer_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = ctrl_we;
     reg_we_check[2] = intr_enable0_we;

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_core_reg_top.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_core_reg_top.sv
@@ -503,7 +503,6 @@ module soc_dbg_ctrl_core_reg_top (
 
   logic [6:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[0] = (reg_addr == SOC_DBG_CTRL_ALERT_TEST_OFFSET);
     addr_hit[1] = (reg_addr == SOC_DBG_CTRL_DEBUG_POLICY_VALID_SHADOWED_OFFSET);
     addr_hit[2] = (reg_addr == SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED_OFFSET);
@@ -558,7 +557,6 @@ module soc_dbg_ctrl_core_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = debug_policy_valid_shadowed_we;
     reg_we_check[2] = debug_policy_category_shadowed_we;

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_jtag_reg_top.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_jtag_reg_top.sv
@@ -476,7 +476,6 @@ module soc_dbg_ctrl_jtag_reg_top (
 
   logic [5:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[0] = (reg_addr == SOC_DBG_CTRL_JTAG_TRACE_DEBUG_POLICY_CATEGORY_OFFSET);
     addr_hit[1] = (reg_addr == SOC_DBG_CTRL_JTAG_TRACE_DEBUG_POLICY_VALID_RELOCKED_OFFSET);
     addr_hit[2] = (reg_addr == SOC_DBG_CTRL_JTAG_CONTROL_OFFSET);
@@ -508,7 +507,6 @@ module soc_dbg_ctrl_jtag_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = jtag_control_we;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -19494,7 +19494,6 @@ module spi_device_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -21045,7 +21044,6 @@ module spi_device_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -1749,7 +1749,6 @@ module spi_host_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == SPI_HOST_INTR_STATE_OFFSET);
@@ -1908,7 +1907,6 @@ module spi_host_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -674,7 +674,6 @@ module sram_ctrl_regs_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[0] = (reg_addr == SRAM_CTRL_ALERT_TEST_OFFSET);
@@ -762,7 +761,6 @@ module sram_ctrl_regs_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = exec_regwen_we;

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -6555,7 +6555,6 @@ module sysrst_ctrl_reg_top (
 
   logic [42:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SYSRST_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == SYSRST_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == SYSRST_CTRL_INTR_TEST_OFFSET);
@@ -6879,7 +6878,6 @@ module sysrst_ctrl_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -1099,7 +1099,6 @@ module trial1_reg_top (
 
   logic [19:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == TRIAL1_RWTYPE0_OFFSET);
     addr_hit[ 1] = (reg_addr == TRIAL1_RWTYPE1_OFFSET);
     addr_hit[ 2] = (reg_addr == TRIAL1_RWTYPE2_OFFSET);
@@ -1228,7 +1227,6 @@ module trial1_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = rwtype0_we;
     reg_we_check[1] = rwtype1_we;
     reg_we_check[2] = rwtype2_we;

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1595,7 +1595,6 @@ module uart_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == UART_INTR_STATE_OFFSET);
@@ -1764,7 +1763,6 @@ module uart_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -8680,7 +8680,6 @@ module usbdev_reg_top (
 
   logic [42:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == USBDEV_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == USBDEV_INTR_TEST_OFFSET);
@@ -9380,7 +9379,6 @@ module usbdev_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_darjeeling/ip/ast/rtl/ast_reg_top.sv
@@ -1232,7 +1232,6 @@ module ast_reg_top (
 
   logic [35:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == AST_REGA0_OFFSET);
     addr_hit[ 1] = (reg_addr == AST_REGA1_OFFSET);
     addr_hit[ 2] = (reg_addr == AST_REGA2_OFFSET);
@@ -1417,7 +1416,6 @@ module ast_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = rega2_we;

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy_core_reg_top.sv
@@ -709,7 +709,6 @@ module soc_proxy_core_reg_top (
 
   logic [3:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[0] = (reg_addr == SOC_PROXY_INTR_STATE_OFFSET);
     addr_hit[1] = (reg_addr == SOC_PROXY_INTR_ENABLE_OFFSET);
     addr_hit[2] = (reg_addr == SOC_PROXY_INTR_TEST_OFFSET);
@@ -799,7 +798,6 @@ module soc_proxy_core_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -12016,7 +12016,6 @@ module ac_range_check_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[  0] = (reg_addr == AC_RANGE_CHECK_INTR_STATE_OFFSET);
@@ -13252,7 +13251,6 @@ module ac_range_check_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -21568,7 +21568,6 @@ module alert_handler_reg_top (
 
   logic [501:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == ALERT_HANDLER_INTR_STATE_OFFSET);
     addr_hit[  1] = (reg_addr == ALERT_HANDLER_INTR_ENABLE_OFFSET);
     addr_hit[  2] = (reg_addr == ALERT_HANDLER_INTR_TEST_OFFSET);
@@ -24416,7 +24415,6 @@ module alert_handler_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -1423,7 +1423,6 @@ module clkmgr_reg_top (
 
   logic [15:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CLKMGR_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == CLKMGR_EXTCLK_CTRL_REGWEN_OFFSET);
     addr_hit[ 2] = (reg_addr == CLKMGR_EXTCLK_CTRL_OFFSET);
@@ -1529,7 +1528,6 @@ module clkmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = extclk_ctrl_regwen_we;
     reg_we_check[2] = extclk_ctrl_gated_we;

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -2173,7 +2173,6 @@ module gpio_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == GPIO_INTR_STATE_OFFSET);
@@ -2456,7 +2455,6 @@ module gpio_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -3058,7 +3058,6 @@ module otp_ctrl_core_reg_top (
 
   logic [94:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OTP_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == OTP_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == OTP_CTRL_INTR_TEST_OFFSET);
@@ -3438,7 +3437,6 @@ module otp_ctrl_core_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -1265,7 +1265,6 @@ module otp_ctrl_prim_reg_top (
 
   logic [7:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[0] = (reg_addr == OTP_CTRL_CSR0_OFFSET);
     addr_hit[1] = (reg_addr == OTP_CTRL_CSR1_OFFSET);
     addr_hit[2] = (reg_addr == OTP_CTRL_CSR2_OFFSET);
@@ -1352,7 +1351,6 @@ module otp_ctrl_prim_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = csr0_we;
     reg_we_check[1] = csr1_we;
     reg_we_check[2] = csr2_we;

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -34425,7 +34425,6 @@ module pinmux_reg_top (
 
   logic [502:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == PINMUX_ALERT_TEST_OFFSET);
     addr_hit[  1] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_0_OFFSET);
     addr_hit[  2] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_1_OFFSET);
@@ -38729,7 +38728,6 @@ module pinmux_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = mio_periph_insel_regwen_0_we;
     reg_we_check[2] = mio_periph_insel_regwen_1_we;

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -1053,7 +1053,6 @@ module pwrmgr_reg_top (
 
   logic [16:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PWRMGR_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == PWRMGR_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == PWRMGR_INTR_TEST_OFFSET);
@@ -1157,7 +1156,6 @@ module pwrmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -727,7 +727,6 @@ module racl_ctrl_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[0] = (reg_addr == RACL_CTRL_POLICY_ALL_RD_WR_SHADOWED_OFFSET);
@@ -820,7 +819,6 @@ module racl_ctrl_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = policy_all_rd_wr_shadowed_we;
     reg_we_check[1] = policy_rot_private_shadowed_we;
     reg_we_check[2] = policy_soc_rot_shadowed_we;

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -877,7 +877,6 @@ module rstmgr_reg_top (
 
   logic [17:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RSTMGR_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == RSTMGR_RESET_REQ_OFFSET);
     addr_hit[ 2] = (reg_addr == RSTMGR_RESET_INFO_OFFSET);
@@ -982,7 +981,6 @@ module rstmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = reset_req_we;
     reg_we_check[2] = reset_info_we;

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -9391,7 +9391,6 @@ module rv_core_ibex_cfg_reg_top (
 
   logic [264:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_CORE_IBEX_ALERT_TEST_OFFSET);
     addr_hit[  1] = (reg_addr == RV_CORE_IBEX_SW_RECOV_ERR_OFFSET);
     addr_hit[  2] = (reg_addr == RV_CORE_IBEX_SW_FATAL_ERR_OFFSET);
@@ -10740,7 +10739,6 @@ module rv_core_ibex_cfg_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = sw_recov_err_we;
     reg_we_check[2] = sw_fatal_err_we;

--- a/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -14509,7 +14509,6 @@ module rv_plic_reg_top (
 
   logic [173:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_PLIC_PRIO_0_OFFSET);
     addr_hit[  1] = (reg_addr == RV_PLIC_PRIO_1_OFFSET);
     addr_hit[  2] = (reg_addr == RV_PLIC_PRIO_2_OFFSET);
@@ -15689,7 +15688,6 @@ module rv_plic_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = prio_0_we;
     reg_we_check[1] = prio_1_we;
     reg_we_check[2] = prio_2_we;

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -1480,7 +1480,6 @@ module ast_reg_top (
 
   logic [43:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == AST_REGA0_OFFSET);
     addr_hit[ 1] = (reg_addr == AST_REGA1_OFFSET);
     addr_hit[ 2] = (reg_addr == AST_REGA2_OFFSET);
@@ -1705,7 +1704,6 @@ module ast_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = rega2_we;

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -2501,7 +2501,6 @@ module sensor_ctrl_reg_top (
 
   logic [28:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SENSOR_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == SENSOR_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == SENSOR_CTRL_INTR_TEST_OFFSET);
@@ -2742,7 +2741,6 @@ module sensor_ctrl_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -15564,7 +15564,6 @@ module alert_handler_reg_top (
 
   logic [349:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == ALERT_HANDLER_INTR_STATE_OFFSET);
     addr_hit[  1] = (reg_addr == ALERT_HANDLER_INTR_ENABLE_OFFSET);
     addr_hit[  2] = (reg_addr == ALERT_HANDLER_INTR_TEST_OFFSET);
@@ -17576,7 +17575,6 @@ module alert_handler_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -2424,7 +2424,6 @@ module clkmgr_reg_top (
 
   logic [21:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CLKMGR_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == CLKMGR_EXTCLK_CTRL_REGWEN_OFFSET);
     addr_hit[ 2] = (reg_addr == CLKMGR_EXTCLK_CTRL_OFFSET);
@@ -2576,7 +2575,6 @@ module clkmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = extclk_ctrl_regwen_we;
     reg_we_check[2] = extclk_ctrl_gated_we;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -11820,7 +11820,6 @@ module flash_ctrl_core_reg_top (
 
   logic [107:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
     addr_hit[  1] = (reg_addr == FLASH_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[  2] = (reg_addr == FLASH_CTRL_INTR_TEST_OFFSET);
@@ -12857,7 +12856,6 @@ module flash_ctrl_core_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -2003,7 +2003,6 @@ module flash_ctrl_prim_reg_top (
 
   logic [20:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_CSR0_REGWEN_OFFSET);
     addr_hit[ 1] = (reg_addr == FLASH_CTRL_CSR1_OFFSET);
     addr_hit[ 2] = (reg_addr == FLASH_CTRL_CSR2_OFFSET);
@@ -2200,7 +2199,6 @@ module flash_ctrl_prim_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = csr0_regwen_we;
     reg_we_check[1] = csr1_gated_we;
     reg_we_check[2] = csr2_we;

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -725,7 +725,6 @@ module gpio_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == GPIO_INTR_STATE_OFFSET);
@@ -864,7 +863,6 @@ module gpio_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -1983,7 +1983,6 @@ module otp_ctrl_core_reg_top (
 
   logic [55:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OTP_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == OTP_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == OTP_CTRL_INTR_TEST_OFFSET);
@@ -2226,7 +2225,6 @@ module otp_ctrl_core_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -1265,7 +1265,6 @@ module otp_ctrl_prim_reg_top (
 
   logic [7:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[0] = (reg_addr == OTP_CTRL_CSR0_OFFSET);
     addr_hit[1] = (reg_addr == OTP_CTRL_CSR1_OFFSET);
     addr_hit[2] = (reg_addr == OTP_CTRL_CSR2_OFFSET);
@@ -1352,7 +1351,6 @@ module otp_ctrl_prim_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = csr0_we;
     reg_we_check[1] = csr1_we;
     reg_we_check[2] = csr2_we;

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -32529,7 +32529,6 @@ module pinmux_reg_top (
 
   logic [567:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == PINMUX_ALERT_TEST_OFFSET);
     addr_hit[  1] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_0_OFFSET);
     addr_hit[  2] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_1_OFFSET);
@@ -36698,7 +36697,6 @@ module pinmux_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = mio_periph_insel_regwen_0_we;
     reg_we_check[2] = mio_periph_insel_regwen_1_we;

--- a/hw/top_earlgrey/ip_autogen/pwm/rtl/pwm_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pwm/rtl/pwm_reg_top.sv
@@ -3121,7 +3121,6 @@ module pwm_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == PWM_ALERT_TEST_OFFSET);
@@ -3295,7 +3294,6 @@ module pwm_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = regwen_we;
     reg_we_check[2] = cfg_we;

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -1225,7 +1225,6 @@ module pwrmgr_reg_top (
 
   logic [16:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PWRMGR_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == PWRMGR_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == PWRMGR_INTR_TEST_OFFSET);
@@ -1337,7 +1336,6 @@ module pwrmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -1212,7 +1212,6 @@ module rstmgr_reg_top (
 
   logic [27:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RSTMGR_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == RSTMGR_RESET_REQ_OFFSET);
     addr_hit[ 2] = (reg_addr == RSTMGR_RESET_INFO_OFFSET);
@@ -1367,7 +1366,6 @@ module rstmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = reset_req_we;
     reg_we_check[2] = reset_info_we;

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -1171,7 +1171,6 @@ module rv_core_ibex_cfg_reg_top (
 
   logic [24:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_CORE_IBEX_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == RV_CORE_IBEX_SW_RECOV_ERR_OFFSET);
     addr_hit[ 2] = (reg_addr == RV_CORE_IBEX_SW_FATAL_ERR_OFFSET);
@@ -1320,7 +1319,6 @@ module rv_core_ibex_cfg_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = sw_recov_err_we;
     reg_we_check[2] = sw_fatal_err_we;

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -16830,7 +16830,6 @@ module rv_plic_reg_top (
 
   logic [201:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == RV_PLIC_PRIO_0_OFFSET);
     addr_hit[  1] = (reg_addr == RV_PLIC_PRIO_1_OFFSET);
     addr_hit[  2] = (reg_addr == RV_PLIC_PRIO_2_OFFSET);
@@ -18197,7 +18196,6 @@ module rv_plic_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = prio_0_we;
     reg_we_check[1] = prio_1_we;
     reg_we_check[2] = prio_2_we;

--- a/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_englishbreakfast/ip/ast/rtl/ast_reg_top.sv
@@ -1480,7 +1480,6 @@ module ast_reg_top (
 
   logic [43:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == AST_REGA0_OFFSET);
     addr_hit[ 1] = (reg_addr == AST_REGA1_OFFSET);
     addr_hit[ 2] = (reg_addr == AST_REGA2_OFFSET);
@@ -1705,7 +1704,6 @@ module ast_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = 1'b0;
     reg_we_check[1] = 1'b0;
     reg_we_check[2] = rega2_we;

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -1936,7 +1936,6 @@ module clkmgr_reg_top (
 
   logic [19:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CLKMGR_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == CLKMGR_EXTCLK_CTRL_REGWEN_OFFSET);
     addr_hit[ 2] = (reg_addr == CLKMGR_EXTCLK_CTRL_OFFSET);
@@ -2068,7 +2067,6 @@ module clkmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = extclk_ctrl_regwen_we;
     reg_we_check[2] = extclk_ctrl_gated_we;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -11820,7 +11820,6 @@ module flash_ctrl_core_reg_top (
 
   logic [107:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
     addr_hit[  1] = (reg_addr == FLASH_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[  2] = (reg_addr == FLASH_CTRL_INTR_TEST_OFFSET);
@@ -12857,7 +12856,6 @@ module flash_ctrl_core_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -2003,7 +2003,6 @@ module flash_ctrl_prim_reg_top (
 
   logic [20:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_CSR0_REGWEN_OFFSET);
     addr_hit[ 1] = (reg_addr == FLASH_CTRL_CSR1_OFFSET);
     addr_hit[ 2] = (reg_addr == FLASH_CTRL_CSR2_OFFSET);
@@ -2200,7 +2199,6 @@ module flash_ctrl_prim_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = csr0_regwen_we;
     reg_we_check[1] = csr1_gated_we;
     reg_we_check[2] = csr2_we;

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_top.sv
@@ -725,7 +725,6 @@ module gpio_reg_top
   end
 
   always_comb begin
-    addr_hit = '0;
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == GPIO_INTR_STATE_OFFSET);
@@ -864,7 +863,6 @@ module gpio_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_top.sv
@@ -30548,7 +30548,6 @@ module pinmux_reg_top (
 
   logic [519:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[  0] = (reg_addr == PINMUX_ALERT_TEST_OFFSET);
     addr_hit[  1] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_0_OFFSET);
     addr_hit[  2] = (reg_addr == PINMUX_MIO_PERIPH_INSEL_REGWEN_1_OFFSET);
@@ -34435,7 +34434,6 @@ module pinmux_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = mio_periph_insel_regwen_0_we;
     reg_we_check[2] = mio_periph_insel_regwen_1_we;

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -995,7 +995,6 @@ module pwrmgr_reg_top (
 
   logic [16:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PWRMGR_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == PWRMGR_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == PWRMGR_INTR_TEST_OFFSET);
@@ -1099,7 +1098,6 @@ module pwrmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = intr_state_we;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_top.sv
@@ -877,7 +877,6 @@ module rstmgr_reg_top (
 
   logic [17:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RSTMGR_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == RSTMGR_RESET_REQ_OFFSET);
     addr_hit[ 2] = (reg_addr == RSTMGR_RESET_INFO_OFFSET);
@@ -982,7 +981,6 @@ module rstmgr_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = reset_req_we;
     reg_we_check[2] = reset_info_we;

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -1171,7 +1171,6 @@ module rv_core_ibex_cfg_reg_top (
 
   logic [24:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_CORE_IBEX_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == RV_CORE_IBEX_SW_RECOV_ERR_OFFSET);
     addr_hit[ 2] = (reg_addr == RV_CORE_IBEX_SW_FATAL_ERR_OFFSET);
@@ -1320,7 +1319,6 @@ module rv_core_ibex_cfg_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = sw_recov_err_we;
     reg_we_check[2] = sw_fatal_err_we;

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -8087,7 +8087,6 @@ module rv_plic_reg_top (
 
   logic [97:0] addr_hit;
   always_comb begin
-    addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_PRIO_0_OFFSET);
     addr_hit[ 1] = (reg_addr == RV_PLIC_PRIO_1_OFFSET);
     addr_hit[ 2] = (reg_addr == RV_PLIC_PRIO_2_OFFSET);
@@ -8753,7 +8752,6 @@ module rv_plic_reg_top (
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     reg_we_check[0] = prio_0_we;
     reg_we_check[1] = prio_1_we;
     reg_we_check[2] = prio_2_we;

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -702,7 +702,6 @@ ${finst_gen(sr, field, finst_name, fsig_name, fidx)}
 
 % endif
   always_comb begin
-    addr_hit = '0;
   % if racl_support:
     racl_addr_hit_read  = '0;
     racl_addr_hit_write = '0;
@@ -793,7 +792,6 @@ ${field_wd_gen(f, r.name.lower() + "_" + f.name.lower(), r.hwext, r.shadowed, r.
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check = '0;
     % for i, r in enumerate(regs_flat):
 <%
     # The WE checking logic does NOT protect RC fields.


### PR DESCRIPTION
This PR removes a zero assignment to avoid possibility of undetectable code