### PR TITLE
[darjeeling, plic] Fix plic_all_irqs_test path in dv

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1275,7 +1275,7 @@
     {
       name: chip_sw_sram_ctrl_scrambled_access
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["//sw/device/tests/sim_dv:sram_ctrl_scrambled_access_test:6:new_rules"]
+      sw_images: ["//sw/device/tests:sram_ctrl_scrambled_access_test:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=12_000_000", "+en_scb_tl_err_chk=0",
                  "+bypass_alert_ready_to_end_check=1"]

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1342,11 +1342,16 @@
       run_opts: ["+en_scb=0", "+en_scb_tl_err_chk=0"]
     }
     {
-      name: chip_plic_all_irqs
+      name: chip_plic_all_irqs_0
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/autogen/{top_chip}:plic_all_irqs_test:6:new_rules"]
+      sw_images: ["//hw/{top_chip}/sw/autogen/tests:plic_all_irqs_test_0:6:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_timeout_mins: 120
+    }
+    {
+      name: chip_plic_all_irqs_10
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//hw/{top_chip}/sw/autogen/tests:plic_all_irqs_test_10:6:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_plic_sw_irq


### PR DESCRIPTION
The sw image was moved to the hw folder as part of the multitop work.