### PR TITLE
[ipgen,otp_ctrl] Generate the otp_ctrl_mem_bkdr_util code

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_csrng_lc_hw_debug_en_vseq.sv
@@ -40,6 +40,8 @@ class chip_sw_csrng_lc_hw_debug_en_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");
+    localparam logic [31:0] SOC_DBG_RAW = '0;
+
     super.dut_init(reset_kind);
     // Make sure entropy_src and csrng fuses are setup correctly independent
     // of which OTP image was loaded. The C portion of this test checks the
@@ -49,8 +51,10 @@ class chip_sw_csrng_lc_hw_debug_en_vseq extends chip_sw_base_vseq;
       .device_id(DEVICE_ID), .manuf_state(MANUF_STATE));
     otp_write_hw_cfg1_partition(
       .mem_bkdr_util_h(cfg.mem_bkdr_util_h[Otp]),
-      .en_sram_ifetch(MUBI8FALSE), .en_csrng_sw_app_read(MUBI8TRUE),
-      .dis_rv_dm_late_debug(MUBI8TRUE));
+      // This means SOC_DEBUG won't block debug access.
+      .soc_dbg_state(SOC_DBG_RAW),
+      .en_csrng_sw_app_read(MUBI8TRUE),
+      .en_sram_ifetch(MUBI8FALSE));
   endtask
 
   virtual task body();

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -23,8 +23,8 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_lc_base_vseq;
 
     // Override the test exit token to match SW test's input token.
     otp_write_secret0_partition(cfg.mem_bkdr_util_h[Otp],
-        .unlock_token(dec_otp_token_from_lc_csrs(lc_unlock_token)),
-        .exit_token(dec_otp_token_from_lc_csrs(lc_exit_token)));
+        .test_unlock_token(dec_otp_token_from_lc_csrs(lc_unlock_token)),
+        .test_exit_token(dec_otp_token_from_lc_csrs(lc_exit_token)));
   endfunction
 
   virtual task body();

--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv
@@ -13,8 +13,8 @@ class chip_sw_sram_ctrl_execution_main_vseq extends chip_sw_base_vseq;
       256'h41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D523D5C06786AAC34;
   localparam logic [7:0] MUBI8TRUE = prim_mubi_pkg::MuBi8True;
   localparam logic [7:0] MUBI8FALSE = prim_mubi_pkg::MuBi8False;
+  localparam logic [31:0] SOC_DBG_RAW = '0;
   localparam logic [7:0] EN_CSRNG_SW_APP_READ = MUBI8FALSE;
-  localparam logic [7:0] DIS_RV_DM_LATE_DEBUG = MUBI8FALSE;
 
   virtual task do_test(logic [7:0] en_sram_ifetch, bit set_prod_lc);
 
@@ -26,11 +26,12 @@ class chip_sw_sram_ctrl_execution_main_vseq extends chip_sw_base_vseq;
     otp_write_hw_cfg0_partition(
         .mem_bkdr_util_h(cfg.mem_bkdr_util_h[Otp]),
         .device_id(DEVICE_ID), .manuf_state(MANUF_STATE));
+    // This means SOC_DEBUG won't block debug access.
     otp_write_hw_cfg1_partition(
         .mem_bkdr_util_h(cfg.mem_bkdr_util_h[Otp]),
-        .en_sram_ifetch(en_sram_ifetch),
+        .soc_dbg_state(SOC_DBG_RAW),
         .en_csrng_sw_app_read(EN_CSRNG_SW_APP_READ),
-        .dis_rv_dm_late_debug(DIS_RV_DM_LATE_DEBUG));
+        .en_sram_ifetch(en_sram_ifetch));
 
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest)
     `DV_WAIT(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi)

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -52,97 +52,32 @@ package otp_ctrl_mem_bkdr_util_pkg;
     otp_write_lc_partition_state(mem_bkdr_util_h, lc_state);
   endfunction : otp_write_lc_partition
 
+  // The following steps are needed to backdoor write a non-secret partition:
+  // 1). Backdoor write the input data to OTP memory.
+  // 2). Calculate the correct digest for the secret partition.
+  // 3). Backdoor write digest data to OTP memory.
+
   // The following steps are needed to backdoor write a secret partition:
   // 1). Scramble the RAW input data.
   // 2). Backdoor write the scrambled input data to OTP memory.
   // 3). Calculate the correct digest for the secret partition.
   // 4). Backdoor write digest data to OTP memory.
-  function automatic void otp_write_secret0_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [TestUnlockTokenSize*8-1:0] unlock_token,
-      bit [TestExitTokenSize*8-1:0]   exit_token
-  );
-    bit [Secret0DigestSize*8-1:0] digest;
 
-    bit [TestUnlockTokenSize*8-1:0] scrambled_unlock_token;
-    bit [TestExitTokenSize*8-1:0] scrambled_exit_token;
-    bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
-
-    for (int i = 0; i < TestUnlockTokenSize; i += 8) begin
-      scrambled_unlock_token[i*8+:64] = scramble_data(unlock_token[i*8+:64], Secret0Idx);
-      mem_bkdr_util_h.write64(i + TestUnlockTokenOffset, scrambled_unlock_token[i*8+:64]);
-    end
-    for (int i = 0; i < TestExitTokenSize; i += 8) begin
-      scrambled_exit_token[i*8+:64] = scramble_data(exit_token[i*8+:64], Secret0Idx);
-      mem_bkdr_util_h.write64(i + TestExitTokenOffset, scrambled_exit_token[i*8+:64]);
-    end
-
-    secret_data = {<<32{scrambled_exit_token, scrambled_unlock_token}};
-    digest = cal_digest(Secret0Idx, secret_data);
-
-    mem_bkdr_util_h.write64(Secret0DigestOffset, digest);
-  endfunction
-
-  function automatic void otp_write_secret1_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [SramDataKeySeedSize*8-1:0]  sram_data_key_seed
-  );
-    bit [Secret1DigestSize*8-1:0] digest;
-
-    bit [SramDataKeySeedSize*8-1:0] scrambled_sram_data_key;
-    bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
-
-    for (int i = 0; i < SramDataKeySeedSize; i += 8) begin
-      scrambled_sram_data_key[i*8+:64] = scramble_data(sram_data_key_seed[i*8+:64], Secret1Idx);
-      mem_bkdr_util_h.write64(i + SramDataKeySeedOffset, scrambled_sram_data_key[i*8+:64]);
-    end
-
-    secret_data = {<<32 {scrambled_sram_data_key}};
-    digest = cal_digest(Secret1Idx, secret_data);
-
-    mem_bkdr_util_h.write64(Secret1DigestOffset, digest);
-  endfunction
-
-  function automatic void otp_write_secret2_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [RmaTokenSize*8-1:0] rma_unlock_token,
-      bit [CreatorRootKeyShare0Size*8-1:0] creator_root_key0,
-      bit [CreatorRootKeyShare1Size*8-1:0] creator_root_key1
-  );
-
-    bit [Secret2DigestSize*8-1:0] digest;
-
-    bit [RmaTokenSize*8-1:0] scrambled_unlock_token;
-    bit [CreatorRootKeyShare0Size*8-1:0] scrambled_root_key0;
-    bit [CreatorRootKeyShare1Size*8-1:0] scrambled_root_key1;
-    bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
-
-    for (int i = 0; i < RmaTokenSize; i+=8) begin
-      scrambled_unlock_token[i*8+:64] = scramble_data(rma_unlock_token[i*8+:64], Secret2Idx);
-      mem_bkdr_util_h.write64(i + RmaTokenOffset, scrambled_unlock_token[i*8+:64]);
-    end
-    for (int i = 0; i < CreatorRootKeyShare0Size; i+=8) begin
-      scrambled_root_key0[i*8+:64] = scramble_data(creator_root_key0[i*8+:64], Secret2Idx);
-      mem_bkdr_util_h.write64(i + CreatorRootKeyShare0Offset, scrambled_root_key0[i*8+:64]);
-    end
-    for (int i = 0; i < CreatorRootKeyShare1Size; i+=8) begin
-      scrambled_root_key1[i*8+:64] = scramble_data(creator_root_key1[i*8+:64], Secret2Idx);
-      mem_bkdr_util_h.write64(i + CreatorRootKeyShare1Offset, scrambled_root_key1[i*8+:64]);
-    end
-
-    secret_data = {<<32 {scrambled_root_key1, scrambled_root_key0, scrambled_unlock_token}};
-    digest = cal_digest(Secret2Idx, secret_data);
-
-    mem_bkdr_util_h.write64(Secret2DigestOffset, digest);
-  endfunction
+  // The HW_CFG1 partition needs to be a special case since it has items
+  // smaller than 4 bytes and need to be concatenated. To make sure
+  // this special case won't end up broken if the OTP layout changes
+  // beyond what this supports the following checks are in place and
+  // will cause a failure.
+  // - No other partition except for HW_CFG1 has such small items.
+  // - The small items in HW_CFG1 will be contained within 32 bits.
 
   function automatic void otp_write_hw_cfg0_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [DeviceIdSize*8-1:0] device_id, bit [ManufStateSize*8-1:0] manuf_state
+      bit [DeviceIdSize*8-1:0] device_id,
+      bit [ManufStateSize*8-1:0] manuf_state
   );
     bit [HwCfg0DigestSize*8-1:0] digest;
-
-    bit [bus_params_pkg::BUS_DW-1:0] hw_cfg0_data[$];
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
 
     for (int i = 0; i < DeviceIdSize; i += 4) begin
       mem_bkdr_util_h.write32(i + DeviceIdOffset, device_id[i*8+:32]);
@@ -151,33 +86,183 @@ package otp_ctrl_mem_bkdr_util_pkg;
       mem_bkdr_util_h.write32(i + ManufStateOffset, manuf_state[i*8+:32]);
     end
 
-    hw_cfg0_data = {<<32 {manuf_state, device_id}};
-    digest = cal_digest(HwCfg0Idx, hw_cfg0_data);
-
+    partition_data = {<<32{
+      manuf_state,
+      device_id
+    }};
+    digest = cal_digest(HwCfg0Idx, partition_data);
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [SocDbgStateSize*8-1:0] soc_dbg_state,
       bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
-      bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
-      bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
+      bit [EnSramIfetchSize*8-1:0] en_sram_ifetch
   );
     bit [HwCfg1DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [bus_params_pkg::BUS_DW-1:0] concat_data[$];
+    bit [31:0] word;
 
-    bit [bus_params_pkg::BUS_DW-1:0] hw_cfg1_data[$];
+    for (int i = 0; i < SocDbgStateSize; i += 4) begin
+      mem_bkdr_util_h.write32(i + SocDbgStateOffset, soc_dbg_state[i*8+:32]);
+      concat_data.push_front(soc_dbg_state[i*8+:32]);
+    end
+    word = {
+      en_sram_ifetch,
+      en_csrng_sw_app_read
+    };
+    mem_bkdr_util_h.write32(1 + EnCsrngSwAppReadOffset, word);
+    concat_data.push_front(word);
 
-    mem_bkdr_util_h.write32(EnSramIfetchOffset,
-                            {dis_rv_dm_late_debug, en_csrng_sw_app_read, en_sram_ifetch});
-
-    hw_cfg1_data = {<<32 {32'h0, dis_rv_dm_late_debug, en_csrng_sw_app_read, en_sram_ifetch}};
-    digest = cal_digest(HwCfg1Idx, hw_cfg1_data);
-
+    partition_data = {<<32{concat_data}};
+    digest = cal_digest(HwCfg1Idx, partition_data);
     mem_bkdr_util_h.write64(HwCfg1DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret0_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [TestUnlockTokenSize*8-1:0] test_unlock_token,
+      bit [TestExitTokenSize*8-1:0] test_exit_token
+  );
+    bit [Secret0DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [TestUnlockTokenSize*8-1:0] scrambled_test_unlock_token;
+    bit [TestExitTokenSize*8-1:0] scrambled_test_exit_token;
+
+    for (int i = 0; i < TestUnlockTokenSize; i += 8) begin
+      scrambled_test_unlock_token[i*8+:64] = scramble_data(
+          test_unlock_token[i*8+:64], Secret0Idx);
+      mem_bkdr_util_h.write64(i + TestUnlockTokenOffset,
+                              scrambled_test_unlock_token[i*8+:64]);
+    end
+    for (int i = 0; i < TestExitTokenSize; i += 8) begin
+      scrambled_test_exit_token[i*8+:64] = scramble_data(
+          test_exit_token[i*8+:64], Secret0Idx);
+      mem_bkdr_util_h.write64(i + TestExitTokenOffset,
+                              scrambled_test_exit_token[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_test_exit_token,
+      scrambled_test_unlock_token
+    }};
+    digest = cal_digest(Secret0Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret0DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret1_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [SramDataKeySeedSize*8-1:0] sram_data_key_seed
+  );
+    bit [Secret1DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [SramDataKeySeedSize*8-1:0] scrambled_sram_data_key_seed;
+
+    for (int i = 0; i < SramDataKeySeedSize; i += 8) begin
+      scrambled_sram_data_key_seed[i*8+:64] = scramble_data(
+          sram_data_key_seed[i*8+:64], Secret1Idx);
+      mem_bkdr_util_h.write64(i + SramDataKeySeedOffset,
+                              scrambled_sram_data_key_seed[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_sram_data_key_seed
+    }};
+    digest = cal_digest(Secret1Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret1DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret2_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [RmaTokenSize*8-1:0] rma_token,
+      bit [CreatorRootKeyShare0Size*8-1:0] creator_root_key_share0,
+      bit [CreatorRootKeyShare1Size*8-1:0] creator_root_key_share1,
+      bit [CreatorSeedSize*8-1:0] creator_seed
+  );
+    bit [Secret2DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [RmaTokenSize*8-1:0] scrambled_rma_token;
+    bit [CreatorRootKeyShare0Size*8-1:0] scrambled_creator_root_key_share0;
+    bit [CreatorRootKeyShare1Size*8-1:0] scrambled_creator_root_key_share1;
+    bit [CreatorSeedSize*8-1:0] scrambled_creator_seed;
+
+    for (int i = 0; i < RmaTokenSize; i += 8) begin
+      scrambled_rma_token[i*8+:64] = scramble_data(
+          rma_token[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + RmaTokenOffset,
+                              scrambled_rma_token[i*8+:64]);
+    end
+    for (int i = 0; i < CreatorRootKeyShare0Size; i += 8) begin
+      scrambled_creator_root_key_share0[i*8+:64] = scramble_data(
+          creator_root_key_share0[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + CreatorRootKeyShare0Offset,
+                              scrambled_creator_root_key_share0[i*8+:64]);
+    end
+    for (int i = 0; i < CreatorRootKeyShare1Size; i += 8) begin
+      scrambled_creator_root_key_share1[i*8+:64] = scramble_data(
+          creator_root_key_share1[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + CreatorRootKeyShare1Offset,
+                              scrambled_creator_root_key_share1[i*8+:64]);
+    end
+    for (int i = 0; i < CreatorSeedSize; i += 8) begin
+      scrambled_creator_seed[i*8+:64] = scramble_data(
+          creator_seed[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + CreatorSeedOffset,
+                              scrambled_creator_seed[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_creator_seed,
+      scrambled_creator_root_key_share1,
+      scrambled_creator_root_key_share0,
+      scrambled_rma_token
+    }};
+    digest = cal_digest(Secret2Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret2DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret3_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [OwnerSeedSize*8-1:0] owner_seed
+  );
+    bit [Secret3DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [OwnerSeedSize*8-1:0] scrambled_owner_seed;
+
+    for (int i = 0; i < OwnerSeedSize; i += 8) begin
+      scrambled_owner_seed[i*8+:64] = scramble_data(
+          owner_seed[i*8+:64], Secret3Idx);
+      mem_bkdr_util_h.write64(i + OwnerSeedOffset,
+                              scrambled_owner_seed[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_owner_seed
+    }};
+    digest = cal_digest(Secret3Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret3DigestOffset, digest);
   endfunction
 
   // Functions that clear the provisioning state of the buffered partitions.
   // This is useful in tests that make front-door accesses for provisioning purposes.
+  function automatic void otp_clear_hw_cfg0_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
+  );
+    for (int i = 0; i < HwCfg0Size; i += 4) begin
+      mem_bkdr_util_h.write32(i + HwCfg0Offset, 32'h0);
+    end
+  endfunction
+
+  function automatic void otp_clear_hw_cfg1_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
+  );
+    for (int i = 0; i < HwCfg1Size; i += 4) begin
+      mem_bkdr_util_h.write32(i + HwCfg1Offset, 32'h0);
+    end
+  endfunction
+
   function automatic void otp_clear_secret0_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
   );
@@ -202,11 +287,12 @@ package otp_ctrl_mem_bkdr_util_pkg;
     end
   endfunction
 
-  function automatic void otp_clear_hw_cfg0_partition(
+  function automatic void otp_clear_secret3_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
   );
-    for (int i = 0; i < HwCfg0Size; i += 4) begin
-      mem_bkdr_util_h.write32(i + HwCfg0Offset, 32'h0);
+    for (int i = 0; i < Secret3Size; i += 4) begin
+      mem_bkdr_util_h.write32(i + Secret3Offset, 32'h0);
     end
   endfunction
+
 endpackage : otp_ctrl_mem_bkdr_util_pkg

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -342,7 +342,7 @@ class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
             // The actual data is irrelevant as long as the partition becomes locked.
             otp_write_secret2_partition(
               .mem_bkdr_util_h(cfg.mem_bkdr_util_h[Otp]),
-              .rma_unlock_token('0), .creator_root_key0('0), .creator_root_key1('0));
+              .rma_token('0), .creator_root_key_share0('0), .creator_root_key_share1('0));
           end
 
           KeyMgrTest1: begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
@@ -147,9 +147,9 @@ class chip_sw_flash_rma_unlocked_vseq extends chip_sw_base_vseq;
     // Override the rma unlock token to match SW test's input token.
     otp_write_secret2_partition(
         .mem_bkdr_util_h(cfg.mem_bkdr_util_h[Otp]),
-        .rma_unlock_token(dec_otp_token_from_lc_csrs(rma_unlock_token)),
-        .creator_root_key0(get_otp_key(creator_root_key0)),
-        .creator_root_key1(get_otp_key(creator_root_key1)));
+        .rma_token(dec_otp_token_from_lc_csrs(rma_unlock_token)),
+        .creator_root_key_share0(get_otp_key(creator_root_key0)),
+        .creator_root_key_share1(get_otp_key(creator_root_key1)));
     // Convert to right format for jtag_lc_state_transition function below.
     rma_unlock_token_vector = {<< byte {rma_unlock_token}};
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -24,8 +24,8 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_lc_base_vseq;
     // Override the test exit token to match SW test's input token.
     otp_write_secret0_partition(
         .mem_bkdr_util_h(cfg.mem_bkdr_util_h[Otp]),
-        .unlock_token(dec_otp_token_from_lc_csrs(lc_unlock_token)),
-        .exit_token(dec_otp_token_from_lc_csrs(lc_exit_token)));
+        .test_unlock_token(dec_otp_token_from_lc_csrs(lc_unlock_token)),
+        .test_exit_token(dec_otp_token_from_lc_csrs(lc_exit_token)));
   endfunction
 
   virtual task body();

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_mem_bkdr_util_pkg.sv
@@ -52,110 +52,32 @@ package otp_ctrl_mem_bkdr_util_pkg;
     otp_write_lc_partition_state(mem_bkdr_util_h, lc_state);
   endfunction : otp_write_lc_partition
 
+  // The following steps are needed to backdoor write a non-secret partition:
+  // 1). Backdoor write the input data to OTP memory.
+  // 2). Calculate the correct digest for the secret partition.
+  // 3). Backdoor write digest data to OTP memory.
+
   // The following steps are needed to backdoor write a secret partition:
   // 1). Scramble the RAW input data.
   // 2). Backdoor write the scrambled input data to OTP memory.
   // 3). Calculate the correct digest for the secret partition.
   // 4). Backdoor write digest data to OTP memory.
-  function automatic void otp_write_secret0_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [TestUnlockTokenSize*8-1:0] unlock_token,
-      bit [TestExitTokenSize*8-1:0]   exit_token
-  );
-    bit [Secret0DigestSize*8-1:0] digest;
 
-    bit [TestUnlockTokenSize*8-1:0] scrambled_unlock_token;
-    bit [TestExitTokenSize*8-1:0] scrambled_exit_token;
-    bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
-
-    for (int i = 0; i < TestUnlockTokenSize; i += 8) begin
-      scrambled_unlock_token[i*8+:64] = scramble_data(unlock_token[i*8+:64], Secret0Idx);
-      mem_bkdr_util_h.write64(i + TestUnlockTokenOffset, scrambled_unlock_token[i*8+:64]);
-    end
-    for (int i = 0; i < TestExitTokenSize; i += 8) begin
-      scrambled_exit_token[i*8+:64] = scramble_data(exit_token[i*8+:64], Secret0Idx);
-      mem_bkdr_util_h.write64(i + TestExitTokenOffset, scrambled_exit_token[i*8+:64]);
-    end
-
-    secret_data = {<<32{scrambled_exit_token, scrambled_unlock_token}};
-    digest = cal_digest(Secret0Idx, secret_data);
-
-    mem_bkdr_util_h.write64(Secret0DigestOffset, digest);
-  endfunction
-
-  function automatic void otp_write_secret1_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [FlashAddrKeySeedSize*8-1:0] flash_addr_key_seed,
-      bit [FlashDataKeySeedSize*8-1:0] flash_data_key_seed,
-      bit [SramDataKeySeedSize*8-1:0]  sram_data_key_seed
-  );
-    bit [Secret1DigestSize*8-1:0] digest;
-
-    bit [FlashAddrKeySeedSize*8-1:0] scrambled_flash_addr_key;
-    bit [FlashDataKeySeedSize*8-1:0] scrambled_flash_data_key;
-    bit [SramDataKeySeedSize*8-1:0] scrambled_sram_data_key;
-    bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
-
-    for (int i = 0; i < FlashAddrKeySeedSize; i += 8) begin
-      scrambled_flash_addr_key[i*8+:64] = scramble_data(flash_addr_key_seed[i*8+:64], Secret1Idx);
-      mem_bkdr_util_h.write64(i + FlashAddrKeySeedOffset, scrambled_flash_addr_key[i*8+:64]);
-    end
-    for (int i = 0; i < FlashDataKeySeedSize; i += 8) begin
-      scrambled_flash_data_key[i*8+:64] = scramble_data(flash_data_key_seed[i*8+:64], Secret1Idx);
-      mem_bkdr_util_h.write64(i + FlashDataKeySeedOffset, scrambled_flash_data_key[i*8+:64]);
-    end
-    for (int i = 0; i < SramDataKeySeedSize; i += 8) begin
-      scrambled_sram_data_key[i*8+:64] = scramble_data(sram_data_key_seed[i*8+:64], Secret1Idx);
-      mem_bkdr_util_h.write64(i + SramDataKeySeedOffset, scrambled_sram_data_key[i*8+:64]);
-    end
-
-    secret_data = {<<32 {scrambled_sram_data_key, scrambled_flash_data_key,
-                         scrambled_flash_addr_key}};
-    digest = cal_digest(Secret1Idx, secret_data);
-
-    mem_bkdr_util_h.write64(Secret1DigestOffset, digest);
-  endfunction
-
-  function automatic void otp_write_secret2_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [RmaTokenSize*8-1:0] rma_unlock_token,
-      bit [CreatorRootKeyShare0Size*8-1:0] creator_root_key0,
-      bit [CreatorRootKeyShare1Size*8-1:0] creator_root_key1
-  );
-
-    bit [Secret2DigestSize*8-1:0] digest;
-
-    bit [RmaTokenSize*8-1:0] scrambled_unlock_token;
-    bit [CreatorRootKeyShare0Size*8-1:0] scrambled_root_key0;
-    bit [CreatorRootKeyShare1Size*8-1:0] scrambled_root_key1;
-    bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
-
-    for (int i = 0; i < RmaTokenSize; i+=8) begin
-      scrambled_unlock_token[i*8+:64] = scramble_data(rma_unlock_token[i*8+:64], Secret2Idx);
-      mem_bkdr_util_h.write64(i + RmaTokenOffset, scrambled_unlock_token[i*8+:64]);
-    end
-    for (int i = 0; i < CreatorRootKeyShare0Size; i+=8) begin
-      scrambled_root_key0[i*8+:64] = scramble_data(creator_root_key0[i*8+:64], Secret2Idx);
-      mem_bkdr_util_h.write64(i + CreatorRootKeyShare0Offset, scrambled_root_key0[i*8+:64]);
-    end
-    for (int i = 0; i < CreatorRootKeyShare1Size; i+=8) begin
-      scrambled_root_key1[i*8+:64] = scramble_data(creator_root_key1[i*8+:64], Secret2Idx);
-      mem_bkdr_util_h.write64(i + CreatorRootKeyShare1Offset, scrambled_root_key1[i*8+:64]);
-    end
-
-    secret_data = {<<32 {scrambled_root_key1, scrambled_root_key0, scrambled_unlock_token}};
-    digest = cal_digest(Secret2Idx, secret_data);
-
-    mem_bkdr_util_h.write64(Secret2DigestOffset, digest);
-  endfunction
+  // The HW_CFG1 partition needs to be a special case since it has items
+  // smaller than 4 bytes and need to be concatenated. To make sure
+  // this special case won't end up broken if the OTP layout changes
+  // beyond what this supports the following checks are in place and
+  // will cause a failure.
+  // - No other partition except for HW_CFG1 has such small items.
+  // - The small items in HW_CFG1 will be contained within 32 bits.
 
   function automatic void otp_write_hw_cfg0_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [DeviceIdSize*8-1:0] device_id, bit [ManufStateSize*8-1:0] manuf_state
+      bit [DeviceIdSize*8-1:0] device_id,
+      bit [ManufStateSize*8-1:0] manuf_state
   );
     bit [HwCfg0DigestSize*8-1:0] digest;
-
-    bit [bus_params_pkg::BUS_DW-1:0] hw_cfg0_data[$];
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
 
     for (int i = 0; i < DeviceIdSize; i += 4) begin
       mem_bkdr_util_h.write32(i + DeviceIdOffset, device_id[i*8+:32]);
@@ -164,33 +86,167 @@ package otp_ctrl_mem_bkdr_util_pkg;
       mem_bkdr_util_h.write32(i + ManufStateOffset, manuf_state[i*8+:32]);
     end
 
-    hw_cfg0_data = {<<32 {manuf_state, device_id}};
-    digest = cal_digest(HwCfg0Idx, hw_cfg0_data);
-
+    partition_data = {<<32{
+      manuf_state,
+      device_id
+    }};
+    digest = cal_digest(HwCfg0Idx, partition_data);
     mem_bkdr_util_h.write64(HwCfg0DigestOffset, digest);
   endfunction
 
   function automatic void otp_write_hw_cfg1_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
-      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
       bit [EnSramIfetchSize*8-1:0] en_sram_ifetch,
-      bit [EnSramIfetchSize*8-1:0] dis_rv_dm_late_debug
+      bit [EnCsrngSwAppReadSize*8-1:0] en_csrng_sw_app_read,
+      bit [DisRvDmLateDebugSize*8-1:0] dis_rv_dm_late_debug
   );
     bit [HwCfg1DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [bus_params_pkg::BUS_DW-1:0] concat_data[$];
+    bit [31:0] word;
 
-    bit [bus_params_pkg::BUS_DW-1:0] hw_cfg1_data[$];
+    word = {
+      dis_rv_dm_late_debug,
+      en_csrng_sw_app_read,
+      en_sram_ifetch
+    };
+    mem_bkdr_util_h.write32(0 + EnSramIfetchOffset, word);
+    concat_data.push_front(word);
 
-    mem_bkdr_util_h.write32(EnSramIfetchOffset,
-                            {dis_rv_dm_late_debug, en_csrng_sw_app_read, en_sram_ifetch});
-
-    hw_cfg1_data = {<<32 {32'h0, dis_rv_dm_late_debug, en_csrng_sw_app_read, en_sram_ifetch}};
-    digest = cal_digest(HwCfg1Idx, hw_cfg1_data);
-
+    partition_data = {<<32{concat_data}};
+    digest = cal_digest(HwCfg1Idx, partition_data);
     mem_bkdr_util_h.write64(HwCfg1DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret0_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [TestUnlockTokenSize*8-1:0] test_unlock_token,
+      bit [TestExitTokenSize*8-1:0] test_exit_token
+  );
+    bit [Secret0DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [TestUnlockTokenSize*8-1:0] scrambled_test_unlock_token;
+    bit [TestExitTokenSize*8-1:0] scrambled_test_exit_token;
+
+    for (int i = 0; i < TestUnlockTokenSize; i += 8) begin
+      scrambled_test_unlock_token[i*8+:64] = scramble_data(
+          test_unlock_token[i*8+:64], Secret0Idx);
+      mem_bkdr_util_h.write64(i + TestUnlockTokenOffset,
+                              scrambled_test_unlock_token[i*8+:64]);
+    end
+    for (int i = 0; i < TestExitTokenSize; i += 8) begin
+      scrambled_test_exit_token[i*8+:64] = scramble_data(
+          test_exit_token[i*8+:64], Secret0Idx);
+      mem_bkdr_util_h.write64(i + TestExitTokenOffset,
+                              scrambled_test_exit_token[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_test_exit_token,
+      scrambled_test_unlock_token
+    }};
+    digest = cal_digest(Secret0Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret0DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret1_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [FlashAddrKeySeedSize*8-1:0] flash_addr_key_seed,
+      bit [FlashDataKeySeedSize*8-1:0] flash_data_key_seed,
+      bit [SramDataKeySeedSize*8-1:0] sram_data_key_seed
+  );
+    bit [Secret1DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [FlashAddrKeySeedSize*8-1:0] scrambled_flash_addr_key_seed;
+    bit [FlashDataKeySeedSize*8-1:0] scrambled_flash_data_key_seed;
+    bit [SramDataKeySeedSize*8-1:0] scrambled_sram_data_key_seed;
+
+    for (int i = 0; i < FlashAddrKeySeedSize; i += 8) begin
+      scrambled_flash_addr_key_seed[i*8+:64] = scramble_data(
+          flash_addr_key_seed[i*8+:64], Secret1Idx);
+      mem_bkdr_util_h.write64(i + FlashAddrKeySeedOffset,
+                              scrambled_flash_addr_key_seed[i*8+:64]);
+    end
+    for (int i = 0; i < FlashDataKeySeedSize; i += 8) begin
+      scrambled_flash_data_key_seed[i*8+:64] = scramble_data(
+          flash_data_key_seed[i*8+:64], Secret1Idx);
+      mem_bkdr_util_h.write64(i + FlashDataKeySeedOffset,
+                              scrambled_flash_data_key_seed[i*8+:64]);
+    end
+    for (int i = 0; i < SramDataKeySeedSize; i += 8) begin
+      scrambled_sram_data_key_seed[i*8+:64] = scramble_data(
+          sram_data_key_seed[i*8+:64], Secret1Idx);
+      mem_bkdr_util_h.write64(i + SramDataKeySeedOffset,
+                              scrambled_sram_data_key_seed[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_sram_data_key_seed,
+      scrambled_flash_data_key_seed,
+      scrambled_flash_addr_key_seed
+    }};
+    digest = cal_digest(Secret1Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret1DigestOffset, digest);
+  endfunction
+
+  function automatic void otp_write_secret2_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h,
+      bit [RmaTokenSize*8-1:0] rma_token,
+      bit [CreatorRootKeyShare0Size*8-1:0] creator_root_key_share0,
+      bit [CreatorRootKeyShare1Size*8-1:0] creator_root_key_share1
+  );
+    bit [Secret2DigestSize*8-1:0] digest;
+    bit [bus_params_pkg::BUS_DW-1:0] partition_data[$];
+    bit [RmaTokenSize*8-1:0] scrambled_rma_token;
+    bit [CreatorRootKeyShare0Size*8-1:0] scrambled_creator_root_key_share0;
+    bit [CreatorRootKeyShare1Size*8-1:0] scrambled_creator_root_key_share1;
+
+    for (int i = 0; i < RmaTokenSize; i += 8) begin
+      scrambled_rma_token[i*8+:64] = scramble_data(
+          rma_token[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + RmaTokenOffset,
+                              scrambled_rma_token[i*8+:64]);
+    end
+    for (int i = 0; i < CreatorRootKeyShare0Size; i += 8) begin
+      scrambled_creator_root_key_share0[i*8+:64] = scramble_data(
+          creator_root_key_share0[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + CreatorRootKeyShare0Offset,
+                              scrambled_creator_root_key_share0[i*8+:64]);
+    end
+    for (int i = 0; i < CreatorRootKeyShare1Size; i += 8) begin
+      scrambled_creator_root_key_share1[i*8+:64] = scramble_data(
+          creator_root_key_share1[i*8+:64], Secret2Idx);
+      mem_bkdr_util_h.write64(i + CreatorRootKeyShare1Offset,
+                              scrambled_creator_root_key_share1[i*8+:64]);
+    end
+
+    partition_data = {<<32{
+      scrambled_creator_root_key_share1,
+      scrambled_creator_root_key_share0,
+      scrambled_rma_token
+    }};
+    digest = cal_digest(Secret2Idx, partition_data);
+    mem_bkdr_util_h.write64(Secret2DigestOffset, digest);
   endfunction
 
   // Functions that clear the provisioning state of the buffered partitions.
   // This is useful in tests that make front-door accesses for provisioning purposes.
+  function automatic void otp_clear_hw_cfg0_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
+  );
+    for (int i = 0; i < HwCfg0Size; i += 4) begin
+      mem_bkdr_util_h.write32(i + HwCfg0Offset, 32'h0);
+    end
+  endfunction
+
+  function automatic void otp_clear_hw_cfg1_partition(
+      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
+  );
+    for (int i = 0; i < HwCfg1Size; i += 4) begin
+      mem_bkdr_util_h.write32(i + HwCfg1Offset, 32'h0);
+    end
+  endfunction
+
   function automatic void otp_clear_secret0_partition(
       mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
   );
@@ -215,11 +271,4 @@ package otp_ctrl_mem_bkdr_util_pkg;
     end
   endfunction
 
-  function automatic void otp_clear_hw_cfg0_partition(
-      mem_bkdr_util_pkg::mem_bkdr_util mem_bkdr_util_h
-  );
-    for (int i = 0; i < HwCfg0Size; i += 4) begin
-      mem_bkdr_util_h.write32(i + HwCfg0Offset, 32'h0);
-    end
-  endfunction
 endpackage : otp_ctrl_mem_bkdr_util_pkg


### PR DESCRIPTION
Generate this code to handle the differences between tops. Change top-level tests to accomodate the changes. Most work happens in darjeeling since the previous interface was simply not right.

Fixes #26288