### PR TITLE
[sival] Add `alert_handler` log utilities.

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -380,6 +380,21 @@ dif_result_t dif_alert_handler_configure_class(
     dif_toggle_t locked);
 
 /**
+ * Configures the crash dump trigger for an alert class in the alert
+ * handler.
+ *
+ * @param alert_handler An alert handler handle.
+ * @param alert_class The class to be configured.
+ * @param crashdump_phase The crash dump trigger phase.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_crash_dump_trigger_set(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_class_t alert_class,
+    dif_alert_handler_class_state_t crashdump_phase);
+
+/**
  * Configures the ping timer in the alert handler.
  *
  * This operation is lock-protected, meaning once the configuration is locked,
@@ -677,6 +692,19 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_alert_handler_get_escalation_counter(
     const dif_alert_handler_t *alert_handler,
     dif_alert_handler_class_t alert_class, uint32_t *cycles);
+
+/**
+ * Checks whether this class is enabled.
+ *
+ * @param alert_handler An alert handler handle.
+ * @param alert_class The class to check.
+ * @param[out] is_enabled Out-param for the enablement state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_is_class_enabled(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_class_t alert_class, bool *is_enabled);
 
 /**
  * Gets the current state of this class.

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -66,6 +66,7 @@ cc_library(
     deps = [
         "//sw/device/lib/dif:alert_handler",
         "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:edn",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -7,12 +7,17 @@
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/dif/dif_alert_handler.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_edn.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 #include "alert_handler_regs.h"  // Generated
 
 #define MODULE_ID MAKE_MODULE_ID('a', 'h', 't')
+
+const char kAlertClassName[] = {'A', 'B', 'C', 'D'};
+static_assert(ARRAYSIZE(kAlertClassName) == ALERT_HANDLER_PARAM_N_CLASSES,
+              "Expected four alert classes!");
 
 /**
  * This is used to traverse the dump treating it as an array of bits, and
@@ -156,4 +161,144 @@ status_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds,
 
 uint32_t alert_handler_testutils_cycle_rescaling_factor(void) {
   return kDeviceType == kDeviceSimDV ? 1 : 10;
+}
+
+static status_t alert_handler_class_info_log(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_class_t alert_class) {
+  dif_alert_handler_class_state_t state;
+  TRY(dif_alert_handler_get_class_state(alert_handler, alert_class, &state));
+
+  uint16_t num_alerts;
+  TRY(dif_alert_handler_get_accumulator(alert_handler, alert_class,
+                                        &num_alerts));
+
+  if (num_alerts > 0) {
+    LOG_INFO("Alert class %c state: %d, acc_cnt: %d",
+             kAlertClassName[alert_class], state, num_alerts);
+
+    for (dif_alert_handler_alert_t alert = 0;
+         alert < ALERT_HANDLER_PARAM_N_ALERTS; ++alert) {
+      bool is_cause;
+      TRY(dif_alert_handler_alert_is_cause(alert_handler, alert, &is_cause));
+      if (is_cause) {
+        LOG_INFO("Alert %d is set", alert);
+      }
+    }
+
+    bool can_clear;
+    TRY(dif_alert_handler_escalation_can_clear(alert_handler, alert_class,
+                                               &can_clear));
+    if (can_clear) {
+      TRY(dif_alert_handler_escalation_clear(alert_handler, alert_class));
+    } else {
+      LOG_INFO("Alert class %c can't be cleared", kAlertClassName[alert_class]);
+    }
+  }
+
+  return OK_STATUS();
+}
+
+static status_t alert_handler_class_log(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_class_t alert_class) {
+  dif_alert_handler_class_state_t state;
+  TRY(dif_alert_handler_get_class_state(alert_handler, alert_class, &state));
+
+  uint16_t num_alerts;
+  TRY(dif_alert_handler_get_accumulator(alert_handler, alert_class,
+                                        &num_alerts));
+
+  if (num_alerts > 0) {
+    LOG_INFO("Alert class %c state: %d, acc_cnt: %d",
+             kAlertClassName[alert_class], state, num_alerts);
+    for (dif_alert_handler_alert_t alert = 0;
+         alert < ALERT_HANDLER_PARAM_N_ALERTS; ++alert) {
+      bool is_cause;
+      TRY(dif_alert_handler_alert_is_cause(alert_handler, alert, &is_cause));
+      if (is_cause) {
+        LOG_INFO("Alert %d is set", alert);
+      }
+    }
+  }
+
+  return OK_STATUS();
+}
+
+status_t alert_handler_testutils_status_log(
+    const dif_alert_handler_t *alert_handler) {
+  TRY_CHECK(alert_handler != NULL);
+
+  for (dif_alert_handler_class_t alert_class = 0;
+       alert_class < ALERT_HANDLER_PARAM_N_CLASSES; ++alert_class) {
+    TRY(alert_handler_class_log(alert_handler, alert_class));
+  }
+
+  return OK_STATUS();
+}
+
+status_t alert_handler_testutils_dump_log(const dif_rstmgr_t *rstmgr) {
+  TRY_CHECK(rstmgr != NULL);
+
+  dif_rstmgr_alert_info_dump_segment_t dump[DIF_RSTMGR_ALERT_INFO_MAX_SIZE];
+  size_t seg_size;
+  alert_handler_testutils_info_t actual_info;
+
+  uint32_t log_count = 0;
+
+  CHECK_DIF_OK(dif_rstmgr_alert_info_dump_read(
+      rstmgr, dump, DIF_RSTMGR_ALERT_INFO_MAX_SIZE, &seg_size));
+  CHECK(seg_size <= INT_MAX, "seg_size must fit in int");
+  CHECK_STATUS_OK(
+      alert_handler_testutils_info_parse(dump, (int)seg_size, &actual_info));
+
+  for (dif_alert_handler_class_t alert_class = 0;
+       alert_class < ALERT_HANDLER_PARAM_N_CLASSES; ++alert_class) {
+    if (actual_info.class_esc_state[alert_class] != kCstateIdle) {
+      LOG_INFO("crashdump - Alert class %c state: %d, acc_cnt: %d, esc_cnt: %d",
+               kAlertClassName[alert_class],
+               actual_info.class_esc_state[alert_class],
+               actual_info.class_accum_cnt[alert_class],
+               actual_info.class_esc_cnt[alert_class]);
+      log_count++;
+    }
+  }
+  for (dif_alert_handler_alert_t alert = 0;
+       alert < ALERT_HANDLER_PARAM_N_ALERTS; ++alert) {
+    if (actual_info.alert_cause[alert]) {
+      LOG_INFO("crashdump - Alert %d is set", alert);
+      log_count++;
+    }
+  }
+
+  if (log_count == 0) {
+    LOG_INFO("crashdump - No alerts reported");
+  }
+
+  return OK_STATUS();
+}
+
+status_t alert_handler_testutils_dump_enable(
+    const dif_alert_handler_t *alert_handler, const dif_rstmgr_t *rstmgr) {
+  TRY_CHECK(alert_handler != NULL);
+  TRY_CHECK(rstmgr != NULL);
+
+  uint32_t enable_count = 0;
+  for (dif_alert_handler_class_t alert_class = 0;
+       alert_class < ALERT_HANDLER_PARAM_N_CLASSES; ++alert_class) {
+    bool is_enabled;
+    TRY(dif_alert_handler_is_class_enabled(alert_handler, alert_class,
+                                           &is_enabled));
+    if (is_enabled) {
+      TRY(dif_alert_handler_crash_dump_trigger_set(
+          alert_handler, alert_class, kDifAlertHandlerClassStatePhase3));
+      enable_count++;
+    }
+  }
+
+  if (enable_count) {
+    CHECK_DIF_OK(dif_rstmgr_alert_info_set_enabled(rstmgr, kDifToggleEnabled));
+  }
+
+  return OK_STATUS();
 }

--- a/sw/device/lib/testing/alert_handler_testutils.h
+++ b/sw/device/lib/testing/alert_handler_testutils.h
@@ -109,4 +109,49 @@ status_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds,
  */
 uint32_t alert_handler_testutils_cycle_rescaling_factor(void);
 
+/**
+ * Logs the status of the alert handler.
+ *
+ * This function will log the state of each alert class, including the
+ * number of alerts that have been accumulated.
+ *
+ * Only the alert classes that have accumulated alerts will be logged.
+ *
+ * @param alert_handler An alert handler handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t alert_handler_testutils_status_log(
+    const dif_alert_handler_t *alert_handler);
+
+/**
+ * Logs the alert handler crash dump.
+ *
+ * This function will log the state of each alert class, including the
+ * number of alerts that have been accumulated.
+ *
+ * Only alerts that have been set will be logged, as well as the alert
+ * classes that are in non-idle states.
+ *
+ * @param rstmgr A RSTMGR handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t alert_handler_testutils_dump_log(const dif_rstmgr_t *rstmgr);
+
+/**
+ * Enables the alert handler crash dump.
+ *
+ * This function will enable the alert handler crash dump, which will
+ * cause the alert handler to dump its state to the RSTMGR when an
+ * alert is triggered.
+ *
+ * @param alert_handler An alert handler handle.
+ * @param rstmgr A RSTMGR handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t alert_handler_testutils_dump_enable(
+    const dif_alert_handler_t *alert_handler, const dif_rstmgr_t *rstmgr);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_ALERT_HANDLER_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5530,6 +5530,7 @@ opentitan_test(
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:hmac_testutils",
         "//sw/device/lib/testing:i2c_testutils",

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -26,6 +26,7 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/aes_testutils.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/hmac_testutils.h"
 #include "sw/device/lib/testing/i2c_testutils.h"
@@ -57,30 +58,32 @@ OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = true,
 /**
  * Peripheral DIF Handles.
  */
-static dif_pinmux_t pinmux;
-static dif_gpio_t gpio;
 static dif_adc_ctrl_t adc_ctrl;
-static dif_entropy_src_t entropy_src;
+static dif_aes_t aes;
+static dif_alert_handler_t alert_handler;
 static dif_csrng_t csrng;
 static dif_edn_t edn_0;
 static dif_edn_t edn_1;
-static dif_aes_t aes;
+static dif_entropy_src_t entropy_src;
+static dif_flash_ctrl_state_t flash_ctrl;
+static dif_gpio_t gpio;
 static dif_hmac_t hmac;
-static dif_kmac_t kmac;
-static dif_otbn_t otbn;
 static dif_i2c_t i2c_0;
 static dif_i2c_t i2c_1;
 static dif_i2c_t i2c_2;
+static dif_kmac_t kmac;
+static dif_otbn_t otbn;
+static dif_pattgen_t pattgen;
+static dif_pinmux_t pinmux;
+static dif_pwm_t pwm;
+static dif_rstmgr_t rstmgr;
+static dif_rv_plic_t rv_plic;
 static dif_spi_device_handle_t spi_device;
 static dif_spi_host_t spi_host_0;
 static dif_spi_host_t spi_host_1;
 static dif_uart_t uart_1;
 static dif_uart_t uart_2;
 static dif_uart_t uart_3;
-static dif_pattgen_t pattgen;
-static dif_pwm_t pwm;
-static dif_flash_ctrl_state_t flash_ctrl;
-static dif_rv_plic_t rv_plic;
 
 static const dif_i2c_t *i2c_handles[] = {&i2c_0, &i2c_1, &i2c_2};
 static const dif_uart_t *uart_handles[] = {&uart_1, &uart_2, &uart_3};
@@ -351,6 +354,9 @@ static void init_peripheral_handles(void) {
       mmio_region_from_addr(TOP_EARLGREY_ADC_CTRL_AON_BASE_ADDR), &adc_ctrl));
   CHECK_DIF_OK(
       dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
   CHECK_DIF_OK(dif_csrng_init(
       mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
   CHECK_DIF_OK(
@@ -392,6 +398,8 @@ static void init_peripheral_handles(void) {
       mmio_region_from_addr(TOP_EARLGREY_PATTGEN_BASE_ADDR), &pattgen));
   CHECK_DIF_OK(dif_pwm_init(
       mmio_region_from_addr(TOP_EARLGREY_PWM_AON_BASE_ADDR), &pwm));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
   CHECK_DIF_OK(dif_flash_ctrl_init_state(
       &flash_ctrl,
       mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
@@ -1460,6 +1468,15 @@ bool test_main(void) {
   // Initialize and configure all IPs.
   // ***************************************************************************
   init_peripheral_handles();
+
+  if (kDeviceType == kDeviceSilicon || kDeviceType == kDeviceFpgaCw310 ||
+      kDeviceType == kDeviceFpgaCw340) {
+    CHECK_STATUS_OK(alert_handler_testutils_status_log(&alert_handler));
+    CHECK_STATUS_OK(alert_handler_testutils_dump_log(&rstmgr));
+    CHECK_STATUS_OK(
+        alert_handler_testutils_dump_enable(&alert_handler, &rstmgr));
+  }
+
   configure_pinmux();
   // To be compatible with the configs in chip_if.sv,
   // apply the additional pinmux settings.


### PR DESCRIPTION
The following utilities are introduced to facilitate triaging of issues in silicon:

1. `alert_handler_testutils_status_log`: Log any alert counts accumulated across any of the alert handler classes.
2. `alert_handler_testutils_dump_log`: Log any alerts and alert handler class counters captured in the reset manager crash dump.
3. `alert_handler_testutils_dump_enable`: Enable crash dump for any enabled alert handler classes.