### PR TITLE
[silicon_creator,hmac] add HMAC-SHA256 driver function

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -13,7 +13,7 @@
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-void hmac_sha256_configure(bool big_endian_digest) {
+static void hmac_configure(bool big_endian_digest, bool hmac_mode) {
   // Clear the config, stopping the SHA engine.
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, 0u);
 
@@ -27,13 +27,26 @@ void hmac_sha256_configure(bool big_endian_digest) {
   reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, big_endian_digest);
   reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, false);
   reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
-  reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
+  reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, hmac_mode);
   // configure to run SHA-2 256 with 256-bit key
   reg = bitfield_field32_write(reg, HMAC_CFG_DIGEST_SIZE_FIELD,
                                HMAC_CFG_DIGEST_SIZE_VALUE_SHA2_256);
   reg = bitfield_field32_write(reg, HMAC_CFG_KEY_LENGTH_FIELD,
                                HMAC_CFG_KEY_LENGTH_VALUE_KEY_256);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, reg);
+}
+
+void hmac_hmac_sha256_configure(bool big_endian_digest, hmac_key_t key) {
+  hmac_configure(big_endian_digest, /*hmac_mode=*/true);
+  for (size_t i = 0; i < kHmacKeyNumWords; ++i) {
+    abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_KEY_0_REG_OFFSET +
+                         i * sizeof(uint32_t),
+                     key.key[i]);
+  }
+}
+
+void hmac_sha256_configure(bool big_endian_digest) {
+  hmac_configure(big_endian_digest, /*hmac_mode=*/false);
 }
 
 inline void hmac_sha256_start(void) {
@@ -125,6 +138,14 @@ void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest) {
   hmac_sha256_final(digest);
 }
 
+void hmac_hmac_sha256(const void *data, size_t len, hmac_key_t key,
+                      bool big_endian_digest, hmac_digest_t *digest) {
+  hmac_hmac_sha256_init(key, big_endian_digest);
+  hmac_sha256_update(data, len);
+  hmac_sha256_process();
+  hmac_sha256_final(digest);
+}
+
 void hmac_sha256_save(hmac_context_t *ctx) {
   // Issue the STOP command to halt the operation and compute the intermediate
   // digest.
@@ -191,5 +212,6 @@ void hmac_sha256_restore(const hmac_context_t *ctx) {
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd);
 }
 
+extern void hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest);
 extern void hmac_sha256_init(void);
 extern void hmac_sha256_final(hmac_digest_t *digest);

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -22,6 +22,14 @@ enum {
    * Size of a SHA-256 digest in 32-bit words.
    */
   kHmacDigestNumWords = kHmacDigestNumBytes / sizeof(uint32_t),
+  /**
+   * Size of a HMAC-SHA-256 key in bytes.
+   */
+  kHmacKeyNumBytes = kHmacDigestNumBytes,
+  /**
+   * Size of a HMAC-SHA-256 key in 32-bit words.
+   */
+  kHmacKeyNumWords = kHmacDigestNumWords,
 };
 
 /**
@@ -30,6 +38,13 @@ enum {
 typedef struct hmac_digest {
   uint32_t digest[kHmacDigestNumWords];
 } hmac_digest_t;
+
+/**
+ * A typed representation of the HMAC secret key (for HMAC-SHA256 mode).
+ */
+typedef struct hmac_key {
+  uint32_t key[kHmacDigestNumWords];
+} hmac_key_t;
 
 /**
  * Stored SHA256 operation state.
@@ -43,6 +58,32 @@ typedef struct hmac_context {
   uint32_t msg_len_lower;
   uint32_t digest[kHmacDigestNumWords];
 } hmac_context_t;
+
+/**
+ * Configure the HMAC block in HMAC-SHA256 mode.
+ *
+ * This function resets the HMAC module to clear the digest register.
+ * It then configures the HMAC block in HMAC mode with digest output
+ * in the requested endianness.
+ *
+ * @param big_endian Whether or not to initialize the peripheral for big-endian
+ *                   results.
+ */
+void hmac_hmac_sha256_configure(bool big_endian_digest, hmac_key_t key);
+
+/**
+ * Convenience single-shot function for computing the HMAC-SHA-256 keyed-digest
+ * of a contiguous buffer.
+ *
+ * @param data Buffer to copy data from.
+ * @param len Size of the `data` buffer in bytes.
+ * @param key Secret key to use.
+ * @param big_endian_digest Whether to configure the hardware to produce a
+ *                          big-endian digest.
+ * @param[out] digest Buffer to copy digest to.
+ */
+void hmac_hmac_sha256(const void *data, size_t len, hmac_key_t key,
+                      bool big_endian_digest, hmac_digest_t *digest);
 
 /**
  * Configure the HMAC block in SHA256 mode.
@@ -68,6 +109,14 @@ void hmac_sha256_start(void);
  */
 inline void hmac_sha256_init(void) {
   hmac_sha256_configure(false);
+  hmac_sha256_start();
+}
+
+/**
+ * Configures and starts HMAC in HMAC mode with little-endian output.
+ */
+inline void hmac_hmac_sha256_init(hmac_key_t key, bool big_endian_digest) {
+  hmac_hmac_sha256_configure(big_endian_digest, key);
   hmac_sha256_start();
 }
 

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -56,7 +56,7 @@ static const uint32_t kGettysburgDigest[] = {
 static const char kGettysburgDigestBigEndian[] =
     "1e6fd4030f9034cd775708a396c324ed420ec587eb3dd433e29f6ac08b8cc7ba";
 
-rom_error_t hmac_test(void) {
+rom_error_t hmac_sha256_test(void) {
   hmac_digest_t digest;
   hmac_sha256(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1, &digest);
 
@@ -64,6 +64,38 @@ rom_error_t hmac_test(void) {
   for (int i = 0; i < len; ++i) {
     LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);
     if (digest.digest[i] != kGettysburgDigest[i]) {
+      return kErrorUnknown;
+    }
+  }
+  return kErrorOk;
+}
+
+static const hmac_key_t kHmacKey = {.key = {0x11112222, 0x33334444, 0x55556666,
+                                            0x77778888, 0x9999aaaa, 0xbbbbcccc,
+                                            0xddddeeee, 0xffff0000}};
+
+// The following shell command will produce the HMAC-SHA256 digest, and convert
+// it into valid C hexadecimal constants:
+//
+// $ echo -n "Four score and seven years ago our fathers brought forth on this
+// continent, a new nation, conceived in Liberty, and dedicated to the
+// proposition that all men are created equal." | openssl dgst \
+//     -sha256 -mac HMAC -macopt \
+//     hexkey:111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000 \
+//     | cut -f2 -d' ' | sed -e "s/......../0x&,\n/g" | tac
+static const uint32_t kGettysburgHmacSha256Digest[] = {
+    0xa63131bc, 0xeb1cb98b, 0xa0888a13, 0x497f2087,
+    0xb54e0af5, 0x9d85e15b, 0xa9a3bafe, 0x9d115197,
+};
+
+rom_error_t hmac_hmac_sha256_test(void) {
+  hmac_digest_t digest;
+  hmac_hmac_sha256(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1, kHmacKey,
+                   /*big_endian_digest=*/false, &digest);
+  const size_t len = ARRAYSIZE(digest.digest);
+  for (int i = 0; i < len; ++i) {
+    LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);
+    if (digest.digest[i] != kGettysburgHmacSha256Digest[i]) {
       return kErrorUnknown;
     }
   }
@@ -258,7 +290,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
-  EXECUTE_TEST(result, hmac_test);
+  EXECUTE_TEST(result, hmac_sha256_test);
+  EXECUTE_TEST(result, hmac_hmac_sha256_test);
   EXECUTE_TEST(result, hmac_process_nowait_test);
   EXECUTE_TEST(result, hmac_process_wait_test);
   EXECUTE_TEST(result, hmac_truncated_test);


### PR DESCRIPTION
This adds a function to the silicon_creator HMAC driver lib to compute an HMAC-SHA256 keyed digest. This is required to implement the WAS authentication flow during personalization required by #22274.