### PR TITLE
[dv,chip] Use uvm_object_param_utils in some chip environment files

### DIFF
--- a/hw/top_darjeeling/dv/env/chip_env_cfg.sv
+++ b/hw/top_darjeeling/dv/env/chip_env_cfg.sv
@@ -130,12 +130,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
   `uvm_object_new
 
-  `uvm_object_utils_begin(chip_env_cfg)
+  `uvm_object_param_utils_begin(chip_env_cfg#(RAL_T))
     `uvm_field_object(m_jtag_riscv_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(m_spi_host_agent_cfg,   UVM_DEFAULT)
     `uvm_field_object(jtag_dmi_ral,           UVM_DEFAULT)
     `uvm_field_object(debugger,               UVM_DEFAULT)
-  `uvm_object_utils_end
+  `uvm_object_param_utils_end
 
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_base_vseq.sv
@@ -10,7 +10,7 @@ class chip_base_vseq #(
   .COV_T              (chip_env_cov),
   .VIRTUAL_SEQUENCER_T(chip_virtual_sequencer)
 );
-  `uvm_object_utils(chip_base_vseq)
+  `uvm_object_param_utils(chip_base_vseq#(RAL_T))
 
   jtag_dmi_reg_block jtag_dmi_ral;
   chip_soc_dbg_reg_block chip_soc_dbg_ral;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -143,12 +143,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
   `uvm_object_new
 
-  `uvm_object_utils_begin(chip_env_cfg)
+  `uvm_object_param_utils_begin(chip_env_cfg#(RAL_T))
     `uvm_field_object(m_jtag_riscv_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(m_spi_host_agent_cfg,   UVM_DEFAULT)
     `uvm_field_object(jtag_dmi_ral,           UVM_DEFAULT)
     `uvm_field_object(debugger,               UVM_DEFAULT)
-  `uvm_object_utils_end
+  `uvm_object_param_utils_end
 
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -10,7 +10,7 @@ class chip_base_vseq #(
   .COV_T              (chip_env_cov),
   .VIRTUAL_SEQUENCER_T(chip_virtual_sequencer)
 );
-  `uvm_object_utils(chip_base_vseq)
+  `uvm_object_param_utils(chip_base_vseq#(RAL_T))
 
   jtag_dmi_reg_block jtag_dmi_ral;
 


### PR DESCRIPTION
Using the non-parameterised version causes lint errors from Verissimo, which this should fix.