### PR TITLE
[darjeeling] Bring up a few more top-level SW tests

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1169,22 +1169,6 @@
       run_timeout_mins: 120
     }
     {
-      name: chip_sw_edn_entropy_reqs
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:entropy_src_edn_reqs_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000", "+rng_srate_value_min=15",
-                 "+rng_srate_value_max=30"]
-    }
-    {
-      name: chip_sw_edn_entropy_reqs_jitter
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:entropy_src_edn_reqs_test:6:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=15000000", "+rng_srate_value_min=15",
-                 "+rng_srate_value_max=30", "+en_jitter=1"]
-    }
-    {
       name: chip_sw_hmac_enc
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:hmac_enc_test:6:new_rules"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2816,6 +2816,7 @@ opentitan_test(
     srcs = ["otbn_mem_scramble_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
@@ -2825,7 +2826,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:otbn",
         "//sw/device/lib/dif:rv_core_ibex",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2560,6 +2560,7 @@ opentitan_test(
     srcs = ["kmac_entropy_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:sim_dv": None,
@@ -2568,7 +2569,7 @@ opentitan_test(
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/runtime:irq",

--- a/sw/device/tests/kmac_entropy_test.c
+++ b/sw/device/tests/kmac_entropy_test.c
@@ -10,8 +10,12 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "kmac_regs.h"  // Generated.
+
+static_assert(kDtKmacCount >= 1,
+              "This test requires at least one KMAC instance");
+
+static dt_kmac_t kTestKmac = (dt_kmac_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -138,8 +142,7 @@ status_t test_kmac_entropy_stall(void) {
 
   // Initialize KMAC HWIP
   dif_kmac_t kmac;
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kTestKmac, &kmac));
 
   // Configure KMAC to use EDN entropy
   dif_kmac_config_t config = {
@@ -225,8 +228,7 @@ status_t test_kmac_entropy(void) {
 
   // Initialize KMAC HWIP
   dif_kmac_t kmac;
-  CHECK_DIF_OK(
-      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_kmac_init_from_dt(kTestKmac, &kmac));
 
   // Configure KMAC to use EDN entropy
   dif_kmac_config_t config = {

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -10,7 +10,14 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static_assert(kDtOtbnCount >= 1,
+              "This test requires at least one OTBN instance");
+// rv_core_ibex wrapper around the Ibex CPU provides additional functionality.
+static_assert(kDtRvCoreIbexCount >= 1,
+              "This test requires at least one rv_core_ibex instance");
+
+static dt_otbn_t kTestOtbn = (dt_otbn_t)0;
+static dt_rv_core_ibex_t kTestRvCoreIbex = (dt_rv_core_ibex_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -185,14 +192,11 @@ static void otbn_check_mem_words(const dif_otbn_t *otbn, const int num,
 bool test_main(void) {
   // Init OTBN DIF.
   dif_otbn_t otbn;
-  mmio_region_t otbn_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR);
-  CHECK_DIF_OK(dif_otbn_init(otbn_addr, &otbn));
+  CHECK_DIF_OK(dif_otbn_init_from_dt(kTestOtbn, &otbn));
 
   // Init Ibex DIF.
   dif_rv_core_ibex_t ibex;
-  mmio_region_t ibex_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_core_ibex_init(ibex_addr, &ibex));
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kTestRvCoreIbex, &ibex));
 
   uint32_t imem_offsets[kNumAddrs];
   uint32_t dmem_offsets[kNumAddrs];


### PR DESCRIPTION
Ported `kmac_entropy_test` and `otbn_mem_scramble_test` to DT and thus Darjeeling.
Drop from the Darjeeling chip configuration those tests which rely upon the presence of an entropy source IP block; Darjeeling does not include one a la Earl Grey so these tests are not relevant.