### PR TITLE
[aes] Port aes_masking_off_test to Darjeeling using DT

### DIFF
--- a/sw/device/lib/testing/aes_testutils.h
+++ b/sw/device/lib/testing/aes_testutils.h
@@ -6,6 +6,10 @@
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_AES_TESTUTILS_H_
 
 #include "sw/device/lib/dif/dif_aes.h"
+#ifndef OPENTITAN_IS_ENGLISHBREAKFAST
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#endif
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
@@ -33,7 +37,7 @@ inline bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t status) {
   IBEX_TRY_SPIN_FOR(aes_testutils_get_status((aes_), (status_)) == (flag_), \
                     (timeout_usec_))
 
-#if !OT_IS_ENGLISH_BREAKFAST
+#ifndef OPENTITAN_IS_ENGLISHBREAKFAST
 /**
  * Initializes the entropy complex for performing AES SCA measurements with
  * masking switched off.
@@ -42,10 +46,13 @@ inline bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t status) {
  * into AES causes the AES masking PRNG to output an all-zero vector. Entropy
  * src and EDN1 are left untouched.
  *
+ * @param csrng A CSRNG DIF handle.
+ * @param edn0 An EDN DIF handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t aes_testutils_masking_prng_zero_output_seed(void);
+status_t aes_testutils_masking_prng_zero_output_seed(const dif_csrng_t *csrng,
+                                                     const dif_edn_t *edn0);
 
 /**
  * CTR_DRBG Known-Answer-Test (KAT) using the CSRNG SW application interface.
@@ -54,10 +61,11 @@ status_t aes_testutils_masking_prng_zero_output_seed(void);
  * ensure the seed leading to an all-zero output of the AES masking PRNG can
  * repeatedly be generated.
  *
+ * @param csrng A CSRNG DIF handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t aes_testutils_csrng_kat(void);
+status_t aes_testutils_csrng_kat(const dif_csrng_t *csrng);
 #endif
 
 /**

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -52,13 +52,16 @@ exports_files(glob([
 opentitan_test(
     name = "aes_masking_off_test",
     srcs = ["aes_masking_off_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        DARJEELING_TEST_ENVS,
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),
     deps = [
         "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aes",

--- a/sw/device/tests/aes_masking_off_test.c
+++ b/sw/device/tests/aes_masking_off_test.c
@@ -16,8 +16,6 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
 enum {
   kTestTimeout = (1000 * 1000),
 };
@@ -31,11 +29,20 @@ static const uint8_t kKeyShare1[] = {
     0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
 };
 
+static_assert(kDtAesCount >= 1, "This test requires at least one AES instance");
+static_assert(kDtCsrngCount >= 1,
+              "This test requires at least one CSRNG instance");
+static_assert(kDtEdnCount >= 1, "This test requires at least one EDN instance");
+
+static dt_aes_t kTestAes = (dt_aes_t)0;
+static dt_csrng_t kTestCsrng = (dt_csrng_t)0;
+static dt_edn_t kTestEdn = (dt_edn_t)0;
+
 OTTF_DEFINE_TEST_CONFIG();
 
-status_t execute_test(void) {
+status_t execute_test(const dif_csrng_t *csrng, const dif_edn_t *edn0) {
   // Perform the known-answer testing on the CSRNG SW application interface.
-  CHECK_STATUS_OK(aes_testutils_csrng_kat());
+  CHECK_STATUS_OK(aes_testutils_csrng_kat(csrng));
 
   // Test AES with masking switched off.
   //
@@ -51,12 +58,11 @@ status_t execute_test(void) {
   LOG_INFO("Testing AES with masking switched off");
 
   // Initialize EDN and CSRNG to generate the required seed.
-  CHECK_STATUS_OK(aes_testutils_masking_prng_zero_output_seed());
+  CHECK_STATUS_OK(aes_testutils_masking_prng_zero_output_seed(csrng, edn0));
 
   // Initialise AES.
   dif_aes_t aes;
-  CHECK_DIF_OK(
-      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  CHECK_DIF_OK(dif_aes_init_from_dt(kTestAes, &aes));
   CHECK_DIF_OK(dif_aes_reset(&aes));
 
   // Mask the key. Note that this should not be done manually. Software is
@@ -131,15 +137,15 @@ bool test_main(void) {
   LOG_INFO("Testing CSRNG SW application interface");
 
   // Disable EDN connected to AES as well as CSRNG.
-  const dif_edn_t edn = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
-  const dif_csrng_t csrng = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+  dif_csrng_t csrng;
+  dif_edn_t edn;
+  CHECK_DIF_OK(dif_csrng_init_from_dt(kTestCsrng, &csrng));
+  CHECK_DIF_OK(dif_edn_init_from_dt(kTestEdn, &edn));
   CHECK_DIF_OK(dif_edn_stop(&edn));
   CHECK_DIF_OK(dif_csrng_stop(&csrng));
 
   // Re-enable CSRNG.
   CHECK_DIF_OK(dif_csrng_configure(&csrng));
 
-  return status_ok(execute_test());
+  return status_ok(execute_test(&csrng, &edn));
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -17,7 +17,7 @@
 #include "sw/device/tests/penetrationtests/json/aes_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/commands.h"
 
-#if !OT_IS_ENGLISH_BREAKFAST
+#ifndef OPENTITAN_IS_ENGLISHBREAKFAST
 #include "sw/device/lib/testing/aes_testutils.h"
 #endif
 
@@ -202,7 +202,7 @@ static status_t aes_key_mask_and_config(const uint8_t *key, size_t key_len) {
   }
   TRY(dif_aes_start(&aes, &transaction, &key_shares, NULL));
 
-#if !OT_IS_ENGLISH_BREAKFAST
+#ifndef OPENTITAN_IS_ENGLISHBREAKFAST
   if (transaction.force_masks) {
     // Disable masking. Force the masking PRNG output value to 0.
     TRY(aes_sca_load_fixed_seed());
@@ -652,10 +652,15 @@ status_t handle_aes_pentest_seed_lfsr(ujson_t *uj) {
   }
   pentest_seed_lfsr(seed_local, kPentestLfsrMasking);
 
-#if !OT_IS_ENGLISH_BREAKFAST
+#ifndef OPENTITAN_IS_ENGLISHBREAKFAST
   if (transaction.force_masks) {
     LOG_INFO("Disabling masks.");
-    status_t res = aes_testutils_masking_prng_zero_output_seed();
+    const dif_csrng_t csrng = {
+        .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+    const dif_edn_t edn0 = {
+        .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+
+    status_t res = aes_testutils_masking_prng_zero_output_seed(&csrng, &edn0);
     if (res.value != 0) {
       return ABORTED();
     }


### PR DESCRIPTION
Port the aes_masking_off_test and associated testutils functions to Darjeeling using DT.

Minimally update both aes_sca and aes_serial to avoid introducing additional bit rot, but leave them as Earl Grey only for now.