### PR TITLE
[topgen] Remove ac_range_check key from top validate

### DIFF
--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -58,7 +58,6 @@ top_required = {
 }
 
 top_optional = {
-    'ac_range_check': ['g', 'Optional AC range configuration'],
     'alert_module':
     ['l', 'list of the modules that connects to alert_handler'],
     'datawidth': ['pn', "default data width"],


### PR DESCRIPTION
This key is superseded by using an ipgen_param in the top-level instantiation.