### PR TITLE
[dv, cip_base_vseq] alert check fix on `check_fatal_alert_nonblocking`

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -986,7 +986,8 @@ class cip_base_vseq #(
       `DV_SPINWAIT_EXIT(
           forever begin
             // 1 extra cycle to make sure no race condition
-            repeat (alert_esc_agent_pkg::ALERT_B2B_DELAY + 1) begin
+            // Plus 2 extra cycles due to alert sampling delay of 2 cycles at the VIF
+            repeat (alert_esc_agent_pkg::ALERT_B2B_DELAY + 1 + 2) begin
               cfg.clk_rst_vif.wait_n_clks(1);
               if (cfg.m_alert_agent_cfgs[alert_name].vif.get_alert() == 1) break;
             end


### PR DESCRIPTION
Updating the existing check in `check_fatal_alert_nonblocking` to consider the extra two clock cycles introduced by the sampling delay at the VIF

This PR is meant to fix the AES failures found in the [nightly darjeeling run](https://nightly.reports.lowrisc.org/opentitan_nightly_darjeeling/2025_03_31/hw/ip/aes_unmasked/dv/latest/report.html)