### PR TITLE
[hmac,dv] Add more seeds to ensure CCov

### DIFF
--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -144,13 +144,13 @@
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all
-      reseed: 25
+      reseed: 50
     }
 
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all_with_rand_reset
-      reseed: 25
+      reseed: 35
     }
 
     {


### PR DESCRIPTION
- A regression was showing few ccov holes, and I've noticed from a previous regression results that these holes were actually covered by hmac_stress_all or by hmac_stress_all_with_rand_reset tests.