### PR TITLE
[fusesoc,flash_ctrl] Move top-specific items out of flash_ctrl_pkg

### DIFF
--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent.core
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
-      - lowrisc:virtual_ip:flash_ctrl_pkg
+      - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg
     files:
       - flash_phy_prim_if.sv
       - flash_phy_prim_agent_pkg.sv

--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent_pkg.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_agent_pkg.sv
@@ -7,7 +7,7 @@ package flash_phy_prim_agent_pkg;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/ip/flash_ctrl/flash_ctrl_pkg.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:flash_ctrl_pkg:0.1"
+description: "Generic flash package"
+
+filesets:
+  files_rtl:
+    files:
+      - rtl/flash_ctrl_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash Controller generic package.
+// This has no top-specific items so it is okay to use by generic IPs.
+
+package flash_ctrl_pkg;
+  // Parameters for keymgr.
+  parameter int NumSeeds = 2;
+  parameter bit [0:0] CreatorSeedIdx = 0;
+  parameter bit [0:0] OwnerSeedIdx = 1;
+  parameter int SeedWidth = 256;
+  parameter int KeyWidth  = 128;
+  typedef logic [KeyWidth-1:0] flash_key_t;
+
+  // flash_ctrl to keymgr
+  typedef struct packed {
+    logic [NumSeeds-1:0][SeedWidth-1:0] seeds;
+  } keymgr_flash_t;
+
+  parameter keymgr_flash_t KEYMGR_FLASH_DEFAULT = '{
+    seeds: '{
+     256'h9152e32c9380a4bcc3e0ab263581e6b0e8825186e1e445631646e8bef8c45d47,
+     256'hfa365df52da48cd752fb3a026a8e608f0098cfe5fa9810494829d0cd9479eb78
+    }
+  };
+
+endpackage : flash_ctrl_pkg

--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -18,7 +18,7 @@ filesets:
       - lowrisc:prim:sec_anchor
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
-      - lowrisc:virtual_ip:flash_ctrl_pkg
+      - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:kmac_pkg
       - lowrisc:ip:otp_ctrl_pkg

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:prim:ram_1p
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
-      - lowrisc:virtual_ip:flash_ctrl_pkg
+      - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg
       - lowrisc:virtual_ip:flash_ctrl_prim_reg_top
     files:
       - rtl/prim_generic_flash_bank.sv

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -52,8 +52,8 @@ module prim_generic_flash #(
   assign init_busy_o = |init_busy;
 
   // this represents the type of program operations that are supported
-  assign prog_type_avail_o[flash_ctrl_pkg::FlashProgNormal] = 1'b1;
-  assign prog_type_avail_o[flash_ctrl_pkg::FlashProgRepair] = 1'b1;
+  assign prog_type_avail_o[flash_ctrl_top_specific_pkg::FlashProgNormal] = 1'b1;
+  assign prog_type_avail_o[flash_ctrl_top_specific_pkg::FlashProgRepair] = 1'b1;
 
   for (genvar bank = 0; bank < NumBanks; bank++) begin : gen_prim_flash_banks
 

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -448,7 +448,9 @@ module prim_generic_flash_bank #(
   end
 
   assign rd_data_info = rd_nom_data_info[info_sel_q];
-  assign rd_data_d    = rd_part_q == flash_ctrl_top_specific_pkg::FlashPartData ? rd_data_main : rd_data_info;
+  assign rd_data_d    = rd_part_q == flash_ctrl_top_specific_pkg::FlashPartData
+                                         ? rd_data_main
+                                         : rd_data_info;
 
   flash_ctrl_top_specific_pkg::flash_prog_e unused_prog_type;
   assign unused_prog_type = cmd_q.prog_type;

--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -419,19 +419,19 @@
     },
     { name:      "RndCnstAllSeeds",
       desc:      "Compile-time random bits for default seeds",
-      type:      "flash_ctrl_pkg::all_seeds_t"
+      type:      "flash_ctrl_top_specific_pkg::all_seeds_t"
       randcount: "512",
       randtype:  "data", // randomize randcount databits
     },
     { name:      "RndCnstLfsrSeed",
       desc:      "Compile-time random bits for initial LFSR seed",
-      type:      "flash_ctrl_pkg::lfsr_seed_t"
+      type:      "flash_ctrl_top_specific_pkg::lfsr_seed_t"
       randcount: "32",
       randtype:  "data",
     },
     { name:      "RndCnstLfsrPerm",
       desc:      "Compile-time random permutation for LFSR output",
-      type:      "flash_ctrl_pkg::lfsr_perm_t"
+      type:      "flash_ctrl_top_specific_pkg::lfsr_perm_t"
       randcount: "32",
       randtype:  "perm",
     },

--- a/hw/ip_templates/flash_ctrl/dv/README.md.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/README.md.tpl
@@ -191,7 +191,7 @@ typedef struct packed {
     uint             num_words;   // number of words to read or program (TL_DW)
     addr_t           addr;        // starting addr for the op
     // addres for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_pkg::BusAddrByteW-2:0] otf_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
 ```

--- a/hw/ip_templates/flash_ctrl/dv/cov/flash_ctrl_phy_cov_if.sv
+++ b/hw/ip_templates/flash_ctrl/dv/cov/flash_ctrl_phy_cov_if.sv
@@ -4,7 +4,7 @@
 //
 // Sampling physical interface of the flash
 // tb.dut.u_eflash.u_flash
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 interface flash_ctrl_phy_cov_if
 (
   input logic        clk_i,

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core.tpl
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_prince:0.1
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
-      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg")}
       - lowrisc:dv:mem_bkdr_util
     files:
       - flash_ctrl_bkdr_util_pkg.sv

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_dv_if.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_dv_if.sv
@@ -6,7 +6,7 @@ interface flash_ctrl_dv_if (
   input logic rst_ni
 );
 
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import lc_ctrl_pkg::*;
 
   logic       rd_buf_en;

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.core.tpl
@@ -14,7 +14,7 @@ filesets:
       - ${instance_vlnv("lowrisc:dv:flash_ctrl_bkdr_util")}
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
-      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg")}
       - ${instance_vlnv("lowrisc:constants:top_pkg")}
     files:
       - flash_ctrl_eflash_ral_pkg.sv

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -67,7 +67,7 @@ class flash_ctrl_env #(
     end
 
     if (cfg.scb_otf_en) begin
-      for (int i = 0; i < flash_ctrl_pkg::NumBanks; ++i) begin
+      for (int i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; ++i) begin
         virtual_sequencer.eg_exp_ctrl_port[i].connect(
                 m_otf_scb.eg_exp_ctrl_fifo[i].analysis_export);
         virtual_sequencer.eg_exp_host_port[i].connect(

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -834,7 +834,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction
 
   // Task for clean scb memory
-  virtual function reset_scb_mem();
+  virtual function void reset_scb_mem();
     scb_flash_data.delete();
     scb_flash_info.delete();
     scb_flash_info1.delete();
@@ -842,9 +842,9 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction : reset_scb_mem
 
   // Task for set scb memory
-  virtual function set_scb_mem(int bkd_num_words, flash_dv_part_e bkd_partition,
-                               addr_t write_bkd_addr,flash_scb_wr_e val_type,
-                               data_b_t custom_val = {});
+  virtual function void set_scb_mem(int bkd_num_words, flash_dv_part_e bkd_partition,
+                                    addr_t write_bkd_addr,flash_scb_wr_e val_type,
+                                    data_b_t custom_val = {});
     addr_t wr_bkd_addr;
     data_t wr_value;
 
@@ -1172,7 +1172,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   function flash_dv_part_e get_part(flash_part_e part,
                                     logic [InfoTypesWidth-1:0] mem_info_sel);
-    if (part == FlashPartData) begin
+    if (part == flash_ctrl_top_specific_pkg::FlashPartData) begin
       return FlashPartData;
     end else begin
       case (mem_info_sel)

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -106,7 +106,7 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
     key_instr_cross : cross key_cp, instr_type_cp;
   endgroup // fetch_code_cg
 
-  covergroup rma_init_cg with function sample(flash_ctrl_pkg::rma_state_e st);
+  covergroup rma_init_cg with function sample(flash_ctrl_top_specific_pkg::rma_state_e st);
     rma_start_cp: coverpoint st {
       bins rma_st[2] = {StRmaIdle, [StRmaPageSel:StRmaInvalid]};
     }

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -12,7 +12,7 @@ package flash_ctrl_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_core_ral_pkg::*;
   import flash_ctrl_eflash_ral_pkg::*;
   import flash_ctrl_prim_ral_pkg::*;
@@ -48,9 +48,10 @@ package flash_ctrl_env_pkg;
   };
 
   parameter uint NUM_ALERTS = 5;
-  parameter uint FlashNumPages = flash_ctrl_pkg::NumBanks * flash_ctrl_pkg::PagesPerBank;
-  parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_pkg::WordsPerPage *
-                                  flash_ctrl_pkg::DataWidth / 8;
+  parameter uint FlashNumPages = flash_ctrl_top_specific_pkg::NumBanks *
+                                 flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_top_specific_pkg::WordsPerPage *
+                                  flash_ctrl_top_specific_pkg::DataWidth / 8;
 
   parameter uint ProgFifoDepth = 4;
   parameter uint ReadFifoDepth = 16;
@@ -59,31 +60,33 @@ package flash_ctrl_env_pkg;
   parameter uint BytesPerPage = FlashSizeBytes / FlashNumPages;
 
   // Num of bytes in each of the flash banks for each of the flash partitions.
-  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_pkg::NumBanks;
+  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_top_specific_pkg::NumBanks;
 
-  parameter uint InfoTypeBytes[flash_ctrl_pkg::InfoTypes] = '{
-      flash_ctrl_pkg::InfoTypeSize[0] * BytesPerPage,
-      flash_ctrl_pkg::InfoTypeSize[1] * BytesPerPage,
-      flash_ctrl_pkg::InfoTypeSize[2] * BytesPerPage
+  parameter uint InfoTypeBytes[flash_ctrl_top_specific_pkg::InfoTypes] = '{
+      flash_ctrl_top_specific_pkg::InfoTypeSize[0] * BytesPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[1] * BytesPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[2] * BytesPerPage
   };
 
   parameter uint FlashNumBusWords = FlashSizeBytes / top_pkg::TL_DBW;
-  parameter uint FlashNumBusWordsPerBank = FlashNumBusWords / flash_ctrl_pkg::NumBanks;
-  parameter uint FlashNumBusWordsPerPage = FlashNumBusWordsPerBank / flash_ctrl_pkg::PagesPerBank;
+  parameter uint FlashNumBusWordsPerBank = FlashNumBusWords /
+                                           flash_ctrl_top_specific_pkg::NumBanks;
+  parameter uint FlashNumBusWordsPerPage = FlashNumBusWordsPerBank /
+                                           flash_ctrl_top_specific_pkg::PagesPerBank;
 
-  parameter uint InfoTypeBusWords[flash_ctrl_pkg::InfoTypes] = '{
-      flash_ctrl_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
-      flash_ctrl_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
-      flash_ctrl_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
+  parameter uint InfoTypeBusWords[flash_ctrl_top_specific_pkg::InfoTypes] = '{
+      flash_ctrl_top_specific_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
   };
 
-  parameter uint FlashBankBytesPerWord = flash_ctrl_pkg::DataWidth / 8;
+  parameter uint FlashBankBytesPerWord = flash_ctrl_top_specific_pkg::DataWidth / 8;
 
   parameter uint FlashDataByteWidth = $clog2(FlashBankBytesPerWord);
-  parameter uint FlashWordLineWidth = $clog2(flash_ctrl_pkg::WordsPerPage);
-  parameter uint FlashPageWidth = $clog2(flash_ctrl_pkg::PagesPerBank);
-  parameter uint FlashBankWidth = $clog2(flash_ctrl_pkg::NumBanks);
-  parameter uint FlashPgmRes = flash_ctrl_pkg::BusPgmRes;
+  parameter uint FlashWordLineWidth = $clog2(flash_ctrl_top_specific_pkg::WordsPerPage);
+  parameter uint FlashPageWidth = $clog2(flash_ctrl_top_specific_pkg::PagesPerBank);
+  parameter uint FlashBankWidth = $clog2(flash_ctrl_top_specific_pkg::NumBanks);
+  parameter uint FlashPgmRes = flash_ctrl_top_specific_pkg::BusPgmRes;
   parameter uint FlashPgmResWidth = $clog2(FlashPgmRes);
 
   parameter uint FlashMemAddrWordMsbBit = FlashDataByteWidth - 1;
@@ -99,10 +102,10 @@ package flash_ctrl_env_pkg;
   parameter uint NUM_BK_INFO_WORDS = InfoTypeBusWords[0];  // 10 pages
 
   // params for num of pages
-  parameter uint NUM_PAGE_PART_DATA = flash_ctrl_pkg::PagesPerBank;
-  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_pkg::InfoTypeSize[0];
-  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_pkg::InfoTypeSize[1];
-  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_pkg::InfoTypeSize[2];
+  parameter uint NUM_PAGE_PART_DATA = flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_top_specific_pkg::InfoTypeSize[0];
+  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_top_specific_pkg::InfoTypeSize[1];
+  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_top_specific_pkg::InfoTypeSize[2];
 
   parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
       data_ack: 1'b1,
@@ -214,7 +217,8 @@ package flash_ctrl_env_pkg;
   } flash_mem_init_e;
 
   // Partition select for DV
-  typedef enum logic [flash_ctrl_pkg::InfoTypes:0] {  // Data partition and all info partitions
+  // Data partition and all info partitions
+  typedef enum logic [flash_ctrl_top_specific_pkg::InfoTypes:0] {
     FlashPartData  = 0,
     FlashPartInfo  = 1,
     FlashPartInfo1 = 2,
@@ -300,7 +304,7 @@ package flash_ctrl_env_pkg;
   // Useful for the flash model.
   typedef data_t data_model_t[addr_t];
   // Otf address in a bank.
-  typedef bit [flash_ctrl_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
+  typedef bit [flash_ctrl_top_specific_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
 
   typedef struct packed {
     flash_dv_part_e  partition;   // data or one of the info partitions
@@ -310,7 +314,7 @@ package flash_ctrl_env_pkg;
     uint             num_words;   // number of words to read or program (TL_DW)
     addr_t           addr;        // starting addr for the op
     // address for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_pkg::BusAddrByteW-2:0] otf_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
   // Address combined with region
@@ -331,7 +335,8 @@ package flash_ctrl_env_pkg;
   parameter uint RMA_FSM_STATE_ST_RMA_RSP = 11'b10110001010;
 
   // Indicate host read
-  parameter int unsigned OTFBankId = flash_ctrl_pkg::BusAddrByteW - FlashBankWidth; // bit19
+  parameter int unsigned OTFBankId = flash_ctrl_top_specific_pkg::BusAddrByteW - // bit 19
+                                     FlashBankWidth;
   parameter int unsigned OTFHostId = OTFBankId - 1; // bit 18
   parameter int unsigned DVPageMSB = 18;
   parameter int unsigned DVPageLSB = 11;
@@ -348,7 +353,7 @@ package flash_ctrl_env_pkg;
   localparam int unsigned FlashAddrWidth = 16;
 
   // remove bank select
-  localparam int unsigned FlashByteAddrWidth = flash_ctrl_pkg::BusAddrByteW - 1;
+  localparam int unsigned FlashByteAddrWidth = flash_ctrl_top_specific_pkg::BusAddrByteW - 1;
 
   function automatic bit[63:0] create_flash_data(
            bit [FlashDataWidth-1:0] data, bit [FlashByteAddrWidth-1:0] byte_addr,

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -10,7 +10,7 @@ interface flash_ctrl_if (
 
   import lc_ctrl_pkg::*;
   import pwrmgr_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_phy_pkg::*;
   import otp_ctrl_pkg::*;
   import ast_pkg::*;
@@ -47,10 +47,10 @@ interface flash_ctrl_if (
   logic                             power_ready_h = 1'b1;
 
   // eviction
-  logic [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
-  rd_buf_t [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
-  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_prog;
-  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_erase;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
+  rd_buf_t [flash_ctrl_top_specific_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0]             evict_prog;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0]             evict_erase;
   logic                                            fatal_err;
 
   // rma coverage

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 interface flash_ctrl_mem_if (
   input logic clk_i,
   input logic rst_ni,

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -430,7 +430,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                 rcv.mem_info_sel = cfg.flash_ctrl_mem_vif[bank].mem_info_sel;
                 @(negedge cfg.flash_ctrl_mem_vif[bank].clk_i);
                 if (cfg.seq_cfg.use_vendor_flash == 0) begin
-                  if (rcv.mem_part == FlashPartData) begin
+                  if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
                     `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].data_mem_req, 1,,, name)
                   end else begin
                     case (rcv.mem_info_sel)
@@ -498,7 +498,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
           `DV_CHECK_EQ(rcv.mem_wdata, {flash_phy_pkg::FullDataWidth{1'b1}},,, name)
 
 
-          if (rcv.mem_part == FlashPartData) begin
+          if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
             data_mem[bank].delete(rcv.mem_addr);
           end else begin
             info_mem[bank][rcv.mem_info_sel].delete(rcv.mem_addr);
@@ -519,7 +519,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       end
 
       // Data will be corrupted if some bits to be written cannot be flipped to 1.
-      if (rcv.mem_part == FlashPartData) begin
+      if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
         if (data_mem[bank].exists(rcv.mem_addr)) begin
           rd_data = data_mem[bank][rcv.mem_addr];
           if ((exp.req.prog_full_data & rd_data) != exp.req.prog_full_data) begin

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -182,7 +182,7 @@ class flash_ctrl_scoreboard #(
 
     flash_read.partition  = FlashPartData;
     flash_read.erase_type = FlashErasePage;
-    flash_read.op         = flash_ctrl_pkg::FlashOpRead;
+    flash_read.op         = flash_ctrl_top_specific_pkg::FlashOpRead;
     flash_read.num_words  = 1;
     flash_read.addr       = trans.a_addr;
 
@@ -423,7 +423,7 @@ class flash_ctrl_scoreboard #(
       if (part_sel == 1 || part == FlashPartData) begin
         for (int j = 0; j < partition_words_num; j++) begin
           scb_flash_model[addr_attr.addr] = ALL_ONES;
-          addr_attr.incr(flash_ctrl_pkg::BusBytes);
+          addr_attr.incr(flash_ctrl_top_specific_pkg::BusBytes);
         end
         case (part)
           FlashPartData: cfg.scb_flash_data = scb_flash_model;

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -19,11 +19,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   // Weights for enable bits for each of the flash banks information partitions memory protection
   //  configuration registers.
-  uint mp_info_page_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                         [flash_ctrl_top_specific_pkg::InfoTypes];
 
   // When this knob is NOT FlashOpInvalid (default) the selected operation will be the only
   //  operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
-  flash_ctrl_pkg::flash_op_e flash_only_op;
+  flash_ctrl_top_specific_pkg::flash_op_e flash_only_op;
 
   // Weights to enable read / program and erase for each mem region.
   uint mp_region_en_pc;
@@ -49,12 +50,18 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Weights to enable read / program and erase for each information partition page.
   // For each of the information partitions in each of the banks there is a single variable to
   //  control all of this partition pages.
-  uint mp_info_page_read_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_program_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_erase_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_scramble_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_ecc_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_he_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_read_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                              [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_program_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                                 [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_erase_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                               [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_scramble_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                                  [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_ecc_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                            [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_he_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                            [flash_ctrl_top_specific_pkg::InfoTypes];
 
   // Control the number of flash ops.
   uint max_flash_ops_per_cfg;
@@ -183,7 +190,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   virtual function void configure();
     max_num_trans                 = 20;
 
-    num_en_mp_regions             = flash_ctrl_pkg::MpRegions;
+    num_en_mp_regions             = flash_ctrl_top_specific_pkg::MpRegions;
 
     allow_mp_region_overlap       = 1'b0;
 

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_otf_item.sv
@@ -7,9 +7,9 @@ class flash_otf_item extends uvm_object;
   flash_op_t cmd;
   data_q_t   dq;
   fdata_q_t  raw_fq, fq;
-  bit[flash_ctrl_pkg::BusAddrByteW-1:0] start_addr;
+  bit[flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr;
   bit[flash_phy_pkg::KeySize-1:0]      addr_key, data_key;
-  bit [flash_ctrl_pkg::BusAddrByteW-2:0] mem_addr;
+  bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] mem_addr;
   bit                                    head_pad, tail_pad;
   bit                                    scr_en, ecc_en;
   int                                    page;
@@ -115,7 +115,7 @@ class flash_otf_item extends uvm_object;
   // Use 'create_flash_data' function from package
   function void scramble(bit [flash_phy_pkg::KeySize-1:0] addr_key,
                          bit [flash_phy_pkg::KeySize-1:0] data_key,
-                         bit [flash_ctrl_pkg::BusAddrByteW-2:0] addr,
+                         bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] addr,
                          bit dis = 1,
                          bit add_icv_err = 0);
     bit [FlashDataWidth-1:0] data;
@@ -173,7 +173,7 @@ class flash_otf_item extends uvm_object;
     prim_secded_pkg::secded_hamming_76_68_t dec68;
     bit [flash_phy_pkg::FullDataWidth-1:0] data; // 76 bits
     bit [71:0]               data_with_icv;
-    bit[flash_ctrl_pkg::BusAddrByteW-2:0] addr = mem_addr;
+    bit[flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] addr = mem_addr;
     data_q_t   tmp_dq;
 
     ecc_err = 'h0;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -418,7 +418,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   endtask : flash_ctrl_mp_info_page_cfg
 
   // Configure bank erasability.
-  virtual task flash_ctrl_bank_erase_cfg(bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en);
+  virtual task flash_ctrl_bank_erase_cfg(
+      bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en);
     csr_wr(.ptr(ral.mp_bank_cfg_shadowed[0]), .value(bank_erase_en));
   endtask : flash_ctrl_bank_erase_cfg
 
@@ -1621,8 +1622,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       // Only scr/ecc enable matter; cfg.ovrd_src_dis can be randomized in directed test,
       // but otherwise it has the same default value as HW_INFO_CFG_OVERRIDE.
       if (page != 3) begin
-        scramble_en = prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
-                                                  mubi4_t'(~cfg.ovrd_scr_dis));
+        scramble_en = prim_mubi_pkg::mubi4_and_hi(
+            flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en, mubi4_t'(~cfg.ovrd_scr_dis));
         ecc_en = prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                              mubi4_t'(~cfg.ovrd_ecc_dis));
       end else begin

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -112,7 +112,8 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                          [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -47,15 +47,15 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
-    flash_op.op == flash_ctrl_pkg::FlashOpErase;
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase;
 
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -63,12 +63,12 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -112,13 +112,13 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
 
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
 
@@ -163,7 +163,7 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -265,7 +265,7 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
                      flash_op.partition != flash_op_erase.partition ||
                      flash_op.addr[FlashMemAddrBankMsbBit-:(FlashBankWidth+FlashPageWidth)] !=
                      flash_op_erase.addr[FlashMemAddrBankMsbBit-:(FlashBankWidth+FlashPageWidth)];
-                     if (flash_op_erase.erase_type == flash_ctrl_pkg::FlashEraseBank) {
+                     if (flash_op_erase.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank) {
                        flash_op.addr[FlashMemAddrBankMsbBit] !=
                        flash_op_erase.addr[FlashMemAddrBankMsbBit];
                      })

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -36,7 +36,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Copies of the MP Region Settings (Data and Info Partitions)
   flash_mp_region_cfg_t mp_data_regions[flash_ctrl_top_specific_pkg::MpRegions];
   flash_bank_mp_info_page_cfg_t
-    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks]
+                   [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   // Constraint for Bank.
   constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
@@ -61,18 +62,23 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
      flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info2_partition) {
-      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
+      if (flash_op.partition == FlashPartInfo2) {
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      }
     }
 
-    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                        flash_ctrl_top_specific_pkg::FlashOpProgram,
                         flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
@@ -88,7 +94,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -145,7 +152,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                 [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
@@ -457,7 +465,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       unique case (flash_op.op)
         flash_ctrl_top_specific_pkg::FlashOpErase : begin
           // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
+          if ((info_part == 0) &&
+              (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
             rsp = MP_PASS;
           else
             rsp = (mp_info_regions[info_bank][info_part][info_page].erase_en == MuBi4False);
@@ -490,7 +499,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       en_msg = (mp_data_regions[i].en == MuBi4True) ? "Enabled": "Disabled";
       `uvm_info(`gfn,
         $sformatf("MPR%0d : From : 0x%03x, To : 0x%03x : From : 0x%08x, To : 0x%08x, %s", i,
-          mp_data_regions[i].start_page, mp_data_regions[i].start_page+mp_data_regions[i].num_pages,
+          mp_data_regions[i].start_page,
+          mp_data_regions[i].start_page+mp_data_regions[i].num_pages,
             mp_data_regions[i].start_page*(FullPageNumWords*4),
               (mp_data_regions[i].start_page+mp_data_regions[i].num_pages)*(FullPageNumWords*4),
                 en_msg), UVM_MEDIUM)

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -34,12 +34,12 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   uint            erase_err_cnt = 0;
 
   // Copies of the MP Region Settings (Data and Info Partitions)
-  flash_mp_region_cfg_t mp_data_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_data_regions[flash_ctrl_top_specific_pkg::MpRegions];
   flash_bank_mp_info_page_cfg_t
-    mp_info_regions[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   // Constraint for Bank.
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in the relevant range for
   // the selected partition.
@@ -58,26 +58,26 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Bank Erase is only supported for Data & 1st Info Partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-     flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info2_partition) {
-      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_pkg::FlashOpRead;}
+      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
     }
 
-    flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram,
-                        flash_ctrl_pkg::FlashOpErase};
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+                        flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -88,14 +88,14 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
     }
   }
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
 
@@ -145,13 +145,13 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].scramble_en == MuBi4False;
         mp_info_pages[i][j][k].ecc_en      == MuBi4False;
         mp_info_pages[i][j][k].he_en dist {
@@ -170,7 +170,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   rand mubi4_t default_region_he_en;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -232,7 +232,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
       // Initialise Flash Content
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
       end else begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
@@ -245,7 +245,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       case (flash_op.op)
 
         // ERASE
-        flash_ctrl_pkg::FlashOpErase : begin
+        flash_ctrl_top_specific_pkg::FlashOpErase : begin
           `uvm_info(`gfn, $sformatf("Flash : ERASE exp_alert:%0d", exp_alert), UVM_LOW)
           flash_ctrl_start_op(flash_op);
           wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.erase_timeout_ns));
@@ -256,7 +256,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
         end
 
         // PROGRAM
-        flash_ctrl_pkg::FlashOpProgram : begin
+        flash_ctrl_top_specific_pkg::FlashOpProgram : begin
           `uvm_info(`gfn, $sformatf("Flash : PROGRAM exp_alert:%0d", exp_alert), UVM_LOW)
           exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
           flash_ctrl_start_op(flash_op);
@@ -269,7 +269,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
         end
 
         // READ
-        flash_ctrl_pkg::FlashOpRead : begin
+        flash_ctrl_top_specific_pkg::FlashOpRead : begin
           `uvm_info(`gfn, $sformatf("Flash : READ exp_alert:%0d", exp_alert), UVM_LOW)
           flash_op_data.delete();
           flash_ctrl_start_op(flash_op);
@@ -384,9 +384,9 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Assign op_msg to Op Type (used below)
     unique case (flash_op.op)
-      flash_ctrl_pkg::FlashOpErase   : op_msg = "Erase";
-      flash_ctrl_pkg::FlashOpProgram : op_msg = "Program";
-      flash_ctrl_pkg::FlashOpRead    : op_msg = "Read";
+      flash_ctrl_top_specific_pkg::FlashOpErase   : op_msg = "Erase";
+      flash_ctrl_top_specific_pkg::FlashOpProgram : op_msg = "Program";
+      flash_ctrl_top_specific_pkg::FlashOpRead    : op_msg = "Read";
       default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
     endcase
 
@@ -401,16 +401,16 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
           UVM_MEDIUM)
         if (mp_data_regions[i].en == MuBi4True) begin
           unique case (flash_op.op)
-            flash_ctrl_pkg::FlashOpErase : begin
+            flash_ctrl_top_specific_pkg::FlashOpErase : begin
               // Bank Erase Defeats the MP Settings
-              if (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank)
+              if (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank)
                 rsp_vec[i] = MP_PASS;
               else
                 rsp_vec[i] = (mp_data_regions[i].erase_en == MuBi4False);
             end
-            flash_ctrl_pkg::FlashOpProgram : rsp_vec[i] =
+            flash_ctrl_top_specific_pkg::FlashOpProgram : rsp_vec[i] =
               (mp_data_regions[i].program_en == MuBi4False);
-            flash_ctrl_pkg::FlashOpRead : rsp_vec[i] =
+            flash_ctrl_top_specific_pkg::FlashOpRead : rsp_vec[i] =
               (mp_data_regions[i].read_en == MuBi4False);
             default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
           endcase
@@ -455,16 +455,16 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     // Look for MP Area Violations
     if (mp_info_regions[info_bank][info_part][info_page].en == MuBi4True) begin
       unique case (flash_op.op)
-        flash_ctrl_pkg::FlashOpErase : begin
+        flash_ctrl_top_specific_pkg::FlashOpErase : begin
           // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank))
+          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
             rsp = MP_PASS;
           else
             rsp = (mp_info_regions[info_bank][info_part][info_page].erase_en == MuBi4False);
         end
-        flash_ctrl_pkg::FlashOpProgram :
+        flash_ctrl_top_specific_pkg::FlashOpProgram :
           rsp = (mp_info_regions[info_bank][info_part][info_page].program_en == MuBi4False);
-        flash_ctrl_pkg::FlashOpRead :
+        flash_ctrl_top_specific_pkg::FlashOpRead :
           rsp = (mp_info_regions[info_bank][info_part][info_page].read_en == MuBi4False);
         default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
       endcase
@@ -472,8 +472,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     else
     begin
       // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-      if ((info_part == 0) && (flash_op.op == flash_ctrl_pkg::FlashOpErase) &&
-          (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank))
+      if ((info_part == 0) && (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase) &&
+          (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
         rsp = MP_PASS;
       else
         rsp = MP_VIOLATION;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -47,8 +47,8 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for the Flash Operation
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
-    flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Use only Flash Program
+    flash_op.partition == FlashPartData;  // Use only Data Partitions
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -37,7 +37,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
   constraint y_max_c { y_max inside {[16:32]}; }  // Inner Loop - Num Transactions
 
   // Constraint for Bank.
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in relevant range the for the selected partition.
   constraint addr_c {
@@ -47,7 +47,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for the Flash Operation
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;  // Only Flash Program Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
     flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -62,7 +62,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
     flash_op_data.size() == flash_op.num_words;
   }
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
 
@@ -99,13 +99,13 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -128,7 +128,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
   rand mubi4_t default_region_ecc_en;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
@@ -46,7 +46,7 @@ class flash_ctrl_error_prog_win_vseq extends flash_ctrl_fetch_code_vseq;
   // Constraint for the Flash Operation
   constraint flash_op_c {
 
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;  // Only Flash Program Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
     flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
@@ -46,8 +46,8 @@ class flash_ctrl_error_prog_win_vseq extends flash_ctrl_fetch_code_vseq;
   // Constraint for the Flash Operation
   constraint flash_op_c {
 
-    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
-    flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Use only Flash Program
+    flash_op.partition == FlashPartData;  // Use only Data Partitions
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -67,16 +67,21 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
+    if (flash_op.partition == FlashPartInfo2) {
+      flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+    }
 
-    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                        flash_ctrl_top_specific_pkg::FlashOpProgram,
                         flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
@@ -93,7 +98,8 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {
+        flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -142,7 +148,8 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                 [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -48,7 +48,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     };
   }
 
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
@@ -64,24 +64,24 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   constraint flash_op_c {
     // Bank Erase is only supported for Data & 1st Info Partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_pkg::FlashOpRead;}
+    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
 
-    flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram,
-                        flash_ctrl_pkg::FlashOpErase};
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+                        flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
-     flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+     flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words >= 10;
@@ -93,7 +93,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -101,12 +101,12 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   // Memory Protection Regions
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -142,13 +142,13 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -172,7 +172,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en = MuBi4False;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -27,7 +27,8 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                          [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -23,16 +23,16 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   addr_t bank_start_addr;
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -56,7 +56,7 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {
@@ -111,8 +111,8 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
 
     flash_op_sw_rw.partition  = FlashPartData;
-    flash_op_sw_rw.erase_type = flash_ctrl_pkg::FlashEraseBank;
-    flash_op_sw_rw.op         = flash_ctrl_pkg::FlashOpProgram;
+    flash_op_sw_rw.erase_type = flash_ctrl_top_specific_pkg::FlashEraseBank;
+    flash_op_sw_rw.op         = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op_sw_rw.num_words  = 16;
     flash_op_sw_rw.addr       = bank_start_addr;
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
@@ -123,7 +123,7 @@ class flash_ctrl_host_ctrl_arb_vseq extends flash_ctrl_fetch_code_vseq;
     if (op_cnt <= apply_rma) begin
       // Initialise Flash Content
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
       end else begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
@@ -34,7 +34,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
   }
 
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.partition == FlashPartData;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -172,7 +172,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller read data
     flash_ctrl_start_op(flash_op);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -40,19 +40,19 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
     // ERASE
 
     `uvm_info(`gfn, "ERASE", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpErase, ReadCheckNorm);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     // PROGRAM
 
     `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpProgram, ReadCheckNorm);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
     `uvm_info(`gfn, "READ", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckNorm);
 
     // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
     fork
@@ -132,7 +132,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
 
     `uvm_info(`gfn, "READ", UVM_LOW)
 
-    do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckRand);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckRand);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
   endtask : body

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -4,8 +4,6 @@
 
 // flash_ctrl_hw_rma Test
 
-import lc_ctrl_pkg::*;
-
 class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
   `uvm_object_utils(flash_ctrl_hw_rma_err_vseq)
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -61,8 +61,9 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
                        cfg.seq_cfg.state_wait_timeout_ns)
           // Give more cycles for long stages
           // to trigger reset in the middle of the state.
-          if (reset_state_index inside {StRmaRdVerify, StRmaErase}) cfg.clk_rst_vif.wait_clks(10);
-
+          if (reset_state_index inside {DVStRmaRdVerify, DVStRmaErase}) begin
+            cfg.clk_rst_vif.wait_clks(10);
+          end
           if (flash_dis) begin
             `uvm_info("Test", "set disable_flash", UVM_MEDIUM)
             cfg.scb_h.do_alert_check = 0;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -91,19 +91,19 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
       // ERASE
 
       `uvm_info(`gfn, "ERASE", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpErase, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // PROGRAM
 
       `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpProgram, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
       `uvm_info(`gfn, "READ", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckNorm);
 
       // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
       fork
@@ -167,7 +167,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
       `uvm_info(`gfn, "READ", UVM_LOW)
 
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckRand);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckRand);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     end
@@ -178,8 +178,8 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
     // DATA PARTITION
 
-    flash_mp_region_cfg_t mp_regions [flash_ctrl_pkg::MpRegions];
-    bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+    flash_mp_region_cfg_t mp_regions [flash_ctrl_top_specific_pkg::MpRegions];
+    bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
     mubi4_t default_region_read_en;
     mubi4_t default_region_program_en;
     mubi4_t default_region_erase_en;
@@ -263,7 +263,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     `uvm_info(`gfn, "Attempting to READ from Flash", UVM_INFO)
 
     // Attempt to Read from FLASH, No Access Expected after RMA
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Select a Random Partition to try to Read From
     randcase
@@ -292,8 +292,8 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
     // Arbitrary num_words - Access should fail on the first attempt
     flash_op.num_words  = $urandom_range(8, 16);
-    flash_op.erase_type = $urandom ? flash_ctrl_pkg::FlashErasePage :
-                                     flash_ctrl_pkg::FlashEraseBank;
+    flash_op.erase_type = $urandom ? flash_ctrl_top_specific_pkg::FlashErasePage :
+                                     flash_ctrl_top_specific_pkg::FlashEraseBank;
 
     // Start Read Operation
     flash_ctrl_start_op(flash_op);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -21,8 +21,6 @@
 // #Random Order : Creator(page), Owner(page), Isolation(page),
 //                 Data0(random page), Data1(random page)
 
-import lc_ctrl_pkg::*;
-
 class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
   `uvm_object_utils(flash_ctrl_hw_rma_vseq)
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -80,28 +80,28 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
@@ -117,18 +117,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Choose Erase/Program Combination to perform this iteration
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -140,18 +140,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Note: Uses case_sel value from above
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -162,18 +162,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
       endcase
 
@@ -199,7 +199,7 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
     // DATA PARTITION
 
-    flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+    flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
     mubi4_t default_region_read_en;
     mubi4_t default_region_program_en;
     mubi4_t default_region_erase_en;
@@ -236,10 +236,10 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
     flash_bank_mp_info_page_cfg_t info_regions[flash_ctrl_reg_pkg::NumInfos0];
 
     foreach (info_regions[i]) begin
-      // Get secret partition cfg from flash_ctrl_pkg
+      // Get secret partition cfg from flash_ctrl_top_specific_pkg
       if ( i inside {1, 2}) begin
         // Copy protection from hw_cfg0.
-        info_regions[i] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+        info_regions[i] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
         // Update program and erase control for the test purpose.
         info_regions[i].program_en = MuBi4True;
         info_regions[i].erase_en   = MuBi4True;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -80,28 +80,34 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
@@ -117,18 +123,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Choose Erase/Program Combination to perform this iteration
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -140,18 +152,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Note: Uses case_sel value from above
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -162,18 +180,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+             FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
       endcase
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -121,9 +121,9 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
       scr_en = 1;
       ecc_en = 1;
     end else begin
-      scr_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_pkg::CfgAllowRead.scramble_en,
+      scr_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
                                            mubi4_t'(~cfg.ovrd_scr_dis)) == MuBi4True);
-      ecc_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_pkg::CfgAllowRead.ecc_en,
+      ecc_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                            mubi4_t'(~cfg.ovrd_ecc_dis)) == MuBi4True);
     end
 
@@ -174,14 +174,14 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
     for (int i = 1; i < 4; i++) begin
       if (i < 3) begin
          info_regions.scramble_en = prim_mubi_pkg::mubi4_and_hi(
-                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
+                                    flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
                                     mubi4_t'(~cfg.ovrd_scr_dis));
          info_regions.ecc_en = prim_mubi_pkg::mubi4_and_hi(
-                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
+                               flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                mubi4_t'(~cfg.ovrd_ecc_dis));
       end else begin
-        info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-        info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
+        info_regions.scramble_en = flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en;
+        info_regions.ecc_en = flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en;
       end
       flash_ctrl_mp_info_page_cfg(0, 0, i, info_regions);
     end

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -68,7 +68,8 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                      [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -48,7 +48,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     // With scramble enabled, odd size of word access (or address) will cause
     // ecc errors.
     flash_op.addr[2:0] == 3'h0;
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
     flash_op.num_words < FlashPgmRes - flash_op.addr[TL_SZW+:FlashPgmResWidth];
@@ -64,15 +64,15 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   }
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
       foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
@@ -97,7 +97,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -19,14 +19,16 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     // This added because in some extending env the info2 has special use.

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -19,14 +19,14 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     // This added because in some extending env the info2 has special use.

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -59,7 +59,8 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                      [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -42,7 +42,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.prog_sel == FlashProgSelNormal;
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
     flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -55,16 +55,16 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   }
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -88,7 +88,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -33,11 +33,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   int     exp_alert_cnt = 0;
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
   // Information partitions memory protection pages settings.
   rand
   flash_bank_mp_info_page_cfg_t
-  mp_info_pages[NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  mp_info_pages[NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint solv_order_c {
     solve mp_regions, mp_info_pages before flash_op;
@@ -57,11 +57,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     flash_op.otf_addr == flash_op.addr[OTFHostId-1:0];
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -110,7 +110,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     }
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
        mp_info_pages[i][j][k].en dist {
@@ -139,7 +139,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {
@@ -328,7 +328,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
     poll_fifo_status           = 1;
 
-    flash_op.erase_type = flash_ctrl_pkg::FlashEraseBank;
+    flash_op.erase_type = flash_ctrl_top_specific_pkg::FlashEraseBank;
     flash_op.num_words  = 16;
     info_sel = flash_op.partition >> 1;
     bank = flash_op.addr[19];

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -109,14 +109,14 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
@@ -183,8 +183,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     if (cfg.en_all_info_acc) allow_spec_info_acc = 3'h7;
 
     // overwrite secret_partition cfg with hw_cfg0
-    rand_info[0][0][1] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
-    rand_info[0][0][2] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+    rand_info[0][0][1] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
+    rand_info[0][0][2] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
   endfunction : post_randomize
 
   virtual task pre_start();
@@ -570,7 +570,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     data_q_t flash_read_data;
     flash_otf_item exp_item;
     bit poll_fifo_status = ~in_err;
-    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr, end_addr;
     int page;
     bit overflow = 0;
     uvm_reg_data_t reg_data;
@@ -1389,8 +1389,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (ecc_mode != OTFCfgRand) cfg.mp_info[i][j][k].ecc_en = ecc_en;
 
       // overwrite secret_partition cfg with hw_cfg0
-      cfg.mp_info[0][0][1] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
-      cfg.mp_info[0][0][2] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+      cfg.mp_info[0][0][1] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
+      cfg.mp_info[0][0][2] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
 
       flash_ctrl_mp_info_page_cfg(i, j, k, cfg.mp_info[i][j][k]);
       `uvm_info("otf_info_cfg", $sformatf("bank:type:page:[%0d][%0d][%0d] = %p",

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -121,7 +121,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
           rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
-    rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+    rand_op.partition dist {
+      FlashPartData := 6,
+      FlashPartInfo := 1,
+      FlashPartInfo1 := 1,
+      FlashPartInfo2 := 1
+    };
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
     cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -109,14 +109,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -24,8 +24,8 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
   constraint bank_c {
     solve bank before bank_rd;
     if (bank_same == 1) {bank == bank_rd;} else {bank != bank_rd;}
-    bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
-    bank_rd inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
+    bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
+    bank_rd inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
   }
 
   // Constraint host read address to be in relevant range for the selected partition.
@@ -95,9 +95,9 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       ), UVM_HIGH)
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
       cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      end else if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+      end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
       end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_host_rd), .scheme(FlashMemInitRandomize));
@@ -120,9 +120,9 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       ), UVM_HIGH)
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
       cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      end else if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+      end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
       end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_host_rd), .scheme(FlashMemInitRandomize));
@@ -138,7 +138,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
     flash_op.partition = FlashPartData;
     flash_op_host_rd.addr = 0;
     flash_op_host_rd.num_words = 30;
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.addr = 'h14;
     flash_op.num_words = 10;
     cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
@@ -175,11 +175,11 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       end
       begin
         // controller read, program or erase
-        if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+        if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
           controller_read_data(flash_op);
-        end else if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+        end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
           controller_program_data(flash_op, flash_op_data);
-        end else begin  //flash_op.op == flash_ctrl_pkg::FlashOpErase
+        end else begin  //flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase
           controller_erase_data(flash_op);
         end
       end

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -61,13 +61,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
       flash_op.num_words <= cfg.seq_cfg.op_max_words;
       // end of transaction must be within the program resolution
@@ -81,7 +84,8 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -32,16 +32,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     flash_op.op inside {FlashOpRead, FlashOpProgram, FlashOpErase};
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
 
-    if (!cfg.seq_cfg.op_allow_invalid) {flash_op.op != flash_ctrl_pkg::FlashOpInvalid;}
+    if (!cfg.seq_cfg.op_allow_invalid) {flash_op.op != flash_ctrl_top_specific_pkg::FlashOpInvalid;}
 
-    if (cfg.seq_cfg.flash_only_op != flash_ctrl_pkg::FlashOpInvalid) {
+    if (cfg.seq_cfg.flash_only_op != flash_ctrl_top_specific_pkg::FlashOpInvalid) {
       flash_op.op == cfg.seq_cfg.flash_only_op;
     }
 
-    (flash_op.op == flash_ctrl_pkg::FlashOpErase) ->
+    (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase) ->
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.prog_sel dist {
@@ -58,16 +58,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
 
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
       flash_op.num_words <= cfg.seq_cfg.op_max_words;
       // end of transaction must be within the program resolution
@@ -81,7 +81,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -89,12 +89,12 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -171,13 +171,13 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   // Information partitions memory protection rpages settings.
   rand
   flash_bank_mp_info_page_cfg_t
-  mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
 
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
 
@@ -221,7 +221,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -358,20 +358,20 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
         // Calculate expected data for post-transaction checks
         exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
         case (flash_op.op)
-          flash_ctrl_pkg::FlashOpRead: begin
+          flash_ctrl_top_specific_pkg::FlashOpRead: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_read(flash_op.num_words, flash_op_data, poll_fifo_status);
             wait_flash_op_done();
             if (cfg.seq_cfg.check_mem_post_tran)
               cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
           end
-          flash_ctrl_pkg::FlashOpProgram: begin
+          flash_ctrl_top_specific_pkg::FlashOpProgram: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_write(flash_op_data, poll_fifo_status);
             wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
             if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, exp_data);
           end
-          flash_ctrl_pkg::FlashOpErase: begin
+          flash_ctrl_top_specific_pkg::FlashOpErase: begin
             wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
             if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_erase_check(flash_op, exp_data);
           end
@@ -392,12 +392,12 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     // region exposing the issue.
     cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
     case (flash_op.op)
-      flash_ctrl_pkg::FlashOpRead: begin
+      flash_ctrl_top_specific_pkg::FlashOpRead: begin
         // Initialize the targeted mem region with random data.
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
         cfg.clk_rst_vif.wait_clks(1);
       end
-      flash_ctrl_pkg::FlashOpProgram: begin
+      flash_ctrl_top_specific_pkg::FlashOpProgram: begin
         // Initialize the targeted mem region with all 1s. This is required because the flash
         // needs to be erased to all 1s between each successive programming.
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -32,14 +32,14 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
     solve bank before flash_op;
-    bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
+    bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
 
   constraint flash_op_c {
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.partition == FlashPartData;
@@ -61,12 +61,12 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -106,7 +106,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -413,7 +413,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Controller read data.
   virtual task controller_read_op_data(ref flash_op_t flash_op);
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
     flash_rd_data.delete();
     flash_ctrl_start_op(flash_op);
     flash_ctrl_read(flash_op.num_words, flash_rd_data, poll_fifo_status);
@@ -423,7 +423,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Controller program data.
   virtual task controller_program_data(ref flash_op_t flash_op, data_q_t flash_op_data);
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
     flash_ctrl_start_op(flash_op);
     flash_ctrl_write(flash_op_data, poll_fifo_status);
@@ -433,7 +433,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Erase data.
   virtual task erase_data(ref flash_op_t flash_op);
-    flash_op.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpErase;
     flash_ctrl_start_op(flash_op);
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_hw_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_hw_vseq.sv
@@ -36,7 +36,7 @@ class flash_ctrl_smoke_hw_vseq extends flash_ctrl_base_vseq;
     flash_op_t flash_op;
 
     // Bit vector representing which of the mp region cfg CSRs to enable.
-    bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+    bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
     // Memory protection regions settings. One MP region, Single Page
     flash_mp_region_cfg_t mp_region;
@@ -49,7 +49,7 @@ class flash_ctrl_smoke_hw_vseq extends flash_ctrl_base_vseq;
     bank = 0;
 
     flash_op.addr = 0;
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.partition = FlashPartData;
     flash_op.num_words = 10;
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -56,7 +56,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Configure the FLASH Controller
 
     // Memory protection regions settings. One MP region, Single Page
-    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_top_specific_pkg::MpRegions];
+    flash_mp_region_cfg_t             mp_regions [flash_ctrl_top_specific_pkg::MpRegions];
 
     foreach (mp_regions[i]) begin
       mp_regions[i].en         = mubi4_bool_to_mubi(en_mp_regions[i]);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -19,7 +19,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
   uint                                          bank;
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  bit           [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  bit           [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   // Indicates whether to poll before writing to the prog_fifo or reading from the rd_fifo. If interupts are
   // enabled, the interrupt signals will be used instead. When set to 0, it will continuously write
@@ -56,7 +56,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Configure the FLASH Controller
 
     // Memory protection regions settings. One MP region, Single Page
-    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_pkg::MpRegions];
+    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_top_specific_pkg::MpRegions];
 
     foreach (mp_regions[i]) begin
       mp_regions[i].en         = mubi4_bool_to_mubi(en_mp_regions[i]);
@@ -106,7 +106,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Read Frontdoor, Compare Backdoor
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);
@@ -118,10 +118,10 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // FLASH ERASE
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpErase;
 
     // Select Page Erase
-    flash_op.erase_type = flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type = flash_ctrl_top_specific_pkg::FlashErasePage;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);
@@ -133,7 +133,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Write Frontdoor, Read backdoor
 
     // Select FLASH Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
 
     // Randomize Write Data
     `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(flash_op_data, flash_op_data.size == flash_op.num_words;)
@@ -152,7 +152,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Read Frontdoor, Compare Backdoor
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);

--- a/hw/ip_templates/flash_ctrl/dv/sva/flash_ctrl_sva.core.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/sva/flash_ctrl_sva.core.tpl
@@ -8,7 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg")}
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
     files:

--- a/hw/ip_templates/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip_templates/flash_ctrl/dv/tb/tb.sv
@@ -7,7 +7,7 @@ module tb;
   import uvm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_env_pkg::*;
   import flash_ctrl_test_pkg::*;
   import flash_ctrl_bkdr_util_pkg::flash_ctrl_bkdr_util;
@@ -74,7 +74,7 @@ module tb;
   `define FLASH_DEVICE_HIER tb.dut.u_eflash.u_flash
   assign fpp_if.req = `FLASH_DEVICE_HIER.flash_req_i;
   assign fpp_if.rsp = `FLASH_DEVICE_HIER.flash_rsp_o;
-  for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_bank_loop
+  for (genvar i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; i++) begin : gen_bank_loop
     assign fpp_if.rreq[i] = tb.dut.u_eflash.gen_flash_cores[i].u_core.u_rd.req_i;
     assign fpp_if.rdy[i] = tb.dut.u_eflash.gen_flash_cores[i].u_core.u_rd.rdy_o;
 
@@ -258,7 +258,7 @@ module tb;
                  "u_info_mem.gen_generic.u_impl_generic.mem"}, i, j)
 
   if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_generic
-    for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_each_bank
+    for (genvar i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; i++) begin : gen_each_bank
       flash_dv_part_e part = part.first();
 
       initial begin
@@ -275,7 +275,7 @@ module tb;
         part = part.next();
       end
 
-      for (genvar j = 0; j < flash_ctrl_pkg::InfoTypes; j++) begin : gen_each_info_type
+      for (genvar j = 0; j < flash_ctrl_top_specific_pkg::InfoTypes; j++) begin : gen_each_info_type
         initial begin
           flash_ctrl_bkdr_util m_mem_bkdr_util;
           m_mem_bkdr_util = new(

--- a/hw/ip_templates/flash_ctrl/flash_ctrl.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl.core.tpl
@@ -20,7 +20,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:otp_ctrl_pkg
-      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg")}
       - ${instance_vlnv("lowrisc:ip:flash_ctrl_reg")}
       - ${instance_vlnv("lowrisc:constants:top_pkg")}
       - lowrisc:ip:jtag_pkg

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_prim_reg_top.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_prim_reg_top.core.tpl
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg")}
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_reg.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_reg.core.tpl
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg")}
+      - ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg")}
     files:
       - rtl/flash_ctrl_core_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_top_specific_pkg.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_top_specific_pkg.core.tpl
@@ -2,26 +2,27 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:earlgrey_ip:flash_ctrl_pkg:0.1
-description: "Top specific flash package"
+name: ${instance_vlnv("lowrisc:ip:flash_ctrl_top_specific_pkg:0.1")}
+description: "Top specific flash ctrl package"
 virtual:
-  - lowrisc:virtual_ip:flash_ctrl_pkg
+  - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg
 
 filesets:
   files_rtl:
     depend:
-      - lowrisc:earlgrey_constants:top_pkg
+      - ${instance_vlnv("lowrisc:constants:top_pkg")}
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:earlgrey_ip:pwrmgr_pkg
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers
+      - lowrisc:ip:flash_ctrl_pkg
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
     files:
       - rtl/flash_ctrl_reg_pkg.sv
-      - rtl/flash_ctrl_pkg.sv
+      - rtl/flash_ctrl_top_specific_pkg.sv
       - rtl/flash_phy_pkg.sv
     file_type: systemVerilogSource
 
@@ -31,7 +32,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/flash_ctrl_pkg.vlt
+      - lint/flash_ctrl_top_specific_pkg.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
@@ -40,7 +41,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/flash_ctrl_pkg.waiver
+      - lint/flash_ctrl_top_specific_pkg.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip_templates/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/ip_templates/flash_ctrl/lint/flash_ctrl.waiver
@@ -20,5 +20,5 @@ waive -rules CONST_FF -location {flash_ctrl_core_reg_top.sv} \
 waive -rules MISSING_STATE -location {flash_phy_core.sv} \
       -regexp {.*'StDisable' does not have corresponding case branch tag}
 
-waive -rules USE_BEFORE_DECL -location {flash_ctrl_pkg.sv} -msg {'max_info_pages' is referenced before its declaration at flash_ctrl_pkg.sv} \
+waive -rules USE_BEFORE_DECL -location {flash_ctrl_top_specific_pkg.sv} -msg {'max_info_pages' is referenced before its declaration at flash_ctrl_top_specific_pkg.sv} \
       -comment "max_info_pages is a function defined towards the end of the file."

--- a/hw/ip_templates/flash_ctrl/lint/flash_ctrl_pkg.waiver
+++ b/hw/ip_templates/flash_ctrl/lint/flash_ctrl_pkg.waiver
@@ -1,8 +1,0 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
-#
-
-
-waive -rules UNSIZED_BIT_CONTEXT -location {flash_ctrl_pkg.sv} -regexp {Unsized bit literal "'1" encountered within a parameter declaration} \
-      -comment "This instance of an unsized parameter literal is difficult to circumvent, as the width of the assigned field is not readily available in this package."

--- a/hw/ip_templates/flash_ctrl/lint/flash_ctrl_top_specific_pkg.vlt
+++ b/hw/ip_templates/flash_ctrl/lint/flash_ctrl_top_specific_pkg.vlt
@@ -2,4 +2,4 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// waiver file for flash_ctrl_pkg
+// waiver file for flash_ctrl_top_specific_pkg

--- a/hw/ip_templates/flash_ctrl/lint/flash_ctrl_top_specific_pkg.waiver
+++ b/hw/ip_templates/flash_ctrl/lint/flash_ctrl_top_specific_pkg.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
@@ -10,7 +10,7 @@
 `include "prim_fifo_assert.svh"
 
 module flash_ctrl
-  import flash_ctrl_pkg::*;  import flash_ctrl_reg_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
@@ -1273,8 +1273,8 @@ module flash_ctrl
   logic flash_host_req_rdy;
   logic flash_host_req_done;
   logic flash_host_rderr;
-  logic [flash_ctrl_pkg::BusFullWidth-1:0] flash_host_rdata;
-  logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
+  logic [BusFullWidth-1:0] flash_host_rdata;
+  logic [BusAddrW-1:0] flash_host_addr;
 
   lc_ctrl_pkg::lc_tx_t host_enable;
 

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -12,7 +12,7 @@
 //
 // This module arbitrates and muxes the controls between the two interfaces.
 
-module flash_ctrl_arb import flash_ctrl_pkg::*; (
+module flash_ctrl_arb import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -5,7 +5,7 @@
 // Faux Flash Erase Control
 //
 
-module flash_ctrl_erase import flash_ctrl_pkg::*; (
+module flash_ctrl_erase import flash_ctrl_top_specific_pkg::*; (
   // Software Interface
   input                       op_start_i,
   input flash_erase_e         op_type_i,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_ctrl_info_cfg import flash_ctrl_pkg::*; # (
+module flash_ctrl_info_cfg import flash_ctrl_top_specific_pkg::*; # (
   parameter logic [BankW-1:0] Bank = 0,
   parameter logic [InfoTypesWidth-1:0] InfoSel = 0
 ) (

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -6,7 +6,7 @@
 //
 
 module flash_ctrl_lcmgr
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import lc_ctrl_pkg::lc_tx_t;
 #(
   parameter flash_key_t RndCnstAddrKey  = RndCnstAddrKeyDefault,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -5,7 +5,7 @@
 // Faux Flash Prog Control
 //
 
-module flash_ctrl_prog import flash_ctrl_pkg::*; (
+module flash_ctrl_prog import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -5,7 +5,7 @@
 // Faux Flash Read Control
 //
 
-module flash_ctrl_rd import flash_ctrl_pkg::*; (
+module flash_ctrl_rd import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_region_cfg.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_region_cfg.sv.tpl
@@ -9,7 +9,7 @@
 // 2. generate shadow update and storage errors
 
 module flash_ctrl_region_cfg
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_reg_pkg::*;
 (
   input clk_i,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_top_specific_pkg.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_top_specific_pkg.sv.tpl
@@ -2,10 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Flash Controller package.
+// Flash Controller top-specific package.
 //
 
-package flash_ctrl_pkg;
+package flash_ctrl_top_specific_pkg;
+
+  // Treat items from flash_ctrl_pkg as if they were declared here.
+  import flash_ctrl_pkg::*;
+  export flash_ctrl_pkg::NumSeeds;
+  export flash_ctrl_pkg::CreatorSeedIdx;
+  export flash_ctrl_pkg::OwnerSeedIdx;
+  export flash_ctrl_pkg::SeedWidth;
+  export flash_ctrl_pkg::KeyWidth;
+  export flash_ctrl_pkg::flash_key_t;
+  export flash_ctrl_pkg::keymgr_flash_t;
 
   // design parameters that can be altered through topgen
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
@@ -15,19 +25,19 @@ package flash_ctrl_pkg;
   parameter int InfoTypes                = flash_ctrl_reg_pkg::NumInfoTypes;
 
   // fixed parameters of flash derived from topgen parameters
-  parameter int DataWidth       = 64;
-  parameter int MetaDataWidth   = 12;
+  parameter int DataWidth       = ${data_width};
+  parameter int MetaDataWidth   = ${metadata_width};
 
 // The following hard-wired values are there to work-around verilator.
 // For some reason if the values are assigned through parameters verilator thinks
 // they are not constant
   parameter int InfoTypeSize [InfoTypes] = '{
-    flash_ctrl_reg_pkg::NumInfos0,
-    flash_ctrl_reg_pkg::NumInfos1,
-    flash_ctrl_reg_pkg::NumInfos2
+% for type in range(info_types):
+    flash_ctrl_reg_pkg::NumInfos${type}${"," if not loop.last else ""}
+% endfor
   };
   parameter int InfosPerBank    = max_info_pages(InfoTypeSize);
-  parameter int WordsPerPage    = 256; // Number of flash words per page
+  parameter int WordsPerPage    = ${words_per_page}; // Number of flash words per page
   parameter int BusWidth        = top_pkg::TL_DW;
   parameter int BusIntgWidth    = tlul_pkg::DataIntgWidth;
   parameter int BusFullWidth    = BusWidth + BusIntgWidth;
@@ -66,9 +76,9 @@ package flash_ctrl_pkg;
   // The end address in bus words for each kind of partition in each bank
   parameter logic [PageW-1:0] DataPartitionEndAddr = PageW'(PagesPerBank - 1);
   parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
-    PageW'(InfoTypeSize[0] - 1),
-    PageW'(InfoTypeSize[1] - 1),
-    PageW'(InfoTypeSize[2] - 1)
+% for type in range(info_types):
+    PageW'(InfoTypeSize[${type}] - 1)${"," if not loop.last else ""}
+% endfor
   };
 
   // Flash Disable usage
@@ -90,10 +100,7 @@ package flash_ctrl_pkg;
   ////////////////////////////
 
   // parameters for connected components
-  parameter int SeedWidth = 256;
-  parameter int KeyWidth  = 128;
   parameter int EdnWidth  = edn_pkg::ENDPOINT_BUS_WIDTH;
-  typedef logic [KeyWidth-1:0] flash_key_t;
 
   // Default Lfsr configurations
   // These LFSR parameters have been generated with
@@ -184,11 +191,8 @@ package flash_ctrl_pkg;
   // One page for creator seeds
   // One page for owner seeds
   // One page for isolated flash page
-  parameter int NumSeeds = 2;
   parameter bit [BankW-1:0] SeedBank = 0;
   parameter bit [InfoTypesWidth-1:0] SeedInfoSel = 0;
-  parameter bit [0:0] CreatorSeedIdx = 0;
-  parameter bit [0:0] OwnerSeedIdx = 1;
   parameter bit [PageW-1:0] CreatorInfoPage = 1;
   parameter bit [PageW-1:0] OwnerInfoPage = 2;
   parameter bit [PageW-1:0] IsolatedInfoPage = 3;
@@ -513,19 +517,6 @@ package flash_ctrl_pkg;
      }
   };
 
-
-  // flash_ctrl to keymgr
-  typedef struct packed {
-    logic [NumSeeds-1:0][SeedWidth-1:0] seeds;
-  } keymgr_flash_t;
-
-  parameter keymgr_flash_t KEYMGR_FLASH_DEFAULT = '{
-    seeds: '{
-     256'h9152e32c9380a4bcc3e0ab263581e6b0e8825186e1e445631646e8bef8c45d47,
-     256'hfa365df52da48cd752fb3a026a8e608f0098cfe5fa9810494829d0cd9479eb78
-    }
-  };
-
   // dft_en jtag selection
   typedef enum logic [2:0] {
     FlashLcTckSel,
@@ -567,11 +558,12 @@ package flash_ctrl_pkg;
       end
     end
     return current_max;
-  endfunction // max_info_banks
+  endfunction : max_info_pages
 
   // RMA control FSM encoding
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 7 -n 10   //      -s 3319803877 --language=sv
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 7 -n 10 \
+  //      -s 3319803877 --language=sv
   //
   // Hamming distance histogram:
   //
@@ -623,6 +615,6 @@ package flash_ctrl_pkg;
     };
 
     return out_cfg;
-  endfunction // max_info_banks
+  endfunction : info_cfg_qual
 
-endpackage : flash_ctrl_pkg
+endpackage : flash_ctrl_top_specific_pkg

--- a/hw/ip_templates/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_mp.sv
@@ -9,7 +9,7 @@
 
 module flash_mp
 import prim_mubi_pkg::mubi4_t;
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 import flash_ctrl_reg_pkg::*; (
   input clk_i,
   input rst_ni,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_mp_data_region_sel.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_mp_data_region_sel.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_mp_data_region_sel import flash_ctrl_pkg::*; #(
+module flash_mp_data_region_sel import flash_ctrl_top_specific_pkg::*; #(
   parameter int Regions = 4
 ) (
   input req_i,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy.sv
@@ -11,7 +11,7 @@
 // correctly collecting the responses in order.
 
 module flash_phy
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter bit SecScrambleEn = 1'b1

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
@@ -29,12 +29,12 @@ module flash_phy_core
   input                              pg_erase_i,
   input                              bk_erase_i,
   input                              erase_suspend_req_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
+  input flash_ctrl_top_specific_pkg::flash_part_e part_i,
   input [InfoTypesWidth-1:0]         info_sel_i,
   input [BusBankAddrW-1:0]           addr_i,
   input [BusFullWidth-1:0]           prog_data_i,
   input                              prog_last_i,
-  input flash_ctrl_pkg::flash_prog_e prog_type_i,
+  input flash_ctrl_top_specific_pkg::flash_prog_e prog_type_i,
   input                              rd_buf_en_i,
   input prim_mubi_pkg::mubi4_t       flash_disable_i,
   output scramble_req_t              scramble_req_o,
@@ -122,7 +122,7 @@ module flash_phy_core
 
   // interface with flash macro
   logic [BusBankAddrW-1:0] muxed_addr;
-  flash_ctrl_pkg::flash_part_e muxed_part;
+  flash_ctrl_top_specific_pkg::flash_part_e muxed_part;
   logic muxed_scramble_en;
   logic muxed_ecc_en;
 
@@ -193,7 +193,7 @@ module flash_phy_core
   // SEC_CM: PHY_HOST_GRANT.CTRL.CONSISTENCY
   // A host transaction was granted to the muxed partition, this is illegal
   logic host_gnt_err_event;
-  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_pkg::FlashPartData);
+  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_top_specific_pkg::FlashPartData);
   // Controller fsm became non idle when there are pending host transactions, this is
   // illegal.
   logic host_outstanding_err_event;
@@ -390,7 +390,7 @@ module flash_phy_core
 
   // transactions coming from flash controller are always data type
   assign muxed_addr = host_sel ? host_addr_i : addr_i;
-  assign muxed_part = host_sel ? flash_ctrl_pkg::FlashPartData : part_i;
+  assign muxed_part = host_sel ? flash_ctrl_top_specific_pkg::FlashPartData : part_i;
   assign muxed_scramble_en = host_sel ? host_scramble_en_i : scramble_en_i;
   assign muxed_ecc_en = host_sel ? host_ecc_en_i : ecc_en_i;
   assign rd_done_o = ctrl_rsp_vld & rd_i;

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
@@ -193,7 +193,8 @@ module flash_phy_core
   // SEC_CM: PHY_HOST_GRANT.CTRL.CONSISTENCY
   // A host transaction was granted to the muxed partition, this is illegal
   logic host_gnt_err_event;
-  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_top_specific_pkg::FlashPartData);
+  assign host_gnt_err_event = (host_gnt && muxed_part !=
+                               flash_ctrl_top_specific_pkg::FlashPartData);
   // Controller fsm became non idle when there are pending host transactions, this is
   // illegal.
   logic host_outstanding_err_event;

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -8,18 +8,18 @@
 package flash_phy_pkg;
 
   // flash phy parameters
-  parameter int unsigned NumBanks       = flash_ctrl_pkg::NumBanks;
-  parameter int unsigned InfosPerBank   = flash_ctrl_pkg::InfosPerBank;
-  parameter int unsigned PagesPerBank   = flash_ctrl_pkg::PagesPerBank;
-  parameter int unsigned WordsPerPage   = flash_ctrl_pkg::WordsPerPage;
-  parameter int unsigned BankW          = flash_ctrl_pkg::BankW;
-  parameter int unsigned PageW          = flash_ctrl_pkg::PageW;
-  parameter int unsigned WordW          = flash_ctrl_pkg::WordW;
-  parameter int unsigned BankAddrW      = flash_ctrl_pkg::BankAddrW;
-  parameter int unsigned DataWidth      = flash_ctrl_pkg::DataWidth;
+  parameter int unsigned NumBanks       = flash_ctrl_top_specific_pkg::NumBanks;
+  parameter int unsigned InfosPerBank   = flash_ctrl_top_specific_pkg::InfosPerBank;
+  parameter int unsigned PagesPerBank   = flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter int unsigned WordsPerPage   = flash_ctrl_top_specific_pkg::WordsPerPage;
+  parameter int unsigned BankW          = flash_ctrl_top_specific_pkg::BankW;
+  parameter int unsigned PageW          = flash_ctrl_top_specific_pkg::PageW;
+  parameter int unsigned WordW          = flash_ctrl_top_specific_pkg::WordW;
+  parameter int unsigned BankAddrW      = flash_ctrl_top_specific_pkg::BankAddrW;
+  parameter int unsigned DataWidth      = flash_ctrl_top_specific_pkg::DataWidth;
   parameter int unsigned EccWidth       = 8;
-  parameter int unsigned MetaDataWidth  = flash_ctrl_pkg::MetaDataWidth;
-  parameter int unsigned WidthMultiple  = flash_ctrl_pkg::WidthMultiple;
+  parameter int unsigned MetaDataWidth  = flash_ctrl_top_specific_pkg::MetaDataWidth;
+  parameter int unsigned WidthMultiple  = flash_ctrl_top_specific_pkg::WidthMultiple;
   parameter int unsigned NumBuf         = 4; // number of flash read buffers
   parameter int unsigned RspOrderDepth  = 2; // this should be DataWidth / BusWidth
                                              // will switch to this after bus widening
@@ -27,15 +27,15 @@ package flash_phy_pkg;
   parameter int unsigned PlainDataWidth = DataWidth + PlainIntgWidth;
   //parameter int unsigned ScrDataWidth   = DataWidth + EccWidth;
   parameter int unsigned FullDataWidth  = DataWidth + MetaDataWidth;
-  parameter int unsigned InfoTypes      = flash_ctrl_pkg::InfoTypes;
-  parameter int unsigned InfoTypesWidth = flash_ctrl_pkg::InfoTypesWidth;
+  parameter int unsigned InfoTypes      = flash_ctrl_top_specific_pkg::InfoTypes;
+  parameter int unsigned InfoTypesWidth = flash_ctrl_top_specific_pkg::InfoTypesWidth;
 
   // flash ctrl / bus parameters
-  parameter int unsigned BusWidth       = flash_ctrl_pkg::BusWidth;
-  parameter int unsigned BusFullWidth   = flash_ctrl_pkg::BusFullWidth;
-  parameter int unsigned BusBankAddrW   = flash_ctrl_pkg::BusBankAddrW;
-  parameter int unsigned BusWordW       = flash_ctrl_pkg::BusWordW;
-  parameter int unsigned ProgTypes      = flash_ctrl_pkg::ProgTypes;
+  parameter int unsigned BusWidth       = flash_ctrl_top_specific_pkg::BusWidth;
+  parameter int unsigned BusFullWidth   = flash_ctrl_top_specific_pkg::BusFullWidth;
+  parameter int unsigned BusBankAddrW   = flash_ctrl_top_specific_pkg::BusBankAddrW;
+  parameter int unsigned BusWordW       = flash_ctrl_top_specific_pkg::BusWordW;
+  parameter int unsigned ProgTypes      = flash_ctrl_top_specific_pkg::ProgTypes;
 
   // address bits remain must be 0
   parameter int unsigned AddrBitsRemain = DataWidth % BusWidth;
@@ -119,13 +119,13 @@ package flash_phy_pkg;
     logic rd_req;
     logic prog_req;
     logic prog_last;
-    flash_ctrl_pkg::flash_prog_e prog_type;
+    flash_ctrl_top_specific_pkg::flash_prog_e prog_type;
     logic pg_erase_req;
     logic bk_erase_req;
     logic erase_suspend_req;
     logic he;
     logic [BankAddrW-1:0] addr;
-    flash_ctrl_pkg::flash_part_e part;
+    flash_ctrl_top_specific_pkg::flash_part_e part;
     logic [InfoTypesWidth-1:0] info_sel;
     logic [FullDataWidth-1:0] prog_full_data;
   } flash_phy_prim_flash_req_t;

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
@@ -44,7 +44,7 @@ module flash_phy_rd
   input pg_erase_i,
   input bk_erase_i,
   input [BusBankAddrW-1:0] addr_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
+  input flash_ctrl_top_specific_pkg::flash_part_e part_i,
   input [InfoTypesWidth-1:0] info_sel_i,
   output logic rdy_o,
   output logic data_valid_o,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -38,7 +38,7 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
     if (!rst_ni) begin
       out_o.data <= '0;
       out_o.addr <= '0;
-      out_o.part <= flash_ctrl_pkg::FlashPartData;
+      out_o.part <= flash_ctrl_top_specific_pkg::FlashPartData;
       out_o.info_sel <= '0;
       out_o.attr <= Invalid;
       out_o.err <= '0;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6098,7 +6098,7 @@
         {
           name: RndCnstAllSeeds
           desc: Compile-time random bits for default seeds
-          type: flash_ctrl_pkg::all_seeds_t
+          type: flash_ctrl_top_specific_pkg::all_seeds_t
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
@@ -6108,7 +6108,7 @@
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
-          type: flash_ctrl_pkg::lfsr_seed_t
+          type: flash_ctrl_top_specific_pkg::lfsr_seed_t
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
@@ -6118,7 +6118,7 @@
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
-          type: flash_ctrl_pkg::lfsr_perm_t
+          type: flash_ctrl_top_specific_pkg::lfsr_perm_t
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -32,9 +32,9 @@ class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
   localparam uint SEED_WIDTH = flash_ctrl_pkg::SeedWidth;
   localparam uint FLASH_PAGE_SIZE_BYTES = flash_ctrl_reg_pkg::BytesPerPage;
   localparam uint FLASH_PAGES_PER_BANK = flash_ctrl_reg_pkg::RegPagesPerBank;
-  localparam uint CREATOR_SECRET_PAGE_ID = flash_ctrl_pkg::CreatorInfoPage;
-  localparam uint OWNER_SECRET_PAGE_ID = flash_ctrl_pkg::OwnerInfoPage;
-  localparam uint ISO_PART_PAGE_ID = flash_ctrl_pkg::IsolatedInfoPage;
+  localparam uint CREATOR_SECRET_PAGE_ID = flash_ctrl_top_specific_pkg::CreatorInfoPage;
+  localparam uint OWNER_SECRET_PAGE_ID = flash_ctrl_top_specific_pkg::OwnerInfoPage;
+  localparam uint ISO_PART_PAGE_ID = flash_ctrl_top_specific_pkg::IsolatedInfoPage;
 
   localparam uint NUM_TEST_WORDS = 16;
   typedef enum {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_inject_scramble_seed_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_inject_scramble_seed_vseq.sv
@@ -8,8 +8,9 @@ class chip_sw_inject_scramble_seed_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   localparam uint ISO_PART_SIZE = 8 * flash_phy_pkg::DataWidth/8;
-  localparam uint ISO_PART_ADDR = flash_ctrl_pkg::IsolatedInfoPage *
-                                  (flash_ctrl_pkg::WordsPerPage * (flash_ctrl_pkg::DataWidth / 8));
+  localparam uint ISO_PART_ADDR = flash_ctrl_top_specific_pkg::IsolatedInfoPage *
+                                  (flash_ctrl_top_specific_pkg::WordsPerPage *
+                                  (flash_ctrl_top_specific_pkg::DataWidth / 8));
   rand bit [7:0] iso_part_data [ISO_PART_SIZE];
 
   virtual task dut_init(string reset_kind = "HARD");

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -497,7 +497,8 @@ module tb;
           .n_bits($bits(`FLASH1_DATA_MEM_HIER)),
           .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68),
           .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_EFLASH_BASE_ADDR +
-              top_earlgrey_pkg::TOP_EARLGREY_EFLASH_SIZE_BYTES / flash_ctrl_pkg::NumBanks));
+              top_earlgrey_pkg::TOP_EARLGREY_EFLASH_SIZE_BYTES /
+              flash_ctrl_top_specific_pkg::NumBanks));
       m_mem_bkdr_util[FlashBank1Data] = data1;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Data], `FLASH1_DATA_MEM_HIER)
 
@@ -509,7 +510,8 @@ module tb;
           .n_bits($bits(`FLASH1_INFO_MEM_HIER)),
           .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68),
           .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_EFLASH_BASE_ADDR +
-              top_earlgrey_pkg::TOP_EARLGREY_EFLASH_SIZE_BYTES / flash_ctrl_pkg::NumBanks));
+              top_earlgrey_pkg::TOP_EARLGREY_EFLASH_SIZE_BYTES /
+              flash_ctrl_top_specific_pkg::NumBanks));
       m_mem_bkdr_util[FlashBank1Info] = info1;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Info], `FLASH1_INFO_MEM_HIER)
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
@@ -408,19 +408,19 @@
     },
     { name:      "RndCnstAllSeeds",
       desc:      "Compile-time random bits for default seeds",
-      type:      "flash_ctrl_pkg::all_seeds_t"
+      type:      "flash_ctrl_top_specific_pkg::all_seeds_t"
       randcount: "512",
       randtype:  "data", // randomize randcount databits
     },
     { name:      "RndCnstLfsrSeed",
       desc:      "Compile-time random bits for initial LFSR seed",
-      type:      "flash_ctrl_pkg::lfsr_seed_t"
+      type:      "flash_ctrl_top_specific_pkg::lfsr_seed_t"
       randcount: "32",
       randtype:  "data",
     },
     { name:      "RndCnstLfsrPerm",
       desc:      "Compile-time random permutation for LFSR output",
-      type:      "flash_ctrl_pkg::lfsr_perm_t"
+      type:      "flash_ctrl_top_specific_pkg::lfsr_perm_t"
       randcount: "32",
       randtype:  "perm",
     },

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/README.md
@@ -191,7 +191,7 @@ typedef struct packed {
     uint             num_words;   // number of words to read or program (TL_DW)
     addr_t           addr;        // starting addr for the op
     // addres for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_pkg::BusAddrByteW-2:0] otf_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
 ```

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_phy_cov_if.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_phy_cov_if.sv
@@ -4,7 +4,7 @@
 //
 // Sampling physical interface of the flash
 // tb.dut.u_eflash.u_flash
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 interface flash_ctrl_phy_cov_if
 (
   input logic        clk_i,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_prince:0.1
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
-      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg
       - lowrisc:dv:mem_bkdr_util
     files:
       - flash_ctrl_bkdr_util_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_dv_if.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_dv_if.sv
@@ -6,7 +6,7 @@ interface flash_ctrl_dv_if (
   input logic rst_ni
 );
 
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import lc_ctrl_pkg::*;
 
   logic       rd_buf_en;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:earlgrey_dv:flash_ctrl_bkdr_util
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg
       - lowrisc:earlgrey_constants:top_pkg
     files:
       - flash_ctrl_eflash_ral_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -67,7 +67,7 @@ class flash_ctrl_env #(
     end
 
     if (cfg.scb_otf_en) begin
-      for (int i = 0; i < flash_ctrl_pkg::NumBanks; ++i) begin
+      for (int i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; ++i) begin
         virtual_sequencer.eg_exp_ctrl_port[i].connect(
                 m_otf_scb.eg_exp_ctrl_fifo[i].analysis_export);
         virtual_sequencer.eg_exp_host_port[i].connect(

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -834,7 +834,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction
 
   // Task for clean scb memory
-  virtual function reset_scb_mem();
+  virtual function void reset_scb_mem();
     scb_flash_data.delete();
     scb_flash_info.delete();
     scb_flash_info1.delete();
@@ -842,9 +842,9 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction : reset_scb_mem
 
   // Task for set scb memory
-  virtual function set_scb_mem(int bkd_num_words, flash_dv_part_e bkd_partition,
-                               addr_t write_bkd_addr,flash_scb_wr_e val_type,
-                               data_b_t custom_val = {});
+  virtual function void set_scb_mem(int bkd_num_words, flash_dv_part_e bkd_partition,
+                                    addr_t write_bkd_addr,flash_scb_wr_e val_type,
+                                    data_b_t custom_val = {});
     addr_t wr_bkd_addr;
     data_t wr_value;
 
@@ -1172,7 +1172,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   function flash_dv_part_e get_part(flash_part_e part,
                                     logic [InfoTypesWidth-1:0] mem_info_sel);
-    if (part == FlashPartData) begin
+    if (part == flash_ctrl_top_specific_pkg::FlashPartData) begin
       return FlashPartData;
     end else begin
       case (mem_info_sel)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -106,7 +106,7 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
     key_instr_cross : cross key_cp, instr_type_cp;
   endgroup // fetch_code_cg
 
-  covergroup rma_init_cg with function sample(flash_ctrl_pkg::rma_state_e st);
+  covergroup rma_init_cg with function sample(flash_ctrl_top_specific_pkg::rma_state_e st);
     rma_start_cp: coverpoint st {
       bins rma_st[2] = {StRmaIdle, [StRmaPageSel:StRmaInvalid]};
     }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -12,7 +12,7 @@ package flash_ctrl_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_core_ral_pkg::*;
   import flash_ctrl_eflash_ral_pkg::*;
   import flash_ctrl_prim_ral_pkg::*;
@@ -48,9 +48,10 @@ package flash_ctrl_env_pkg;
   };
 
   parameter uint NUM_ALERTS = 5;
-  parameter uint FlashNumPages = flash_ctrl_pkg::NumBanks * flash_ctrl_pkg::PagesPerBank;
-  parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_pkg::WordsPerPage *
-                                  flash_ctrl_pkg::DataWidth / 8;
+  parameter uint FlashNumPages = flash_ctrl_top_specific_pkg::NumBanks *
+                                 flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_top_specific_pkg::WordsPerPage *
+                                  flash_ctrl_top_specific_pkg::DataWidth / 8;
 
   parameter uint ProgFifoDepth = 4;
   parameter uint ReadFifoDepth = 16;
@@ -59,31 +60,33 @@ package flash_ctrl_env_pkg;
   parameter uint BytesPerPage = FlashSizeBytes / FlashNumPages;
 
   // Num of bytes in each of the flash banks for each of the flash partitions.
-  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_pkg::NumBanks;
+  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_top_specific_pkg::NumBanks;
 
-  parameter uint InfoTypeBytes[flash_ctrl_pkg::InfoTypes] = '{
-      flash_ctrl_pkg::InfoTypeSize[0] * BytesPerPage,
-      flash_ctrl_pkg::InfoTypeSize[1] * BytesPerPage,
-      flash_ctrl_pkg::InfoTypeSize[2] * BytesPerPage
+  parameter uint InfoTypeBytes[flash_ctrl_top_specific_pkg::InfoTypes] = '{
+      flash_ctrl_top_specific_pkg::InfoTypeSize[0] * BytesPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[1] * BytesPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[2] * BytesPerPage
   };
 
   parameter uint FlashNumBusWords = FlashSizeBytes / top_pkg::TL_DBW;
-  parameter uint FlashNumBusWordsPerBank = FlashNumBusWords / flash_ctrl_pkg::NumBanks;
-  parameter uint FlashNumBusWordsPerPage = FlashNumBusWordsPerBank / flash_ctrl_pkg::PagesPerBank;
+  parameter uint FlashNumBusWordsPerBank = FlashNumBusWords /
+                                           flash_ctrl_top_specific_pkg::NumBanks;
+  parameter uint FlashNumBusWordsPerPage = FlashNumBusWordsPerBank /
+                                           flash_ctrl_top_specific_pkg::PagesPerBank;
 
-  parameter uint InfoTypeBusWords[flash_ctrl_pkg::InfoTypes] = '{
-      flash_ctrl_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
-      flash_ctrl_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
-      flash_ctrl_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
+  parameter uint InfoTypeBusWords[flash_ctrl_top_specific_pkg::InfoTypes] = '{
+      flash_ctrl_top_specific_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
   };
 
-  parameter uint FlashBankBytesPerWord = flash_ctrl_pkg::DataWidth / 8;
+  parameter uint FlashBankBytesPerWord = flash_ctrl_top_specific_pkg::DataWidth / 8;
 
   parameter uint FlashDataByteWidth = $clog2(FlashBankBytesPerWord);
-  parameter uint FlashWordLineWidth = $clog2(flash_ctrl_pkg::WordsPerPage);
-  parameter uint FlashPageWidth = $clog2(flash_ctrl_pkg::PagesPerBank);
-  parameter uint FlashBankWidth = $clog2(flash_ctrl_pkg::NumBanks);
-  parameter uint FlashPgmRes = flash_ctrl_pkg::BusPgmRes;
+  parameter uint FlashWordLineWidth = $clog2(flash_ctrl_top_specific_pkg::WordsPerPage);
+  parameter uint FlashPageWidth = $clog2(flash_ctrl_top_specific_pkg::PagesPerBank);
+  parameter uint FlashBankWidth = $clog2(flash_ctrl_top_specific_pkg::NumBanks);
+  parameter uint FlashPgmRes = flash_ctrl_top_specific_pkg::BusPgmRes;
   parameter uint FlashPgmResWidth = $clog2(FlashPgmRes);
 
   parameter uint FlashMemAddrWordMsbBit = FlashDataByteWidth - 1;
@@ -99,10 +102,10 @@ package flash_ctrl_env_pkg;
   parameter uint NUM_BK_INFO_WORDS = InfoTypeBusWords[0];  // 10 pages
 
   // params for num of pages
-  parameter uint NUM_PAGE_PART_DATA = flash_ctrl_pkg::PagesPerBank;
-  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_pkg::InfoTypeSize[0];
-  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_pkg::InfoTypeSize[1];
-  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_pkg::InfoTypeSize[2];
+  parameter uint NUM_PAGE_PART_DATA = flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_top_specific_pkg::InfoTypeSize[0];
+  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_top_specific_pkg::InfoTypeSize[1];
+  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_top_specific_pkg::InfoTypeSize[2];
 
   parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
       data_ack: 1'b1,
@@ -214,7 +217,8 @@ package flash_ctrl_env_pkg;
   } flash_mem_init_e;
 
   // Partition select for DV
-  typedef enum logic [flash_ctrl_pkg::InfoTypes:0] {  // Data partition and all info partitions
+  // Data partition and all info partitions
+  typedef enum logic [flash_ctrl_top_specific_pkg::InfoTypes:0] {
     FlashPartData  = 0,
     FlashPartInfo  = 1,
     FlashPartInfo1 = 2,
@@ -300,7 +304,7 @@ package flash_ctrl_env_pkg;
   // Useful for the flash model.
   typedef data_t data_model_t[addr_t];
   // Otf address in a bank.
-  typedef bit [flash_ctrl_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
+  typedef bit [flash_ctrl_top_specific_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
 
   typedef struct packed {
     flash_dv_part_e  partition;   // data or one of the info partitions
@@ -310,7 +314,7 @@ package flash_ctrl_env_pkg;
     uint             num_words;   // number of words to read or program (TL_DW)
     addr_t           addr;        // starting addr for the op
     // address for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_pkg::BusAddrByteW-2:0] otf_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
   // Address combined with region
@@ -331,7 +335,8 @@ package flash_ctrl_env_pkg;
   parameter uint RMA_FSM_STATE_ST_RMA_RSP = 11'b10110001010;
 
   // Indicate host read
-  parameter int unsigned OTFBankId = flash_ctrl_pkg::BusAddrByteW - FlashBankWidth; // bit19
+  parameter int unsigned OTFBankId = flash_ctrl_top_specific_pkg::BusAddrByteW - // bit 19
+                                     FlashBankWidth;
   parameter int unsigned OTFHostId = OTFBankId - 1; // bit 18
   parameter int unsigned DVPageMSB = 18;
   parameter int unsigned DVPageLSB = 11;
@@ -348,7 +353,7 @@ package flash_ctrl_env_pkg;
   localparam int unsigned FlashAddrWidth = 16;
 
   // remove bank select
-  localparam int unsigned FlashByteAddrWidth = flash_ctrl_pkg::BusAddrByteW - 1;
+  localparam int unsigned FlashByteAddrWidth = flash_ctrl_top_specific_pkg::BusAddrByteW - 1;
 
   function automatic bit[63:0] create_flash_data(
            bit [FlashDataWidth-1:0] data, bit [FlashByteAddrWidth-1:0] byte_addr,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -10,7 +10,7 @@ interface flash_ctrl_if (
 
   import lc_ctrl_pkg::*;
   import pwrmgr_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_phy_pkg::*;
   import otp_ctrl_pkg::*;
   import ast_pkg::*;
@@ -47,10 +47,10 @@ interface flash_ctrl_if (
   logic                             power_ready_h = 1'b1;
 
   // eviction
-  logic [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
-  rd_buf_t [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
-  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_prog;
-  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_erase;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
+  rd_buf_t [flash_ctrl_top_specific_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0]             evict_prog;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0]             evict_erase;
   logic                                            fatal_err;
 
   // rma coverage

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 interface flash_ctrl_mem_if (
   input logic clk_i,
   input logic rst_ni,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -430,7 +430,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                 rcv.mem_info_sel = cfg.flash_ctrl_mem_vif[bank].mem_info_sel;
                 @(negedge cfg.flash_ctrl_mem_vif[bank].clk_i);
                 if (cfg.seq_cfg.use_vendor_flash == 0) begin
-                  if (rcv.mem_part == FlashPartData) begin
+                  if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
                     `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].data_mem_req, 1,,, name)
                   end else begin
                     case (rcv.mem_info_sel)
@@ -498,7 +498,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
           `DV_CHECK_EQ(rcv.mem_wdata, {flash_phy_pkg::FullDataWidth{1'b1}},,, name)
 
 
-          if (rcv.mem_part == FlashPartData) begin
+          if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
             data_mem[bank].delete(rcv.mem_addr);
           end else begin
             info_mem[bank][rcv.mem_info_sel].delete(rcv.mem_addr);
@@ -519,7 +519,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       end
 
       // Data will be corrupted if some bits to be written cannot be flipped to 1.
-      if (rcv.mem_part == FlashPartData) begin
+      if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
         if (data_mem[bank].exists(rcv.mem_addr)) begin
           rd_data = data_mem[bank][rcv.mem_addr];
           if ((exp.req.prog_full_data & rd_data) != exp.req.prog_full_data) begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -182,7 +182,7 @@ class flash_ctrl_scoreboard #(
 
     flash_read.partition  = FlashPartData;
     flash_read.erase_type = FlashErasePage;
-    flash_read.op         = flash_ctrl_pkg::FlashOpRead;
+    flash_read.op         = flash_ctrl_top_specific_pkg::FlashOpRead;
     flash_read.num_words  = 1;
     flash_read.addr       = trans.a_addr;
 
@@ -423,7 +423,7 @@ class flash_ctrl_scoreboard #(
       if (part_sel == 1 || part == FlashPartData) begin
         for (int j = 0; j < partition_words_num; j++) begin
           scb_flash_model[addr_attr.addr] = ALL_ONES;
-          addr_attr.incr(flash_ctrl_pkg::BusBytes);
+          addr_attr.incr(flash_ctrl_top_specific_pkg::BusBytes);
         end
         case (part)
           FlashPartData: cfg.scb_flash_data = scb_flash_model;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -19,11 +19,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   // Weights for enable bits for each of the flash banks information partitions memory protection
   //  configuration registers.
-  uint mp_info_page_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                         [flash_ctrl_top_specific_pkg::InfoTypes];
 
   // When this knob is NOT FlashOpInvalid (default) the selected operation will be the only
   //  operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
-  flash_ctrl_pkg::flash_op_e flash_only_op;
+  flash_ctrl_top_specific_pkg::flash_op_e flash_only_op;
 
   // Weights to enable read / program and erase for each mem region.
   uint mp_region_en_pc;
@@ -49,12 +50,18 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Weights to enable read / program and erase for each information partition page.
   // For each of the information partitions in each of the banks there is a single variable to
   //  control all of this partition pages.
-  uint mp_info_page_read_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_program_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_erase_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_scramble_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_ecc_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_he_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_read_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                              [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_program_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                                 [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_erase_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                               [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_scramble_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                                  [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_ecc_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                            [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_he_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                            [flash_ctrl_top_specific_pkg::InfoTypes];
 
   // Control the number of flash ops.
   uint max_flash_ops_per_cfg;
@@ -183,7 +190,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   virtual function void configure();
     max_num_trans                 = 20;
 
-    num_en_mp_regions             = flash_ctrl_pkg::MpRegions;
+    num_en_mp_regions             = flash_ctrl_top_specific_pkg::MpRegions;
 
     allow_mp_region_overlap       = 1'b0;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
@@ -7,9 +7,9 @@ class flash_otf_item extends uvm_object;
   flash_op_t cmd;
   data_q_t   dq;
   fdata_q_t  raw_fq, fq;
-  bit[flash_ctrl_pkg::BusAddrByteW-1:0] start_addr;
+  bit[flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr;
   bit[flash_phy_pkg::KeySize-1:0]      addr_key, data_key;
-  bit [flash_ctrl_pkg::BusAddrByteW-2:0] mem_addr;
+  bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] mem_addr;
   bit                                    head_pad, tail_pad;
   bit                                    scr_en, ecc_en;
   int                                    page;
@@ -115,7 +115,7 @@ class flash_otf_item extends uvm_object;
   // Use 'create_flash_data' function from package
   function void scramble(bit [flash_phy_pkg::KeySize-1:0] addr_key,
                          bit [flash_phy_pkg::KeySize-1:0] data_key,
-                         bit [flash_ctrl_pkg::BusAddrByteW-2:0] addr,
+                         bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] addr,
                          bit dis = 1,
                          bit add_icv_err = 0);
     bit [FlashDataWidth-1:0] data;
@@ -173,7 +173,7 @@ class flash_otf_item extends uvm_object;
     prim_secded_pkg::secded_hamming_76_68_t dec68;
     bit [flash_phy_pkg::FullDataWidth-1:0] data; // 76 bits
     bit [71:0]               data_with_icv;
-    bit[flash_ctrl_pkg::BusAddrByteW-2:0] addr = mem_addr;
+    bit[flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] addr = mem_addr;
     data_q_t   tmp_dq;
 
     ecc_err = 'h0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -418,7 +418,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   endtask : flash_ctrl_mp_info_page_cfg
 
   // Configure bank erasability.
-  virtual task flash_ctrl_bank_erase_cfg(bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en);
+  virtual task flash_ctrl_bank_erase_cfg(
+      bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en);
     csr_wr(.ptr(ral.mp_bank_cfg_shadowed[0]), .value(bank_erase_en));
   endtask : flash_ctrl_bank_erase_cfg
 
@@ -1621,8 +1622,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       // Only scr/ecc enable matter; cfg.ovrd_src_dis can be randomized in directed test,
       // but otherwise it has the same default value as HW_INFO_CFG_OVERRIDE.
       if (page != 3) begin
-        scramble_en = prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
-                                                  mubi4_t'(~cfg.ovrd_scr_dis));
+        scramble_en = prim_mubi_pkg::mubi4_and_hi(
+            flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en, mubi4_t'(~cfg.ovrd_scr_dis));
         ecc_en = prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                              mubi4_t'(~cfg.ovrd_ecc_dis));
       end else begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -112,7 +112,8 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                          [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -47,15 +47,15 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
-    flash_op.op == flash_ctrl_pkg::FlashOpErase;
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase;
 
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -63,12 +63,12 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -112,13 +112,13 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
 
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
 
@@ -163,7 +163,7 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -265,7 +265,7 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
                      flash_op.partition != flash_op_erase.partition ||
                      flash_op.addr[FlashMemAddrBankMsbBit-:(FlashBankWidth+FlashPageWidth)] !=
                      flash_op_erase.addr[FlashMemAddrBankMsbBit-:(FlashBankWidth+FlashPageWidth)];
-                     if (flash_op_erase.erase_type == flash_ctrl_pkg::FlashEraseBank) {
+                     if (flash_op_erase.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank) {
                        flash_op.addr[FlashMemAddrBankMsbBit] !=
                        flash_op_erase.addr[FlashMemAddrBankMsbBit];
                      })

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -36,7 +36,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Copies of the MP Region Settings (Data and Info Partitions)
   flash_mp_region_cfg_t mp_data_regions[flash_ctrl_top_specific_pkg::MpRegions];
   flash_bank_mp_info_page_cfg_t
-    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks]
+                   [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   // Constraint for Bank.
   constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
@@ -61,18 +62,23 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
      flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info2_partition) {
-      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
+      if (flash_op.partition == FlashPartInfo2) {
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      }
     }
 
-    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                        flash_ctrl_top_specific_pkg::FlashOpProgram,
                         flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
@@ -88,7 +94,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -145,7 +152,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                 [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
@@ -457,7 +465,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       unique case (flash_op.op)
         flash_ctrl_top_specific_pkg::FlashOpErase : begin
           // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
+          if ((info_part == 0) &&
+              (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
             rsp = MP_PASS;
           else
             rsp = (mp_info_regions[info_bank][info_part][info_page].erase_en == MuBi4False);
@@ -490,7 +499,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       en_msg = (mp_data_regions[i].en == MuBi4True) ? "Enabled": "Disabled";
       `uvm_info(`gfn,
         $sformatf("MPR%0d : From : 0x%03x, To : 0x%03x : From : 0x%08x, To : 0x%08x, %s", i,
-          mp_data_regions[i].start_page, mp_data_regions[i].start_page+mp_data_regions[i].num_pages,
+          mp_data_regions[i].start_page,
+          mp_data_regions[i].start_page+mp_data_regions[i].num_pages,
             mp_data_regions[i].start_page*(FullPageNumWords*4),
               (mp_data_regions[i].start_page+mp_data_regions[i].num_pages)*(FullPageNumWords*4),
                 en_msg), UVM_MEDIUM)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -34,12 +34,12 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   uint            erase_err_cnt = 0;
 
   // Copies of the MP Region Settings (Data and Info Partitions)
-  flash_mp_region_cfg_t mp_data_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_data_regions[flash_ctrl_top_specific_pkg::MpRegions];
   flash_bank_mp_info_page_cfg_t
-    mp_info_regions[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   // Constraint for Bank.
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in the relevant range for
   // the selected partition.
@@ -58,26 +58,26 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Bank Erase is only supported for Data & 1st Info Partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-     flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info2_partition) {
-      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_pkg::FlashOpRead;}
+      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
     }
 
-    flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram,
-                        flash_ctrl_pkg::FlashOpErase};
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+                        flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -88,14 +88,14 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
     }
   }
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
 
@@ -145,13 +145,13 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].scramble_en == MuBi4False;
         mp_info_pages[i][j][k].ecc_en      == MuBi4False;
         mp_info_pages[i][j][k].he_en dist {
@@ -170,7 +170,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   rand mubi4_t default_region_he_en;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -232,7 +232,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
       // Initialise Flash Content
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
       end else begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
@@ -245,7 +245,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       case (flash_op.op)
 
         // ERASE
-        flash_ctrl_pkg::FlashOpErase : begin
+        flash_ctrl_top_specific_pkg::FlashOpErase : begin
           `uvm_info(`gfn, $sformatf("Flash : ERASE exp_alert:%0d", exp_alert), UVM_LOW)
           flash_ctrl_start_op(flash_op);
           wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.erase_timeout_ns));
@@ -256,7 +256,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
         end
 
         // PROGRAM
-        flash_ctrl_pkg::FlashOpProgram : begin
+        flash_ctrl_top_specific_pkg::FlashOpProgram : begin
           `uvm_info(`gfn, $sformatf("Flash : PROGRAM exp_alert:%0d", exp_alert), UVM_LOW)
           exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
           flash_ctrl_start_op(flash_op);
@@ -269,7 +269,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
         end
 
         // READ
-        flash_ctrl_pkg::FlashOpRead : begin
+        flash_ctrl_top_specific_pkg::FlashOpRead : begin
           `uvm_info(`gfn, $sformatf("Flash : READ exp_alert:%0d", exp_alert), UVM_LOW)
           flash_op_data.delete();
           flash_ctrl_start_op(flash_op);
@@ -384,9 +384,9 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Assign op_msg to Op Type (used below)
     unique case (flash_op.op)
-      flash_ctrl_pkg::FlashOpErase   : op_msg = "Erase";
-      flash_ctrl_pkg::FlashOpProgram : op_msg = "Program";
-      flash_ctrl_pkg::FlashOpRead    : op_msg = "Read";
+      flash_ctrl_top_specific_pkg::FlashOpErase   : op_msg = "Erase";
+      flash_ctrl_top_specific_pkg::FlashOpProgram : op_msg = "Program";
+      flash_ctrl_top_specific_pkg::FlashOpRead    : op_msg = "Read";
       default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
     endcase
 
@@ -401,16 +401,16 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
           UVM_MEDIUM)
         if (mp_data_regions[i].en == MuBi4True) begin
           unique case (flash_op.op)
-            flash_ctrl_pkg::FlashOpErase : begin
+            flash_ctrl_top_specific_pkg::FlashOpErase : begin
               // Bank Erase Defeats the MP Settings
-              if (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank)
+              if (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank)
                 rsp_vec[i] = MP_PASS;
               else
                 rsp_vec[i] = (mp_data_regions[i].erase_en == MuBi4False);
             end
-            flash_ctrl_pkg::FlashOpProgram : rsp_vec[i] =
+            flash_ctrl_top_specific_pkg::FlashOpProgram : rsp_vec[i] =
               (mp_data_regions[i].program_en == MuBi4False);
-            flash_ctrl_pkg::FlashOpRead : rsp_vec[i] =
+            flash_ctrl_top_specific_pkg::FlashOpRead : rsp_vec[i] =
               (mp_data_regions[i].read_en == MuBi4False);
             default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
           endcase
@@ -455,16 +455,16 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     // Look for MP Area Violations
     if (mp_info_regions[info_bank][info_part][info_page].en == MuBi4True) begin
       unique case (flash_op.op)
-        flash_ctrl_pkg::FlashOpErase : begin
+        flash_ctrl_top_specific_pkg::FlashOpErase : begin
           // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank))
+          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
             rsp = MP_PASS;
           else
             rsp = (mp_info_regions[info_bank][info_part][info_page].erase_en == MuBi4False);
         end
-        flash_ctrl_pkg::FlashOpProgram :
+        flash_ctrl_top_specific_pkg::FlashOpProgram :
           rsp = (mp_info_regions[info_bank][info_part][info_page].program_en == MuBi4False);
-        flash_ctrl_pkg::FlashOpRead :
+        flash_ctrl_top_specific_pkg::FlashOpRead :
           rsp = (mp_info_regions[info_bank][info_part][info_page].read_en == MuBi4False);
         default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
       endcase
@@ -472,8 +472,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     else
     begin
       // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-      if ((info_part == 0) && (flash_op.op == flash_ctrl_pkg::FlashOpErase) &&
-          (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank))
+      if ((info_part == 0) && (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase) &&
+          (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
         rsp = MP_PASS;
       else
         rsp = MP_VIOLATION;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -47,8 +47,8 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for the Flash Operation
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
-    flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Use only Flash Program
+    flash_op.partition == FlashPartData;  // Use only Data Partitions
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -37,7 +37,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
   constraint y_max_c { y_max inside {[16:32]}; }  // Inner Loop - Num Transactions
 
   // Constraint for Bank.
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in relevant range the for the selected partition.
   constraint addr_c {
@@ -47,7 +47,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for the Flash Operation
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;  // Only Flash Program Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
     flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -62,7 +62,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
     flash_op_data.size() == flash_op.num_words;
   }
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
 
@@ -99,13 +99,13 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -128,7 +128,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
   rand mubi4_t default_region_ecc_en;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
@@ -46,7 +46,7 @@ class flash_ctrl_error_prog_win_vseq extends flash_ctrl_fetch_code_vseq;
   // Constraint for the Flash Operation
   constraint flash_op_c {
 
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;  // Only Flash Program Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
     flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
@@ -46,8 +46,8 @@ class flash_ctrl_error_prog_win_vseq extends flash_ctrl_fetch_code_vseq;
   // Constraint for the Flash Operation
   constraint flash_op_c {
 
-    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
-    flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Use only Flash Program
+    flash_op.partition == FlashPartData;  // Use only Data Partitions
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -67,16 +67,21 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
+    if (flash_op.partition == FlashPartInfo2) {
+      flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+    }
 
-    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                        flash_ctrl_top_specific_pkg::FlashOpProgram,
                         flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
@@ -93,7 +98,8 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {
+        flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -142,7 +148,8 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                 [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -48,7 +48,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     };
   }
 
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
@@ -64,24 +64,24 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   constraint flash_op_c {
     // Bank Erase is only supported for Data & 1st Info Partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_pkg::FlashOpRead;}
+    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
 
-    flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram,
-                        flash_ctrl_pkg::FlashOpErase};
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+                        flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
-     flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+     flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words >= 10;
@@ -93,7 +93,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -101,12 +101,12 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   // Memory Protection Regions
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -142,13 +142,13 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -172,7 +172,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en = MuBi4False;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -27,7 +27,8 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                          [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -23,16 +23,16 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   addr_t bank_start_addr;
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -56,7 +56,7 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {
@@ -111,8 +111,8 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
 
     flash_op_sw_rw.partition  = FlashPartData;
-    flash_op_sw_rw.erase_type = flash_ctrl_pkg::FlashEraseBank;
-    flash_op_sw_rw.op         = flash_ctrl_pkg::FlashOpProgram;
+    flash_op_sw_rw.erase_type = flash_ctrl_top_specific_pkg::FlashEraseBank;
+    flash_op_sw_rw.op         = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op_sw_rw.num_words  = 16;
     flash_op_sw_rw.addr       = bank_start_addr;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
@@ -123,7 +123,7 @@ class flash_ctrl_host_ctrl_arb_vseq extends flash_ctrl_fetch_code_vseq;
     if (op_cnt <= apply_rma) begin
       // Initialise Flash Content
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
       end else begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
@@ -34,7 +34,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
   }
 
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.partition == FlashPartData;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -172,7 +172,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller read data
     flash_ctrl_start_op(flash_op);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -40,19 +40,19 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
     // ERASE
 
     `uvm_info(`gfn, "ERASE", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpErase, ReadCheckNorm);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     // PROGRAM
 
     `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpProgram, ReadCheckNorm);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
     `uvm_info(`gfn, "READ", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckNorm);
 
     // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
     fork
@@ -132,7 +132,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
 
     `uvm_info(`gfn, "READ", UVM_LOW)
 
-    do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckRand);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckRand);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
   endtask : body

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -4,8 +4,6 @@
 
 // flash_ctrl_hw_rma Test
 
-import lc_ctrl_pkg::*;
-
 class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
   `uvm_object_utils(flash_ctrl_hw_rma_err_vseq)
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -61,8 +61,9 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
                        cfg.seq_cfg.state_wait_timeout_ns)
           // Give more cycles for long stages
           // to trigger reset in the middle of the state.
-          if (reset_state_index inside {StRmaRdVerify, StRmaErase}) cfg.clk_rst_vif.wait_clks(10);
-
+          if (reset_state_index inside {DVStRmaRdVerify, DVStRmaErase}) begin
+            cfg.clk_rst_vif.wait_clks(10);
+          end
           if (flash_dis) begin
             `uvm_info("Test", "set disable_flash", UVM_MEDIUM)
             cfg.scb_h.do_alert_check = 0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -91,19 +91,19 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
       // ERASE
 
       `uvm_info(`gfn, "ERASE", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpErase, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // PROGRAM
 
       `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpProgram, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
       `uvm_info(`gfn, "READ", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckNorm);
 
       // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
       fork
@@ -167,7 +167,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
       `uvm_info(`gfn, "READ", UVM_LOW)
 
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckRand);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckRand);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     end
@@ -178,8 +178,8 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
     // DATA PARTITION
 
-    flash_mp_region_cfg_t mp_regions [flash_ctrl_pkg::MpRegions];
-    bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+    flash_mp_region_cfg_t mp_regions [flash_ctrl_top_specific_pkg::MpRegions];
+    bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
     mubi4_t default_region_read_en;
     mubi4_t default_region_program_en;
     mubi4_t default_region_erase_en;
@@ -263,7 +263,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     `uvm_info(`gfn, "Attempting to READ from Flash", UVM_INFO)
 
     // Attempt to Read from FLASH, No Access Expected after RMA
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Select a Random Partition to try to Read From
     randcase
@@ -292,8 +292,8 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
     // Arbitrary num_words - Access should fail on the first attempt
     flash_op.num_words  = $urandom_range(8, 16);
-    flash_op.erase_type = $urandom ? flash_ctrl_pkg::FlashErasePage :
-                                     flash_ctrl_pkg::FlashEraseBank;
+    flash_op.erase_type = $urandom ? flash_ctrl_top_specific_pkg::FlashErasePage :
+                                     flash_ctrl_top_specific_pkg::FlashEraseBank;
 
     // Start Read Operation
     flash_ctrl_start_op(flash_op);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -21,8 +21,6 @@
 // #Random Order : Creator(page), Owner(page), Isolation(page),
 //                 Data0(random page), Data1(random page)
 
-import lc_ctrl_pkg::*;
-
 class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
   `uvm_object_utils(flash_ctrl_hw_rma_vseq)
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -80,28 +80,28 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
@@ -117,18 +117,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Choose Erase/Program Combination to perform this iteration
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -140,18 +140,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Note: Uses case_sel value from above
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -162,18 +162,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
       endcase
 
@@ -199,7 +199,7 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
     // DATA PARTITION
 
-    flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+    flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
     mubi4_t default_region_read_en;
     mubi4_t default_region_program_en;
     mubi4_t default_region_erase_en;
@@ -236,10 +236,10 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
     flash_bank_mp_info_page_cfg_t info_regions[flash_ctrl_reg_pkg::NumInfos0];
 
     foreach (info_regions[i]) begin
-      // Get secret partition cfg from flash_ctrl_pkg
+      // Get secret partition cfg from flash_ctrl_top_specific_pkg
       if ( i inside {1, 2}) begin
         // Copy protection from hw_cfg0.
-        info_regions[i] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+        info_regions[i] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
         // Update program and erase control for the test purpose.
         info_regions[i].program_en = MuBi4True;
         info_regions[i].erase_en   = MuBi4True;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -80,28 +80,34 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
@@ -117,18 +123,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Choose Erase/Program Combination to perform this iteration
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -140,18 +152,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Note: Uses case_sel value from above
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -162,18 +180,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+             FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
       endcase
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -121,9 +121,9 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
       scr_en = 1;
       ecc_en = 1;
     end else begin
-      scr_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_pkg::CfgAllowRead.scramble_en,
+      scr_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
                                            mubi4_t'(~cfg.ovrd_scr_dis)) == MuBi4True);
-      ecc_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_pkg::CfgAllowRead.ecc_en,
+      ecc_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                            mubi4_t'(~cfg.ovrd_ecc_dis)) == MuBi4True);
     end
 
@@ -174,14 +174,14 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
     for (int i = 1; i < 4; i++) begin
       if (i < 3) begin
          info_regions.scramble_en = prim_mubi_pkg::mubi4_and_hi(
-                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
+                                    flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
                                     mubi4_t'(~cfg.ovrd_scr_dis));
          info_regions.ecc_en = prim_mubi_pkg::mubi4_and_hi(
-                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
+                               flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                mubi4_t'(~cfg.ovrd_ecc_dis));
       end else begin
-        info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-        info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
+        info_regions.scramble_en = flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en;
+        info_regions.ecc_en = flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en;
       end
       flash_ctrl_mp_info_page_cfg(0, 0, i, info_regions);
     end

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -68,7 +68,8 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                      [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -48,7 +48,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     // With scramble enabled, odd size of word access (or address) will cause
     // ecc errors.
     flash_op.addr[2:0] == 3'h0;
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
     flash_op.num_words < FlashPgmRes - flash_op.addr[TL_SZW+:FlashPgmResWidth];
@@ -64,15 +64,15 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   }
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
       foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
@@ -97,7 +97,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -19,14 +19,16 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     // This added because in some extending env the info2 has special use.

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -19,14 +19,14 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     // This added because in some extending env the info2 has special use.

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -59,7 +59,8 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                      [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -42,7 +42,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.prog_sel == FlashProgSelNormal;
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
     flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -55,16 +55,16 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   }
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -88,7 +88,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -33,11 +33,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   int     exp_alert_cnt = 0;
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
   // Information partitions memory protection pages settings.
   rand
   flash_bank_mp_info_page_cfg_t
-  mp_info_pages[NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  mp_info_pages[NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint solv_order_c {
     solve mp_regions, mp_info_pages before flash_op;
@@ -57,11 +57,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     flash_op.otf_addr == flash_op.addr[OTFHostId-1:0];
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -110,7 +110,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     }
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
        mp_info_pages[i][j][k].en dist {
@@ -139,7 +139,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {
@@ -328,7 +328,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
     poll_fifo_status           = 1;
 
-    flash_op.erase_type = flash_ctrl_pkg::FlashEraseBank;
+    flash_op.erase_type = flash_ctrl_top_specific_pkg::FlashEraseBank;
     flash_op.num_words  = 16;
     info_sel = flash_op.partition >> 1;
     bank = flash_op.addr[19];

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -109,14 +109,14 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
@@ -183,8 +183,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     if (cfg.en_all_info_acc) allow_spec_info_acc = 3'h7;
 
     // overwrite secret_partition cfg with hw_cfg0
-    rand_info[0][0][1] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
-    rand_info[0][0][2] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+    rand_info[0][0][1] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
+    rand_info[0][0][2] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
   endfunction : post_randomize
 
   virtual task pre_start();
@@ -570,7 +570,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     data_q_t flash_read_data;
     flash_otf_item exp_item;
     bit poll_fifo_status = ~in_err;
-    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr, end_addr;
     int page;
     bit overflow = 0;
     uvm_reg_data_t reg_data;
@@ -1389,8 +1389,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (ecc_mode != OTFCfgRand) cfg.mp_info[i][j][k].ecc_en = ecc_en;
 
       // overwrite secret_partition cfg with hw_cfg0
-      cfg.mp_info[0][0][1] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
-      cfg.mp_info[0][0][2] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+      cfg.mp_info[0][0][1] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
+      cfg.mp_info[0][0][2] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
 
       flash_ctrl_mp_info_page_cfg(i, j, k, cfg.mp_info[i][j][k]);
       `uvm_info("otf_info_cfg", $sformatf("bank:type:page:[%0d][%0d][%0d] = %p",

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -121,7 +121,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
           rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
-    rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+    rand_op.partition dist {
+      FlashPartData := 6,
+      FlashPartInfo := 1,
+      FlashPartInfo1 := 1,
+      FlashPartInfo2 := 1
+    };
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
     cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -109,14 +109,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -24,8 +24,8 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
   constraint bank_c {
     solve bank before bank_rd;
     if (bank_same == 1) {bank == bank_rd;} else {bank != bank_rd;}
-    bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
-    bank_rd inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
+    bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
+    bank_rd inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
   }
 
   // Constraint host read address to be in relevant range for the selected partition.
@@ -95,9 +95,9 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       ), UVM_HIGH)
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
       cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      end else if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+      end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
       end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_host_rd), .scheme(FlashMemInitRandomize));
@@ -120,9 +120,9 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       ), UVM_HIGH)
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
       cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      end else if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+      end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
       end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_host_rd), .scheme(FlashMemInitRandomize));
@@ -138,7 +138,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
     flash_op.partition = FlashPartData;
     flash_op_host_rd.addr = 0;
     flash_op_host_rd.num_words = 30;
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.addr = 'h14;
     flash_op.num_words = 10;
     cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
@@ -175,11 +175,11 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       end
       begin
         // controller read, program or erase
-        if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+        if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
           controller_read_data(flash_op);
-        end else if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+        end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
           controller_program_data(flash_op, flash_op_data);
-        end else begin  //flash_op.op == flash_ctrl_pkg::FlashOpErase
+        end else begin  //flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase
           controller_erase_data(flash_op);
         end
       end

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -61,13 +61,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
       flash_op.num_words <= cfg.seq_cfg.op_max_words;
       // end of transaction must be within the program resolution
@@ -81,7 +84,8 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -32,16 +32,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     flash_op.op inside {FlashOpRead, FlashOpProgram, FlashOpErase};
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
 
-    if (!cfg.seq_cfg.op_allow_invalid) {flash_op.op != flash_ctrl_pkg::FlashOpInvalid;}
+    if (!cfg.seq_cfg.op_allow_invalid) {flash_op.op != flash_ctrl_top_specific_pkg::FlashOpInvalid;}
 
-    if (cfg.seq_cfg.flash_only_op != flash_ctrl_pkg::FlashOpInvalid) {
+    if (cfg.seq_cfg.flash_only_op != flash_ctrl_top_specific_pkg::FlashOpInvalid) {
       flash_op.op == cfg.seq_cfg.flash_only_op;
     }
 
-    (flash_op.op == flash_ctrl_pkg::FlashOpErase) ->
+    (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase) ->
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.prog_sel dist {
@@ -58,16 +58,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
 
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
       flash_op.num_words <= cfg.seq_cfg.op_max_words;
       // end of transaction must be within the program resolution
@@ -81,7 +81,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -89,12 +89,12 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -171,13 +171,13 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   // Information partitions memory protection rpages settings.
   rand
   flash_bank_mp_info_page_cfg_t
-  mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
 
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
 
@@ -221,7 +221,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -358,20 +358,20 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
         // Calculate expected data for post-transaction checks
         exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
         case (flash_op.op)
-          flash_ctrl_pkg::FlashOpRead: begin
+          flash_ctrl_top_specific_pkg::FlashOpRead: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_read(flash_op.num_words, flash_op_data, poll_fifo_status);
             wait_flash_op_done();
             if (cfg.seq_cfg.check_mem_post_tran)
               cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
           end
-          flash_ctrl_pkg::FlashOpProgram: begin
+          flash_ctrl_top_specific_pkg::FlashOpProgram: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_write(flash_op_data, poll_fifo_status);
             wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
             if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, exp_data);
           end
-          flash_ctrl_pkg::FlashOpErase: begin
+          flash_ctrl_top_specific_pkg::FlashOpErase: begin
             wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
             if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_erase_check(flash_op, exp_data);
           end
@@ -392,12 +392,12 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     // region exposing the issue.
     cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
     case (flash_op.op)
-      flash_ctrl_pkg::FlashOpRead: begin
+      flash_ctrl_top_specific_pkg::FlashOpRead: begin
         // Initialize the targeted mem region with random data.
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
         cfg.clk_rst_vif.wait_clks(1);
       end
-      flash_ctrl_pkg::FlashOpProgram: begin
+      flash_ctrl_top_specific_pkg::FlashOpProgram: begin
         // Initialize the targeted mem region with all 1s. This is required because the flash
         // needs to be erased to all 1s between each successive programming.
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -32,14 +32,14 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
     solve bank before flash_op;
-    bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
+    bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
 
   constraint flash_op_c {
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.partition == FlashPartData;
@@ -61,12 +61,12 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -106,7 +106,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -413,7 +413,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Controller read data.
   virtual task controller_read_op_data(ref flash_op_t flash_op);
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
     flash_rd_data.delete();
     flash_ctrl_start_op(flash_op);
     flash_ctrl_read(flash_op.num_words, flash_rd_data, poll_fifo_status);
@@ -423,7 +423,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Controller program data.
   virtual task controller_program_data(ref flash_op_t flash_op, data_q_t flash_op_data);
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
     flash_ctrl_start_op(flash_op);
     flash_ctrl_write(flash_op_data, poll_fifo_status);
@@ -433,7 +433,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Erase data.
   virtual task erase_data(ref flash_op_t flash_op);
-    flash_op.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpErase;
     flash_ctrl_start_op(flash_op);
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_hw_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_hw_vseq.sv
@@ -36,7 +36,7 @@ class flash_ctrl_smoke_hw_vseq extends flash_ctrl_base_vseq;
     flash_op_t flash_op;
 
     // Bit vector representing which of the mp region cfg CSRs to enable.
-    bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+    bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
     // Memory protection regions settings. One MP region, Single Page
     flash_mp_region_cfg_t mp_region;
@@ -49,7 +49,7 @@ class flash_ctrl_smoke_hw_vseq extends flash_ctrl_base_vseq;
     bank = 0;
 
     flash_op.addr = 0;
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.partition = FlashPartData;
     flash_op.num_words = 10;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -56,7 +56,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Configure the FLASH Controller
 
     // Memory protection regions settings. One MP region, Single Page
-    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_top_specific_pkg::MpRegions];
+    flash_mp_region_cfg_t             mp_regions [flash_ctrl_top_specific_pkg::MpRegions];
 
     foreach (mp_regions[i]) begin
       mp_regions[i].en         = mubi4_bool_to_mubi(en_mp_regions[i]);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -19,7 +19,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
   uint                                          bank;
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  bit           [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  bit           [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   // Indicates whether to poll before writing to the prog_fifo or reading from the rd_fifo. If interupts are
   // enabled, the interrupt signals will be used instead. When set to 0, it will continuously write
@@ -56,7 +56,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Configure the FLASH Controller
 
     // Memory protection regions settings. One MP region, Single Page
-    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_pkg::MpRegions];
+    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_top_specific_pkg::MpRegions];
 
     foreach (mp_regions[i]) begin
       mp_regions[i].en         = mubi4_bool_to_mubi(en_mp_regions[i]);
@@ -106,7 +106,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Read Frontdoor, Compare Backdoor
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);
@@ -118,10 +118,10 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // FLASH ERASE
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpErase;
 
     // Select Page Erase
-    flash_op.erase_type = flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type = flash_ctrl_top_specific_pkg::FlashErasePage;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);
@@ -133,7 +133,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Write Frontdoor, Read backdoor
 
     // Select FLASH Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
 
     // Randomize Write Data
     `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(flash_op_data, flash_op_data.size == flash_op.num_words;)
@@ -152,7 +152,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Read Frontdoor, Compare Backdoor
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
@@ -8,7 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
     files:

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/tb/tb.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/tb/tb.sv
@@ -7,7 +7,7 @@ module tb;
   import uvm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_env_pkg::*;
   import flash_ctrl_test_pkg::*;
   import flash_ctrl_bkdr_util_pkg::flash_ctrl_bkdr_util;
@@ -74,7 +74,7 @@ module tb;
   `define FLASH_DEVICE_HIER tb.dut.u_eflash.u_flash
   assign fpp_if.req = `FLASH_DEVICE_HIER.flash_req_i;
   assign fpp_if.rsp = `FLASH_DEVICE_HIER.flash_rsp_o;
-  for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_bank_loop
+  for (genvar i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; i++) begin : gen_bank_loop
     assign fpp_if.rreq[i] = tb.dut.u_eflash.gen_flash_cores[i].u_core.u_rd.req_i;
     assign fpp_if.rdy[i] = tb.dut.u_eflash.gen_flash_cores[i].u_core.u_rd.rdy_o;
 
@@ -258,7 +258,7 @@ module tb;
                  "u_info_mem.gen_generic.u_impl_generic.mem"}, i, j)
 
   if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_generic
-    for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_each_bank
+    for (genvar i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; i++) begin : gen_each_bank
       flash_dv_part_e part = part.first();
 
       initial begin
@@ -275,7 +275,7 @@ module tb;
         part = part.next();
       end
 
-      for (genvar j = 0; j < flash_ctrl_pkg::InfoTypes; j++) begin : gen_each_info_type
+      for (genvar j = 0; j < flash_ctrl_top_specific_pkg::InfoTypes; j++) begin : gen_each_info_type
         initial begin
           flash_ctrl_bkdr_util m_mem_bkdr_util;
           m_mem_bkdr_util = new(

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl.core
@@ -20,7 +20,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg
       - lowrisc:earlgrey_ip:flash_ctrl_reg
       - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:ip:jtag_pkg

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_reg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_reg.core
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:earlgrey_ip:flash_ctrl_pkg
+      - lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg
     files:
       - rtl/flash_ctrl_core_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
@@ -2,26 +2,27 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: ${instance_vlnv("lowrisc:ip:flash_ctrl_pkg:0.1")}
-description: "Top specific flash package"
+name: lowrisc:earlgrey_ip:flash_ctrl_top_specific_pkg:0.1
+description: "Top specific flash ctrl package"
 virtual:
-  - lowrisc:virtual_ip:flash_ctrl_pkg
+  - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg
 
 filesets:
   files_rtl:
     depend:
-      - ${instance_vlnv("lowrisc:constants:top_pkg")}
+      - lowrisc:earlgrey_constants:top_pkg
       - lowrisc:prim:util
       - lowrisc:ip:lc_ctrl_pkg
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
+      - lowrisc:earlgrey_ip:pwrmgr_pkg
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers
+      - lowrisc:ip:flash_ctrl_pkg
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
     files:
       - rtl/flash_ctrl_reg_pkg.sv
-      - rtl/flash_ctrl_pkg.sv
+      - rtl/flash_ctrl_top_specific_pkg.sv
       - rtl/flash_phy_pkg.sv
     file_type: systemVerilogSource
 
@@ -31,7 +32,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/flash_ctrl_pkg.vlt
+      - lint/flash_ctrl_top_specific_pkg.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
@@ -40,7 +41,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/flash_ctrl_pkg.waiver
+      - lint/flash_ctrl_top_specific_pkg.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl.waiver
@@ -20,5 +20,5 @@ waive -rules CONST_FF -location {flash_ctrl_core_reg_top.sv} \
 waive -rules MISSING_STATE -location {flash_phy_core.sv} \
       -regexp {.*'StDisable' does not have corresponding case branch tag}
 
-waive -rules USE_BEFORE_DECL -location {flash_ctrl_pkg.sv} -msg {'max_info_pages' is referenced before its declaration at flash_ctrl_pkg.sv} \
+waive -rules USE_BEFORE_DECL -location {flash_ctrl_top_specific_pkg.sv} -msg {'max_info_pages' is referenced before its declaration at flash_ctrl_top_specific_pkg.sv} \
       -comment "max_info_pages is a function defined towards the end of the file."

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl_pkg.waiver
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl_pkg.waiver
@@ -1,8 +1,0 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
-#
-
-
-waive -rules UNSIZED_BIT_CONTEXT -location {flash_ctrl_pkg.sv} -regexp {Unsized bit literal "'1" encountered within a parameter declaration} \
-      -comment "This instance of an unsized parameter literal is difficult to circumvent, as the width of the assigned field is not readily available in this package."

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.vlt
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.vlt
@@ -2,4 +2,4 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// waiver file for flash_ctrl_pkg
+// waiver file for flash_ctrl_top_specific_pkg

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.waiver
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -10,7 +10,7 @@
 `include "prim_fifo_assert.svh"
 
 module flash_ctrl
-  import flash_ctrl_pkg::*;  import flash_ctrl_reg_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
@@ -1274,8 +1274,8 @@ module flash_ctrl
   logic flash_host_req_rdy;
   logic flash_host_req_done;
   logic flash_host_rderr;
-  logic [flash_ctrl_pkg::BusFullWidth-1:0] flash_host_rdata;
-  logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
+  logic [BusFullWidth-1:0] flash_host_rdata;
+  logic [BusAddrW-1:0] flash_host_addr;
 
   lc_ctrl_pkg::lc_tx_t host_enable;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -12,7 +12,7 @@
 //
 // This module arbitrates and muxes the controls between the two interfaces.
 
-module flash_ctrl_arb import flash_ctrl_pkg::*; (
+module flash_ctrl_arb import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -5,7 +5,7 @@
 // Faux Flash Erase Control
 //
 
-module flash_ctrl_erase import flash_ctrl_pkg::*; (
+module flash_ctrl_erase import flash_ctrl_top_specific_pkg::*; (
   // Software Interface
   input                       op_start_i,
   input flash_erase_e         op_type_i,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_ctrl_info_cfg import flash_ctrl_pkg::*; # (
+module flash_ctrl_info_cfg import flash_ctrl_top_specific_pkg::*; # (
   parameter logic [BankW-1:0] Bank = 0,
   parameter logic [InfoTypesWidth-1:0] InfoSel = 0
 ) (

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -6,7 +6,7 @@
 //
 
 module flash_ctrl_lcmgr
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import lc_ctrl_pkg::lc_tx_t;
 #(
   parameter flash_key_t RndCnstAddrKey  = RndCnstAddrKeyDefault,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -5,7 +5,7 @@
 // Faux Flash Prog Control
 //
 
-module flash_ctrl_prog import flash_ctrl_pkg::*; (
+module flash_ctrl_prog import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -5,7 +5,7 @@
 // Faux Flash Read Control
 //
 
-module flash_ctrl_rd import flash_ctrl_pkg::*; (
+module flash_ctrl_rd import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
@@ -9,7 +9,7 @@
 // 2. generate shadow update and storage errors
 
 module flash_ctrl_region_cfg
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_reg_pkg::*;
 (
   input clk_i,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_top_specific_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_top_specific_pkg.sv
@@ -2,10 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Flash Controller package.
+// Flash Controller top-specific package.
 //
 
-package flash_ctrl_pkg;
+package flash_ctrl_top_specific_pkg;
+
+  // Treat items from flash_ctrl_pkg as if they were declared here.
+  import flash_ctrl_pkg::*;
+  export flash_ctrl_pkg::NumSeeds;
+  export flash_ctrl_pkg::CreatorSeedIdx;
+  export flash_ctrl_pkg::OwnerSeedIdx;
+  export flash_ctrl_pkg::SeedWidth;
+  export flash_ctrl_pkg::KeyWidth;
+  export flash_ctrl_pkg::flash_key_t;
+  export flash_ctrl_pkg::keymgr_flash_t;
 
   // design parameters that can be altered through topgen
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
@@ -90,10 +100,7 @@ package flash_ctrl_pkg;
   ////////////////////////////
 
   // parameters for connected components
-  parameter int SeedWidth = 256;
-  parameter int KeyWidth  = 128;
   parameter int EdnWidth  = edn_pkg::ENDPOINT_BUS_WIDTH;
-  typedef logic [KeyWidth-1:0] flash_key_t;
 
   // Default Lfsr configurations
   // These LFSR parameters have been generated with
@@ -184,11 +191,8 @@ package flash_ctrl_pkg;
   // One page for creator seeds
   // One page for owner seeds
   // One page for isolated flash page
-  parameter int NumSeeds = 2;
   parameter bit [BankW-1:0] SeedBank = 0;
   parameter bit [InfoTypesWidth-1:0] SeedInfoSel = 0;
-  parameter bit [0:0] CreatorSeedIdx = 0;
-  parameter bit [0:0] OwnerSeedIdx = 1;
   parameter bit [PageW-1:0] CreatorInfoPage = 1;
   parameter bit [PageW-1:0] OwnerInfoPage = 2;
   parameter bit [PageW-1:0] IsolatedInfoPage = 3;
@@ -513,19 +517,6 @@ package flash_ctrl_pkg;
      }
   };
 
-
-  // flash_ctrl to keymgr
-  typedef struct packed {
-    logic [NumSeeds-1:0][SeedWidth-1:0] seeds;
-  } keymgr_flash_t;
-
-  parameter keymgr_flash_t KEYMGR_FLASH_DEFAULT = '{
-    seeds: '{
-     256'h9152e32c9380a4bcc3e0ab263581e6b0e8825186e1e445631646e8bef8c45d47,
-     256'hfa365df52da48cd752fb3a026a8e608f0098cfe5fa9810494829d0cd9479eb78
-    }
-  };
-
   // dft_en jtag selection
   typedef enum logic [2:0] {
     FlashLcTckSel,
@@ -567,7 +558,7 @@ package flash_ctrl_pkg;
       end
     end
     return current_max;
-  endfunction // max_info_banks
+  endfunction : max_info_pages
 
   // RMA control FSM encoding
   // Encoding generated with:
@@ -623,6 +614,6 @@ package flash_ctrl_pkg;
     };
 
     return out_cfg;
-  endfunction // max_info_banks
+  endfunction : info_cfg_qual
 
-endpackage : flash_ctrl_pkg
+endpackage : flash_ctrl_top_specific_pkg

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_mp.sv
@@ -9,7 +9,7 @@
 
 module flash_mp
 import prim_mubi_pkg::mubi4_t;
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 import flash_ctrl_reg_pkg::*; (
   input clk_i,
   input rst_ni,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_mp_data_region_sel.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_mp_data_region_sel.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_mp_data_region_sel import flash_ctrl_pkg::*; #(
+module flash_mp_data_region_sel import flash_ctrl_top_specific_pkg::*; #(
   parameter int Regions = 4
 ) (
   input req_i,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy.sv
@@ -11,7 +11,7 @@
 // correctly collecting the responses in order.
 
 module flash_phy
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter bit SecScrambleEn = 1'b1

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
@@ -29,12 +29,12 @@ module flash_phy_core
   input                              pg_erase_i,
   input                              bk_erase_i,
   input                              erase_suspend_req_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
+  input flash_ctrl_top_specific_pkg::flash_part_e part_i,
   input [InfoTypesWidth-1:0]         info_sel_i,
   input [BusBankAddrW-1:0]           addr_i,
   input [BusFullWidth-1:0]           prog_data_i,
   input                              prog_last_i,
-  input flash_ctrl_pkg::flash_prog_e prog_type_i,
+  input flash_ctrl_top_specific_pkg::flash_prog_e prog_type_i,
   input                              rd_buf_en_i,
   input prim_mubi_pkg::mubi4_t       flash_disable_i,
   output scramble_req_t              scramble_req_o,
@@ -122,7 +122,7 @@ module flash_phy_core
 
   // interface with flash macro
   logic [BusBankAddrW-1:0] muxed_addr;
-  flash_ctrl_pkg::flash_part_e muxed_part;
+  flash_ctrl_top_specific_pkg::flash_part_e muxed_part;
   logic muxed_scramble_en;
   logic muxed_ecc_en;
 
@@ -193,7 +193,7 @@ module flash_phy_core
   // SEC_CM: PHY_HOST_GRANT.CTRL.CONSISTENCY
   // A host transaction was granted to the muxed partition, this is illegal
   logic host_gnt_err_event;
-  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_pkg::FlashPartData);
+  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_top_specific_pkg::FlashPartData);
   // Controller fsm became non idle when there are pending host transactions, this is
   // illegal.
   logic host_outstanding_err_event;
@@ -390,7 +390,7 @@ module flash_phy_core
 
   // transactions coming from flash controller are always data type
   assign muxed_addr = host_sel ? host_addr_i : addr_i;
-  assign muxed_part = host_sel ? flash_ctrl_pkg::FlashPartData : part_i;
+  assign muxed_part = host_sel ? flash_ctrl_top_specific_pkg::FlashPartData : part_i;
   assign muxed_scramble_en = host_sel ? host_scramble_en_i : scramble_en_i;
   assign muxed_ecc_en = host_sel ? host_ecc_en_i : ecc_en_i;
   assign rd_done_o = ctrl_rsp_vld & rd_i;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
@@ -193,7 +193,8 @@ module flash_phy_core
   // SEC_CM: PHY_HOST_GRANT.CTRL.CONSISTENCY
   // A host transaction was granted to the muxed partition, this is illegal
   logic host_gnt_err_event;
-  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_top_specific_pkg::FlashPartData);
+  assign host_gnt_err_event = (host_gnt && muxed_part !=
+                               flash_ctrl_top_specific_pkg::FlashPartData);
   // Controller fsm became non idle when there are pending host transactions, this is
   // illegal.
   logic host_outstanding_err_event;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -8,18 +8,18 @@
 package flash_phy_pkg;
 
   // flash phy parameters
-  parameter int unsigned NumBanks       = flash_ctrl_pkg::NumBanks;
-  parameter int unsigned InfosPerBank   = flash_ctrl_pkg::InfosPerBank;
-  parameter int unsigned PagesPerBank   = flash_ctrl_pkg::PagesPerBank;
-  parameter int unsigned WordsPerPage   = flash_ctrl_pkg::WordsPerPage;
-  parameter int unsigned BankW          = flash_ctrl_pkg::BankW;
-  parameter int unsigned PageW          = flash_ctrl_pkg::PageW;
-  parameter int unsigned WordW          = flash_ctrl_pkg::WordW;
-  parameter int unsigned BankAddrW      = flash_ctrl_pkg::BankAddrW;
-  parameter int unsigned DataWidth      = flash_ctrl_pkg::DataWidth;
+  parameter int unsigned NumBanks       = flash_ctrl_top_specific_pkg::NumBanks;
+  parameter int unsigned InfosPerBank   = flash_ctrl_top_specific_pkg::InfosPerBank;
+  parameter int unsigned PagesPerBank   = flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter int unsigned WordsPerPage   = flash_ctrl_top_specific_pkg::WordsPerPage;
+  parameter int unsigned BankW          = flash_ctrl_top_specific_pkg::BankW;
+  parameter int unsigned PageW          = flash_ctrl_top_specific_pkg::PageW;
+  parameter int unsigned WordW          = flash_ctrl_top_specific_pkg::WordW;
+  parameter int unsigned BankAddrW      = flash_ctrl_top_specific_pkg::BankAddrW;
+  parameter int unsigned DataWidth      = flash_ctrl_top_specific_pkg::DataWidth;
   parameter int unsigned EccWidth       = 8;
-  parameter int unsigned MetaDataWidth  = flash_ctrl_pkg::MetaDataWidth;
-  parameter int unsigned WidthMultiple  = flash_ctrl_pkg::WidthMultiple;
+  parameter int unsigned MetaDataWidth  = flash_ctrl_top_specific_pkg::MetaDataWidth;
+  parameter int unsigned WidthMultiple  = flash_ctrl_top_specific_pkg::WidthMultiple;
   parameter int unsigned NumBuf         = 4; // number of flash read buffers
   parameter int unsigned RspOrderDepth  = 2; // this should be DataWidth / BusWidth
                                              // will switch to this after bus widening
@@ -27,15 +27,15 @@ package flash_phy_pkg;
   parameter int unsigned PlainDataWidth = DataWidth + PlainIntgWidth;
   //parameter int unsigned ScrDataWidth   = DataWidth + EccWidth;
   parameter int unsigned FullDataWidth  = DataWidth + MetaDataWidth;
-  parameter int unsigned InfoTypes      = flash_ctrl_pkg::InfoTypes;
-  parameter int unsigned InfoTypesWidth = flash_ctrl_pkg::InfoTypesWidth;
+  parameter int unsigned InfoTypes      = flash_ctrl_top_specific_pkg::InfoTypes;
+  parameter int unsigned InfoTypesWidth = flash_ctrl_top_specific_pkg::InfoTypesWidth;
 
   // flash ctrl / bus parameters
-  parameter int unsigned BusWidth       = flash_ctrl_pkg::BusWidth;
-  parameter int unsigned BusFullWidth   = flash_ctrl_pkg::BusFullWidth;
-  parameter int unsigned BusBankAddrW   = flash_ctrl_pkg::BusBankAddrW;
-  parameter int unsigned BusWordW       = flash_ctrl_pkg::BusWordW;
-  parameter int unsigned ProgTypes      = flash_ctrl_pkg::ProgTypes;
+  parameter int unsigned BusWidth       = flash_ctrl_top_specific_pkg::BusWidth;
+  parameter int unsigned BusFullWidth   = flash_ctrl_top_specific_pkg::BusFullWidth;
+  parameter int unsigned BusBankAddrW   = flash_ctrl_top_specific_pkg::BusBankAddrW;
+  parameter int unsigned BusWordW       = flash_ctrl_top_specific_pkg::BusWordW;
+  parameter int unsigned ProgTypes      = flash_ctrl_top_specific_pkg::ProgTypes;
 
   // address bits remain must be 0
   parameter int unsigned AddrBitsRemain = DataWidth % BusWidth;
@@ -119,13 +119,13 @@ package flash_phy_pkg;
     logic rd_req;
     logic prog_req;
     logic prog_last;
-    flash_ctrl_pkg::flash_prog_e prog_type;
+    flash_ctrl_top_specific_pkg::flash_prog_e prog_type;
     logic pg_erase_req;
     logic bk_erase_req;
     logic erase_suspend_req;
     logic he;
     logic [BankAddrW-1:0] addr;
-    flash_ctrl_pkg::flash_part_e part;
+    flash_ctrl_top_specific_pkg::flash_part_e part;
     logic [InfoTypesWidth-1:0] info_sel;
     logic [FullDataWidth-1:0] prog_full_data;
   } flash_phy_prim_flash_req_t;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
@@ -44,7 +44,7 @@ module flash_phy_rd
   input pg_erase_i,
   input bk_erase_i,
   input [BusBankAddrW-1:0] addr_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
+  input flash_ctrl_top_specific_pkg::flash_part_e part_i,
   input [InfoTypesWidth-1:0] info_sel_i,
   output logic rdy_o,
   output logic data_valid_o,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -38,7 +38,7 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
     if (!rst_ni) begin
       out_o.data <= '0;
       out_o.addr <= '0;
-      out_o.part <= flash_ctrl_pkg::FlashPartData;
+      out_o.part <= flash_ctrl_top_specific_pkg::FlashPartData;
       out_o.info_sel <= '0;
       out_o.attr <= Invalid;
       out_o.err <= '0;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -117,18 +117,18 @@ package top_earlgrey_rnd_cnst_pkg;
   };
 
   // Compile-time random bits for default seeds
-  parameter flash_ctrl_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
+  parameter flash_ctrl_top_specific_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
     256'hF67F318B_5A490E55_F7D8B832_5652A924_82CC3446_8C37BFEE_731A0AB4_30181CDE,
     256'h15F40D83_472DD252_E38F2C5E_24D201BD_B435D5CF_F95C40A1_643CC8F5_40230522
   };
 
   // Compile-time random bits for initial LFSR seed
-  parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
+  parameter flash_ctrl_top_specific_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
     32'hD33A4EA4
   };
 
   // Compile-time random permutation for LFSR output
-  parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
+  parameter flash_ctrl_top_specific_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
     160'hB16325F5_4D0ED9E3_1C04C3EB_9D5F8812_7F41CDD0
   };
 

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3087,7 +3087,7 @@
         {
           name: RndCnstAllSeeds
           desc: Compile-time random bits for default seeds
-          type: flash_ctrl_pkg::all_seeds_t
+          type: flash_ctrl_top_specific_pkg::all_seeds_t
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
@@ -3097,7 +3097,7 @@
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
-          type: flash_ctrl_pkg::lfsr_seed_t
+          type: flash_ctrl_top_specific_pkg::lfsr_seed_t
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
@@ -3107,7 +3107,7 @@
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
-          type: flash_ctrl_pkg::lfsr_perm_t
+          type: flash_ctrl_top_specific_pkg::lfsr_perm_t
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
@@ -408,19 +408,19 @@
     },
     { name:      "RndCnstAllSeeds",
       desc:      "Compile-time random bits for default seeds",
-      type:      "flash_ctrl_pkg::all_seeds_t"
+      type:      "flash_ctrl_top_specific_pkg::all_seeds_t"
       randcount: "512",
       randtype:  "data", // randomize randcount databits
     },
     { name:      "RndCnstLfsrSeed",
       desc:      "Compile-time random bits for initial LFSR seed",
-      type:      "flash_ctrl_pkg::lfsr_seed_t"
+      type:      "flash_ctrl_top_specific_pkg::lfsr_seed_t"
       randcount: "32",
       randtype:  "data",
     },
     { name:      "RndCnstLfsrPerm",
       desc:      "Compile-time random permutation for LFSR output",
-      type:      "flash_ctrl_pkg::lfsr_perm_t"
+      type:      "flash_ctrl_top_specific_pkg::lfsr_perm_t"
       randcount: "32",
       randtype:  "perm",
     },

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/README.md
@@ -191,7 +191,7 @@ typedef struct packed {
     uint             num_words;   // number of words to read or program (TL_DW)
     addr_t           addr;        // starting addr for the op
     // addres for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_pkg::BusAddrByteW-2:0] otf_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
 ```

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_phy_cov_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/cov/flash_ctrl_phy_cov_if.sv
@@ -4,7 +4,7 @@
 //
 // Sampling physical interface of the flash
 // tb.dut.u_eflash.u_flash
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 interface flash_ctrl_phy_cov_if
 (
   input logic        clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_bkdr_util.core
@@ -13,7 +13,7 @@ filesets:
       - lowrisc:dv:crypto_dpi_prince:0.1
       - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:secded:0.1
-      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg
       - lowrisc:dv:mem_bkdr_util
     files:
       - flash_ctrl_bkdr_util_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_dv_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_dv_if.sv
@@ -6,7 +6,7 @@ interface flash_ctrl_dv_if (
   input logic rst_ni
 );
 
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import lc_ctrl_pkg::*;
 
   logic       rd_buf_en;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:englishbreakfast_dv:flash_ctrl_bkdr_util
       - lowrisc:dv:flash_phy_prim_agent
       - lowrisc:dv:mem_bkdr_util
-      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg
       - lowrisc:englishbreakfast_constants:top_pkg
     files:
       - flash_ctrl_eflash_ral_pkg.sv

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -67,7 +67,7 @@ class flash_ctrl_env #(
     end
 
     if (cfg.scb_otf_en) begin
-      for (int i = 0; i < flash_ctrl_pkg::NumBanks; ++i) begin
+      for (int i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; ++i) begin
         virtual_sequencer.eg_exp_ctrl_port[i].connect(
                 m_otf_scb.eg_exp_ctrl_fifo[i].analysis_export);
         virtual_sequencer.eg_exp_host_port[i].connect(

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -834,7 +834,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction
 
   // Task for clean scb memory
-  virtual function reset_scb_mem();
+  virtual function void reset_scb_mem();
     scb_flash_data.delete();
     scb_flash_info.delete();
     scb_flash_info1.delete();
@@ -842,9 +842,9 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction : reset_scb_mem
 
   // Task for set scb memory
-  virtual function set_scb_mem(int bkd_num_words, flash_dv_part_e bkd_partition,
-                               addr_t write_bkd_addr,flash_scb_wr_e val_type,
-                               data_b_t custom_val = {});
+  virtual function void set_scb_mem(int bkd_num_words, flash_dv_part_e bkd_partition,
+                                    addr_t write_bkd_addr,flash_scb_wr_e val_type,
+                                    data_b_t custom_val = {});
     addr_t wr_bkd_addr;
     data_t wr_value;
 
@@ -1172,7 +1172,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   function flash_dv_part_e get_part(flash_part_e part,
                                     logic [InfoTypesWidth-1:0] mem_info_sel);
-    if (part == FlashPartData) begin
+    if (part == flash_ctrl_top_specific_pkg::FlashPartData) begin
       return FlashPartData;
     end else begin
       case (mem_info_sel)

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -106,7 +106,7 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
     key_instr_cross : cross key_cp, instr_type_cp;
   endgroup // fetch_code_cg
 
-  covergroup rma_init_cg with function sample(flash_ctrl_pkg::rma_state_e st);
+  covergroup rma_init_cg with function sample(flash_ctrl_top_specific_pkg::rma_state_e st);
     rma_start_cp: coverpoint st {
       bins rma_st[2] = {StRmaIdle, [StRmaPageSel:StRmaInvalid]};
     }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -12,7 +12,7 @@ package flash_ctrl_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_core_ral_pkg::*;
   import flash_ctrl_eflash_ral_pkg::*;
   import flash_ctrl_prim_ral_pkg::*;
@@ -48,9 +48,10 @@ package flash_ctrl_env_pkg;
   };
 
   parameter uint NUM_ALERTS = 5;
-  parameter uint FlashNumPages = flash_ctrl_pkg::NumBanks * flash_ctrl_pkg::PagesPerBank;
-  parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_pkg::WordsPerPage *
-                                  flash_ctrl_pkg::DataWidth / 8;
+  parameter uint FlashNumPages = flash_ctrl_top_specific_pkg::NumBanks *
+                                 flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter uint FlashSizeBytes = FlashNumPages * flash_ctrl_top_specific_pkg::WordsPerPage *
+                                  flash_ctrl_top_specific_pkg::DataWidth / 8;
 
   parameter uint ProgFifoDepth = 4;
   parameter uint ReadFifoDepth = 16;
@@ -59,31 +60,33 @@ package flash_ctrl_env_pkg;
   parameter uint BytesPerPage = FlashSizeBytes / FlashNumPages;
 
   // Num of bytes in each of the flash banks for each of the flash partitions.
-  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_pkg::NumBanks;
+  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_top_specific_pkg::NumBanks;
 
-  parameter uint InfoTypeBytes[flash_ctrl_pkg::InfoTypes] = '{
-      flash_ctrl_pkg::InfoTypeSize[0] * BytesPerPage,
-      flash_ctrl_pkg::InfoTypeSize[1] * BytesPerPage,
-      flash_ctrl_pkg::InfoTypeSize[2] * BytesPerPage
+  parameter uint InfoTypeBytes[flash_ctrl_top_specific_pkg::InfoTypes] = '{
+      flash_ctrl_top_specific_pkg::InfoTypeSize[0] * BytesPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[1] * BytesPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[2] * BytesPerPage
   };
 
   parameter uint FlashNumBusWords = FlashSizeBytes / top_pkg::TL_DBW;
-  parameter uint FlashNumBusWordsPerBank = FlashNumBusWords / flash_ctrl_pkg::NumBanks;
-  parameter uint FlashNumBusWordsPerPage = FlashNumBusWordsPerBank / flash_ctrl_pkg::PagesPerBank;
+  parameter uint FlashNumBusWordsPerBank = FlashNumBusWords /
+                                           flash_ctrl_top_specific_pkg::NumBanks;
+  parameter uint FlashNumBusWordsPerPage = FlashNumBusWordsPerBank /
+                                           flash_ctrl_top_specific_pkg::PagesPerBank;
 
-  parameter uint InfoTypeBusWords[flash_ctrl_pkg::InfoTypes] = '{
-      flash_ctrl_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
-      flash_ctrl_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
-      flash_ctrl_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
+  parameter uint InfoTypeBusWords[flash_ctrl_top_specific_pkg::InfoTypes] = '{
+      flash_ctrl_top_specific_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
+      flash_ctrl_top_specific_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
   };
 
-  parameter uint FlashBankBytesPerWord = flash_ctrl_pkg::DataWidth / 8;
+  parameter uint FlashBankBytesPerWord = flash_ctrl_top_specific_pkg::DataWidth / 8;
 
   parameter uint FlashDataByteWidth = $clog2(FlashBankBytesPerWord);
-  parameter uint FlashWordLineWidth = $clog2(flash_ctrl_pkg::WordsPerPage);
-  parameter uint FlashPageWidth = $clog2(flash_ctrl_pkg::PagesPerBank);
-  parameter uint FlashBankWidth = $clog2(flash_ctrl_pkg::NumBanks);
-  parameter uint FlashPgmRes = flash_ctrl_pkg::BusPgmRes;
+  parameter uint FlashWordLineWidth = $clog2(flash_ctrl_top_specific_pkg::WordsPerPage);
+  parameter uint FlashPageWidth = $clog2(flash_ctrl_top_specific_pkg::PagesPerBank);
+  parameter uint FlashBankWidth = $clog2(flash_ctrl_top_specific_pkg::NumBanks);
+  parameter uint FlashPgmRes = flash_ctrl_top_specific_pkg::BusPgmRes;
   parameter uint FlashPgmResWidth = $clog2(FlashPgmRes);
 
   parameter uint FlashMemAddrWordMsbBit = FlashDataByteWidth - 1;
@@ -99,10 +102,10 @@ package flash_ctrl_env_pkg;
   parameter uint NUM_BK_INFO_WORDS = InfoTypeBusWords[0];  // 10 pages
 
   // params for num of pages
-  parameter uint NUM_PAGE_PART_DATA = flash_ctrl_pkg::PagesPerBank;
-  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_pkg::InfoTypeSize[0];
-  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_pkg::InfoTypeSize[1];
-  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_pkg::InfoTypeSize[2];
+  parameter uint NUM_PAGE_PART_DATA = flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_top_specific_pkg::InfoTypeSize[0];
+  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_top_specific_pkg::InfoTypeSize[1];
+  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_top_specific_pkg::InfoTypeSize[2];
 
   parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
       data_ack: 1'b1,
@@ -214,7 +217,8 @@ package flash_ctrl_env_pkg;
   } flash_mem_init_e;
 
   // Partition select for DV
-  typedef enum logic [flash_ctrl_pkg::InfoTypes:0] {  // Data partition and all info partitions
+  // Data partition and all info partitions
+  typedef enum logic [flash_ctrl_top_specific_pkg::InfoTypes:0] {
     FlashPartData  = 0,
     FlashPartInfo  = 1,
     FlashPartInfo1 = 2,
@@ -300,7 +304,7 @@ package flash_ctrl_env_pkg;
   // Useful for the flash model.
   typedef data_t data_model_t[addr_t];
   // Otf address in a bank.
-  typedef bit [flash_ctrl_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
+  typedef bit [flash_ctrl_top_specific_pkg::BusAddrByteW-FlashBankWidth-1 : 0] otf_addr_t;
 
   typedef struct packed {
     flash_dv_part_e  partition;   // data or one of the info partitions
@@ -310,7 +314,7 @@ package flash_ctrl_env_pkg;
     uint             num_words;   // number of words to read or program (TL_DW)
     addr_t           addr;        // starting addr for the op
     // address for the ctrl interface per bank, 18:0
-    bit [flash_ctrl_pkg::BusAddrByteW-2:0] otf_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] otf_addr;
   } flash_op_t;
 
   // Address combined with region
@@ -331,7 +335,8 @@ package flash_ctrl_env_pkg;
   parameter uint RMA_FSM_STATE_ST_RMA_RSP = 11'b10110001010;
 
   // Indicate host read
-  parameter int unsigned OTFBankId = flash_ctrl_pkg::BusAddrByteW - FlashBankWidth; // bit19
+  parameter int unsigned OTFBankId = flash_ctrl_top_specific_pkg::BusAddrByteW - // bit 19
+                                     FlashBankWidth;
   parameter int unsigned OTFHostId = OTFBankId - 1; // bit 18
   parameter int unsigned DVPageMSB = 18;
   parameter int unsigned DVPageLSB = 11;
@@ -348,7 +353,7 @@ package flash_ctrl_env_pkg;
   localparam int unsigned FlashAddrWidth = 16;
 
   // remove bank select
-  localparam int unsigned FlashByteAddrWidth = flash_ctrl_pkg::BusAddrByteW - 1;
+  localparam int unsigned FlashByteAddrWidth = flash_ctrl_top_specific_pkg::BusAddrByteW - 1;
 
   function automatic bit[63:0] create_flash_data(
            bit [FlashDataWidth-1:0] data, bit [FlashByteAddrWidth-1:0] byte_addr,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -10,7 +10,7 @@ interface flash_ctrl_if (
 
   import lc_ctrl_pkg::*;
   import pwrmgr_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_phy_pkg::*;
   import otp_ctrl_pkg::*;
   import ast_pkg::*;
@@ -47,10 +47,10 @@ interface flash_ctrl_if (
   logic                             power_ready_h = 1'b1;
 
   // eviction
-  logic [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
-  rd_buf_t [flash_ctrl_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
-  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_prog;
-  logic [flash_ctrl_pkg::NumBanks-1:0]             evict_erase;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0][NumBuf-1:0] hazard;
+  rd_buf_t [flash_ctrl_top_specific_pkg::NumBanks-1:0][NumBuf-1:0] rd_buf;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0]             evict_prog;
+  logic [flash_ctrl_top_specific_pkg::NumBanks-1:0]             evict_erase;
   logic                                            fatal_err;
 
   // rma coverage

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_mem_if.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 interface flash_ctrl_mem_if (
   input logic clk_i,
   input logic rst_ni,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -430,7 +430,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                 rcv.mem_info_sel = cfg.flash_ctrl_mem_vif[bank].mem_info_sel;
                 @(negedge cfg.flash_ctrl_mem_vif[bank].clk_i);
                 if (cfg.seq_cfg.use_vendor_flash == 0) begin
-                  if (rcv.mem_part == FlashPartData) begin
+                  if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
                     `DV_CHECK_EQ(cfg.flash_ctrl_mem_vif[bank].data_mem_req, 1,,, name)
                   end else begin
                     case (rcv.mem_info_sel)
@@ -498,7 +498,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
           `DV_CHECK_EQ(rcv.mem_wdata, {flash_phy_pkg::FullDataWidth{1'b1}},,, name)
 
 
-          if (rcv.mem_part == FlashPartData) begin
+          if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
             data_mem[bank].delete(rcv.mem_addr);
           end else begin
             info_mem[bank][rcv.mem_info_sel].delete(rcv.mem_addr);
@@ -519,7 +519,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       end
 
       // Data will be corrupted if some bits to be written cannot be flipped to 1.
-      if (rcv.mem_part == FlashPartData) begin
+      if (rcv.mem_part == flash_ctrl_top_specific_pkg::FlashPartData) begin
         if (data_mem[bank].exists(rcv.mem_addr)) begin
           rd_data = data_mem[bank][rcv.mem_addr];
           if ((exp.req.prog_full_data & rd_data) != exp.req.prog_full_data) begin

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -182,7 +182,7 @@ class flash_ctrl_scoreboard #(
 
     flash_read.partition  = FlashPartData;
     flash_read.erase_type = FlashErasePage;
-    flash_read.op         = flash_ctrl_pkg::FlashOpRead;
+    flash_read.op         = flash_ctrl_top_specific_pkg::FlashOpRead;
     flash_read.num_words  = 1;
     flash_read.addr       = trans.a_addr;
 
@@ -423,7 +423,7 @@ class flash_ctrl_scoreboard #(
       if (part_sel == 1 || part == FlashPartData) begin
         for (int j = 0; j < partition_words_num; j++) begin
           scb_flash_model[addr_attr.addr] = ALL_ONES;
-          addr_attr.incr(flash_ctrl_pkg::BusBytes);
+          addr_attr.incr(flash_ctrl_top_specific_pkg::BusBytes);
         end
         case (part)
           FlashPartData: cfg.scb_flash_data = scb_flash_model;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -19,11 +19,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   // Weights for enable bits for each of the flash banks information partitions memory protection
   //  configuration registers.
-  uint mp_info_page_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                         [flash_ctrl_top_specific_pkg::InfoTypes];
 
   // When this knob is NOT FlashOpInvalid (default) the selected operation will be the only
   //  operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
-  flash_ctrl_pkg::flash_op_e flash_only_op;
+  flash_ctrl_top_specific_pkg::flash_op_e flash_only_op;
 
   // Weights to enable read / program and erase for each mem region.
   uint mp_region_en_pc;
@@ -49,12 +50,18 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Weights to enable read / program and erase for each information partition page.
   // For each of the information partitions in each of the banks there is a single variable to
   //  control all of this partition pages.
-  uint mp_info_page_read_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_program_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_erase_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_scramble_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_ecc_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
-  uint mp_info_page_he_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_read_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                              [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_program_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                                 [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_erase_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                               [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_scramble_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                                  [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_ecc_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                            [flash_ctrl_top_specific_pkg::InfoTypes];
+  uint mp_info_page_he_en_pc[flash_ctrl_top_specific_pkg::NumBanks]
+                            [flash_ctrl_top_specific_pkg::InfoTypes];
 
   // Control the number of flash ops.
   uint max_flash_ops_per_cfg;
@@ -183,7 +190,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   virtual function void configure();
     max_num_trans                 = 20;
 
-    num_en_mp_regions             = flash_ctrl_pkg::MpRegions;
+    num_en_mp_regions             = flash_ctrl_top_specific_pkg::MpRegions;
 
     allow_mp_region_overlap       = 1'b0;
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
@@ -7,9 +7,9 @@ class flash_otf_item extends uvm_object;
   flash_op_t cmd;
   data_q_t   dq;
   fdata_q_t  raw_fq, fq;
-  bit[flash_ctrl_pkg::BusAddrByteW-1:0] start_addr;
+  bit[flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr;
   bit[flash_phy_pkg::KeySize-1:0]      addr_key, data_key;
-  bit [flash_ctrl_pkg::BusAddrByteW-2:0] mem_addr;
+  bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] mem_addr;
   bit                                    head_pad, tail_pad;
   bit                                    scr_en, ecc_en;
   int                                    page;
@@ -115,7 +115,7 @@ class flash_otf_item extends uvm_object;
   // Use 'create_flash_data' function from package
   function void scramble(bit [flash_phy_pkg::KeySize-1:0] addr_key,
                          bit [flash_phy_pkg::KeySize-1:0] data_key,
-                         bit [flash_ctrl_pkg::BusAddrByteW-2:0] addr,
+                         bit [flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] addr,
                          bit dis = 1,
                          bit add_icv_err = 0);
     bit [FlashDataWidth-1:0] data;
@@ -173,7 +173,7 @@ class flash_otf_item extends uvm_object;
     prim_secded_pkg::secded_hamming_76_68_t dec68;
     bit [flash_phy_pkg::FullDataWidth-1:0] data; // 76 bits
     bit [71:0]               data_with_icv;
-    bit[flash_ctrl_pkg::BusAddrByteW-2:0] addr = mem_addr;
+    bit[flash_ctrl_top_specific_pkg::BusAddrByteW-2:0] addr = mem_addr;
     data_q_t   tmp_dq;
 
     ecc_err = 'h0;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -418,7 +418,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   endtask : flash_ctrl_mp_info_page_cfg
 
   // Configure bank erasability.
-  virtual task flash_ctrl_bank_erase_cfg(bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en);
+  virtual task flash_ctrl_bank_erase_cfg(
+      bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en);
     csr_wr(.ptr(ral.mp_bank_cfg_shadowed[0]), .value(bank_erase_en));
   endtask : flash_ctrl_bank_erase_cfg
 
@@ -1621,8 +1622,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       // Only scr/ecc enable matter; cfg.ovrd_src_dis can be randomized in directed test,
       // but otherwise it has the same default value as HW_INFO_CFG_OVERRIDE.
       if (page != 3) begin
-        scramble_en = prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
-                                                  mubi4_t'(~cfg.ovrd_scr_dis));
+        scramble_en = prim_mubi_pkg::mubi4_and_hi(
+            flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en, mubi4_t'(~cfg.ovrd_scr_dis));
         ecc_en = prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                              mubi4_t'(~cfg.ovrd_ecc_dis));
       end else begin

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -112,7 +112,8 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                          [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -47,15 +47,15 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
-    flash_op.op == flash_ctrl_pkg::FlashOpErase;
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase;
 
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -63,12 +63,12 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -112,13 +112,13 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
 
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
 
@@ -163,7 +163,7 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -265,7 +265,7 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
                      flash_op.partition != flash_op_erase.partition ||
                      flash_op.addr[FlashMemAddrBankMsbBit-:(FlashBankWidth+FlashPageWidth)] !=
                      flash_op_erase.addr[FlashMemAddrBankMsbBit-:(FlashBankWidth+FlashPageWidth)];
-                     if (flash_op_erase.erase_type == flash_ctrl_pkg::FlashEraseBank) {
+                     if (flash_op_erase.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank) {
                        flash_op.addr[FlashMemAddrBankMsbBit] !=
                        flash_op_erase.addr[FlashMemAddrBankMsbBit];
                      })

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -36,7 +36,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Copies of the MP Region Settings (Data and Info Partitions)
   flash_mp_region_cfg_t mp_data_regions[flash_ctrl_top_specific_pkg::MpRegions];
   flash_bank_mp_info_page_cfg_t
-    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks]
+                   [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   // Constraint for Bank.
   constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
@@ -61,18 +62,23 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
      flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info2_partition) {
-      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
+      if (flash_op.partition == FlashPartInfo2) {
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      }
     }
 
-    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                        flash_ctrl_top_specific_pkg::FlashOpProgram,
                         flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
@@ -88,7 +94,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -145,7 +152,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                 [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
@@ -457,7 +465,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       unique case (flash_op.op)
         flash_ctrl_top_specific_pkg::FlashOpErase : begin
           // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
+          if ((info_part == 0) &&
+              (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
             rsp = MP_PASS;
           else
             rsp = (mp_info_regions[info_bank][info_part][info_page].erase_en == MuBi4False);
@@ -490,7 +499,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       en_msg = (mp_data_regions[i].en == MuBi4True) ? "Enabled": "Disabled";
       `uvm_info(`gfn,
         $sformatf("MPR%0d : From : 0x%03x, To : 0x%03x : From : 0x%08x, To : 0x%08x, %s", i,
-          mp_data_regions[i].start_page, mp_data_regions[i].start_page+mp_data_regions[i].num_pages,
+          mp_data_regions[i].start_page,
+          mp_data_regions[i].start_page+mp_data_regions[i].num_pages,
             mp_data_regions[i].start_page*(FullPageNumWords*4),
               (mp_data_regions[i].start_page+mp_data_regions[i].num_pages)*(FullPageNumWords*4),
                 en_msg), UVM_MEDIUM)

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -34,12 +34,12 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   uint            erase_err_cnt = 0;
 
   // Copies of the MP Region Settings (Data and Info Partitions)
-  flash_mp_region_cfg_t mp_data_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_data_regions[flash_ctrl_top_specific_pkg::MpRegions];
   flash_bank_mp_info_page_cfg_t
-    mp_info_regions[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_regions[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   // Constraint for Bank.
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in the relevant range for
   // the selected partition.
@@ -58,26 +58,26 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Bank Erase is only supported for Data & 1st Info Partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-     flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info2_partition) {
-      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_pkg::FlashOpRead;}
+      if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
     }
 
-    flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram,
-                        flash_ctrl_pkg::FlashOpErase};
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+                        flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -88,14 +88,14 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
     }
   }
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
 
@@ -145,13 +145,13 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].scramble_en == MuBi4False;
         mp_info_pages[i][j][k].ecc_en      == MuBi4False;
         mp_info_pages[i][j][k].he_en dist {
@@ -170,7 +170,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
   rand mubi4_t default_region_he_en;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -232,7 +232,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
       // Initialise Flash Content
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
       end else begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
@@ -245,7 +245,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
       case (flash_op.op)
 
         // ERASE
-        flash_ctrl_pkg::FlashOpErase : begin
+        flash_ctrl_top_specific_pkg::FlashOpErase : begin
           `uvm_info(`gfn, $sformatf("Flash : ERASE exp_alert:%0d", exp_alert), UVM_LOW)
           flash_ctrl_start_op(flash_op);
           wait_flash_op_done(.clear_op_status(0), .timeout_ns(cfg.seq_cfg.erase_timeout_ns));
@@ -256,7 +256,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
         end
 
         // PROGRAM
-        flash_ctrl_pkg::FlashOpProgram : begin
+        flash_ctrl_top_specific_pkg::FlashOpProgram : begin
           `uvm_info(`gfn, $sformatf("Flash : PROGRAM exp_alert:%0d", exp_alert), UVM_LOW)
           exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
           flash_ctrl_start_op(flash_op);
@@ -269,7 +269,7 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
         end
 
         // READ
-        flash_ctrl_pkg::FlashOpRead : begin
+        flash_ctrl_top_specific_pkg::FlashOpRead : begin
           `uvm_info(`gfn, $sformatf("Flash : READ exp_alert:%0d", exp_alert), UVM_LOW)
           flash_op_data.delete();
           flash_ctrl_start_op(flash_op);
@@ -384,9 +384,9 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     // Assign op_msg to Op Type (used below)
     unique case (flash_op.op)
-      flash_ctrl_pkg::FlashOpErase   : op_msg = "Erase";
-      flash_ctrl_pkg::FlashOpProgram : op_msg = "Program";
-      flash_ctrl_pkg::FlashOpRead    : op_msg = "Read";
+      flash_ctrl_top_specific_pkg::FlashOpErase   : op_msg = "Erase";
+      flash_ctrl_top_specific_pkg::FlashOpProgram : op_msg = "Program";
+      flash_ctrl_top_specific_pkg::FlashOpRead    : op_msg = "Read";
       default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
     endcase
 
@@ -401,16 +401,16 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
           UVM_MEDIUM)
         if (mp_data_regions[i].en == MuBi4True) begin
           unique case (flash_op.op)
-            flash_ctrl_pkg::FlashOpErase : begin
+            flash_ctrl_top_specific_pkg::FlashOpErase : begin
               // Bank Erase Defeats the MP Settings
-              if (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank)
+              if (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank)
                 rsp_vec[i] = MP_PASS;
               else
                 rsp_vec[i] = (mp_data_regions[i].erase_en == MuBi4False);
             end
-            flash_ctrl_pkg::FlashOpProgram : rsp_vec[i] =
+            flash_ctrl_top_specific_pkg::FlashOpProgram : rsp_vec[i] =
               (mp_data_regions[i].program_en == MuBi4False);
-            flash_ctrl_pkg::FlashOpRead : rsp_vec[i] =
+            flash_ctrl_top_specific_pkg::FlashOpRead : rsp_vec[i] =
               (mp_data_regions[i].read_en == MuBi4False);
             default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
           endcase
@@ -455,16 +455,16 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     // Look for MP Area Violations
     if (mp_info_regions[info_bank][info_part][info_page].en == MuBi4True) begin
       unique case (flash_op.op)
-        flash_ctrl_pkg::FlashOpErase : begin
+        flash_ctrl_top_specific_pkg::FlashOpErase : begin
           // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank))
+          if ((info_part == 0) && (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
             rsp = MP_PASS;
           else
             rsp = (mp_info_regions[info_bank][info_part][info_page].erase_en == MuBi4False);
         end
-        flash_ctrl_pkg::FlashOpProgram :
+        flash_ctrl_top_specific_pkg::FlashOpProgram :
           rsp = (mp_info_regions[info_bank][info_part][info_page].program_en == MuBi4False);
-        flash_ctrl_pkg::FlashOpRead :
+        flash_ctrl_top_specific_pkg::FlashOpRead :
           rsp = (mp_info_regions[info_bank][info_part][info_page].read_en == MuBi4False);
         default : `uvm_fatal(`gfn, "Unrecognised Flash Operation, FAIL")
       endcase
@@ -472,8 +472,8 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     else
     begin
       // Bank Erase Defeats the MP Settings, Only valid for Info Partition (not Info1 or info2)
-      if ((info_part == 0) && (flash_op.op == flash_ctrl_pkg::FlashOpErase) &&
-          (flash_op.erase_type == flash_ctrl_pkg::FlashEraseBank))
+      if ((info_part == 0) && (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase) &&
+          (flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashEraseBank))
         rsp = MP_PASS;
       else
         rsp = MP_VIOLATION;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -47,8 +47,8 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for the Flash Operation
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
-    flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Use only Flash Program
+    flash_op.partition == FlashPartData;  // Use only Data Partitions
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -37,7 +37,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
   constraint y_max_c { y_max inside {[16:32]}; }  // Inner Loop - Num Transactions
 
   // Constraint for Bank.
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in relevant range the for the selected partition.
   constraint addr_c {
@@ -47,7 +47,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Constraint for the Flash Operation
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;  // Only Flash Program Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
     flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -62,7 +62,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
     flash_op_data.size() == flash_op.num_words;
   }
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
 
@@ -99,13 +99,13 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -128,7 +128,7 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
   rand mubi4_t default_region_ecc_en;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
@@ -46,7 +46,7 @@ class flash_ctrl_error_prog_win_vseq extends flash_ctrl_fetch_code_vseq;
   // Constraint for the Flash Operation
   constraint flash_op_c {
 
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;  // Only Flash Program Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
     flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_win_vseq.sv
@@ -46,8 +46,8 @@ class flash_ctrl_error_prog_win_vseq extends flash_ctrl_fetch_code_vseq;
   // Constraint for the Flash Operation
   constraint flash_op_c {
 
-    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Only Flash Program Used in this test
-    flash_op.partition == FlashPartData;  // Ony Data Partitions Used in this test
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;  // Use only Flash Program
+    flash_op.partition == FlashPartData;  // Use only Data Partitions
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -67,16 +67,21 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
+    if (flash_op.partition == FlashPartInfo2) {
+      flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+    }
 
-    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                        flash_ctrl_top_specific_pkg::FlashOpProgram,
                         flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
@@ -93,7 +98,8 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {
+        flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -142,7 +148,8 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                 [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -48,7 +48,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     };
   }
 
-  constraint bank_c {bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};}
+  constraint bank_c {bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};}
 
   // Constraint for controller address to be in relevant range for the selected partition.
   constraint addr_c {
@@ -64,24 +64,24 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   constraint flash_op_c {
     // Bank Erase is only supported for Data & 1st Info Partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_pkg::FlashOpRead;}
+    if (flash_op.partition == FlashPartInfo2) {flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;}
 
-    flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram,
-                        flash_ctrl_pkg::FlashOpErase};
+    flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram,
+                        flash_ctrl_top_specific_pkg::FlashOpErase};
 
     flash_op.erase_type dist {
-     flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+     flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words >= 10;
@@ -93,7 +93,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   // Flash ctrl operation data queue - used for programing or reading the flash.
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -101,12 +101,12 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   // Memory Protection Regions
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -142,13 +142,13 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection settings.
   rand flash_bank_mp_info_page_cfg_t
-    mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+    mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -172,7 +172,7 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en = MuBi4False;
 
   // Bank Erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -27,7 +27,8 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                          [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -23,16 +23,16 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   addr_t bank_start_addr;
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+             mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -56,7 +56,7 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {
@@ -111,8 +111,8 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
     flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
 
     flash_op_sw_rw.partition  = FlashPartData;
-    flash_op_sw_rw.erase_type = flash_ctrl_pkg::FlashEraseBank;
-    flash_op_sw_rw.op         = flash_ctrl_pkg::FlashOpProgram;
+    flash_op_sw_rw.erase_type = flash_ctrl_top_specific_pkg::FlashEraseBank;
+    flash_op_sw_rw.op         = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op_sw_rw.num_words  = 16;
     flash_op_sw_rw.addr       = bank_start_addr;
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
@@ -123,7 +123,7 @@ class flash_ctrl_host_ctrl_arb_vseq extends flash_ctrl_fetch_code_vseq;
     if (op_cnt <= apply_rma) begin
       // Initialise Flash Content
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
       end else begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_dir_rd_vseq.sv
@@ -34,7 +34,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
   }
 
   constraint flash_op_c {
-    flash_op.op == flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.partition == FlashPartData;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -172,7 +172,7 @@ class flash_ctrl_host_dir_rd_vseq extends flash_ctrl_fetch_code_vseq;
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller read data
     flash_ctrl_start_op(flash_op);

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -40,19 +40,19 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
     // ERASE
 
     `uvm_info(`gfn, "ERASE", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpErase, ReadCheckNorm);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     // PROGRAM
 
     `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpProgram, ReadCheckNorm);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
     `uvm_info(`gfn, "READ", UVM_LOW)
-    do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckNorm);
 
     // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
     fork
@@ -132,7 +132,7 @@ class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
 
     `uvm_info(`gfn, "READ", UVM_LOW)
 
-    do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckRand);
+    do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckRand);
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
   endtask : body

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_err_vseq.sv
@@ -4,8 +4,6 @@
 
 // flash_ctrl_hw_rma Test
 
-import lc_ctrl_pkg::*;
-
 class flash_ctrl_hw_rma_err_vseq extends flash_ctrl_hw_rma_vseq;
   `uvm_object_utils(flash_ctrl_hw_rma_err_vseq)
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_reset_vseq.sv
@@ -61,8 +61,9 @@ class flash_ctrl_hw_rma_reset_vseq extends flash_ctrl_hw_rma_vseq;
                        cfg.seq_cfg.state_wait_timeout_ns)
           // Give more cycles for long stages
           // to trigger reset in the middle of the state.
-          if (reset_state_index inside {StRmaRdVerify, StRmaErase}) cfg.clk_rst_vif.wait_clks(10);
-
+          if (reset_state_index inside {DVStRmaRdVerify, DVStRmaErase}) begin
+            cfg.clk_rst_vif.wait_clks(10);
+          end
           if (flash_dis) begin
             `uvm_info("Test", "set disable_flash", UVM_MEDIUM)
             cfg.scb_h.do_alert_check = 0;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -91,19 +91,19 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
       // ERASE
 
       `uvm_info(`gfn, "ERASE", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpErase, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpErase, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // PROGRAM
 
       `uvm_info(`gfn, "PROGRAM", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpProgram, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpProgram, ReadCheckNorm);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
       // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
 
       `uvm_info(`gfn, "READ", UVM_LOW)
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckNorm);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckNorm);
 
       // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
       fork
@@ -167,7 +167,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
       `uvm_info(`gfn, "READ", UVM_LOW)
 
-      do_flash_ops(flash_ctrl_pkg::FlashOpRead, ReadCheckRand);
+      do_flash_ops(flash_ctrl_top_specific_pkg::FlashOpRead, ReadCheckRand);
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
     end
@@ -178,8 +178,8 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
     // DATA PARTITION
 
-    flash_mp_region_cfg_t mp_regions [flash_ctrl_pkg::MpRegions];
-    bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+    flash_mp_region_cfg_t mp_regions [flash_ctrl_top_specific_pkg::MpRegions];
+    bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
     mubi4_t default_region_read_en;
     mubi4_t default_region_program_en;
     mubi4_t default_region_erase_en;
@@ -263,7 +263,7 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     `uvm_info(`gfn, "Attempting to READ from Flash", UVM_INFO)
 
     // Attempt to Read from FLASH, No Access Expected after RMA
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Select a Random Partition to try to Read From
     randcase
@@ -292,8 +292,8 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
 
     // Arbitrary num_words - Access should fail on the first attempt
     flash_op.num_words  = $urandom_range(8, 16);
-    flash_op.erase_type = $urandom ? flash_ctrl_pkg::FlashErasePage :
-                                     flash_ctrl_pkg::FlashEraseBank;
+    flash_op.erase_type = $urandom ? flash_ctrl_top_specific_pkg::FlashErasePage :
+                                     flash_ctrl_top_specific_pkg::FlashEraseBank;
 
     // Start Read Operation
     flash_ctrl_start_op(flash_op);

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -21,8 +21,6 @@
 // #Random Order : Creator(page), Owner(page), Isolation(page),
 //                 Data0(random page), Data1(random page)
 
-import lc_ctrl_pkg::*;
-
 class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
   `uvm_object_utils(flash_ctrl_hw_rma_vseq)
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -80,28 +80,28 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
@@ -117,18 +117,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Choose Erase/Program Combination to perform this iteration
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -140,18 +140,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Note: Uses case_sel value from above
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -162,18 +162,18 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
       endcase
 
@@ -199,7 +199,7 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
     // DATA PARTITION
 
-    flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+    flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
     mubi4_t default_region_read_en;
     mubi4_t default_region_program_en;
     mubi4_t default_region_erase_en;
@@ -236,10 +236,10 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
     flash_bank_mp_info_page_cfg_t info_regions[flash_ctrl_reg_pkg::NumInfos0];
 
     foreach (info_regions[i]) begin
-      // Get secret partition cfg from flash_ctrl_pkg
+      // Get secret partition cfg from flash_ctrl_top_specific_pkg
       if ( i inside {1, 2}) begin
         // Copy protection from hw_cfg0.
-        info_regions[i] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+        info_regions[i] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
         // Update program and erase control for the test purpose.
         info_regions[i].program_en = MuBi4True;
         info_regions[i].erase_en   = MuBi4True;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -80,28 +80,34 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
           compare_secret_seed(FlashOwnerPart, flash_op_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, flash_op_data);
           if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
           compare_secret_seed(FlashCreatorPart, flash_op_data);
         end
@@ -117,18 +123,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Choose Erase/Program Combination to perform this iteration
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpErase, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -140,18 +152,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
       // Note: Uses case_sel value from above
       unique case (case_sel)
         0: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         2: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         3: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpProgram, dummy_data);
         end
         default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
       endcase
@@ -162,18 +180,24 @@ class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
 
       randcase
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+             FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
         end
         1: begin
-          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
-          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(
+              FlashOwnerPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(
+              FlashCreatorPart, flash_ctrl_top_specific_pkg::FlashOpRead, exp_creator_data);
         end
       endcase
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_info_part_access_vseq.sv
@@ -121,9 +121,9 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
       scr_en = 1;
       ecc_en = 1;
     end else begin
-      scr_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_pkg::CfgAllowRead.scramble_en,
+      scr_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
                                            mubi4_t'(~cfg.ovrd_scr_dis)) == MuBi4True);
-      ecc_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_pkg::CfgAllowRead.ecc_en,
+      ecc_en = (prim_mubi_pkg::mubi4_and_hi(flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                            mubi4_t'(~cfg.ovrd_ecc_dis)) == MuBi4True);
     end
 
@@ -174,14 +174,14 @@ class flash_ctrl_info_part_access_vseq extends flash_ctrl_hw_sec_otp_vseq;
     for (int i = 1; i < 4; i++) begin
       if (i < 3) begin
          info_regions.scramble_en = prim_mubi_pkg::mubi4_and_hi(
-                                    flash_ctrl_pkg::CfgAllowRead.scramble_en,
+                                    flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en,
                                     mubi4_t'(~cfg.ovrd_scr_dis));
          info_regions.ecc_en = prim_mubi_pkg::mubi4_and_hi(
-                               flash_ctrl_pkg::CfgAllowRead.ecc_en,
+                               flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en,
                                mubi4_t'(~cfg.ovrd_ecc_dis));
       end else begin
-        info_regions.scramble_en = flash_ctrl_pkg::CfgAllowRead.scramble_en;
-        info_regions.ecc_en = flash_ctrl_pkg::CfgAllowRead.ecc_en;
+        info_regions.scramble_en = flash_ctrl_top_specific_pkg::CfgAllowRead.scramble_en;
+        info_regions.ecc_en = flash_ctrl_top_specific_pkg::CfgAllowRead.ecc_en;
       end
       flash_ctrl_mp_info_page_cfg(0, 0, i, info_regions);
     end

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -68,7 +68,8 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                      [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_invalid_op_vseq.sv
@@ -48,7 +48,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
     // With scramble enabled, odd size of word access (or address) will cause
     // ecc errors.
     flash_op.addr[2:0] == 3'h0;
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
     flash_op.num_words < FlashPgmRes - flash_op.addr[TL_SZW+:FlashPgmResWidth];
@@ -64,15 +64,15 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   }
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
       foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
@@ -97,7 +97,7 @@ class flash_ctrl_invalid_op_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -19,14 +19,16 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     // This added because in some extending env the info2 has special use.

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -19,14 +19,14 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     // This added because in some extending env the info2 has special use.

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -59,7 +59,8 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks]
+                      [flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -42,7 +42,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
 
   constraint flash_op_c {
     flash_op.prog_sel == FlashProgSelNormal;
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
     flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
     flash_op.num_words <= cfg.seq_cfg.op_max_words;
@@ -55,16 +55,16 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   }
 
   // Memory protection regions settings.
-  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   // Information partitions memory protection pages settings.
   rand flash_bank_mp_info_page_cfg_t
-         mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+         mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
         mp_info_pages[i][j][k].en == MuBi4True;
         mp_info_pages[i][j][k].read_en == MuBi4True;
         mp_info_pages[i][j][k].program_en == MuBi4True;
@@ -88,7 +88,7 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -33,11 +33,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   int     exp_alert_cnt = 0;
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
   // Information partitions memory protection pages settings.
   rand
   flash_bank_mp_info_page_cfg_t
-  mp_info_pages[NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  mp_info_pages[NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint solv_order_c {
     solve mp_regions, mp_info_pages before flash_op;
@@ -57,11 +57,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     flash_op.otf_addr == flash_op.addr[OTFHostId-1:0];
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.num_words inside {[10 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
@@ -110,7 +110,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     }
 
     foreach (mp_info_pages[i, j]) {
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
        mp_info_pages[i][j][k].en dist {
@@ -139,7 +139,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   mubi4_t default_region_ecc_en;
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint default_region_he_en_c {
     default_region_he_en dist {
@@ -328,7 +328,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
     poll_fifo_status           = 1;
 
-    flash_op.erase_type = flash_ctrl_pkg::FlashEraseBank;
+    flash_op.erase_type = flash_ctrl_top_specific_pkg::FlashEraseBank;
     flash_op.num_words  = 16;
     info_sel = flash_op.partition >> 1;
     bank = flash_op.addr[19];

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -109,14 +109,14 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
@@ -183,8 +183,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     if (cfg.en_all_info_acc) allow_spec_info_acc = 3'h7;
 
     // overwrite secret_partition cfg with hw_cfg0
-    rand_info[0][0][1] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
-    rand_info[0][0][2] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+    rand_info[0][0][1] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
+    rand_info[0][0][2] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
   endfunction : post_randomize
 
   virtual task pre_start();
@@ -570,7 +570,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     data_q_t flash_read_data;
     flash_otf_item exp_item;
     bit poll_fifo_status = ~in_err;
-    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
+    bit [flash_ctrl_top_specific_pkg::BusAddrByteW-1:0] start_addr, end_addr;
     int page;
     bit overflow = 0;
     uvm_reg_data_t reg_data;
@@ -1389,8 +1389,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (ecc_mode != OTFCfgRand) cfg.mp_info[i][j][k].ecc_en = ecc_en;
 
       // overwrite secret_partition cfg with hw_cfg0
-      cfg.mp_info[0][0][1] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
-      cfg.mp_info[0][0][2] = conv2env_mp_info(flash_ctrl_pkg::CfgAllowRead);
+      cfg.mp_info[0][0][1] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
+      cfg.mp_info[0][0][2] = conv2env_mp_info(flash_ctrl_top_specific_pkg::CfgAllowRead);
 
       flash_ctrl_mp_info_page_cfg(i, j, k, cfg.mp_info[i][j][k]);
       `uvm_info("otf_info_cfg", $sformatf("bank:type:page:[%0d][%0d][%0d] = %p",

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -121,7 +121,12 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
           rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
-    rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+    rand_op.partition dist {
+      FlashPartData := 6,
+      FlashPartInfo := 1,
+      FlashPartInfo1 := 1,
+      FlashPartInfo2 := 1
+    };
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
     cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -109,14 +109,16 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo;
       } else {
-        rand_op.partition == FlashPartInfo -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
       if (cfg.seq_cfg.avoid_ro_partitions) {
         rand_op.partition != FlashPartInfo1;
       } else {
-        rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+        rand_op.partition == FlashPartInfo1 ->
+          rand_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
       }
     }
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -24,8 +24,8 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
   constraint bank_c {
     solve bank before bank_rd;
     if (bank_same == 1) {bank == bank_rd;} else {bank != bank_rd;}
-    bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
-    bank_rd inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
+    bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
+    bank_rd inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
   }
 
   // Constraint host read address to be in relevant range for the selected partition.
@@ -95,9 +95,9 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       ), UVM_HIGH)
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
       cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      end else if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+      end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
       end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_host_rd), .scheme(FlashMemInitRandomize));
@@ -120,9 +120,9 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       ), UVM_HIGH)
       cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
       cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
-      if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+      if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      end else if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+      end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
       end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_host_rd), .scheme(FlashMemInitRandomize));
@@ -138,7 +138,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
     flash_op.partition = FlashPartData;
     flash_op_host_rd.addr = 0;
     flash_op_host_rd.num_words = 30;
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.addr = 'h14;
     flash_op.num_words = 10;
     cfg.flash_mem_bkdr_init(flash_op_host_rd.partition, FlashMemInitInvalidate);
@@ -175,11 +175,11 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       end
       begin
         // controller read, program or erase
-        if (flash_op.op == flash_ctrl_pkg::FlashOpRead) begin
+        if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead) begin
           controller_read_data(flash_op);
-        end else if (flash_op.op == flash_ctrl_pkg::FlashOpProgram) begin
+        end else if (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpProgram) begin
           controller_program_data(flash_op, flash_op_data);
-        end else begin  //flash_op.op == flash_ctrl_pkg::FlashOpErase
+        end else begin  //flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase
           controller_erase_data(flash_op);
         end
       end

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -61,13 +61,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 ->
+        flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
       flash_op.num_words <= cfg.seq_cfg.op_max_words;
       // end of transaction must be within the program resolution
@@ -81,7 +84,8 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead,
+                            flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -32,16 +32,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     flash_op.op inside {FlashOpRead, FlashOpProgram, FlashOpErase};
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
 
-    if (!cfg.seq_cfg.op_allow_invalid) {flash_op.op != flash_ctrl_pkg::FlashOpInvalid;}
+    if (!cfg.seq_cfg.op_allow_invalid) {flash_op.op != flash_ctrl_top_specific_pkg::FlashOpInvalid;}
 
-    if (cfg.seq_cfg.flash_only_op != flash_ctrl_pkg::FlashOpInvalid) {
+    if (cfg.seq_cfg.flash_only_op != flash_ctrl_top_specific_pkg::FlashOpInvalid) {
       flash_op.op == cfg.seq_cfg.flash_only_op;
     }
 
-    (flash_op.op == flash_ctrl_pkg::FlashOpErase) ->
+    (flash_op.op == flash_ctrl_top_specific_pkg::FlashOpErase) ->
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.prog_sel dist {
@@ -58,16 +58,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
 
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_top_specific_pkg::FlashErasePage;
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
-      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
     if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_pkg::FlashOpRead;
+      flash_op.partition == FlashPartInfo1 -> flash_op.op == flash_ctrl_top_specific_pkg::FlashOpRead;
     }
 
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op.num_words inside {[1 : FlashNumBusWords - flash_op.addr[TL_AW-1:TL_SZW]]};
       flash_op.num_words <= cfg.seq_cfg.op_max_words;
       // end of transaction must be within the program resolution
@@ -81,7 +81,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   rand data_q_t             flash_op_data;
   constraint flash_op_data_c {
     solve flash_op before flash_op_data;
-    if (flash_op.op inside {flash_ctrl_pkg::FlashOpRead, flash_ctrl_pkg::FlashOpProgram}) {
+    if (flash_op.op inside {flash_ctrl_top_specific_pkg::FlashOpRead, flash_ctrl_top_specific_pkg::FlashOpProgram}) {
       flash_op_data.size() == flash_op.num_words;
     } else {
       flash_op_data.size() == 0;
@@ -89,12 +89,12 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -171,13 +171,13 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   // Information partitions memory protection rpages settings.
   rand
   flash_bank_mp_info_page_cfg_t
-  mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  mp_info_pages[flash_ctrl_top_specific_pkg::NumBanks][flash_ctrl_top_specific_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
     foreach (mp_info_pages[i, j]) {
 
-      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
       foreach (mp_info_pages[i, j, k]) {
 
@@ -221,7 +221,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -358,20 +358,20 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
         // Calculate expected data for post-transaction checks
         exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
         case (flash_op.op)
-          flash_ctrl_pkg::FlashOpRead: begin
+          flash_ctrl_top_specific_pkg::FlashOpRead: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_read(flash_op.num_words, flash_op_data, poll_fifo_status);
             wait_flash_op_done();
             if (cfg.seq_cfg.check_mem_post_tran)
               cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
           end
-          flash_ctrl_pkg::FlashOpProgram: begin
+          flash_ctrl_top_specific_pkg::FlashOpProgram: begin
             `DV_CHECK_MEMBER_RANDOMIZE_FATAL(poll_fifo_status)
             flash_ctrl_write(flash_op_data, poll_fifo_status);
             wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
             if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, exp_data);
           end
-          flash_ctrl_pkg::FlashOpErase: begin
+          flash_ctrl_top_specific_pkg::FlashOpErase: begin
             wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
             if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_erase_check(flash_op, exp_data);
           end
@@ -392,12 +392,12 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
     // region exposing the issue.
     cfg.flash_mem_bkdr_init(flash_op.partition, FlashMemInitInvalidate);
     case (flash_op.op)
-      flash_ctrl_pkg::FlashOpRead: begin
+      flash_ctrl_top_specific_pkg::FlashOpRead: begin
         // Initialize the targeted mem region with random data.
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitRandomize));
         cfg.clk_rst_vif.wait_clks(1);
       end
-      flash_ctrl_pkg::FlashOpProgram: begin
+      flash_ctrl_top_specific_pkg::FlashOpProgram: begin
         // Initialize the targeted mem region with all 1s. This is required because the flash
         // needs to be erased to all 1s between each successive programming.
         cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -32,14 +32,14 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   // Constraint address to be in relevant range for the selected partition.
   constraint addr_c {
     solve bank before flash_op;
-    bank inside {[0 : flash_ctrl_pkg::NumBanks - 1]};
+    bank inside {[0 : flash_ctrl_top_specific_pkg::NumBanks - 1]};
     flash_op.addr inside {[BytesPerBank * bank : BytesPerBank * (bank + 1) - BytesPerBank / 2]};
   }
 
   constraint flash_op_c {
     flash_op.erase_type dist {
-      flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
-      flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
+      flash_ctrl_top_specific_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
+      flash_ctrl_top_specific_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
     flash_op.partition == FlashPartData;
@@ -61,12 +61,12 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  rand bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  rand bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   constraint en_mp_regions_c {$countones(en_mp_regions) == cfg.seq_cfg.num_en_mp_regions;}
 
   // Memory protection regions settings.
-  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+  rand flash_mp_region_cfg_t mp_regions[flash_ctrl_top_specific_pkg::MpRegions];
 
   constraint mp_regions_c {
     solve en_mp_regions before mp_regions;
@@ -106,7 +106,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   }
 
   // Bank erasability.
-  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+  rand bit [flash_ctrl_top_specific_pkg::NumBanks-1:0] bank_erase_en;
 
   constraint bank_erase_en_c {
     foreach (bank_erase_en[i]) {
@@ -413,7 +413,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Controller read data.
   virtual task controller_read_op_data(ref flash_op_t flash_op);
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
     flash_rd_data.delete();
     flash_ctrl_start_op(flash_op);
     flash_ctrl_read(flash_op.num_words, flash_rd_data, poll_fifo_status);
@@ -423,7 +423,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Controller program data.
   virtual task controller_program_data(ref flash_op_t flash_op, data_q_t flash_op_data);
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
     flash_ctrl_start_op(flash_op);
     flash_ctrl_write(flash_op_data, poll_fifo_status);
@@ -433,7 +433,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
   // Erase data.
   virtual task erase_data(ref flash_op_t flash_op);
-    flash_op.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpErase;
     flash_ctrl_start_op(flash_op);
     wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_hw_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_hw_vseq.sv
@@ -36,7 +36,7 @@ class flash_ctrl_smoke_hw_vseq extends flash_ctrl_base_vseq;
     flash_op_t flash_op;
 
     // Bit vector representing which of the mp region cfg CSRs to enable.
-    bit [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+    bit [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
     // Memory protection regions settings. One MP region, Single Page
     flash_mp_region_cfg_t mp_region;
@@ -49,7 +49,7 @@ class flash_ctrl_smoke_hw_vseq extends flash_ctrl_base_vseq;
     bank = 0;
 
     flash_op.addr = 0;
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
     flash_op.partition = FlashPartData;
     flash_op.num_words = 10;
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -56,7 +56,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Configure the FLASH Controller
 
     // Memory protection regions settings. One MP region, Single Page
-    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_top_specific_pkg::MpRegions];
+    flash_mp_region_cfg_t             mp_regions [flash_ctrl_top_specific_pkg::MpRegions];
 
     foreach (mp_regions[i]) begin
       mp_regions[i].en         = mubi4_bool_to_mubi(en_mp_regions[i]);

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_sw_op_vseq.sv
@@ -19,7 +19,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
   uint                                          bank;
 
   // Bit vector representing which of the mp region cfg CSRs to enable.
-  bit           [flash_ctrl_pkg::MpRegions-1:0] en_mp_regions;
+  bit           [flash_ctrl_top_specific_pkg::MpRegions-1:0] en_mp_regions;
 
   // Indicates whether to poll before writing to the prog_fifo or reading from the rd_fifo. If interupts are
   // enabled, the interrupt signals will be used instead. When set to 0, it will continuously write
@@ -56,7 +56,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Configure the FLASH Controller
 
     // Memory protection regions settings. One MP region, Single Page
-    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_pkg::MpRegions];
+    flash_mp_region_cfg_t             mp_regions                [flash_ctrl_top_specific_pkg::MpRegions];
 
     foreach (mp_regions[i]) begin
       mp_regions[i].en         = mubi4_bool_to_mubi(en_mp_regions[i]);
@@ -106,7 +106,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Read Frontdoor, Compare Backdoor
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);
@@ -118,10 +118,10 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // FLASH ERASE
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpErase;
 
     // Select Page Erase
-    flash_op.erase_type = flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type = flash_ctrl_top_specific_pkg::FlashErasePage;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);
@@ -133,7 +133,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Write Frontdoor, Read backdoor
 
     // Select FLASH Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpProgram;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpProgram;
 
     // Randomize Write Data
     `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(flash_op_data, flash_op_data.size == flash_op.num_words;)
@@ -152,7 +152,7 @@ class flash_ctrl_sw_op_vseq extends flash_ctrl_base_vseq;
     // Read Frontdoor, Compare Backdoor
 
     // Select FLASH Read Operation
-    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+    flash_op.op = flash_ctrl_top_specific_pkg::FlashOpRead;
 
     // Start Controller
     flash_ctrl_start_op(flash_op);

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/sva/flash_ctrl_sva.core
@@ -8,7 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
     files:

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/tb/tb.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/tb/tb.sv
@@ -7,7 +7,7 @@ module tb;
   import uvm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_env_pkg::*;
   import flash_ctrl_test_pkg::*;
   import flash_ctrl_bkdr_util_pkg::flash_ctrl_bkdr_util;
@@ -74,7 +74,7 @@ module tb;
   `define FLASH_DEVICE_HIER tb.dut.u_eflash.u_flash
   assign fpp_if.req = `FLASH_DEVICE_HIER.flash_req_i;
   assign fpp_if.rsp = `FLASH_DEVICE_HIER.flash_rsp_o;
-  for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_bank_loop
+  for (genvar i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; i++) begin : gen_bank_loop
     assign fpp_if.rreq[i] = tb.dut.u_eflash.gen_flash_cores[i].u_core.u_rd.req_i;
     assign fpp_if.rdy[i] = tb.dut.u_eflash.gen_flash_cores[i].u_core.u_rd.rdy_o;
 
@@ -258,7 +258,7 @@ module tb;
                  "u_info_mem.gen_generic.u_impl_generic.mem"}, i, j)
 
   if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_generic
-    for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : gen_each_bank
+    for (genvar i = 0; i < flash_ctrl_top_specific_pkg::NumBanks; i++) begin : gen_each_bank
       flash_dv_part_e part = part.first();
 
       initial begin
@@ -275,7 +275,7 @@ module tb;
         part = part.next();
       end
 
-      for (genvar j = 0; j < flash_ctrl_pkg::InfoTypes; j++) begin : gen_each_info_type
+      for (genvar j = 0; j < flash_ctrl_top_specific_pkg::InfoTypes; j++) begin : gen_each_info_type
         initial begin
           flash_ctrl_bkdr_util m_mem_bkdr_util;
           m_mem_bkdr_util = new(

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl.core
@@ -20,7 +20,7 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg
       - lowrisc:englishbreakfast_ip:flash_ctrl_reg
       - lowrisc:englishbreakfast_constants:top_pkg
       - lowrisc:ip:jtag_pkg

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -10,7 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_reg.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_reg.core
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
-      - lowrisc:englishbreakfast_ip:flash_ctrl_pkg
+      - lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg
     files:
       - rtl/flash_ctrl_core_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/flash_ctrl_top_specific_pkg.core
@@ -2,10 +2,10 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: lowrisc:englishbreakfast_ip:flash_ctrl_pkg:0.1
-description: "Top specific flash package"
+name: lowrisc:englishbreakfast_ip:flash_ctrl_top_specific_pkg:0.1
+description: "Top specific flash ctrl package"
 virtual:
-  - lowrisc:virtual_ip:flash_ctrl_pkg
+  - lowrisc:virtual_ip:flash_ctrl_top_specific_pkg
 
 filesets:
   files_rtl:
@@ -17,11 +17,12 @@ filesets:
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:tlul:headers
+      - lowrisc:ip:flash_ctrl_pkg
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
     files:
       - rtl/flash_ctrl_reg_pkg.sv
-      - rtl/flash_ctrl_pkg.sv
+      - rtl/flash_ctrl_top_specific_pkg.sv
       - rtl/flash_phy_pkg.sv
     file_type: systemVerilogSource
 
@@ -31,7 +32,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/flash_ctrl_pkg.vlt
+      - lint/flash_ctrl_top_specific_pkg.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
@@ -40,7 +41,7 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/flash_ctrl_pkg.waiver
+      - lint/flash_ctrl_top_specific_pkg.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl.waiver
@@ -20,5 +20,5 @@ waive -rules CONST_FF -location {flash_ctrl_core_reg_top.sv} \
 waive -rules MISSING_STATE -location {flash_phy_core.sv} \
       -regexp {.*'StDisable' does not have corresponding case branch tag}
 
-waive -rules USE_BEFORE_DECL -location {flash_ctrl_pkg.sv} -msg {'max_info_pages' is referenced before its declaration at flash_ctrl_pkg.sv} \
+waive -rules USE_BEFORE_DECL -location {flash_ctrl_top_specific_pkg.sv} -msg {'max_info_pages' is referenced before its declaration at flash_ctrl_top_specific_pkg.sv} \
       -comment "max_info_pages is a function defined towards the end of the file."

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl_pkg.waiver
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl_pkg.waiver
@@ -1,8 +1,0 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
-#
-
-
-waive -rules UNSIZED_BIT_CONTEXT -location {flash_ctrl_pkg.sv} -regexp {Unsized bit literal "'1" encountered within a parameter declaration} \
-      -comment "This instance of an unsized parameter literal is difficult to circumvent, as the width of the assigned field is not readily available in this package."

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.vlt
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.vlt
@@ -2,4 +2,4 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// waiver file for flash_ctrl_pkg
+// waiver file for flash_ctrl_top_specific_pkg

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.waiver
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/lint/flash_ctrl_top_specific_pkg.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -10,7 +10,7 @@
 `include "prim_fifo_assert.svh"
 
 module flash_ctrl
-  import flash_ctrl_pkg::*;  import flash_ctrl_reg_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
@@ -1274,8 +1274,8 @@ module flash_ctrl
   logic flash_host_req_rdy;
   logic flash_host_req_done;
   logic flash_host_rderr;
-  logic [flash_ctrl_pkg::BusFullWidth-1:0] flash_host_rdata;
-  logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
+  logic [BusFullWidth-1:0] flash_host_rdata;
+  logic [BusAddrW-1:0] flash_host_addr;
 
   lc_ctrl_pkg::lc_tx_t host_enable;
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -12,7 +12,7 @@
 //
 // This module arbitrates and muxes the controls between the two interfaces.
 
-module flash_ctrl_arb import flash_ctrl_pkg::*; (
+module flash_ctrl_arb import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -5,7 +5,7 @@
 // Faux Flash Erase Control
 //
 
-module flash_ctrl_erase import flash_ctrl_pkg::*; (
+module flash_ctrl_erase import flash_ctrl_top_specific_pkg::*; (
   // Software Interface
   input                       op_start_i,
   input flash_erase_e         op_type_i,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_info_cfg.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_ctrl_info_cfg import flash_ctrl_pkg::*; # (
+module flash_ctrl_info_cfg import flash_ctrl_top_specific_pkg::*; # (
   parameter logic [BankW-1:0] Bank = 0,
   parameter logic [InfoTypesWidth-1:0] InfoSel = 0
 ) (

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -6,7 +6,7 @@
 //
 
 module flash_ctrl_lcmgr
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import lc_ctrl_pkg::lc_tx_t;
 #(
   parameter flash_key_t RndCnstAddrKey  = RndCnstAddrKeyDefault,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -5,7 +5,7 @@
 // Faux Flash Prog Control
 //
 
-module flash_ctrl_prog import flash_ctrl_pkg::*; (
+module flash_ctrl_prog import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -5,7 +5,7 @@
 // Faux Flash Read Control
 //
 
-module flash_ctrl_rd import flash_ctrl_pkg::*; (
+module flash_ctrl_rd import flash_ctrl_top_specific_pkg::*; (
   input clk_i,
   input rst_ni,
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
@@ -9,7 +9,7 @@
 // 2. generate shadow update and storage errors
 
 module flash_ctrl_region_cfg
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import flash_ctrl_reg_pkg::*;
 (
   input clk_i,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_top_specific_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_top_specific_pkg.sv
@@ -2,10 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Flash Controller package.
+// Flash Controller top-specific package.
 //
 
-package flash_ctrl_pkg;
+package flash_ctrl_top_specific_pkg;
+
+  // Treat items from flash_ctrl_pkg as if they were declared here.
+  import flash_ctrl_pkg::*;
+  export flash_ctrl_pkg::NumSeeds;
+  export flash_ctrl_pkg::CreatorSeedIdx;
+  export flash_ctrl_pkg::OwnerSeedIdx;
+  export flash_ctrl_pkg::SeedWidth;
+  export flash_ctrl_pkg::KeyWidth;
+  export flash_ctrl_pkg::flash_key_t;
+  export flash_ctrl_pkg::keymgr_flash_t;
 
   // design parameters that can be altered through topgen
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
@@ -15,19 +25,19 @@ package flash_ctrl_pkg;
   parameter int InfoTypes                = flash_ctrl_reg_pkg::NumInfoTypes;
 
   // fixed parameters of flash derived from topgen parameters
-  parameter int DataWidth       = ${data_width};
-  parameter int MetaDataWidth   = ${metadata_width};
+  parameter int DataWidth       = 64;
+  parameter int MetaDataWidth   = 12;
 
 // The following hard-wired values are there to work-around verilator.
 // For some reason if the values are assigned through parameters verilator thinks
 // they are not constant
   parameter int InfoTypeSize [InfoTypes] = '{
-% for type in range(info_types):
-    flash_ctrl_reg_pkg::NumInfos${type}${"," if not loop.last else ""}
-% endfor
+    flash_ctrl_reg_pkg::NumInfos0,
+    flash_ctrl_reg_pkg::NumInfos1,
+    flash_ctrl_reg_pkg::NumInfos2
   };
   parameter int InfosPerBank    = max_info_pages(InfoTypeSize);
-  parameter int WordsPerPage    = ${words_per_page}; // Number of flash words per page
+  parameter int WordsPerPage    = 256; // Number of flash words per page
   parameter int BusWidth        = top_pkg::TL_DW;
   parameter int BusIntgWidth    = tlul_pkg::DataIntgWidth;
   parameter int BusFullWidth    = BusWidth + BusIntgWidth;
@@ -66,9 +76,9 @@ package flash_ctrl_pkg;
   // The end address in bus words for each kind of partition in each bank
   parameter logic [PageW-1:0] DataPartitionEndAddr = PageW'(PagesPerBank - 1);
   parameter logic [PageW-1:0] InfoPartitionEndAddr [InfoTypes] = '{
-% for type in range(info_types):
-    PageW'(InfoTypeSize[${type}] - 1)${"," if not loop.last else ""}
-% endfor
+    PageW'(InfoTypeSize[0] - 1),
+    PageW'(InfoTypeSize[1] - 1),
+    PageW'(InfoTypeSize[2] - 1)
   };
 
   // Flash Disable usage
@@ -90,10 +100,7 @@ package flash_ctrl_pkg;
   ////////////////////////////
 
   // parameters for connected components
-  parameter int SeedWidth = 256;
-  parameter int KeyWidth  = 128;
   parameter int EdnWidth  = edn_pkg::ENDPOINT_BUS_WIDTH;
-  typedef logic [KeyWidth-1:0] flash_key_t;
 
   // Default Lfsr configurations
   // These LFSR parameters have been generated with
@@ -184,11 +191,8 @@ package flash_ctrl_pkg;
   // One page for creator seeds
   // One page for owner seeds
   // One page for isolated flash page
-  parameter int NumSeeds = 2;
   parameter bit [BankW-1:0] SeedBank = 0;
   parameter bit [InfoTypesWidth-1:0] SeedInfoSel = 0;
-  parameter bit [0:0] CreatorSeedIdx = 0;
-  parameter bit [0:0] OwnerSeedIdx = 1;
   parameter bit [PageW-1:0] CreatorInfoPage = 1;
   parameter bit [PageW-1:0] OwnerInfoPage = 2;
   parameter bit [PageW-1:0] IsolatedInfoPage = 3;
@@ -513,19 +517,6 @@ package flash_ctrl_pkg;
      }
   };
 
-
-  // flash_ctrl to keymgr
-  typedef struct packed {
-    logic [NumSeeds-1:0][SeedWidth-1:0] seeds;
-  } keymgr_flash_t;
-
-  parameter keymgr_flash_t KEYMGR_FLASH_DEFAULT = '{
-    seeds: '{
-     256'h9152e32c9380a4bcc3e0ab263581e6b0e8825186e1e445631646e8bef8c45d47,
-     256'hfa365df52da48cd752fb3a026a8e608f0098cfe5fa9810494829d0cd9479eb78
-    }
-  };
-
   // dft_en jtag selection
   typedef enum logic [2:0] {
     FlashLcTckSel,
@@ -567,12 +558,11 @@ package flash_ctrl_pkg;
       end
     end
     return current_max;
-  endfunction // max_info_banks
+  endfunction : max_info_pages
 
   // RMA control FSM encoding
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 7 -n 10 \
-  //      -s 3319803877 --language=sv
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 7 -n 10   //      -s 3319803877 --language=sv
   //
   // Hamming distance histogram:
   //
@@ -624,6 +614,6 @@ package flash_ctrl_pkg;
     };
 
     return out_cfg;
-  endfunction // max_info_banks
+  endfunction : info_cfg_qual
 
-endpackage : flash_ctrl_pkg
+endpackage : flash_ctrl_top_specific_pkg

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_mp.sv
@@ -9,7 +9,7 @@
 
 module flash_mp
 import prim_mubi_pkg::mubi4_t;
-import flash_ctrl_pkg::*;
+import flash_ctrl_top_specific_pkg::*;
 import flash_ctrl_reg_pkg::*; (
   input clk_i,
   input rst_ni,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_mp_data_region_sel.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_mp_data_region_sel.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_mp_data_region_sel import flash_ctrl_pkg::*; #(
+module flash_mp_data_region_sel import flash_ctrl_top_specific_pkg::*; #(
   parameter int Regions = 4
 ) (
   input req_i,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy.sv
@@ -11,7 +11,7 @@
 // correctly collecting the responses in order.
 
 module flash_phy
-  import flash_ctrl_pkg::*;
+  import flash_ctrl_top_specific_pkg::*;
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter bit SecScrambleEn = 1'b1

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
@@ -29,12 +29,12 @@ module flash_phy_core
   input                              pg_erase_i,
   input                              bk_erase_i,
   input                              erase_suspend_req_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
+  input flash_ctrl_top_specific_pkg::flash_part_e part_i,
   input [InfoTypesWidth-1:0]         info_sel_i,
   input [BusBankAddrW-1:0]           addr_i,
   input [BusFullWidth-1:0]           prog_data_i,
   input                              prog_last_i,
-  input flash_ctrl_pkg::flash_prog_e prog_type_i,
+  input flash_ctrl_top_specific_pkg::flash_prog_e prog_type_i,
   input                              rd_buf_en_i,
   input prim_mubi_pkg::mubi4_t       flash_disable_i,
   output scramble_req_t              scramble_req_o,
@@ -122,7 +122,7 @@ module flash_phy_core
 
   // interface with flash macro
   logic [BusBankAddrW-1:0] muxed_addr;
-  flash_ctrl_pkg::flash_part_e muxed_part;
+  flash_ctrl_top_specific_pkg::flash_part_e muxed_part;
   logic muxed_scramble_en;
   logic muxed_ecc_en;
 
@@ -193,7 +193,7 @@ module flash_phy_core
   // SEC_CM: PHY_HOST_GRANT.CTRL.CONSISTENCY
   // A host transaction was granted to the muxed partition, this is illegal
   logic host_gnt_err_event;
-  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_pkg::FlashPartData);
+  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_top_specific_pkg::FlashPartData);
   // Controller fsm became non idle when there are pending host transactions, this is
   // illegal.
   logic host_outstanding_err_event;
@@ -390,7 +390,7 @@ module flash_phy_core
 
   // transactions coming from flash controller are always data type
   assign muxed_addr = host_sel ? host_addr_i : addr_i;
-  assign muxed_part = host_sel ? flash_ctrl_pkg::FlashPartData : part_i;
+  assign muxed_part = host_sel ? flash_ctrl_top_specific_pkg::FlashPartData : part_i;
   assign muxed_scramble_en = host_sel ? host_scramble_en_i : scramble_en_i;
   assign muxed_ecc_en = host_sel ? host_ecc_en_i : ecc_en_i;
   assign rd_done_o = ctrl_rsp_vld & rd_i;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
@@ -193,7 +193,8 @@ module flash_phy_core
   // SEC_CM: PHY_HOST_GRANT.CTRL.CONSISTENCY
   // A host transaction was granted to the muxed partition, this is illegal
   logic host_gnt_err_event;
-  assign host_gnt_err_event = (host_gnt && muxed_part != flash_ctrl_top_specific_pkg::FlashPartData);
+  assign host_gnt_err_event = (host_gnt && muxed_part !=
+                               flash_ctrl_top_specific_pkg::FlashPartData);
   // Controller fsm became non idle when there are pending host transactions, this is
   // illegal.
   logic host_outstanding_err_event;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -8,18 +8,18 @@
 package flash_phy_pkg;
 
   // flash phy parameters
-  parameter int unsigned NumBanks       = flash_ctrl_pkg::NumBanks;
-  parameter int unsigned InfosPerBank   = flash_ctrl_pkg::InfosPerBank;
-  parameter int unsigned PagesPerBank   = flash_ctrl_pkg::PagesPerBank;
-  parameter int unsigned WordsPerPage   = flash_ctrl_pkg::WordsPerPage;
-  parameter int unsigned BankW          = flash_ctrl_pkg::BankW;
-  parameter int unsigned PageW          = flash_ctrl_pkg::PageW;
-  parameter int unsigned WordW          = flash_ctrl_pkg::WordW;
-  parameter int unsigned BankAddrW      = flash_ctrl_pkg::BankAddrW;
-  parameter int unsigned DataWidth      = flash_ctrl_pkg::DataWidth;
+  parameter int unsigned NumBanks       = flash_ctrl_top_specific_pkg::NumBanks;
+  parameter int unsigned InfosPerBank   = flash_ctrl_top_specific_pkg::InfosPerBank;
+  parameter int unsigned PagesPerBank   = flash_ctrl_top_specific_pkg::PagesPerBank;
+  parameter int unsigned WordsPerPage   = flash_ctrl_top_specific_pkg::WordsPerPage;
+  parameter int unsigned BankW          = flash_ctrl_top_specific_pkg::BankW;
+  parameter int unsigned PageW          = flash_ctrl_top_specific_pkg::PageW;
+  parameter int unsigned WordW          = flash_ctrl_top_specific_pkg::WordW;
+  parameter int unsigned BankAddrW      = flash_ctrl_top_specific_pkg::BankAddrW;
+  parameter int unsigned DataWidth      = flash_ctrl_top_specific_pkg::DataWidth;
   parameter int unsigned EccWidth       = 8;
-  parameter int unsigned MetaDataWidth  = flash_ctrl_pkg::MetaDataWidth;
-  parameter int unsigned WidthMultiple  = flash_ctrl_pkg::WidthMultiple;
+  parameter int unsigned MetaDataWidth  = flash_ctrl_top_specific_pkg::MetaDataWidth;
+  parameter int unsigned WidthMultiple  = flash_ctrl_top_specific_pkg::WidthMultiple;
   parameter int unsigned NumBuf         = 4; // number of flash read buffers
   parameter int unsigned RspOrderDepth  = 2; // this should be DataWidth / BusWidth
                                              // will switch to this after bus widening
@@ -27,15 +27,15 @@ package flash_phy_pkg;
   parameter int unsigned PlainDataWidth = DataWidth + PlainIntgWidth;
   //parameter int unsigned ScrDataWidth   = DataWidth + EccWidth;
   parameter int unsigned FullDataWidth  = DataWidth + MetaDataWidth;
-  parameter int unsigned InfoTypes      = flash_ctrl_pkg::InfoTypes;
-  parameter int unsigned InfoTypesWidth = flash_ctrl_pkg::InfoTypesWidth;
+  parameter int unsigned InfoTypes      = flash_ctrl_top_specific_pkg::InfoTypes;
+  parameter int unsigned InfoTypesWidth = flash_ctrl_top_specific_pkg::InfoTypesWidth;
 
   // flash ctrl / bus parameters
-  parameter int unsigned BusWidth       = flash_ctrl_pkg::BusWidth;
-  parameter int unsigned BusFullWidth   = flash_ctrl_pkg::BusFullWidth;
-  parameter int unsigned BusBankAddrW   = flash_ctrl_pkg::BusBankAddrW;
-  parameter int unsigned BusWordW       = flash_ctrl_pkg::BusWordW;
-  parameter int unsigned ProgTypes      = flash_ctrl_pkg::ProgTypes;
+  parameter int unsigned BusWidth       = flash_ctrl_top_specific_pkg::BusWidth;
+  parameter int unsigned BusFullWidth   = flash_ctrl_top_specific_pkg::BusFullWidth;
+  parameter int unsigned BusBankAddrW   = flash_ctrl_top_specific_pkg::BusBankAddrW;
+  parameter int unsigned BusWordW       = flash_ctrl_top_specific_pkg::BusWordW;
+  parameter int unsigned ProgTypes      = flash_ctrl_top_specific_pkg::ProgTypes;
 
   // address bits remain must be 0
   parameter int unsigned AddrBitsRemain = DataWidth % BusWidth;
@@ -119,13 +119,13 @@ package flash_phy_pkg;
     logic rd_req;
     logic prog_req;
     logic prog_last;
-    flash_ctrl_pkg::flash_prog_e prog_type;
+    flash_ctrl_top_specific_pkg::flash_prog_e prog_type;
     logic pg_erase_req;
     logic bk_erase_req;
     logic erase_suspend_req;
     logic he;
     logic [BankAddrW-1:0] addr;
-    flash_ctrl_pkg::flash_part_e part;
+    flash_ctrl_top_specific_pkg::flash_part_e part;
     logic [InfoTypesWidth-1:0] info_sel;
     logic [FullDataWidth-1:0] prog_full_data;
   } flash_phy_prim_flash_req_t;

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
@@ -44,7 +44,7 @@ module flash_phy_rd
   input pg_erase_i,
   input bk_erase_i,
   input [BusBankAddrW-1:0] addr_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
+  input flash_ctrl_top_specific_pkg::flash_part_e part_i,
   input [InfoTypesWidth-1:0] info_sel_i,
   output logic rdy_o,
   output logic data_valid_o,

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -38,7 +38,7 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
     if (!rst_ni) begin
       out_o.data <= '0;
       out_o.addr <= '0;
-      out_o.part <= flash_ctrl_pkg::FlashPartData;
+      out_o.part <= flash_ctrl_top_specific_pkg::FlashPartData;
       out_o.info_sel <= '0;
       out_o.attr <= Invalid;
       out_o.err <= '0;

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_rnd_cnst_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_rnd_cnst_pkg.sv
@@ -27,18 +27,18 @@ package top_englishbreakfast_rnd_cnst_pkg;
   };
 
   // Compile-time random bits for default seeds
-  parameter flash_ctrl_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
+  parameter flash_ctrl_top_specific_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
     256'hB0F1F422_5B70DE66_AE2A2D2C_AF521284_D078B244_2C4DCDFF_FC136EAE_D4BF1A60,
     256'h0233980B_C4CF2116_DB51EC10_B747B901_1D99F556_B893842A_91CAFC63_CB10B944
   };
 
   // Compile-time random bits for initial LFSR seed
-  parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
+  parameter flash_ctrl_top_specific_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
     32'h601633A4
   };
 
   // Compile-time random permutation for LFSR output
-  parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
+  parameter flash_ctrl_top_specific_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
     160'hEA0DBD7E_58F2DF98_5AE78946_013A6965_1AA0F2A4
   };
 


### PR DESCRIPTION
This has 5 commits:
- The first one modifies the packages so flash_ctrl_pkg is top independent, and what was top-specific is moved to a new flash_ctrl_top_specific_pkg. This is to enable keymgr to use top-independent constructs from flash_ctrl. This only shuffles package items, and has no functional changes.
- The third commit is a fix for DV randomization that was causing occasional failures.
- The fourth commit fixes a test sequence to avoid a type mismatch causing incorrect code.
- The other commits are lint and format fixes, so no functional changes.

Addresses #25921