### PR TITLE
[individualize] remove OTTF console init and all prints

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@//rules:manuf.bzl", "ft_device_id")
+load("@//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load(
     "@provisioning_exts//:cfg.bzl",
     "EXT_SIGNED_PERSO_BINS",
@@ -180,10 +180,8 @@ opentitan_test(
             "//sw/device/lib/dif:gpio",
             "//sw/device/lib/dif:otp_ctrl",
             "//sw/device/lib/dif:pinmux",
-            "//sw/device/lib/runtime:log",
             "//sw/device/lib/testing:pinmux_testutils",
             "//sw/device/lib/testing/test_framework:check",
-            "//sw/device/lib/testing/test_framework:ottf_console",
             "//sw/device/lib/testing/test_framework:ottf_test_config",
             "//sw/device/lib/testing/test_framework:status",
             "//sw/device/silicon_creator/manuf/lib:individualize",

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -10,11 +10,9 @@
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
-#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
-#include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/silicon_creator/manuf/base/flash_info_permissions.h"
 #include "sw/device/silicon_creator/manuf/base/ft_device_id.h"
@@ -26,9 +24,7 @@
 #include "ast_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
-                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
-                        .console.test_may_clobber = false, );
+OTTF_DEFINE_TEST_CONFIG();
 
 static dif_flash_ctrl_state_t flash_ctrl_state;
 static dif_gpio_t gpio;
@@ -101,15 +97,10 @@ static status_t patch_ast_config_value(void) {
 
   // Only patch AST if the patch value is present.
   if (ast_patch_value != 0 && ast_patch_value != UINT32_MAX) {
-    LOG_INFO("Patching AST with:");
-    LOG_INFO("AST patch address offset = 0x%08x", ast_patch_addr_offset);
-    LOG_INFO("AST patch address value  = 0x%08x", ast_patch_value);
-
     // Check the address is within range before programming.
     if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceSimDV) {
       TRY_CHECK(ast_patch_addr_offset <= AST_REGAL_REG_OFFSET);
     }
-
     // Write patch value.
     abs_mmio_write32(
         TOP_EARLGREY_AST_BASE_ADDR + ast_patch_addr_offset * sizeof(uint32_t),
@@ -143,7 +134,6 @@ static status_t provision(void) {
 
 bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
-  ottf_console_init();
   CHECK_STATUS_OK(configure_ate_gpio_indicators());
 
   // Perform provisioning operations.
@@ -154,11 +144,5 @@ bool test_main(void) {
   } else {
     CHECK_DIF_OK(dif_gpio_write(&gpio, kGpioPinTestDone, true));
   }
-
-  // Halt the CPU here to enable JTAG to perform an LC transition to mission
-  // mode, as ROM execution should be active now.
-  LOG_INFO("FT SRAM provisioning done.");
-  abort();
-
   return true;
 }

--- a/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
@@ -289,7 +289,6 @@ pub fn load_elf_sram_program(
                 .chunks(4)
                 .map(LittleEndian::read_u32)
                 .collect();
-            println!("{:?}", data32);
             let mut read_data32 = vec![0u32; data32.len()];
             log::info!("Read back data to verify");
             jtag.read_memory32(section.address() as u32, &mut read_data32)?;

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -221,7 +221,6 @@ fn main() -> Result<()> {
                 opts.init.bootstrap.options.reset_delay,
                 &opts.sram_program,
                 opts.timeout,
-                &spi_console_device,
             )?;
             response.stats.log_elapsed_time("ft-individualize", t0);
 

--- a/sw/host/provisioning/ft_lib/BUILD
+++ b/sw/host/provisioning/ft_lib/BUILD
@@ -17,6 +17,7 @@ package(default_visibility = ["//visibility:public"])
         crate_name = "ft_lib",
         deps = [
             "//sw/host/opentitanlib",
+            "//sw/host/opentitanlib/bindgen",
             "//sw/host/ot_certs",
             "//sw/host/provisioning/cert_lib",
             "//sw/host/provisioning/perso_tlv_lib",

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -6,22 +6,19 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use arrayvec::ArrayVec;
 use zerocopy::AsBytes;
 
+use bindgen::sram_program::SRAM_MAGIC_SP_EXECUTION_DONE;
 use cert_lib::{parse_and_endorse_x509_cert, validate_cert_chain, CaConfig, CaKey, EndorsedCert};
 use ft_ext_lib::ft_ext;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::console::spi::SpiConsoleDevice;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
-use opentitanlib::test_utils::crashdump::{
-    read_alert_crashdump_data, read_cpu_crashdump_data, read_reset_reason,
-};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
 use opentitanlib::test_utils::load_sram_program::{
@@ -80,14 +77,12 @@ pub fn test_unlock(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn run_sram_ft_individualize(
     transport: &TransportWrapper,
     jtag_params: &JtagParams,
     reset_delay: Duration,
     sram_program: &SramProgramParams,
     timeout: Duration,
-    spi_console: &SpiConsoleDevice,
 ) -> Result<()> {
     // Set CPU TAP straps, reset, and connect to the JTAG interface.
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
@@ -99,9 +94,12 @@ pub fn run_sram_ft_individualize(
     jtag.reset(/*run=*/ false)?;
 
     // Load and execute the SRAM program that contains the provisioning code.
-    let result = sram_program.load_and_execute(&mut *jtag, ExecutionMode::Jump)?;
+    let result = sram_program.load_and_execute(&mut *jtag, ExecutionMode::JumpAndWait(timeout))?;
     match result {
-        ExecutionResult::Executing => log::info!("SRAM program loaded and is executing."),
+        ExecutionResult::ExecutionDone(sp_val) => match sp_val {
+            SRAM_MAGIC_SP_EXECUTION_DONE => log::info!("SRAM program completed."),
+            _ => panic!("SRAM program load/execution failed: sp = {:?}.", sp_val),
+        },
         _ => panic!("SRAM program load/execution failed: {:?}.", result),
     }
 
@@ -111,24 +109,7 @@ pub fn run_sram_ft_individualize(
     transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
     transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
 
-    // Wait for provisioning operations to complete. If we see at least 10 NMIs, we know it is time
-    // to capture crashdump information.
-    let console_text = UartConsole::wait_for(
-        spi_console,
-        r"FT SRAM provisioning done.|Processing Alert NMI 10 ...",
-        timeout,
-    )?;
-    match console_text[0].as_str() {
-        "FT SRAM provisioning done." => Ok(()),
-        "Processing Alert NMI 10 ..." => {
-            thread::sleep(Duration::from_millis(10000));
-            read_reset_reason(transport, jtag_params)?;
-            read_cpu_crashdump_data(transport, jtag_params)?;
-            read_alert_crashdump_data(transport, jtag_params)?;
-            Ok(())
-        }
-        _ => Err(anyhow!("Unexpected console_text: {:?}", console_text)),
-    }
+    Ok(())
 }
 
 pub fn test_exit(

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -129,9 +129,25 @@ pub fn test_exit(
     transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
     let mut jtag = jtag_params.create(transport)?.connect(JtagTap::LcTap)?;
 
-    // Check that LC state is currently `TEST_UNLOCKED1`.
-    let state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
-    assert_eq!(state, DifLcCtrlState::TestUnlocked1.redundant_encoding());
+    // Check that LC state is currently `TEST_UNLOCKED*`.
+    let state =
+        DifLcCtrlState::from_redundant_encoding(jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?)?;
+    match state {
+        DifLcCtrlState::TestUnlocked0
+        | DifLcCtrlState::TestUnlocked1
+        | DifLcCtrlState::TestUnlocked2
+        | DifLcCtrlState::TestUnlocked3
+        | DifLcCtrlState::TestUnlocked4
+        | DifLcCtrlState::TestUnlocked5
+        | DifLcCtrlState::TestUnlocked6
+        | DifLcCtrlState::TestUnlocked7 => {
+            log::info!("Starting test exit LC transition ...")
+        }
+        _ => panic!(
+            "Cannot perform test exit LC transition from {:x?} LC state.",
+            state
+        ),
+    }
 
     // ROM execution should now be enabled in OTP so we cannot safely reconnect to the LC TAP after
     // the transition without risking the chip resetting. Therefore, it is the responsibility of the


### PR DESCRIPTION
The OTTF console initialization requires a host--device handshake when using the SPI transport. This causes issues with ATE integration. This removes the OTTF console initialization, and all remaining `LOG_INFO()`s from the individualization firmware.

Additionally, this makes the FT test harness more flexible to enable performing a test exit operation from any TestUnlocked state.