### PR TITLE
[opentitanlib] Fix for HyperDebug I2C driver

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -264,7 +264,7 @@ impl HyperdebugI2cBus {
         rbuf[..databytes].clone_from_slice(&resp.data[..databytes]);
         let mut index = databytes;
         while index < rbuf.len() {
-            let databytes = self.usb_read_bulk(&mut resp.data[index..])?;
+            let databytes = self.usb_read_bulk(&mut rbuf[index..])?;
             ensure!(
                 databytes > 0,
                 TransportError::CommunicationError(


### PR DESCRIPTION
It appears that since its inception, the I2C driver has had a bug in handling USB response spanning more than one 64-byte packet.  (This will happen when more than 59 bytes are received via I2C, as the tunneling protocol adds a 5-byte header in the USB response.)

Recent changes to the TPM driver in opentitanlib stopped it from limiting TPM I2C transfers to 32 bytes, and that revealed this old bug.
