### PR TITLE
[top_darjeeling, rv_dm] Fix sw image path

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1523,7 +1523,7 @@
     {
       name: chip_rv_dm_ndm_reset_req
       uvm_test_seq: "chip_rv_dm_ndm_reset_vseq"
-      sw_images: ["//sw/device/tests:rv_dm_ndm_reset_req:6:new_rules"]
+      sw_images: ["//sw/device/tests:rv_dm_ndm_reset_req_dev:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_scb_tl_err_chk=0", "+use_jtag_dmi=1"]
     }


### PR DESCRIPTION
The bazel path for the SW image needs to indicate the lifecycle.