### PR TITLE
[darjeeling] PLIC and AON Timer smoketests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3790,12 +3790,13 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:uart",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -600,8 +600,10 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        DARJEELING_TEST_ENVS,
     ),
     deps = [
+        "//hw/top:dt",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/runtime:hart",

--- a/sw/device/tests/aon_timer_smoketest.c
+++ b/sw/device/tests/aon_timer_smoketest.c
@@ -13,7 +13,13 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static_assert(kDtAonTimerCount >= 1,
+              "This test requires at least one AON Timer instance");
+static_assert(kDtRvCoreIbexCount >= 1,
+              "This test requires at least one rv_core_ibex instance");
+
+static const dt_aon_timer_t kTestAonTimer = (dt_aon_timer_t)0;
+static const dt_rv_core_ibex_t kTestRvCoreIbex = (dt_rv_core_ibex_t)0;
 
 OTTF_DEFINE_TEST_CONFIG();
 
@@ -99,11 +105,8 @@ bool test_main(void) {
   LOG_INFO("Running AON timer test");
 
   // Initialise AON Timer.
-  CHECK_DIF_OK(dif_aon_timer_init(
-      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon));
-  CHECK_DIF_OK(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  CHECK_DIF_OK(dif_aon_timer_init_from_dt(kTestAonTimer, &aon));
+  CHECK_DIF_OK(dif_rv_core_ibex_init_from_dt(kTestRvCoreIbex, &rv_core_ibex));
 
   aon_timer_test_wakeup_timer(&aon);
   aon_timer_test_watchdog_timer(&aon);

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -12,9 +12,14 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+static_assert(kDtRvPlicCount == 1, "This test expects exactly one rv_plic");
 
-static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static const dt_rv_plic_t kTestRvPlic = (dt_rv_plic_t)0;
+static const dt_uart_t kTestUart = (dt_uart_t)0;
+
+enum {
+  kPlicTarget = 0,
+};
 
 static dif_rv_plic_t plic0;
 static dif_uart_t uart0;
@@ -32,23 +37,19 @@ static volatile bool uart_tx_done_handled;
  * Services UART interrupts, sets the appropriate flags that are used to
  * determine success or failure of the test.
  */
-static void handle_uart_isr(const dif_rv_plic_irq_id_t interrupt_id) {
-  // NOTE: This initialization is superfluous, since the `default` case below
-  // is effectively noreturn, but the compiler is unable to prove this.
-  dif_uart_irq_t uart_irq = 0;
+static void handle_uart_isr(const dif_rv_plic_irq_id_t plic_irq_id) {
+  dt_uart_irq_t uart_irq = dt_uart_irq_from_plic_id(kTestUart, plic_irq_id);
 
-  switch (interrupt_id) {
-    case kTopEarlgreyPlicIrqIdUart0RxOverflow:
+  switch (uart_irq) {
+    case kDtUartIrqRxOverflow:
       CHECK(!uart_rx_overflow_handled,
             "UART RX overflow IRQ asserted more than once");
 
-      uart_irq = kDifUartIrqRxOverflow;
       uart_rx_overflow_handled = true;
       break;
-    case kTopEarlgreyPlicIrqIdUart0TxDone:
+    case kDtUartIrqTxDone:
       CHECK(!uart_tx_done_handled, "UART TX done IRQ asserted more than once");
 
-      uart_irq = kDifUartIrqTxDone;
       uart_tx_done_handled = true;
       break;
     default:
@@ -68,23 +69,23 @@ static void handle_uart_isr(const dif_rv_plic_irq_id_t interrupt_id) {
  */
 void ottf_external_isr(uint32_t *exc_info) {
   // Claim the IRQ by reading the Ibex specific CC register.
-  dif_rv_plic_irq_id_t interrupt_id;
-  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic0, kPlicTarget, &interrupt_id));
+  dif_rv_plic_irq_id_t plic_irq_id;
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic0, kPlicTarget, &plic_irq_id));
 
   // Check if the interrupted peripheral is UART.
-  top_earlgrey_plic_peripheral_t peripheral_id =
-      top_earlgrey_plic_interrupt_for_peripheral[interrupt_id];
-  CHECK(peripheral_id == kTopEarlgreyPlicPeripheralUart0,
-        "ISR interrupted peripheral is not UART!");
-  handle_uart_isr(interrupt_id);
+  dt_instance_id_t inst_id = dt_plic_id_to_instance_id(plic_irq_id);
+  CHECK(inst_id == dt_uart_instance_id(kTestUart),
+        "Interrupt from incorrect peripheral: (exp: %d, obs: %s)",
+        dt_uart_instance_id(kTestUart), inst_id);
+  handle_uart_isr(plic_irq_id);
 
   // Complete the IRQ by writing the IRQ source to the Ibex specific CC
   // register.
-  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic0, kPlicTarget, interrupt_id));
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic0, kPlicTarget, plic_irq_id));
 }
 
-static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
-  CHECK_DIF_OK(dif_uart_init(base_addr, uart));
+static void uart_initialise(dt_uart_t uart_id, dif_uart_t *uart) {
+  CHECK_DIF_OK(dif_uart_init_from_dt(uart_id, uart));
   CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
   CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
         "kClockFreqPeripheralHz must fit in uint32_t");
@@ -113,24 +114,28 @@ static void uart_configure_irqs(dif_uart_t *uart) {
  * Configures all the relevant interrupts in PLIC.
  */
 static void plic_configure_irqs(dif_rv_plic_t *plic) {
-  // Set IRQ priorities to MAX
-  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
-      plic, kTopEarlgreyPlicIrqIdUart0RxOverflow, kDifRvPlicMaxPriority));
+  dt_plic_irq_id_t rx_ovf_irq =
+      dt_uart_irq_to_plic_id(kTestUart, kDtUartIrqRxOverflow);
+  dt_plic_irq_id_t tx_done_irq =
+      dt_uart_irq_to_plic_id(kTestUart, kDtUartIrqTxDone);
 
-  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
-      plic, kTopEarlgreyPlicIrqIdUart0TxDone, kDifRvPlicMaxPriority));
+  // Set IRQ priorities to MAX
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_set_priority(plic, rx_ovf_irq, kDifRvPlicMaxPriority));
+
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_set_priority(plic, tx_done_irq, kDifRvPlicMaxPriority));
 
   // Set Ibex IRQ priority threshold level
   CHECK_DIF_OK(dif_rv_plic_target_set_threshold(&plic0, kPlicTarget,
                                                 kDifRvPlicMinPriority));
 
   // Enable IRQs in PLIC
-  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(plic,
-                                           kTopEarlgreyPlicIrqIdUart0RxOverflow,
-                                           kPlicTarget, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(plic, rx_ovf_irq, kPlicTarget,
+                                           kDifToggleEnabled));
 
-  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
-      plic, kTopEarlgreyPlicIrqIdUart0TxDone, kPlicTarget, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(plic, tx_done_irq, kPlicTarget,
+                                           kDifToggleEnabled));
 }
 
 static void execute_test(dif_uart_t *uart) {
@@ -161,13 +166,9 @@ bool test_main(void) {
   irq_external_ctrl(true);
 
   // No debug output in case of UART initialisation failure.
-  mmio_region_t uart_base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR);
-  uart_initialise(uart_base_addr, &uart0);
+  uart_initialise(kTestUart, &uart0);
 
-  mmio_region_t plic_base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK_DIF_OK(dif_rv_plic_init(plic_base_addr, &plic0));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kTestRvPlic, &plic0));
 
   uart_configure_irqs(&uart0);
   plic_configure_irqs(&plic0);


### PR DESCRIPTION
Port `rv_plic_smoketest` and `aon_timer_smoketest` to DT and thus Darjeeling.
Note that rv_plic_smoketest will pass only in the presence of #26814 which prevents X propagation into the UART on Darjeeling.