### PR TITLE
[ate] remove ECC from AST programming

### DIFF
--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -65,7 +65,12 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
     elif ctx.attr.kind == "ram":
         default = elf
         rom = None
-        vmem = None
+        vmem = convert_to_vmem(
+            ctx,
+            name = name,
+            src = signed_bin if signed_bin else binary,
+            word_size = 32,
+        )
     elif ctx.attr.kind == "flash":
         default = signed_bin if signed_bin else binary
         rom = None

--- a/sw/device/silicon_creator/manuf/lib/ast_program.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program.c
@@ -76,7 +76,7 @@ status_t ast_program_init(bool verbose) {
       kFlashInfoFieldAstCalibrationData.bank,
       kFlashInfoFieldAstCalibrationData.partition,
       (dif_flash_ctrl_region_properties_t){
-          .ecc_en = kMultiBitBool4True,
+          .ecc_en = kMultiBitBool4False,
           .high_endurance_en = kMultiBitBool4False,
           .erase_en = kMultiBitBool4True,
           .prog_en = kMultiBitBool4True,

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -184,7 +184,7 @@ static status_t manuf_individualize_device_ast_cfg(
       kFlashInfoFieldAstCalibrationData.bank,
       kFlashInfoFieldAstCalibrationData.partition,
       (dif_flash_ctrl_region_properties_t){
-          .ecc_en = kMultiBitBool4True,
+          .ecc_en = kMultiBitBool4False,
           .high_endurance_en = kMultiBitBool4False,
           .erase_en = kMultiBitBool4False,
           .prog_en = kMultiBitBool4False,


### PR DESCRIPTION
Additionally, add a rule to generate unscrambled VMEM SRAM binary files for testing SRAM injection in DV.