### PR TITLE
[pentest] Test configuration and reporting

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -229,6 +229,9 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
 }
 
 status_t handle_crypto_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   pentest_init(kPentestTriggerSourceAes,
                kPentestPeripheralIoDiv4 | kPentestPeripheralAes |
@@ -239,7 +242,7 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
   pentest_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Init the AES block.
   TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));

--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -247,8 +247,14 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Init the AES block.
   TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
@@ -287,9 +293,8 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
       &rv_core_ibex));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -156,6 +156,8 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_aes_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Write the key into the AES block. Set and unset the trigger when
   // key_trigger is true.
@@ -214,6 +216,8 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -224,6 +228,8 @@ status_t handle_crypto_fi_aes(ujson_t *uj) {
   uj_output.err_status = codes;
   memcpy(uj_output.ciphertext, ciphertext.data, 16);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_aes_ciphertext_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -294,6 +300,8 @@ status_t handle_crypto_fi_kmac(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_kmac_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Configure and write key to the KMAC block. Set and unset the trigger when
   // key_trigger is true.
@@ -352,6 +360,8 @@ status_t handle_crypto_fi_kmac(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   TRY(dif_kmac_end(&kmac, &kmac_operation_state));
 
@@ -365,6 +375,8 @@ status_t handle_crypto_fi_kmac(ujson_t *uj) {
   memcpy(uj_output.digest, (uint8_t *)digest, 8);
   memcpy(uj_output.digest_2nd, (uint8_t *)digest_2nd, 8);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_kmac_digest_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -375,6 +387,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_kmac_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Configure and write key to the KMAC block.
   dif_kmac_operation_state_t kmac_operation_state;
@@ -400,6 +414,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -420,6 +436,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
   uj_output.err_status = codes;
   memcpy(uj_output.digest, (uint8_t *)digest, 8);
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
 
   RESP_OK(ujson_serialize_crypto_fi_kmac_state_t, uj, &uj_output);
 
@@ -430,6 +448,8 @@ status_t handle_crypto_fi_kmac_state(ujson_t *uj) {
 status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   crypto_fi_test_result_mult_t uj_output;
 
@@ -463,6 +483,8 @@ status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -478,6 +500,8 @@ status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
 
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -486,6 +510,8 @@ status_t handle_crypto_fi_shadow_reg_access(ujson_t *uj) {
 status_t handle_crypto_fi_shadow_reg_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   crypto_fi_test_result_mult_t uj_output;
 
@@ -542,6 +568,8 @@ status_t handle_crypto_fi_shadow_reg_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -562,6 +590,8 @@ status_t handle_crypto_fi_shadow_reg_read(ujson_t *uj) {
 
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -2369,6 +2369,9 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
 }
 
 status_t handle_ibex_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
@@ -2384,7 +2387,7 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   pentest_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Enable the flash.
   flash_info = dif_flash_ctrl_get_device_info();

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -2584,8 +2584,14 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Enable the flash.
   flash_info = dif_flash_ctrl_get_device_info();
@@ -2603,9 +2609,8 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
       &rv_core_ibex));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   // Initialize flash for the flash test and write reference values into page.
   flash_init = false;

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -239,6 +239,8 @@ static inline void read_all_regs(uint32_t buffer[]) {
 static status_t read_otp_partitions(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t
       otp_data_read_res_vendor_test[(OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
@@ -276,6 +278,8 @@ static status_t read_otp_partitions(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Detect potential mismatch caused by faults.
   uint32_t res = 0;
@@ -317,6 +321,8 @@ static status_t read_otp_partitions(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -342,6 +348,8 @@ void not_increment_counter(void) __attribute__((optnone)) {
 status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Create translation descriptions.
   dif_rv_core_ibex_addr_translation_mapping_t increment_100x10_mapping = {
@@ -394,6 +402,8 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   uint32_t result_target = increment_100x1_remapped(0);
   // Compare values
@@ -415,6 +425,8 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -422,6 +434,8 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
 status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1 = {
@@ -452,6 +466,8 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1_read_back;
@@ -487,6 +503,8 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -495,6 +513,8 @@ status_t handle_ibex_fi_char_conditional_branch_beq(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -547,6 +567,8 @@ status_t handle_ibex_fi_char_conditional_branch_beq(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -558,6 +580,8 @@ status_t handle_ibex_fi_char_conditional_branch_beq(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -566,6 +590,8 @@ status_t handle_ibex_fi_char_conditional_branch_bge(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -618,6 +644,8 @@ status_t handle_ibex_fi_char_conditional_branch_bge(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -629,6 +657,8 @@ status_t handle_ibex_fi_char_conditional_branch_bge(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -637,6 +667,8 @@ status_t handle_ibex_fi_char_conditional_branch_bgeu(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -689,6 +721,8 @@ status_t handle_ibex_fi_char_conditional_branch_bgeu(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -700,6 +734,8 @@ status_t handle_ibex_fi_char_conditional_branch_bgeu(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -708,6 +744,8 @@ status_t handle_ibex_fi_char_conditional_branch_blt(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -760,6 +798,8 @@ status_t handle_ibex_fi_char_conditional_branch_blt(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -771,6 +811,8 @@ status_t handle_ibex_fi_char_conditional_branch_blt(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -779,6 +821,8 @@ status_t handle_ibex_fi_char_conditional_branch_bltu(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -831,6 +875,8 @@ status_t handle_ibex_fi_char_conditional_branch_bltu(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -842,6 +888,8 @@ status_t handle_ibex_fi_char_conditional_branch_bltu(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -850,6 +898,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t result1 = 0;
   uint32_t result2 = 0;
@@ -902,6 +952,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -913,6 +965,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
   uj_output.result2 = result2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -920,6 +974,8 @@ status_t handle_ibex_fi_char_conditional_branch_bne(ujson_t *uj)
 status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Write reference value into CSR.
   CSR_WRITE(CSR_REG_MSCRATCH, ref_values[0]);
@@ -947,6 +1003,8 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   uint32_t res = 0;
@@ -965,6 +1023,8 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -973,6 +1033,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Init x5 with reference value.
   asm volatile("li x5, %0" : : "i"(ref_values[0]));
@@ -1014,6 +1076,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   uj_output.result = 0;
@@ -1028,6 +1092,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1035,6 +1101,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
 status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!flash_init) {
     // Configure the data flash.
@@ -1103,6 +1171,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   ibex_fi_faulty_addresses_data_t uj_output;
@@ -1126,6 +1196,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1133,6 +1205,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) __attribute__((optnone)) {
 status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!flash_init) {
     // Configure the data flash.
@@ -1176,6 +1250,8 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[32];
@@ -1197,6 +1273,8 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1205,6 +1283,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_complement_branch(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1228,6 +1308,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_complement_branch(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1238,6 +1320,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_complement_branch(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1247,6 +1331,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_unimp(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1267,6 +1353,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_unimp(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1277,6 +1365,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_unimp(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1286,6 +1376,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_2_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1306,6 +1398,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_2_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1316,6 +1410,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_2_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1325,6 +1421,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_3_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1345,6 +1443,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_3_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1355,6 +1455,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_3_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1364,6 +1466,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_4_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   // uint32_t value1 = 0;
@@ -1384,6 +1488,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_4_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1394,6 +1500,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_4_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1403,6 +1511,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Values are intentially not equal.
   hardened_bool_t value1 = HARDENED_BOOL_TRUE;
@@ -1420,6 +1530,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1430,6 +1542,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
   uj_output.result1 = value1;
   uj_output.result2 = value2;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1438,6 +1552,8 @@ status_t handle_ibex_fi_char_hardened_check_eq_5_unimps(ujson_t *uj)
 status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -1451,6 +1567,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1462,6 +1580,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1469,6 +1589,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t res_values[7];
   // Initialize temporary registers with reference values.
@@ -1486,6 +1608,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Load register values.
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -1514,6 +1638,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1521,6 +1647,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
 status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t res_values[6];
   // Initialize temporary registers with reference values.
@@ -1567,6 +1695,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Load register values.
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -1595,6 +1725,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   // Send result & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1602,6 +1734,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
 status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -1619,6 +1753,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -1630,6 +1766,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1637,6 +1775,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Init t0...t6 with 0.
   init_temp_regs(0);
@@ -1665,6 +1805,8 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   ibex_fi_faulty_addresses_data_t uj_output;
   memset(uj_output.addresses, 0, sizeof(uj_output.addresses));
@@ -1684,6 +1826,8 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1705,6 +1849,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Get address of the ret. SRAM at the beginning of the owner section.
   uintptr_t sram_ret_buffer_addr =
@@ -1725,6 +1871,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare against reference values.
   ibex_fi_faulty_addresses_data_t uj_output;
@@ -1753,6 +1901,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -1760,6 +1910,8 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
 status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -1782,6 +1934,8 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[32];
@@ -1803,6 +1957,8 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1811,6 +1967,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
     __attribute__((optnone)) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize SRAM region with inverse reference value.
   sram_main_buffer[0] = ~ref_values[0];
@@ -1922,6 +2080,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   uint32_t res_values[3];
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -1947,6 +2107,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1954,6 +2116,8 @@ status_t handle_ibex_fi_char_sram_write_read(ujson_t *uj)
 status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -2101,6 +2265,8 @@ status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[64];
@@ -2122,6 +2288,8 @@ status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
   uj_output.result = res;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2129,6 +2297,8 @@ status_t handle_ibex_fi_char_sram_write_static_unrolled(ujson_t *uj) {
 status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t result = 0;
@@ -2172,6 +2342,8 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2182,6 +2354,8 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   uj_output.result = result;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2191,6 +2365,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
   read_all_regs(registers);
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t result = 0;
@@ -2235,6 +2411,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2246,6 +2424,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
   memcpy(uj_output.registers, registers, sizeof(registers));
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_registers_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2253,6 +2433,8 @@ status_t handle_ibex_fi_char_unconditional_branch_nop(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -2271,6 +2453,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2281,6 +2465,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2288,6 +2474,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -2308,6 +2496,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2318,6 +2508,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2325,6 +2517,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
 status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t addresses[8] = {0};
   uint32_t data[8] = {0};
@@ -2353,6 +2547,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -2364,6 +2560,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop_chain(ujson_t *uj) {
   memcpy(uj_output.data, data, sizeof(data));
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_data_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -2440,6 +2638,8 @@ status_t handle_ibex_fi_otp_read_lock(ujson_t *uj) {
 status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint64_t faulty_token[kSecret0TestUnlockTokenSizeIn64BitWords];
   for (size_t i = 0; i < kSecret0TestUnlockTokenSizeIn64BitWords; i++) {
@@ -2453,6 +2653,11 @@ status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) {
   asm volatile(NOP10);
   pentest_set_trigger_low();
 
+  // Get registered alerts from alert handler.
+  reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
+
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
   TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
@@ -2463,6 +2668,8 @@ status_t handle_ibex_fi_otp_write_lock(ujson_t *uj) {
       0;  // Writing to the locked OTP partition crashes the chip.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -24,6 +24,9 @@ static dif_rv_core_ibex_t rv_core_ibex;
 static dif_lc_ctrl_t lc;
 
 status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
@@ -32,7 +35,7 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralCsrng);
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -34,8 +34,14 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
   pentest_init(kPentestTriggerSourceAes,
                kPentestPeripheralIoDiv4 | kPentestPeripheralCsrng);
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -51,9 +57,8 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
   pentest_configure_alert_handler();
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -61,6 +61,8 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
 status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read LC CTRL to get reference values.
   dif_lc_ctrl_state_t lc_state_ref;
@@ -76,6 +78,8 @@ status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Check if we have managed to manipulate the LC Controller.
   dif_lc_ctrl_state_t lc_state_cmp;
@@ -109,6 +113,8 @@ status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
   uj_output.counter = lc_count_cmp;
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_lc_ctrl_fi_corruption_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -1141,6 +1141,9 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
 }
 
 status_t handle_otbn_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   // Configure the entropy complex for OTBN. Set the reseed interval to max
   // to avoid a non-constant trigger window.
   TRY(pentest_configure_entropy_source_max_reseed_interval());
@@ -1165,7 +1168,7 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   pentest_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // The load integrity, key sideloading, and char_mem tests get initialized at
   // the first run.

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -154,6 +154,8 @@ status_t clear_otbn_load_checksum(void) {
 status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_beq);
@@ -170,6 +172,8 @@ status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
@@ -194,6 +198,8 @@ status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_cnt_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -205,6 +211,8 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bn_rshi);
@@ -228,6 +236,8 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read big_num_out from OTBN data memory.
   otbn_fi_big_num_out_t uj_output;
@@ -253,6 +263,8 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_big_num_out_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -264,6 +276,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bn_sel);
@@ -287,6 +301,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read big_num_out from OTBN data memory.
   otbn_fi_big_num_out_t uj_output;
@@ -312,6 +328,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_big_num_out_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -319,6 +337,8 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
 status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bn_wsrr);
@@ -338,6 +358,8 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -363,6 +385,8 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_data_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -371,6 +395,8 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
 status_t handle_otbn_fi_char_bne(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_bne);
@@ -388,6 +414,8 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
   uj_output.result = 0;
@@ -410,6 +438,8 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_cnt_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -417,6 +447,8 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
 status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Config for the otbn.fi.char_dmem_access test.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_dmem_access);
@@ -436,6 +468,8 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -458,6 +492,8 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_data_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -466,6 +502,8 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
 status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Config for the otbn.fi.char_rf test.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_dmem_write);
@@ -619,6 +657,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -648,6 +688,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_array_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -656,6 +698,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_dmem_op_loop);
@@ -675,6 +719,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter);
@@ -696,6 +742,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -703,6 +751,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_reg_op_loop);
@@ -722,6 +772,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter);
@@ -743,6 +795,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -750,6 +804,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
 status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_jal);
@@ -766,6 +822,8 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
@@ -790,6 +848,8 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_cnt_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -797,6 +857,8 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
 status_t handle_otbn_fi_char_lw(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_lw);
@@ -819,6 +881,8 @@ status_t handle_otbn_fi_char_lw(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Compare reference values. 29 values as we are loading into 29 registers.
   otbn_fi_result_array_t uj_output;
@@ -848,6 +912,8 @@ status_t handle_otbn_fi_char_lw(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_array_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -868,6 +934,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Reference values for DMEM and IMEM.
   uint32_t dmem_array_ref[char_mem_num_words];
@@ -898,6 +966,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -957,6 +1027,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_mem_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -965,6 +1037,8 @@ status_t handle_otbn_fi_char_mem(ujson_t *uj) {
 status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Config for the otbn.fi.char_rf test.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_rf);
@@ -992,6 +1066,8 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -1041,6 +1117,8 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_rf_char_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -1049,6 +1127,8 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_dmem_op_loop);
@@ -1068,6 +1148,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter);
@@ -1089,6 +1171,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1096,6 +1180,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_reg_op_loop);
@@ -1115,6 +1201,8 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter);
@@ -1136,6 +1224,8 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1202,6 +1292,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
   TRY(dif_otbn_set_ctrl_software_errs_fatal(&otbn, /*enable=*/false));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!key_sideloading_init) {
     // Setup keymanager for sideloading key into OTBN.
@@ -1226,6 +1318,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
   uint32_t key_share_0_l, key_share_0_h;
@@ -1261,6 +1355,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_keys_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1268,6 +1364,8 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
 status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!load_integrity_init) {
     // Load the OTBN app and read the load checksum without FI to retrieve
@@ -1286,6 +1384,8 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read back checksum.
   uint32_t load_checksum;
@@ -1329,6 +1429,8 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1340,6 +1442,8 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
 
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_pc);
@@ -1369,6 +1473,8 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
   otbn_busy_wait_for_done();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read pc_out from OTBN data memory.
   otbn_fi_pc_out_t uj_output;
@@ -1395,6 +1501,8 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
   uj_output.err_otbn = err_otbn;
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_pc_out_t, uj, &uj_output);
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -1257,8 +1257,14 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // The load integrity, key sideloading, and char_mem tests get initialized at
   // the first run.
@@ -1268,9 +1274,8 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   char_mem_test_cfg_valid = false;
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -139,6 +139,9 @@ status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
 }
 
 status_t handle_otp_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
@@ -154,7 +157,7 @@ status_t handle_otp_fi_init(ujson_t *uj) {
   pentest_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   TRY(dif_otp_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -96,6 +96,8 @@ status_t otp_life_cycle_dump(uint32_t *buffer) {
 status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_hw_cfg_dump(otp_read32_result_hw_cfg_comp));
@@ -116,6 +118,8 @@ status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -133,6 +137,8 @@ status_t handle_otp_fi_hw_cfg(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_hwcfg_partition_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -170,6 +176,8 @@ status_t handle_otp_fi_init(ujson_t *uj) {
 status_t handle_otp_fi_life_cycle(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_life_cycle_dump(otp_read32_result_life_cycle_comp));
@@ -190,6 +198,8 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -207,6 +217,8 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_lifecycle_partition_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -215,6 +227,8 @@ status_t handle_otp_fi_life_cycle(ujson_t *uj) {
 status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_owner_sw_cfg_dump(otp_read32_result_owner_sw_cfg_comp));
@@ -235,6 +249,8 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -252,6 +268,8 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_ownerswcfg_partition_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -260,6 +278,8 @@ status_t handle_otp_fi_owner_sw_cfg(ujson_t *uj) {
 status_t handle_otp_fi_vendor_test(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   // Read OTP partition for comparison values
   TRY(otp_vendor_test_dump(otp_read32_result_vendor_test_comp));
@@ -280,6 +300,8 @@ status_t handle_otp_fi_vendor_test(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Get OTP CTRL status
   dif_otp_ctrl_status_t status;
@@ -297,6 +319,8 @@ status_t handle_otp_fi_vendor_test(ujson_t *uj) {
   uj_output.alerts[0] = reg_alerts.alerts[0];
   uj_output.alerts[1] = reg_alerts.alerts[1];
   uj_output.alerts[2] = reg_alerts.alerts[2];
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_otp_fi_vendortest_partition_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -162,13 +162,23 @@ status_t handle_otp_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   TRY(dif_otp_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
 
   init_otp_mem_dump_buffers();
+
+  // Read device ID and return to host.
+  TRY(pentest_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -385,6 +385,9 @@ status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
 }
 
 status_t handle_rng_fi_edn_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
@@ -394,7 +397,7 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
                    kPentestPeripheralCsrng | kPentestPeripheralEdn);
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -581,6 +584,9 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
 }
 
 status_t handle_rng_fi_csrng_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // pentest_init is not needed. kPentestTriggerSourceAes is selected as a
@@ -589,7 +595,7 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralCsrng);
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -420,8 +420,14 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralEntropy |
                    kPentestPeripheralCsrng | kPentestPeripheralEdn);
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -441,9 +447,8 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
   TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   firmware_override_init = false;
 
@@ -630,8 +635,14 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
   pentest_init(kPentestTriggerSourceAes,
                kPentestPeripheralIoDiv4 | kPentestPeripheralCsrng);
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -648,9 +659,8 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -158,6 +158,8 @@ static void entropy_conditioner_stop(const dif_entropy_src_t *entropy_src) {
 status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   TRY(dif_entropy_src_set_enabled(&entropy_src, kDifToggleDisabled));
 
@@ -193,6 +195,8 @@ status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -204,6 +208,8 @@ status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
   memcpy(uj_output.rand, entropy_bits, sizeof(entropy_bits));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_entropy_src_bias_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -212,6 +218,8 @@ status_t handle_rng_fi_entropy_src_bias(ujson_t *uj) {
 status_t handle_rng_fi_firmware_override(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   if (!firmware_override_init) {
     // Check if we keep heal tests enabled.
@@ -251,6 +259,8 @@ status_t handle_rng_fi_firmware_override(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -262,6 +272,8 @@ status_t handle_rng_fi_firmware_override(ujson_t *uj) {
   memcpy(uj_output.rand, buf, sizeof(buf));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_fw_overwrite_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -270,6 +282,8 @@ status_t handle_rng_fi_firmware_override(ujson_t *uj) {
 status_t handle_rng_fi_edn_bias(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   TRY(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
@@ -320,6 +334,8 @@ status_t handle_rng_fi_edn_bias(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -328,6 +344,8 @@ status_t handle_rng_fi_edn_bias(ujson_t *uj) {
   // Send result & ERR_STATUS to host.
   uj_output.collisions = collisions;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   uj_output.err_status = err_ibx;
   RESP_OK(ujson_serialize_rng_fi_edn_t, uj, &uj_output);
   return OK_STATUS();
@@ -336,6 +354,8 @@ status_t handle_rng_fi_edn_bias(ujson_t *uj) {
 status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
   // Enable entropy complex, CSRNG and EDN so Ibex can get entropy.
   // Configure entropy in auto_mode to avoid starving the system from entropy,
   // given that boot mode entropy has a limited number of generated bits.
@@ -371,6 +391,8 @@ status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -379,6 +401,8 @@ status_t handle_rng_fi_edn_resp_ack(ujson_t *uj) {
   // Send result & ERR_STATUS to host.
   uj_output.collisions = collisions;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   uj_output.err_status = err_ibx;
   RESP_OK(ujson_serialize_rng_fi_edn_t, uj, &uj_output);
   return OK_STATUS();
@@ -432,6 +456,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
   TRY(ujson_deserialize_crypto_fi_csrng_mode_t(uj, &uj_data));
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   TRY(csrng_testutils_cmd_ready_wait(&csrng));
   TRY(dif_csrng_uninstantiate(&csrng));
@@ -479,6 +505,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -502,6 +530,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
   memcpy(uj_output.rand, rand_data_got, sizeof(rand_data_got));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_csrng_output_t, uj, &uj_output);
 
   return OK_STATUS();
@@ -510,6 +540,8 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
 status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   // Clear registered alerts in alert handler.
   pentest_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
+  // Clear the AST recoverable alerts.
+  pentest_clear_sensor_recov_alerts();
 
   uint32_t received_data[kCsrngBiasFWFifoBufferSize];
   const dif_csrng_seed_material_t kEmptySeedMaterial = {0};
@@ -566,6 +598,8 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;
@@ -578,6 +612,8 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   memcpy(uj_output.rand, received_data, sizeof(received_data));
   uj_output.err_status = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rng_fi_csrng_ov_output_t, uj, &uj_output);
 
   return OK_STATUS();

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -75,6 +75,9 @@ status_t handle_rom_read(ujson_t *uj) {
 }
 
 status_t handle_rom_fi_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   pentest_init(kPentestTriggerSourceAes,
                kPentestPeripheralIoDiv4 | kPentestPeripheralEdn |
@@ -86,7 +89,7 @@ status_t handle_rom_fi_init(ujson_t *uj) {
   pentest_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Initialize rom_ctrl.
   mmio_region_t rom_ctrl_reg =

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -51,6 +51,8 @@ status_t handle_rom_read(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -70,6 +72,8 @@ status_t handle_rom_read(ujson_t *uj) {
   // Send the first 8 bytes of the digest and the alerts back to the host.
   uj_output.err_status = codes;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_rom_fi_digest_t, uj, &uj_output);
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -92,8 +92,14 @@ status_t handle_rom_fi_init(ujson_t *uj) {
   // and reported to the test.
   pentest_configure_alert_handler();
 
-  // Disable the instruction cache and dummy instructions for FI attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Initialize rom_ctrl.
   mmio_region_t rom_ctrl_reg =
@@ -106,9 +112,8 @@ status_t handle_rom_fi_init(ujson_t *uj) {
       &rv_core_ibex));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/lib/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/lib/BUILD
@@ -44,6 +44,8 @@ cc_library(
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sensor_ctrl",
+        "//sw/device/lib/dif:sram_ctrl",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:irq",

--- a/sw/device/tests/penetrationtests/firmware/lib/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/lib/BUILD
@@ -27,6 +27,7 @@ cc_library(
     deps = [
         "//hw/ip/aes:model",
         "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -310,16 +310,22 @@ status_t pentest_read_device_id(uint32_t device_id[]) {
   return OK_STATUS();
 }
 
-void pentest_configure_cpu(void) {
+void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr) {
   uint32_t cpuctrl_csr;
   // Get current config.
   CSR_READ(CSR_REG_CPUCTRL, &cpuctrl_csr);
   // Disable the iCache.
-  cpuctrl_csr = bitfield_field32_write(
-      cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 0}, 0);
+  if (disable_icache) {
+    cpuctrl_csr = bitfield_field32_write(
+        cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 0}, 0);
+  }
+
   // Disable dummy instructions.
-  cpuctrl_csr = bitfield_field32_write(
-      cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 2}, 0);
+  if (disable_dummy_instr) {
+    cpuctrl_csr = bitfield_field32_write(
+        cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 2}, 0);
+  }
+
   // Write back config.
   CSR_WRITE(CSR_REG_CPUCTRL, cpuctrl_csr);
 }

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -22,6 +22,8 @@
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/dif/dif_sensor_ctrl.h"
+#include "sw/device/lib/dif/dif_sram_ctrl.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/irq.h"
@@ -34,6 +36,8 @@
 
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
+#include "sensor_ctrl_regs.h"  // Generated.
+#include "sram_ctrl_regs.h"    // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #if !OT_IS_ENGLISH_BREAKFAST
@@ -85,6 +89,7 @@ static unsigned int trigger_bit_index = kTriggerHwGateBitIndex;
 static dif_gpio_t gpio;
 static dif_pinmux_t pinmux;
 static dif_rv_timer_t timer;
+static dif_sensor_ctrl_t sensor_ctrl;
 static dif_uart_t uart0;
 static dif_uart_t uart1;
 
@@ -204,6 +209,22 @@ status_t pentest_configure_entropy_source_max_reseed_interval(void) {
       }));
 #endif
   return OK_STATUS();
+}
+
+pentest_sensor_alerts_t pentest_get_sensor_alerts(void) {
+  pentest_sensor_alerts_t registered;
+  memset(registered.alerts, 0, sizeof(registered.alerts));
+  CHECK_DIF_OK(
+      dif_sensor_ctrl_get_fatal_events(&sensor_ctrl, &registered.alerts[0]));
+  CHECK_DIF_OK(
+      dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &registered.alerts[1]));
+  return registered;
+}
+
+void pentest_clear_sensor_recov_alerts(void) {
+  for (size_t it = 0; it < SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS; it++) {
+    CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, it));
+  }
 }
 
 pentest_registered_alerts_t pentest_get_triggered_alerts(void) {
@@ -422,6 +443,14 @@ static void pentest_init_csrng(void) {
 #endif
 }
 
+static void pentest_init_sensor_ctrl(void) {
+#if !OT_IS_ENGLISH_BREAKFAST
+  CHECK_DIF_OK(dif_sensor_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR),
+      &sensor_ctrl));
+#endif
+}
+
 /**
  * Initializes the EDN handle.
  */
@@ -533,6 +562,7 @@ void pentest_init(pentest_trigger_source_t trigger,
   pentest_init_timer();
   pentest_init_csrng();
   pentest_init_edn();
+  pentest_init_sensor_ctrl();
   sca_disable_peripherals(~enable);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -6,6 +6,7 @@
 
 #include "hw/ip/aes/model/aes.h"
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/macros.h"
@@ -36,9 +37,8 @@
 
 #include "clkmgr_regs.h"  // Generated
 #include "csrng_regs.h"   // Generated
-#include "sensor_ctrl_regs.h"  // Generated.
-#include "sram_ctrl_regs.h"    // Generated
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sensor_ctrl_regs.h"  // Generated.
 
 #if !OT_IS_ENGLISH_BREAKFAST
 #include "sw/device/lib/crypto/drivers/otbn.h"
@@ -48,7 +48,9 @@
 #include "sw/device/lib/testing/alert_handler_testutils.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
 
-#include "edn_regs.h"  // Generated
+#include "edn_regs.h"        // Generated
+#include "sram_ctrl_regs.h"  // Generated
+
 #endif
 
 /**
@@ -331,7 +333,11 @@ status_t pentest_read_device_id(uint32_t device_id[]) {
   return OK_STATUS();
 }
 
-void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr) {
+status_t pentest_configure_cpu(
+    bool disable_icache, bool disable_dummy_instr, bool enable_jittery_clock,
+    bool enable_sram_readback, bool *clock_jitter_locked, bool *clock_jitter_en,
+    bool *sram_main_readback_locked, bool *sram_ret_readback_locked,
+    bool *sram_main_readback_en, bool *sram_ret_readback_en) {
   uint32_t cpuctrl_csr;
   // Get current config.
   CSR_READ(CSR_REG_CPUCTRL, &cpuctrl_csr);
@@ -349,6 +355,81 @@ void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr) {
 
   // Write back config.
   CSR_WRITE(CSR_REG_CPUCTRL, cpuctrl_csr);
+
+  // Enable or disable the jittery clock.
+  dif_clkmgr_t clkmgr;
+  TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
+                      &clkmgr));
+
+  // Check if clock jitter is set as enabled or disabled in the CSR.
+  dif_toggle_t clock_jitter_state;
+  TRY(dif_clkmgr_jitter_get_enabled(&clkmgr, &clock_jitter_state));
+
+  if ((clock_jitter_state == kDifToggleDisabled) && enable_jittery_clock) {
+    // Clock jitter is disabled but host wants to enable it.
+    TRY(dif_clkmgr_jitter_set_enabled(&clkmgr));
+  } else if ((clock_jitter_state == kDifToggleEnabled) &&
+             !enable_jittery_clock) {
+    // Clock jitter is enabled but host wants to disable it. On A1, this will
+    // disable it. On A2, once the clock jitter is enabled it will stay enabled
+    // until the next reset. The host will be notified over uJSON that the
+    // jittery clock is still on.
+    mmio_region_write32(clkmgr.base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET,
+                        kMultiBitBool4False);
+  }
+  // Check if enabling / disabling the clock jitter worked and report it back to
+  // the host.
+  TRY(dif_clkmgr_jitter_get_enabled(&clkmgr, &clock_jitter_state));
+  *clock_jitter_en = (clock_jitter_state == kDifToggleDisabled) ? false : true;
+
+  // As the clock jitter regwen does not have an effect on A1/A2, just set it to
+  // false.
+  *clock_jitter_locked = false;
+
+#if !OT_IS_ENGLISH_BREAKFAST
+  // Enable or disable SRAM main and ret readback feature.
+  dif_sram_ctrl_t sram_ctrl_ret;
+  dif_sram_ctrl_t sram_ctrl_main;
+  TRY(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR),
+      &sram_ctrl_ret));
+  TRY(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
+      &sram_ctrl_main));
+
+  dif_result_t ret_locked;
+  dif_result_t main_locked;
+  if (enable_sram_readback) {
+    ret_locked = dif_sram_ctrl_readback_set(&sram_ctrl_ret, kDifToggleEnabled);
+    main_locked =
+        dif_sram_ctrl_readback_set(&sram_ctrl_main, kDifToggleEnabled);
+  } else {
+    ret_locked = dif_sram_ctrl_readback_set(&sram_ctrl_ret, kDifToggleDisabled);
+    main_locked =
+        dif_sram_ctrl_readback_set(&sram_ctrl_main, kDifToggleDisabled);
+  }
+
+  uint32_t ret_status =
+      abs_mmio_read32(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR +
+                      SRAM_CTRL_READBACK_REG_OFFSET);
+  uint32_t main_status =
+      abs_mmio_read32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
+                      SRAM_CTRL_READBACK_REG_OFFSET);
+
+  // Report the configuration.
+  *sram_main_readback_locked = (main_locked == kDifLocked) ? true : false;
+  *sram_ret_readback_locked = (ret_locked == kDifLocked) ? true : false;
+
+  *sram_ret_readback_en = (ret_status == kMultiBitBool4True) ? true : false;
+  *sram_main_readback_en = (main_status == kMultiBitBool4True) ? true : false;
+#else  // OT_PLATFORM_RV32
+  *sram_main_readback_locked = false;
+  *sram_ret_readback_locked = false;
+
+  *sram_ret_readback_en = false;
+  *sram_main_readback_en = false;
+#endif
+  return OK_STATUS();
 }
 
 /**

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -13,6 +13,10 @@ typedef struct pentest_registered_alerts {
   uint32_t alerts[3];
 } pentest_registered_alerts_t;
 
+typedef struct pentest_sensor_alerts {
+  uint32_t alerts[2];
+} pentest_sensor_alerts_t;
+
 /**
  * Trigger sources.
  *
@@ -155,6 +159,22 @@ typedef enum pentest_lfsr_context {
  * @return OK or error.
  */
 status_t pentest_configure_entropy_source_max_reseed_interval(void);
+
+/**
+ * Returns the registered alerts in the sensor controller.
+ *
+ * This function reads out the recov_alert and fatal_alert registers of the
+ * sensor controller. This controller collects the alerts of the AST.
+ *
+ * @return A struct containing which of the alerts were triggered during the
+ * test.
+ */
+pentest_sensor_alerts_t pentest_get_sensor_alerts(void);
+
+/**
+ * Clears the recoverable AST alerts in the sensor controller.
+ */
+void pentest_clear_sensor_recov_alerts(void);
 
 /**
  * Returns the registered alerts.

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -187,10 +187,21 @@ status_t pentest_read_device_id(uint32_t device_id[]);
 /**
  * Configures CPU for SCA and FI penetration tests.
  *
- * This function disables the iCache and the dummy instructions using the
- * CPU Control and Status Register (cpuctrlsts).
+ * If disable_icache is True, this functions disables the instruction cache. If
+ * disable_icache is False, the instruction cache config remains at
+ * enabled/disabled based on the ROM configuration. This implies that the iCache
+ * could be disabled even though disable_icache is False.
+ *
+ * If disable_dummy_instr is True, this functions disables the dummy
+ * instructions. If disable_dummy_instr is False, the dummy instruction config
+ * remains at the original config that was set in the ROM. This implies that
+ * dummy instructions could disabled even though disable_dummy_instr is False.
+ *
+ * @param disable_icache Disable the instruction cache.
+ * @param disable_dummy_instr Disable the dummy instructions.
+ *
  */
-void pentest_configure_cpu(void);
+void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr);
 
 /**
  * Initializes the peripherals (pinmux, uart, gpio, and timer) used by SCA code.

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -217,11 +217,33 @@ status_t pentest_read_device_id(uint32_t device_id[]);
  * remains at the original config that was set in the ROM. This implies that
  * dummy instructions could disabled even though disable_dummy_instr is False.
  *
+ * For enable_jittery_clock, the function first checks if the write protection
+ * for this register is enabled. Then, by setting enable_jittery_clock True or
+ * False, the jittery clock is enabled or disabled. When regwen is active, no
+ * change happens.
+ *
+ * For enable_sram_readback, the function first checks if the write protection
+ * for this register is enabled. Then, by setting enable_sram_readback True or
+ * False, the SRAM readback feature for the main and ret SRAM iss enabled or
+ * disabled. When regwen is active, no change happens.
+ *
  * @param disable_icache Disable the instruction cache.
  * @param disable_dummy_instr Disable the dummy instructions.
- *
+ * @param enable_jittery_clock: Enable/disable the jittery clock.
+ * @param enable_sram_readback: Enable/disable the SRAM readback feature.
+ * @param clock_jitter_locked: Jittery clock register is locked.
+ * @param clock_jitter_en: Jittery clock feature is enabled.
+ * @param sram_main_readback_locked: SRAM main readback register is locked.
+ * @param sram_ret_readback_locked: SRAM ret readback register is locked.
+ * @param sram_main_readback_en: SRAM main readback feature is enabled.
+ * @param sram_ret_readback_en: SRAM ret readback feature is enabled.
+ * @return OK or error.
  */
-void pentest_configure_cpu(bool disable_icache, bool disable_dummy_instr);
+status_t pentest_configure_cpu(
+    bool disable_icache, bool disable_dummy_instr, bool enable_jittery_clock,
+    bool enable_sram_readback, bool *clock_jitter_locked, bool *clock_jitter_en,
+    bool *sram_main_readback_locked, bool *sram_ret_readback_locked,
+    bool *sram_main_readback_en, bool *sram_ret_readback_en);
 
 /**
  * Initializes the peripherals (pinmux, uart, gpio, and timer) used by SCA code.

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -653,15 +653,18 @@ status_t handle_aes_pentest_init(ujson_t *uj) {
     return ABORTED();
   }
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_cpuctrl.icache_disable,
-                        uj_cpuctrl.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -637,6 +637,10 @@ status_t handle_aes_pentest_init(ujson_t *uj) {
   if (uj_data.fpga_mode == 0x01) {
     fpga_mode = true;
   }
+
+  penetrationtest_cpuctrl_t uj_cpuctrl;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_cpuctrl));
+
   pentest_init(kPentestTriggerSourceAes,
                kPentestPeripheralIoDiv4 | kPentestPeripheralAes);
 
@@ -651,7 +655,8 @@ status_t handle_aes_pentest_init(ujson_t *uj) {
 
   // Disable the instruction cache and dummy instructions for better SCA
   // measurements.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_cpuctrl.icache_disable,
+                        uj_cpuctrl.dummy_instr_disable);
 
   // Read device ID and return to host.
   penetrationtest_device_id_t uj_output;

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
@@ -133,7 +133,13 @@ status_t handle_edn_sca_init(ujson_t *uj) {
                    kPentestPeripheralCsrng | kPentestPeripheralEdn);
 
   // Disable the instruction cache and dummy instructions for SCA attacks.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -143,6 +149,10 @@ status_t handle_edn_sca_init(ujson_t *uj) {
   // Configure the entropy complex. Set the reseed interval to max to avoid
   // reseed during the trigger window.
   TRY(pentest_configure_entropy_source_max_reseed_interval());
+
+  // Read device ID and return to host.
+  TRY(pentest_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
@@ -121,6 +121,9 @@ status_t handle_edn_sca_bus_data(ujson_t *uj) {
 }
 
 status_t handle_edn_sca_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // sca_init is not needed. kPentestTriggerSourceAes is selected as a
@@ -130,7 +133,7 @@ status_t handle_edn_sca_init(ujson_t *uj) {
                    kPentestPeripheralCsrng | kPentestPeripheralEdn);
 
   // Disable the instruction cache and dummy instructions for SCA attacks.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(

--- a/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
@@ -97,12 +97,17 @@ status_t handle_hmac_pentest_init(ujson_t *uj) {
                    kPentestPeripheralEdn | kPentestPeripheralHmac);
 
   // Disable the instruction cache and dummy instructions for SCA.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
@@ -84,6 +84,9 @@ static status_t trigger_hmac(uint8_t key_buf[], uint8_t mask_buf[],
 }
 
 status_t handle_hmac_pentest_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   // Setup trigger and enable peripherals needed for the test.
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // Enable the HMAC module and disable unused IP blocks to improve
@@ -94,7 +97,7 @@ status_t handle_hmac_pentest_init(ujson_t *uj) {
                    kPentestPeripheralEdn | kPentestPeripheralHmac);
 
   // Disable the instruction cache and dummy instructions for SCA.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Read device ID and return to host.
   penetrationtest_device_id_t uj_output;

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -125,15 +125,20 @@ status_t handle_ibex_pentest_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralKmac);
 
   // Disable the instruction cache and dummy instructions for SCA.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Key manager not initialized for the handle_ibex_sca_key_sideloading test.
   key_manager_init = false;
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -113,6 +113,9 @@ static void generate_random(size_t num_iterations, uint32_t values[]) {
 }
 
 status_t handle_ibex_pentest_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   // Setup trigger and enable peripherals needed for the test.
   pentest_select_trigger_type(kPentestTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
@@ -122,7 +125,7 @@ status_t handle_ibex_pentest_init(ujson_t *uj) {
                kPentestPeripheralIoDiv4 | kPentestPeripheralKmac);
 
   // Disable the instruction cache and dummy instructions for SCA.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Key manager not initialized for the handle_ibex_sca_key_sideloading test.
   key_manager_init = false;

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -474,15 +474,18 @@ status_t handle_kmac_pentest_init(ujson_t *uj) {
 
   kmac_block_until_idle();
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_cpuctrl.icache_disable,
-                        uj_cpuctrl.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -451,6 +451,10 @@ status_t handle_kmac_pentest_init(ujson_t *uj) {
   if (uj_data.fpga_mode == 0x01) {
     fpga_mode = true;
   }
+
+  penetrationtest_cpuctrl_t uj_cpuctrl;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_cpuctrl));
+
   // Setup the trigger.
   pentest_init(kPentestTriggerSourceKmac,
                kPentestPeripheralIoDiv4 | kPentestPeripheralKmac);
@@ -472,7 +476,8 @@ status_t handle_kmac_pentest_init(ujson_t *uj) {
 
   // Disable the instruction cache and dummy instructions for better SCA
   // measurements.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_cpuctrl.icache_disable,
+                        uj_cpuctrl.dummy_instr_disable);
 
   // Read device ID and return to host.
   penetrationtest_device_id_t uj_output;

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
@@ -473,6 +473,9 @@ status_t handle_otbn_sca_ecdsa_p256_sign_fvsr_batch(ujson_t *uj) {
 }
 
 status_t handle_otbn_pentest_init(ujson_t *uj) {
+  penetrationtest_cpuctrl_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_data));
+
   // Configure the entropy complex for OTBN. Set the reseed interval to max
   // to avoid a non-constant trigger window.
   TRY(pentest_configure_entropy_source_max_reseed_interval());
@@ -493,7 +496,7 @@ status_t handle_otbn_pentest_init(ujson_t *uj) {
 
   // Disable the instruction cache and dummy instructions for better SCA
   // measurements.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
 
   // Read device ID and return to host.
   penetrationtest_device_id_t uj_output;

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
@@ -494,14 +494,18 @@ status_t handle_otbn_pentest_init(ujson_t *uj) {
     return ABORTED();
   }
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_data.icache_disable, uj_data.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_data.icache_disable, uj_data.dummy_instr_disable,
+      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -594,6 +594,9 @@ status_t handle_sha3_pentest_init(ujson_t *uj) {
     fpga_mode = true;
   }
 
+  penetrationtest_cpuctrl_t uj_cpuctrl;
+  TRY(ujson_deserialize_penetrationtest_cpuctrl_t(uj, &uj_cpuctrl));
+
   pentest_init(kPentestTriggerSourceKmac,
                kPentestPeripheralIoDiv4 | kPentestPeripheralKmac);
 
@@ -605,7 +608,8 @@ status_t handle_sha3_pentest_init(ujson_t *uj) {
 
   // Disable the instruction cache and dummy instructions for better SCA
   // measurements.
-  pentest_configure_cpu();
+  pentest_configure_cpu(uj_cpuctrl.icache_disable,
+                        uj_cpuctrl.dummy_instr_disable);
 
   // Read device ID and return to host.
   penetrationtest_device_id_t uj_output;

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -606,15 +606,18 @@ status_t handle_sha3_pentest_init(ujson_t *uj) {
 
   kmac_block_until_idle();
 
-  // Disable the instruction cache and dummy instructions for better SCA
-  // measurements.
-  pentest_configure_cpu(uj_cpuctrl.icache_disable,
-                        uj_cpuctrl.dummy_instr_disable);
+  // Configure the CPU for the pentest.
+  penetrationtest_device_info_t uj_output;
+  TRY(pentest_configure_cpu(
+      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
+      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
+      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
+      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
-  penetrationtest_device_id_t uj_output;
   TRY(pentest_read_device_id(uj_output.device_id));
-  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+  RESP_OK(ujson_serialize_penetrationtest_device_info_t, uj, &uj_output);
 
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
@@ -37,7 +37,8 @@ UJSON_SERDE_STRUCT(CryptoFiKmacMode, crypto_fi_kmac_mode_t, CRYPTOFI_KMAC_MODE);
 #define CRYPTOFI_AES_CIPHERTEXT(field, string) \
     field(ciphertext, uint8_t, 16) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiAesCiphertext, crypto_fi_aes_ciphertext_t, CRYPTOFI_AES_CIPHERTEXT);
 
 #define CRYPTOFI_KMAC_STATE(field, string) \
@@ -45,20 +46,23 @@ UJSON_SERDE_STRUCT(FiAesCiphertext, crypto_fi_aes_ciphertext_t, CRYPTOFI_AES_CIP
     field(share1, uint8_t, 200) \
     field(digest, uint8_t, 8) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiKmacState, crypto_fi_kmac_state_t, CRYPTOFI_KMAC_STATE);
 
 #define CRYPTOFI_KMAC_DIGEST(field, string) \
     field(digest, uint8_t, 8) \
     field(digest_2nd, uint8_t, 8) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiKmacDigest, crypto_fi_kmac_digest_t, CRYPTOFI_KMAC_DIGEST);
 
 #define CRYPTOFI_TEST_RESULT_MULT(field, string) \
     field(result, uint32_t, 3) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(CRYPTOFITestResultMult, crypto_fi_test_result_mult_t, CRYPTOFI_TEST_RESULT_MULT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -53,47 +53,54 @@ UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_TEST_RESULT_REGISTERS(field, string) \
     field(result, uint32_t) \
     field(registers, uint32_t, 32) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiTestResultRegisters, ibex_fi_test_result_registers_t, IBEXFI_TEST_RESULT_REGISTERS);
 
 #define IBEXFI_TEST_RESULT_MULT(field, string) \
     field(result1, uint32_t) \
     field(result2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
 
 #define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
     field(loop_counter1, uint32_t) \
     field(loop_counter2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 #define IBEXFI_FAULTY_ADDRESSES_DATA(field, string) \
     field(err_status, uint32_t) \
     field(addresses, uint32_t, 8) \
     field(data, uint32_t, 8) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiFaultyAddressesData, ibex_fi_faulty_addresses_data_t, IBEXFI_FAULTY_ADDRESSES_DATA);
 
 #define IBEXFI_FAULTY_ADDRESSES(field, string) \
     field(err_status, uint32_t) \
     field(addresses, uint32_t, 8) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(IbexFiFaultyAddresses, ibex_fi_faulty_addresses_t, IBEXFI_FAULTY_ADDRESSES);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
@@ -21,7 +21,8 @@ UJSON_SERDE_ENUM(LcCtrlFiSubcommand, lc_ctrl_fi_subcommand_t, LCCTRLFI_SUBCOMMAN
     field(state, uint32_t) \
     field(counter, uint32_t) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(LcCtrlFiCorruption, lc_ctrl_fi_corruption_t, LCCTRLFI_CORRUPTION);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
@@ -38,14 +38,16 @@ UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
     field(loop_counter, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
 
 #define OTBNFI_RESULT_OUTPUT(field, string) \
     field(result, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiResultOutput, otbn_fi_result_t, OTBNFI_RESULT_OUTPUT);
 
 #define OTBNFI_KEY_OUTPUT(field, string) \
@@ -53,7 +55,8 @@ UJSON_SERDE_STRUCT(OtbnFiResultOutput, otbn_fi_result_t, OTBNFI_RESULT_OUTPUT);
     field(keys, uint32_t, 4) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiKeyOutput, otbn_fi_keys_t, OTBNFI_KEY_OUTPUT);
 
 #define OTBNFI_MEM_CFG(field, string) \
@@ -71,7 +74,8 @@ UJSON_SERDE_STRUCT(OtbnFiMemCfg, otbn_fi_mem_cfg_t, OTBNFI_MEM_CFG);
     field(dmem_addr, uint32_t, 8) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiMemOutput, otbn_fi_mem_t, OTBNFI_MEM_OUTPUT);
 
 #define OTBNFI_DATA_OUTPUT(field, string) \
@@ -80,7 +84,8 @@ UJSON_SERDE_STRUCT(OtbnFiMemOutput, otbn_fi_mem_t, OTBNFI_MEM_OUTPUT);
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiDataOutput, otbn_fi_data_t, OTBNFI_DATA_OUTPUT);
 
 #define OTBNFI_RF_CHAR_OUTPUT(field, string) \
@@ -89,7 +94,8 @@ UJSON_SERDE_STRUCT(OtbnFiDataOutput, otbn_fi_data_t, OTBNFI_DATA_OUTPUT);
     field(faulty_wdr, uint32_t, 256) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiRfCharOutput, otbn_fi_rf_char_t, OTBNFI_RF_CHAR_OUTPUT);
 
 #define OTBNFI_RESULT_CNT_OUTPUT(field, string) \
@@ -97,7 +103,8 @@ UJSON_SERDE_STRUCT(OtbnFiRfCharOutput, otbn_fi_rf_char_t, OTBNFI_RF_CHAR_OUTPUT)
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiResultCntOutput, otbn_fi_result_cnt_t, OTBNFI_RESULT_CNT_OUTPUT);
 
 #define OTBNFI_RESULT_ARRAY(field, string) \
@@ -105,7 +112,8 @@ UJSON_SERDE_STRUCT(OtbnFiResultCntOutput, otbn_fi_result_cnt_t, OTBNFI_RESULT_CN
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiResultArray, otbn_fi_result_array_t, OTBNFI_RESULT_ARRAY);
 
 #define OTBNFI_BIG_NUM(field, string) \
@@ -117,7 +125,8 @@ UJSON_SERDE_STRUCT(OtbnFiBigNum, otbn_fi_big_num_t, OTBNFI_BIG_NUM);
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiBigNumOutput, otbn_fi_big_num_out_t, OTBNFI_BIG_NUM_OUTPUT);
 
 #define OTBNFI_PC(field, string) \
@@ -130,7 +139,8 @@ UJSON_SERDE_STRUCT(OtbnFiPc, otbn_fi_pc_t, OTBNFI_PC);
     field(insn_cnt, uint32_t) \
     field(err_otbn, uint32_t) \
     field(err_ibx, uint32_t) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtbnFiPcOutput, otbn_fi_pc_out_t, OTBNFI_PC_OUTPUT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otp_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otp_fi_commands.h
@@ -24,7 +24,8 @@ UJSON_SERDE_ENUM(OtpFiSubcommand, otp_fi_subcommand_t, OTPFI_SUBCOMMAND);
     field(vendor_test_fi, uint32_t, 16) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiVendortestPartition, otp_fi_vendortest_partition_t, OTPFI_VENDORTEST_PARTITION);
 
 #define OTPFI_OWNERSWCFG_PARTITION(field, string) \
@@ -32,7 +33,8 @@ UJSON_SERDE_STRUCT(OtpFiVendortestPartition, otp_fi_vendortest_partition_t, OTPF
     field(owner_sw_cfg_fi, uint32_t, 200) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiOwnerswcfgPartition, otp_fi_ownerswcfg_partition_t, OTPFI_OWNERSWCFG_PARTITION);
 
 #define OTPFI_HWCFG_PARTITION(field, string) \
@@ -40,7 +42,8 @@ UJSON_SERDE_STRUCT(OtpFiOwnerswcfgPartition, otp_fi_ownerswcfg_partition_t, OTPF
     field(hw_cfg_fi, uint32_t, 20) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiHwcfgPartition, otp_fi_hwcfg_partition_t, OTPFI_HWCFG_PARTITION);
 
 #define OTPFI_LIFECYCLE_PARTITION(field, string) \
@@ -48,7 +51,8 @@ UJSON_SERDE_STRUCT(OtpFiHwcfgPartition, otp_fi_hwcfg_partition_t, OTPFI_HWCFG_PA
     field(life_cycle_fi, uint32_t, 22) \
     field(otp_status_codes, uint32_t) \
     field(otp_error_causes, uint8_t, 10) \
-    field(alerts, uint32_t, 3)
+    field(alerts, uint32_t, 3) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(OtpFiLifecyclePartition, otp_fi_lifecycle_partition_t, OTPFI_LIFECYCLE_PARTITION);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
@@ -11,13 +11,21 @@ extern "C" {
 
 // clang-format off
 
-#define PENETRATIONTEST_DEVICE_ID(field, string) \
-    field(device_id, uint32_t, 8)
-UJSON_SERDE_STRUCT(PenetrationtestDeviceId, penetrationtest_device_id_t, PENETRATIONTEST_DEVICE_ID);
+#define PENETRATIONTEST_DEVICE_INFO(field, string) \
+    field(device_id, uint32_t, 8) \
+    field(clock_jitter_locked, bool) \
+    field(clock_jitter_en, bool) \
+    field(sram_main_readback_locked, bool) \
+    field(sram_main_readback_en, bool) \
+    field(sram_ret_readback_locked, bool) \
+    field(sram_ret_readback_en, bool)
+UJSON_SERDE_STRUCT(PenetrationtestDeviceInfo, penetrationtest_device_info_t, PENETRATIONTEST_DEVICE_INFO);
 
 #define PENETRATIONTEST_CPUCTRL(field, string) \
     field(icache_disable, bool) \
-    field(dummy_instr_disable, bool)
+    field(dummy_instr_disable, bool) \
+    field(enable_jittery_clock, bool) \
+    field(enable_sram_readback, bool)
 UJSON_SERDE_STRUCT(PenetrationtesCpuctrl, penetrationtest_cpuctrl_t, PENETRATIONTEST_CPUCTRL);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
@@ -15,6 +15,11 @@ extern "C" {
     field(device_id, uint32_t, 8)
 UJSON_SERDE_STRUCT(PenetrationtestDeviceId, penetrationtest_device_id_t, PENETRATIONTEST_DEVICE_ID);
 
+#define PENETRATIONTEST_CPUCTRL(field, string) \
+    field(icache_disable, bool) \
+    field(dummy_instr_disable, bool)
+UJSON_SERDE_STRUCT(PenetrationtesCpuctrl, penetrationtest_cpuctrl_t, PENETRATIONTEST_CPUCTRL);
+
 // clang-format on
 
 #ifdef __cplusplus

--- a/sw/device/tests/penetrationtests/json/rng_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rng_fi_commands.h
@@ -34,33 +34,38 @@ UJSON_SERDE_STRUCT(CryptoFiCsrngMode, crypto_fi_csrng_mode_t, CRYPTOFI_CSRNG_MOD
     field(res, uint32_t) \
     field(rand, uint32_t, 16) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiCsrngOutput, rng_fi_csrng_output_t, RNGFI_CSRNG_OUTPUT);
 
 #define RNGFI_CSRNG_OV_OUTPUT(field, string) \
     field(res, uint32_t) \
     field(rand, uint32_t, 12) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiCsrngOvOutput, rng_fi_csrng_ov_output_t, RNGFI_CSRNG_OV_OUTPUT);
 
 #define RNGFI_ENTRBIAS_OUTPUT(field, string) \
     field(rand, uint32_t, 32) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiEntrBiasOutput, rng_fi_entropy_src_bias_t, RNGFI_ENTRBIAS_OUTPUT);
 
 #define RNGFI_FWOVERWRITE_OUTPUT(field, string) \
     field(rand, uint32_t, 32) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiFwOverwriteOutput, rng_fi_fw_overwrite_t, RNGFI_FWOVERWRITE_OUTPUT);
 
 #define RNGFI_EDN(field, string) \
     field(collisions, uint32_t) \
     field(rand, uint32_t, 16) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiEdn, rng_fi_edn_t, RNGFI_EDN);
 
 #define RNGFI_FWOVERWRITE_HEALTH(field, string) \

--- a/sw/device/tests/penetrationtests/json/rom_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rom_fi_commands.h
@@ -20,7 +20,8 @@ UJSON_SERDE_ENUM(RomFiSubcommand, rom_fi_subcommand_t, ROMFI_SUBCOMMAND);
 #define ROMFI_DIGEST(field, string) \
     field(digest, uint32_t, 8) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RomFiDigest, rom_fi_digest_t, ROMFI_DIGEST);
 
 // clang-format on


### PR DESCRIPTION
This commit pulls over the following two commits from the master branch:

- 6381c7f6dd2f426b6ebe3712be0dd8cf0129b2f0: Read AST alerts and report them to the host
- e4cccb7: Allow configuring iCache and dummy instruction enable / disable

Moreover, commit 2eca32bc881e506d304a4bd8021bf765257ffd96 is changed such that it works with A1 and A2.