### PR TITLE
[rom_ext] bump version to 0.105

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -7,7 +7,7 @@
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "104",
+    MINOR = "105",
     SECURITY = "0",
 )
 


### PR DESCRIPTION
ROM_EXT v0.104 binaries were signed and released in #26798. This updates the verion number to prepare for the next future release.