### PR TITLE
[rv_plic, fpv] Removed the chunk of zero assignment

### DIFF
--- a/hw/ip/tlul/rtl/tlul_err.sv
+++ b/hw/ip/tlul/rtl/tlul_err.sv
@@ -86,10 +86,6 @@ module tlul_err import tlul_pkg::*; (
           fulldata_chk = 1'b0;
         end
       endcase
-    end else begin
-      addr_sz_chk  = 1'b0;
-      mask_chk     = 1'b0;
-      fulldata_chk = 1'b0;
     end
   end
 


### PR DESCRIPTION
Removed the unneccessary chunk of zero assignment code. The reason being that jasper concludes the default zero assignment code as undetectable because the zero assignment to the affected signals happening in two ways:
1) By default
2) If something unexpected happens (in an else or default case)