### PR TITLE
[ac_range_check,doc] Spec clarification

### DIFF
--- a/hw/ip_templates/ac_range_check/README.md
+++ b/hw/ip_templates/ac_range_check/README.md
@@ -65,9 +65,7 @@ See Priority of Matching for the priority based address matching.
 
 ## Priority of Matching
 
-If a request matches multiple ranges with conflicting permissions, the following priority shall be enforced:
-
-* If multiple ranges allow the operation, the first matching range (based on register configuration order) shall determine the access rights.
+If a request matches multiple enabled ranges with conflicting permissions, the lowest-index enabled range determines the permissions that apply to the request.
 
 ## Error Logging and Interrupt Mechanism
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/README.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/README.md
@@ -65,9 +65,7 @@ See Priority of Matching for the priority based address matching.
 
 ## Priority of Matching
 
-If a request matches multiple ranges with conflicting permissions, the following priority shall be enforced:
-
-* If multiple ranges allow the operation, the first matching range (based on register configuration order) shall determine the access rights.
+If a request matches multiple enabled ranges with conflicting permissions, the lowest-index enabled range determines the permissions that apply to the request.
 
 ## Error Logging and Interrupt Mechanism
 


### PR DESCRIPTION
- This is linked to this issue: #26572. The paragraph related to the priority of matching in case of conflicting permissions, have been clarified.