### PR TITLE
[mbx,racl,topgen] Add RACL support for both device interfaces of mbx

### DIFF
--- a/hw/ip/mbx/data/mbx.hjson
+++ b/hw/ip/mbx/data/mbx.hjson
@@ -19,7 +19,7 @@
 
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true}]
   bus_interfaces: [
-    { protocol: "tlul", direction: "device", name: "core" }
+    { protocol: "tlul", direction: "device", name: "core", racl_support: true }
     { protocol: "tlul", direction: "host",   name: "sram" }
     { protocol: "tlul", direction: "device", name: "soc", racl_support: true }
   ]

--- a/hw/ip/mbx/rtl/mbx_core_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_core_reg_top.sv
@@ -6,7 +6,13 @@
 
 `include "prim_assert.sv"
 
-module mbx_core_reg_top (
+module mbx_core_reg_top
+  # (
+    parameter bit          EnableRacl           = 1'b0,
+    parameter bit          RaclErrorRsp         = 1'b1,
+    parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[mbx_reg_pkg::NumRegsCore] =
+      '{mbx_reg_pkg::NumRegsCore{0}}
+  ) (
   input clk_i,
   input rst_ni,
   input  tlul_pkg::tl_h2d_t tl_i,
@@ -14,6 +20,10 @@ module mbx_core_reg_top (
   // To HW
   output mbx_reg_pkg::mbx_core_reg2hw_t reg2hw, // Write
   input  mbx_reg_pkg::mbx_core_hw2reg_t hw2reg, // Read
+
+  // RACL interface
+  input  top_racl_pkg::racl_policy_vec_t racl_policies_i,
+  output top_racl_pkg::racl_error_log_t  racl_error_o,
 
   // Integrity check errors
   output logic intg_err_o
@@ -110,7 +120,8 @@ module mbx_core_reg_top (
     .be_o    (reg_be),
     .busy_i  (reg_busy),
     .rdata_i (reg_rdata),
-    .error_i (reg_error)
+    // Translate RACL error to TLUL error if enabled
+    .error_i (reg_error | (RaclErrorRsp & racl_error_o.valid))
   );
 
   // cdc oversampling signals
@@ -862,8 +873,32 @@ module mbx_core_reg_top (
 
 
   logic [16:0] addr_hit;
+  top_racl_pkg::racl_role_vec_t racl_role_vec;
+  top_racl_pkg::racl_role_t racl_role;
+
+  logic [16:0] racl_addr_hit_read;
+  logic [16:0] racl_addr_hit_write;
+
+  if (EnableRacl) begin : gen_racl_role_logic
+    // Retrieve RACL role from user bits and one-hot encode that for the comparison bitmap
+    assign racl_role = top_racl_pkg::tlul_extract_racl_role_bits(tl_i.a_user.rsvd);
+
+    prim_onehot_enc #(
+      .OneHotWidth( $bits(top_racl_pkg::racl_role_vec_t) )
+    ) u_racl_role_encode (
+      .in_i ( racl_role     ),
+      .en_i ( 1'b1          ),
+      .out_o( racl_role_vec )
+    );
+  end else begin : gen_no_racl_role_logic
+    assign racl_role     = '0;
+    assign racl_role_vec = '0;
+  end
+
   always_comb begin
     addr_hit = '0;
+    racl_addr_hit_read  = '0;
+    racl_addr_hit_write = '0;
     addr_hit[ 0] = (reg_addr == MBX_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == MBX_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == MBX_INTR_TEST_OFFSET);
@@ -881,93 +916,121 @@ module mbx_core_reg_top (
     addr_hit[14] = (reg_addr == MBX_OUTBOUND_OBJECT_SIZE_OFFSET);
     addr_hit[15] = (reg_addr == MBX_DOE_INTR_MSG_ADDR_OFFSET);
     addr_hit[16] = (reg_addr == MBX_DOE_INTR_MSG_DATA_OFFSET);
+
+    if (EnableRacl) begin : gen_racl_hit
+      for (int unsigned slice_idx = 0; slice_idx < 17; slice_idx++) begin
+        racl_addr_hit_read[slice_idx] =
+            addr_hit[slice_idx] & (|(racl_policies_i[RaclPolicySelVec[slice_idx]].read_perm
+                                      & racl_role_vec));
+        racl_addr_hit_write[slice_idx] =
+            addr_hit[slice_idx] & (|(racl_policies_i[RaclPolicySelVec[slice_idx]].write_perm
+                                      & racl_role_vec));
+      end
+    end else begin : gen_no_racl
+      racl_addr_hit_read  = addr_hit;
+      racl_addr_hit_write = addr_hit;
+    end
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
+  // A valid address hit, access, but failed the RACL check
+  assign racl_error_o.valid = |addr_hit & ((reg_re & ~|racl_addr_hit_read) |
+                                           (reg_we & ~|racl_addr_hit_write));
+  assign racl_error_o.request_address = top_pkg::TL_AW'(reg_addr);
+  assign racl_error_o.racl_role       = racl_role;
+  assign racl_error_o.overflow        = 1'b0;
+
+  if (EnableRacl) begin : gen_racl_log
+    assign racl_error_o.ctn_uid     = top_racl_pkg::tlul_extract_ctn_uid_bits(tl_i.a_user.rsvd);
+    assign racl_error_o.read_access = tl_i.a_opcode == tlul_pkg::Get;
+  end else begin : gen_no_racl_log
+    assign racl_error_o.ctn_uid     = '0;
+    assign racl_error_o.read_access = 1'b0;
+  end
 
   // Check sub-word write is permitted
   always_comb begin
     wr_err = (reg_we &
-              ((addr_hit[ 0] & (|(MBX_CORE_PERMIT[ 0] & ~reg_be))) |
-               (addr_hit[ 1] & (|(MBX_CORE_PERMIT[ 1] & ~reg_be))) |
-               (addr_hit[ 2] & (|(MBX_CORE_PERMIT[ 2] & ~reg_be))) |
-               (addr_hit[ 3] & (|(MBX_CORE_PERMIT[ 3] & ~reg_be))) |
-               (addr_hit[ 4] & (|(MBX_CORE_PERMIT[ 4] & ~reg_be))) |
-               (addr_hit[ 5] & (|(MBX_CORE_PERMIT[ 5] & ~reg_be))) |
-               (addr_hit[ 6] & (|(MBX_CORE_PERMIT[ 6] & ~reg_be))) |
-               (addr_hit[ 7] & (|(MBX_CORE_PERMIT[ 7] & ~reg_be))) |
-               (addr_hit[ 8] & (|(MBX_CORE_PERMIT[ 8] & ~reg_be))) |
-               (addr_hit[ 9] & (|(MBX_CORE_PERMIT[ 9] & ~reg_be))) |
-               (addr_hit[10] & (|(MBX_CORE_PERMIT[10] & ~reg_be))) |
-               (addr_hit[11] & (|(MBX_CORE_PERMIT[11] & ~reg_be))) |
-               (addr_hit[12] & (|(MBX_CORE_PERMIT[12] & ~reg_be))) |
-               (addr_hit[13] & (|(MBX_CORE_PERMIT[13] & ~reg_be))) |
-               (addr_hit[14] & (|(MBX_CORE_PERMIT[14] & ~reg_be))) |
-               (addr_hit[15] & (|(MBX_CORE_PERMIT[15] & ~reg_be))) |
-               (addr_hit[16] & (|(MBX_CORE_PERMIT[16] & ~reg_be)))));
+              ((racl_addr_hit_write[ 0] & (|(MBX_CORE_PERMIT[ 0] & ~reg_be))) |
+               (racl_addr_hit_write[ 1] & (|(MBX_CORE_PERMIT[ 1] & ~reg_be))) |
+               (racl_addr_hit_write[ 2] & (|(MBX_CORE_PERMIT[ 2] & ~reg_be))) |
+               (racl_addr_hit_write[ 3] & (|(MBX_CORE_PERMIT[ 3] & ~reg_be))) |
+               (racl_addr_hit_write[ 4] & (|(MBX_CORE_PERMIT[ 4] & ~reg_be))) |
+               (racl_addr_hit_write[ 5] & (|(MBX_CORE_PERMIT[ 5] & ~reg_be))) |
+               (racl_addr_hit_write[ 6] & (|(MBX_CORE_PERMIT[ 6] & ~reg_be))) |
+               (racl_addr_hit_write[ 7] & (|(MBX_CORE_PERMIT[ 7] & ~reg_be))) |
+               (racl_addr_hit_write[ 8] & (|(MBX_CORE_PERMIT[ 8] & ~reg_be))) |
+               (racl_addr_hit_write[ 9] & (|(MBX_CORE_PERMIT[ 9] & ~reg_be))) |
+               (racl_addr_hit_write[10] & (|(MBX_CORE_PERMIT[10] & ~reg_be))) |
+               (racl_addr_hit_write[11] & (|(MBX_CORE_PERMIT[11] & ~reg_be))) |
+               (racl_addr_hit_write[12] & (|(MBX_CORE_PERMIT[12] & ~reg_be))) |
+               (racl_addr_hit_write[13] & (|(MBX_CORE_PERMIT[13] & ~reg_be))) |
+               (racl_addr_hit_write[14] & (|(MBX_CORE_PERMIT[14] & ~reg_be))) |
+               (racl_addr_hit_write[15] & (|(MBX_CORE_PERMIT[15] & ~reg_be))) |
+               (racl_addr_hit_write[16] & (|(MBX_CORE_PERMIT[16] & ~reg_be)))));
   end
 
   // Generate write-enables
-  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+  assign intr_state_we = racl_addr_hit_write[0] & reg_we & !reg_error;
 
   assign intr_state_mbx_ready_wd = reg_wdata[0];
 
   assign intr_state_mbx_abort_wd = reg_wdata[1];
 
   assign intr_state_mbx_error_wd = reg_wdata[2];
-  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+  assign intr_enable_we = racl_addr_hit_write[1] & reg_we & !reg_error;
 
   assign intr_enable_mbx_ready_wd = reg_wdata[0];
 
   assign intr_enable_mbx_abort_wd = reg_wdata[1];
 
   assign intr_enable_mbx_error_wd = reg_wdata[2];
-  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
+  assign intr_test_we = racl_addr_hit_write[2] & reg_we & !reg_error;
 
   assign intr_test_mbx_ready_wd = reg_wdata[0];
 
   assign intr_test_mbx_abort_wd = reg_wdata[1];
 
   assign intr_test_mbx_error_wd = reg_wdata[2];
-  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+  assign alert_test_we = racl_addr_hit_write[3] & reg_we & !reg_error;
 
   assign alert_test_fatal_fault_wd = reg_wdata[0];
 
   assign alert_test_recov_fault_wd = reg_wdata[1];
-  assign control_re = addr_hit[4] & reg_re & !reg_error;
-  assign control_we = addr_hit[4] & reg_we & !reg_error;
+  assign control_re = racl_addr_hit_read[4] & reg_re & !reg_error;
+  assign control_we = racl_addr_hit_write[4] & reg_we & !reg_error;
 
   assign control_abort_wd = reg_wdata[0];
 
   assign control_error_wd = reg_wdata[1];
 
   assign control_sys_async_msg_wd = reg_wdata[3];
-  assign status_re = addr_hit[5] & reg_re & !reg_error;
-  assign address_range_regwen_we = addr_hit[6] & reg_we & !reg_error;
+  assign status_re = racl_addr_hit_read[5] & reg_re & !reg_error;
+  assign address_range_regwen_we = racl_addr_hit_write[6] & reg_we & !reg_error;
 
   assign address_range_regwen_wd = reg_wdata[3:0];
-  assign address_range_valid_we = addr_hit[7] & reg_we & !reg_error;
+  assign address_range_valid_we = racl_addr_hit_write[7] & reg_we & !reg_error;
 
   assign address_range_valid_wd = reg_wdata[0];
-  assign inbound_base_address_we = addr_hit[8] & reg_we & !reg_error;
+  assign inbound_base_address_we = racl_addr_hit_write[8] & reg_we & !reg_error;
 
   assign inbound_base_address_wd = reg_wdata[31:2];
-  assign inbound_limit_address_we = addr_hit[9] & reg_we & !reg_error;
+  assign inbound_limit_address_we = racl_addr_hit_write[9] & reg_we & !reg_error;
 
   assign inbound_limit_address_wd = reg_wdata[31:2];
-  assign inbound_write_ptr_re = addr_hit[10] & reg_re & !reg_error;
-  assign outbound_base_address_we = addr_hit[11] & reg_we & !reg_error;
+  assign inbound_write_ptr_re = racl_addr_hit_read[10] & reg_re & !reg_error;
+  assign outbound_base_address_we = racl_addr_hit_write[11] & reg_we & !reg_error;
 
   assign outbound_base_address_wd = reg_wdata[31:2];
-  assign outbound_limit_address_we = addr_hit[12] & reg_we & !reg_error;
+  assign outbound_limit_address_we = racl_addr_hit_write[12] & reg_we & !reg_error;
 
   assign outbound_limit_address_wd = reg_wdata[31:2];
-  assign outbound_read_ptr_re = addr_hit[13] & reg_re & !reg_error;
-  assign outbound_object_size_we = addr_hit[14] & reg_we & !reg_error;
+  assign outbound_read_ptr_re = racl_addr_hit_read[13] & reg_re & !reg_error;
+  assign outbound_object_size_we = racl_addr_hit_write[14] & reg_we & !reg_error;
 
   assign outbound_object_size_wd = reg_wdata[10:0];
-  assign doe_intr_msg_addr_re = addr_hit[15] & reg_re & !reg_error;
-  assign doe_intr_msg_data_re = addr_hit[16] & reg_re & !reg_error;
+  assign doe_intr_msg_addr_re = racl_addr_hit_read[15] & reg_re & !reg_error;
+  assign doe_intr_msg_data_re = racl_addr_hit_read[16] & reg_re & !reg_error;
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -995,83 +1058,83 @@ module mbx_core_reg_top (
   always_comb begin
     reg_rdata_next = '0;
     unique case (1'b1)
-      addr_hit[0]: begin
+      racl_addr_hit_read[0]: begin
         reg_rdata_next[0] = intr_state_mbx_ready_qs;
         reg_rdata_next[1] = intr_state_mbx_abort_qs;
         reg_rdata_next[2] = intr_state_mbx_error_qs;
       end
 
-      addr_hit[1]: begin
+      racl_addr_hit_read[1]: begin
         reg_rdata_next[0] = intr_enable_mbx_ready_qs;
         reg_rdata_next[1] = intr_enable_mbx_abort_qs;
         reg_rdata_next[2] = intr_enable_mbx_error_qs;
       end
 
-      addr_hit[2]: begin
+      racl_addr_hit_read[2]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
       end
 
-      addr_hit[3]: begin
+      racl_addr_hit_read[3]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
       end
 
-      addr_hit[4]: begin
+      racl_addr_hit_read[4]: begin
         reg_rdata_next[0] = control_abort_qs;
         reg_rdata_next[1] = control_error_qs;
         reg_rdata_next[3] = '0;
       end
 
-      addr_hit[5]: begin
+      racl_addr_hit_read[5]: begin
         reg_rdata_next[0] = status_busy_qs;
         reg_rdata_next[1] = status_sys_intr_state_qs;
         reg_rdata_next[2] = status_sys_intr_enable_qs;
         reg_rdata_next[3] = status_sys_async_enable_qs;
       end
 
-      addr_hit[6]: begin
+      racl_addr_hit_read[6]: begin
         reg_rdata_next[3:0] = address_range_regwen_qs;
       end
 
-      addr_hit[7]: begin
+      racl_addr_hit_read[7]: begin
         reg_rdata_next[0] = address_range_valid_qs;
       end
 
-      addr_hit[8]: begin
+      racl_addr_hit_read[8]: begin
         reg_rdata_next[31:2] = inbound_base_address_qs;
       end
 
-      addr_hit[9]: begin
+      racl_addr_hit_read[9]: begin
         reg_rdata_next[31:2] = inbound_limit_address_qs;
       end
 
-      addr_hit[10]: begin
+      racl_addr_hit_read[10]: begin
         reg_rdata_next[31:2] = inbound_write_ptr_qs;
       end
 
-      addr_hit[11]: begin
+      racl_addr_hit_read[11]: begin
         reg_rdata_next[31:2] = outbound_base_address_qs;
       end
 
-      addr_hit[12]: begin
+      racl_addr_hit_read[12]: begin
         reg_rdata_next[31:2] = outbound_limit_address_qs;
       end
 
-      addr_hit[13]: begin
+      racl_addr_hit_read[13]: begin
         reg_rdata_next[31:2] = outbound_read_ptr_qs;
       end
 
-      addr_hit[14]: begin
+      racl_addr_hit_read[14]: begin
         reg_rdata_next[10:0] = outbound_object_size_qs;
       end
 
-      addr_hit[15]: begin
+      racl_addr_hit_read[15]: begin
         reg_rdata_next[31:0] = doe_intr_msg_addr_qs;
       end
 
-      addr_hit[16]: begin
+      racl_addr_hit_read[16]: begin
         reg_rdata_next[31:0] = doe_intr_msg_data_qs;
       end
 
@@ -1096,6 +1159,8 @@ module mbx_core_reg_top (
   logic unused_be;
   assign unused_wdata = ^reg_wdata;
   assign unused_be = ^reg_be;
+  logic unused_policy_sel;
+  assign unused_policy_sel = ^racl_policies_i;
 
   // Assertions for Register Interface
   `ASSERT_PULSE(wePulse, reg_we, clk_i, !rst_ni)

--- a/hw/ip/mbx/rtl/mbx_sysif.sv
+++ b/hw/ip/mbx/rtl/mbx_sysif.sv
@@ -63,7 +63,6 @@ module mbx_sysif
   input  top_racl_pkg::racl_policy_vec_t racl_policies_i,
   output top_racl_pkg::racl_error_log_t  racl_error_o
 );
-  import mbx_reg_pkg::*;
 
   mbx_soc_reg2hw_t reg2hw;
   mbx_soc_hw2reg_t hw2reg;

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -8421,6 +8421,26 @@
           soc_mbx: 0x01465300
         }
       }
+      racl_mappings:
+      {
+        soc:
+        {
+          racl_group: Null
+          register_mapping:
+          {
+            SOC_CONTROL: 0
+            SOC_STATUS: 0
+            SOC_DOE_INTR_MSG_ADDR: 0
+            SOC_DOE_INTR_MSG_DATA: 0
+          }
+          window_mapping:
+          {
+            WDATA: 0
+            RDATA: 0
+          }
+          range_mapping: []
+        }
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
@@ -8498,6 +8518,8 @@
           act: rcv
           width: 1
           inst_name: mbx3
+          default: ""
+          top_signame: racl_ctrl_racl_policies
           index: -1
         }
         {
@@ -8509,7 +8531,9 @@
           act: req
           width: 1
           inst_name: mbx3
-          index: -1
+          default: ""
+          top_signame: racl_ctrl_racl_error
+          index: 3
         }
         {
           name: sram_tl_h
@@ -8695,7 +8719,7 @@
           inst_name: mbx4
           default: ""
           top_signame: racl_ctrl_racl_error
-          index: 3
+          index: 4
         }
         {
           name: sram_tl_h
@@ -8881,7 +8905,7 @@
           inst_name: mbx5
           default: ""
           top_signame: racl_ctrl_racl_error
-          index: 4
+          index: 5
         }
         {
           name: sram_tl_h
@@ -8953,6 +8977,26 @@
         soc:
         {
           soc_mbx: 0x01496000
+        }
+      }
+      racl_mappings:
+      {
+        soc:
+        {
+          racl_group: Null
+          register_mapping:
+          {
+            SOC_CONTROL: 0
+            SOC_STATUS: 0
+            SOC_DOE_INTR_MSG_ADDR: 0
+            SOC_DOE_INTR_MSG_DATA: 0
+          }
+          window_mapping:
+          {
+            WDATA: 0
+            RDATA: 0
+          }
+          range_mapping: []
         }
       }
       clock_connections:
@@ -9032,6 +9076,8 @@
           act: rcv
           width: 1
           inst_name: mbx6
+          default: ""
+          top_signame: racl_ctrl_racl_policies
           index: -1
         }
         {
@@ -9043,7 +9089,9 @@
           act: req
           width: 1
           inst_name: mbx6
-          index: -1
+          default: ""
+          top_signame: racl_ctrl_racl_error
+          index: 6
         }
         {
           name: sram_tl_h
@@ -9229,7 +9277,7 @@
           inst_name: mbx_jtag
           default: ""
           top_signame: racl_ctrl_racl_error
-          index: 5
+          index: 7
         }
         {
           name: sram_tl_h
@@ -9415,7 +9463,7 @@
           inst_name: mbx_pcie0
           default: ""
           top_signame: racl_ctrl_racl_error
-          index: 6
+          index: 8
         }
         {
           name: sram_tl_h
@@ -9601,7 +9649,7 @@
           inst_name: mbx_pcie1
           default: ""
           top_signame: racl_ctrl_racl_error
-          index: 7
+          index: 9
         }
         {
           name: sram_tl_h
@@ -9858,7 +9906,7 @@
           name: NumSubscribingIps
           desc: Number of subscribing RACL IPs
           type: int
-          default: 9
+          default: 11
           local: "true"
           expose: "true"
           name_top: RaclCtrlNumSubscribingIps
@@ -9909,7 +9957,7 @@
             desc: Number of subscribing RACL IPs
             param_type: int
             unpacked_dimensions: null
-            default: 9
+            default: 11
             local: true
             expose: true
             name_top: RaclCtrlNumSubscribingIps
@@ -10106,7 +10154,7 @@
           inst_name: ac_range_check
           default: ""
           top_signame: racl_ctrl_racl_error
-          index: 8
+          index: 10
         }
         {
           name: tl
@@ -11761,8 +11809,10 @@
         mbx0.racl_policies
         mbx1.racl_policies
         mbx2.racl_policies
+        mbx3.racl_policies
         mbx4.racl_policies
         mbx5.racl_policies
+        mbx6.racl_policies
         mbx_jtag.racl_policies
         mbx_pcie0.racl_policies
         mbx_pcie1.racl_policies
@@ -11773,8 +11823,10 @@
         mbx0.racl_error
         mbx1.racl_error
         mbx2.racl_error
+        mbx3.racl_error
         mbx4.racl_error
         mbx5.racl_error
+        mbx6.racl_error
         mbx_jtag.racl_error
         mbx_pcie0.racl_error
         mbx_pcie1.racl_error
@@ -24876,6 +24928,8 @@
         act: rcv
         width: 1
         inst_name: mbx3
+        default: ""
+        top_signame: racl_ctrl_racl_policies
         index: -1
       }
       {
@@ -24887,7 +24941,9 @@
         act: req
         width: 1
         inst_name: mbx3
-        index: -1
+        default: ""
+        top_signame: racl_ctrl_racl_error
+        index: 3
       }
       {
         name: sram_tl_h
@@ -25011,7 +25067,7 @@
         inst_name: mbx4
         default: ""
         top_signame: racl_ctrl_racl_error
-        index: 3
+        index: 4
       }
       {
         name: sram_tl_h
@@ -25135,7 +25191,7 @@
         inst_name: mbx5
         default: ""
         top_signame: racl_ctrl_racl_error
-        index: 4
+        index: 5
       }
       {
         name: sram_tl_h
@@ -25244,6 +25300,8 @@
         act: rcv
         width: 1
         inst_name: mbx6
+        default: ""
+        top_signame: racl_ctrl_racl_policies
         index: -1
       }
       {
@@ -25255,7 +25313,9 @@
         act: req
         width: 1
         inst_name: mbx6
-        index: -1
+        default: ""
+        top_signame: racl_ctrl_racl_error
+        index: 6
       }
       {
         name: sram_tl_h
@@ -25379,7 +25439,7 @@
         inst_name: mbx_jtag
         default: ""
         top_signame: racl_ctrl_racl_error
-        index: 5
+        index: 7
       }
       {
         name: sram_tl_h
@@ -25503,7 +25563,7 @@
         inst_name: mbx_pcie0
         default: ""
         top_signame: racl_ctrl_racl_error
-        index: 6
+        index: 8
       }
       {
         name: sram_tl_h
@@ -25627,7 +25687,7 @@
         inst_name: mbx_pcie1
         default: ""
         top_signame: racl_ctrl_racl_error
-        index: 7
+        index: 9
       }
       {
         name: sram_tl_h
@@ -25839,7 +25899,7 @@
           desc: Number of subscribing RACL IPs
           param_type: int
           unpacked_dimensions: null
-          default: 9
+          default: 11
           local: true
           expose: true
           name_top: RaclCtrlNumSubscribingIps
@@ -25992,7 +26052,7 @@
         inst_name: ac_range_check
         default: ""
         top_signame: racl_ctrl_racl_error
-        index: 8
+        index: 10
       }
       {
         name: tl
@@ -31608,7 +31668,7 @@
           desc: Number of subscribing RACL IPs
           param_type: int
           unpacked_dimensions: null
-          default: 9
+          default: 11
           local: true
           expose: true
           name_top: RaclCtrlNumSubscribingIps

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -954,6 +954,9 @@
         core: {hart: "0x22000300"},
         soc:  {soc_mbx: "0x01465300"},
       },
+      racl_mappings: {
+        soc: 'racl/all_rd_wr_mapping.hjson'
+      }
     },
     { name: "mbx4",
       type: "mbx",
@@ -990,6 +993,9 @@
         core: {hart: "0x22000600"},
         soc:  {soc_mbx: "0x01496000"},
       },
+      racl_mappings: {
+        soc: 'racl/all_rd_wr_mapping.hjson'
+      }
     },
     { name: "mbx_jtag",
       type: "mbx",

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -64,7 +64,7 @@
     { name: "NumSubscribingIps",
       desc: "Number of subscribing RACL IPs",
       type: "int",
-      default: "9",
+      default: "11",
       expose: "true"
       local: "true"
     },

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -9,7 +9,7 @@
     nr_role_bits: 4
     nr_ctn_uid_bits: 5
     nr_policies: 3
-    nr_subscribing_ips: 9
+    nr_subscribing_ips: 11
     policies:
     [
       {

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/racl_configuration.md
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/doc/racl_configuration.md
@@ -62,6 +62,22 @@
 | mbx2.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465218 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
 | mbx2.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146521c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
 
+### RACL configuration for `mbx3` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1465300
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx3.soc.`SOC_CONTROL`           | 0x8      | 0x1465308 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx3.soc.`SOC_STATUS`            | 0xc      | 0x146530c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx3.soc.`WDATA`                 | 0x10     | 0x1465310 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx3.soc.`RDATA`                 | 0x14     | 0x1465314 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx3.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465318 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx3.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146531c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
 ### RACL configuration for `mbx4` and interface `soc`
 
 - IP: mbx
@@ -93,6 +109,22 @@
 | mbx5.soc.`RDATA`                 | 0x14     | 0x1465514 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
 | mbx5.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1465518 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
 | mbx5.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x146551c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+
+### RACL configuration for `mbx6` and interface `soc`
+
+- IP: mbx
+- Instance base address: 0x1496000
+- RACL group: Null
+
+
+| Name                             | Offset   | Address   | Width   | Policy        | ROT   | ROLE1   | SOC   |
+|:---------------------------------|:---------|:----------|:--------|:--------------|:------|:--------|:------|
+| mbx6.soc.`SOC_CONTROL`           | 0x8      | 0x1496008 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx6.soc.`SOC_STATUS`            | 0xc      | 0x149600c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx6.soc.`WDATA`                 | 0x10     | 0x1496010 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx6.soc.`RDATA`                 | 0x14     | 0x1496014 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx6.soc.`SOC_DOE_INTR_MSG_ADDR` | 0x18     | 0x1496018 | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
+| mbx6.soc.`SOC_DOE_INTR_MSG_DATA` | 0x1c     | 0x149601c | 0x4     | 0 (ALL_RD_WR) | R / W | R / W   | R / W |
 
 ### RACL configuration for `mbx_jtag` and interface `soc`
 

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -331,7 +331,7 @@ module top_darjeeling #(
   // local parameters for sram_ctrl_mbox
   localparam int SramCtrlMboxOutstanding = 2;
   // local parameters for racl_ctrl
-  localparam int RaclCtrlNumSubscribingIps = 9;
+  localparam int RaclCtrlNumSubscribingIps = 11;
 
   // Signals
   logic [3:0] mio_p2d;
@@ -2345,6 +2345,11 @@ module top_darjeeling #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   mbx #(
+    .EnableRacl(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX3_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX3_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX3_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[80:79])
   ) u_mbx3 (
 
@@ -2362,8 +2367,8 @@ module top_darjeeling #(
       .doe_intr_en_o(mbx3_doe_intr_en_o),
       .doe_intr_o(mbx3_doe_intr_o),
       .doe_async_msg_support_o(mbx3_doe_async_msg_support_o),
-      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
-      .racl_error_o(),
+      .racl_policies_i(racl_ctrl_racl_policies),
+      .racl_error_o(racl_ctrl_racl_error[3]),
       .sram_tl_h_o(main_tl_mbx3__sram_req),
       .sram_tl_h_i(main_tl_mbx3__sram_rsp),
       .core_tl_d_i(mbx3_core_tl_d_req),
@@ -2399,7 +2404,7 @@ module top_darjeeling #(
       .doe_intr_o(mbx4_doe_intr_o),
       .doe_async_msg_support_o(mbx4_doe_async_msg_support_o),
       .racl_policies_i(racl_ctrl_racl_policies),
-      .racl_error_o(racl_ctrl_racl_error[3]),
+      .racl_error_o(racl_ctrl_racl_error[4]),
       .sram_tl_h_o(main_tl_mbx4__sram_req),
       .sram_tl_h_i(main_tl_mbx4__sram_rsp),
       .core_tl_d_i(mbx4_core_tl_d_req),
@@ -2435,7 +2440,7 @@ module top_darjeeling #(
       .doe_intr_o(mbx5_doe_intr_o),
       .doe_async_msg_support_o(mbx5_doe_async_msg_support_o),
       .racl_policies_i(racl_ctrl_racl_policies),
-      .racl_error_o(racl_ctrl_racl_error[4]),
+      .racl_error_o(racl_ctrl_racl_error[5]),
       .sram_tl_h_o(main_tl_mbx5__sram_req),
       .sram_tl_h_i(main_tl_mbx5__sram_rsp),
       .core_tl_d_i(mbx5_core_tl_d_req),
@@ -2448,6 +2453,11 @@ module top_darjeeling #(
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   mbx #(
+    .EnableRacl(1'b1),
+    .RaclErrorRsp(top_racl_pkg::ErrorRsp),
+    .RaclPolicySelVecSoc(RACL_POLICY_SEL_VEC_MBX6_SOC),
+    .RaclPolicySelWinSocWdata(RACL_POLICY_SEL_WIN_MBX6_SOC_WDATA),
+    .RaclPolicySelWinSocRdata(RACL_POLICY_SEL_WIN_MBX6_SOC_RDATA),
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[86:85])
   ) u_mbx6 (
 
@@ -2465,8 +2475,8 @@ module top_darjeeling #(
       .doe_intr_en_o(mbx6_doe_intr_en_o),
       .doe_intr_o(mbx6_doe_intr_o),
       .doe_async_msg_support_o(mbx6_doe_async_msg_support_o),
-      .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
-      .racl_error_o(),
+      .racl_policies_i(racl_ctrl_racl_policies),
+      .racl_error_o(racl_ctrl_racl_error[6]),
       .sram_tl_h_o(main_tl_mbx6__sram_req),
       .sram_tl_h_i(main_tl_mbx6__sram_rsp),
       .core_tl_d_i(mbx6_core_tl_d_req),
@@ -2502,7 +2512,7 @@ module top_darjeeling #(
       .doe_intr_o(mbx_jtag_doe_intr_o),
       .doe_async_msg_support_o(mbx_jtag_doe_async_msg_support_o),
       .racl_policies_i(racl_ctrl_racl_policies),
-      .racl_error_o(racl_ctrl_racl_error[5]),
+      .racl_error_o(racl_ctrl_racl_error[7]),
       .sram_tl_h_o(main_tl_mbx_jtag__sram_req),
       .sram_tl_h_i(main_tl_mbx_jtag__sram_rsp),
       .core_tl_d_i(mbx_jtag_core_tl_d_req),
@@ -2538,7 +2548,7 @@ module top_darjeeling #(
       .doe_intr_o(mbx_pcie0_doe_intr_o),
       .doe_async_msg_support_o(mbx_pcie0_doe_async_msg_support_o),
       .racl_policies_i(racl_ctrl_racl_policies),
-      .racl_error_o(racl_ctrl_racl_error[6]),
+      .racl_error_o(racl_ctrl_racl_error[8]),
       .sram_tl_h_o(main_tl_mbx_pcie0__sram_req),
       .sram_tl_h_i(main_tl_mbx_pcie0__sram_rsp),
       .core_tl_d_i(mbx_pcie0_core_tl_d_req),
@@ -2574,7 +2584,7 @@ module top_darjeeling #(
       .doe_intr_o(mbx_pcie1_doe_intr_o),
       .doe_async_msg_support_o(mbx_pcie1_doe_async_msg_support_o),
       .racl_policies_i(racl_ctrl_racl_policies),
-      .racl_error_o(racl_ctrl_racl_error[7]),
+      .racl_error_o(racl_ctrl_racl_error[9]),
       .sram_tl_h_o(main_tl_mbx_pcie1__sram_req),
       .sram_tl_h_i(main_tl_mbx_pcie1__sram_rsp),
       .core_tl_d_i(mbx_pcie1_core_tl_d_req),
@@ -2660,7 +2670,7 @@ module top_darjeeling #(
       .ctn_filtered_tl_h2d_o(ctn_tl_h2d_o),
       .ctn_filtered_tl_d2h_i(ctn_tl_d2h_i),
       .racl_policies_i(racl_ctrl_racl_policies),
-      .racl_error_o(racl_ctrl_racl_error[8]),
+      .racl_error_o(racl_ctrl_racl_error[10]),
       .tl_i(ac_range_check_tl_req),
       .tl_o(ac_range_check_tl_rsp),
 

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_racl_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_racl_pkg.sv
@@ -71,6 +71,22 @@ package top_darjeeling_racl_pkg;
     RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**
+   * Policy selection vector for mbx3
+   *   TLUL interface name: soc
+   *   RACL group: Null
+   */
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX3_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
+  };
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX3_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX3_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+
+  /**
    * Policy selection vector for mbx4
    *   TLUL interface name: soc
    *   RACL group: Null
@@ -100,6 +116,22 @@ package top_darjeeling_racl_pkg;
   parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX5_SOC_WDATA =
     RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
   parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX5_SOC_RDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+
+  /**
+   * Policy selection vector for mbx6
+   *   TLUL interface name: soc
+   *   RACL group: Null
+   */
+  parameter racl_policy_sel_t RACL_POLICY_SEL_VEC_MBX6_SOC [4] = '{
+    RACL_POLICY_SEL_ALL_RD_WR,   // 0 SOC_CONTROL           : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 1 SOC_STATUS            : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR,   // 2 SOC_DOE_INTR_MSG_ADDR : Policy Idx 0
+    RACL_POLICY_SEL_ALL_RD_WR    // 3 SOC_DOE_INTR_MSG_DATA : Policy Idx 0
+  };
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX6_SOC_WDATA =
+    RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
+  parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_MBX6_SOC_RDATA =
     RACL_POLICY_SEL_ALL_RD_WR;   // Policy Idx 0
 
   /**

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -751,20 +751,22 @@ def generate_ac_range_check(top: ConfigT, module: ConfigT,
 def _get_racl_params(top: ConfigT) -> ParamsT:
     """Extracts parameters for racl_ctrl ipgen."""
     module = lib.find_module(top["module"], "racl_ctrl")
+    racl_group = module.get("racl_group", "Null")
     if len(top["racl"]["policies"]) == 1:
         # If there is only one set of policies, take the first one
         policies = list(top["racl"]["policies"].values())[0]
     else:
         # More than one policy, we need to find the matching set of policies
-        racl_group = module.get("racl_group", "Null")
         policies = top["racl"]["policies"][racl_group]
 
     num_subscribing_ips = defaultdict(int)
     for m in top["module"]:
         racl_mappings = m.get("racl_mappings", {})
-        for if_name, mapping in racl_mappings.items():
-            racl_group = racl_mappings[if_name]["racl_group"]
-            num_subscribing_ips[racl_group] += 1
+
+        for group in set(
+            mapping['racl_group'] for mapping in racl_mappings.values()
+        ):
+            num_subscribing_ips[group] += 1
 
     uniquified_modules.add_module(module["template_type"], module["type"])
 


### PR DESCRIPTION
This PR is a follow-up to #26004.

- This commit extends topgen such that a single IP can have RACL
  enabled on multiple interfaces.

- It also adds RACL for mbx's device interface 'core'. Previously,
  only mbx's 'soc' interface had RACL support.

- Finally, it enables RACL for all mbx instances in top_darjeeling.
  Two of them were left disabled by accident.