### PR TITLE
[ac_range_check,dv] Move struct into class wrapper

### DIFF
--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env.core.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env.core.tpl
@@ -14,6 +14,7 @@ filesets:
     files:
       - ac_range_check_env_pkg.sv
       - ac_range_check_dut_cfg.sv: {is_include_file: true}
+      - ac_range_check_scb_item.sv: {is_include_file: true}
       - ac_range_check_env_cfg.sv: {is_include_file: true}
       - ac_range_check_env_cov.sv: {is_include_file: true}
       - ac_range_check_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_env_pkg.sv.tpl
@@ -75,11 +75,6 @@ package ac_range_check_env_pkg;
     bit [DataWidth-1:0] data;
   } tl_main_vars_t;
 
-  typedef struct {
-    tl_seq_item item;
-    int         cnt;
-  } tl_filt_t;
-
   // Functions
   // Retrieve the index of the CSR based on its name
   function automatic int get_csr_idx(string csr_ral_name, string csr_name);
@@ -95,6 +90,7 @@ package ac_range_check_env_pkg;
 
   // Package sources
   `include "ac_range_check_dut_cfg.sv"
+  `include "ac_range_check_scb_item.sv"
   `include "ac_range_check_env_cfg.sv"
   `include "ac_range_check_env_cov.sv"
   `include "ac_range_check_virtual_sequencer.sv"

--- a/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scb_item.sv
+++ b/hw/ip_templates/ac_range_check/dv/env/ac_range_check_scb_item.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper class to hold tl_seq_item and a counter for scoreboarding purposes
+class ac_range_check_scb_item extends uvm_object;
+  `uvm_object_utils(ac_range_check_scb_item)
+
+  tl_seq_item item;
+  int         cnt;
+
+  `uvm_object_new
+endclass : ac_range_check_scb_item

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.core
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env.core
@@ -14,6 +14,7 @@ filesets:
     files:
       - ac_range_check_env_pkg.sv
       - ac_range_check_dut_cfg.sv: {is_include_file: true}
+      - ac_range_check_scb_item.sv: {is_include_file: true}
       - ac_range_check_env_cfg.sv: {is_include_file: true}
       - ac_range_check_env_cov.sv: {is_include_file: true}
       - ac_range_check_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_env_pkg.sv
@@ -75,11 +75,6 @@ package ac_range_check_env_pkg;
     bit [DataWidth-1:0] data;
   } tl_main_vars_t;
 
-  typedef struct {
-    tl_seq_item item;
-    int         cnt;
-  } tl_filt_t;
-
   // Functions
   // Retrieve the index of the CSR based on its name
   function automatic int get_csr_idx(string csr_ral_name, string csr_name);
@@ -95,6 +90,7 @@ package ac_range_check_env_pkg;
 
   // Package sources
   `include "ac_range_check_dut_cfg.sv"
+  `include "ac_range_check_scb_item.sv"
   `include "ac_range_check_env_cfg.sv"
   `include "ac_range_check_env_cov.sv"
   `include "ac_range_check_virtual_sequencer.sv"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scb_item.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/dv/env/ac_range_check_scb_item.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper class to hold tl_seq_item and a counter for scoreboarding purposes
+class ac_range_check_scb_item extends uvm_object;
+  `uvm_object_utils(ac_range_check_scb_item)
+
+  tl_seq_item item;
+  int         cnt;
+
+  `uvm_object_new
+endclass : ac_range_check_scb_item


### PR DESCRIPTION
- This PR addresses this issue #26848. It replaces a struct containing a counter and a tl_seq_item. It's cleaner to move it into a dynamic object to allow more flexibility. This will also be needed by the predictor as TLM port doesn't accept struct types.