### PR TITLE
[jtag,dv] Fix uvm_component_utils macro in jtag_riscv_driver

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -6,9 +6,11 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
 
   protected bit do_hard_reset;
 
-  `uvm_object_utils(jtag_riscv_driver)
+  `uvm_component_utils(jtag_riscv_driver)
 
-  `uvm_object_new
+  function new (string name="", uvm_component parent=null);
+    super.new(name, parent);
+  endfunction
 
   virtual task reset_signals();
     forever begin


### PR DESCRIPTION
We're deriving from uvm_driver, which is derived from uvm_component and needs the corresponding "utils" macro.

This was prompted by a lint warning from Verissimo.