### PR TITLE
[rom_ext] Communicate owner history via the CDI_1 certificate

### DIFF
--- a/sw/device/silicon_creator/lib/cert/cdi_1.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_1.hjson
@@ -40,6 +40,11 @@
             type: "byte-array",
             exact-size: 32,
         },
+        // Hash chain of all previous owners (SHA256).
+        owner_history_hash: {
+            type: "byte-array",
+            exact-size: 32,
+        },
         // Owner security version, used to prevent rollback.
         owner_security_version: {
             type: "byte-array",
@@ -102,6 +107,7 @@
                 fw_ids: [
                     { hash_algorithm: "sha256", digest: { var: "owner_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "owner_manifest_hash" } },
+                    { hash_algorithm: "sha256", digest: { var: "owner_history_hash" } },
                 ],
                 flags: {
                     not_configured: false,

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -146,13 +146,11 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
   return kErrorOk;
 }
 
-rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
-                                  hmac_digest_t *owner_manifest_measurement,
-                                  uint32_t owner_security_version,
-                                  owner_app_domain_t key_domain,
-                                  cert_key_id_pair_t *key_ids,
-                                  ecdsa_p256_public_key_t *cdi_1_pubkey,
-                                  uint8_t *cert, size_t *cert_size) {
+rom_error_t dice_cdi_1_cert_build(
+    hmac_digest_t *owner_measurement, hmac_digest_t *owner_manifest_measurement,
+    hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
+    owner_app_domain_t key_domain, cert_key_id_pair_t *key_ids,
+    ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert, size_t *cert_size) {
   hmac_digest_t owner_hash = *owner_measurement;
   hmac_digest_t owner_manifest_hash = *owner_manifest_measurement;
   util_reverse_bytes(&owner_hash, sizeof(owner_hash));
@@ -167,6 +165,8 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
   TEMPLATE_SET(cdi_1_tbs_params, Cdi1, OwnerHash, owner_hash.digest);
   TEMPLATE_SET(cdi_1_tbs_params, Cdi1, OwnerManifestHash,
                owner_manifest_hash.digest);
+  TEMPLATE_SET(cdi_1_tbs_params, Cdi1, OwnerHistoryHash,
+               owner_history_hash->digest);
   TEMPLATE_SET(cdi_1_tbs_params, Cdi1, OwnerSecurityVersion,
                &owner_security_version_be);
   TEMPLATE_SET(cdi_1_tbs_params, Cdi1, DebugFlag,

--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -84,6 +84,7 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
  *
  * @param owner_measurement Pointer to the owner firmware measurement.
  * @param owner_manifest_measurement Pointer to the owner manifest measurement.
+ * @param owner_history_hash Pointer to the owner history hash.
  * @param owner_security_version Owner firmware security version.
  * @param key_domain Domain of the Owner SW signing key.
  * @param key_ids Pointer to the (current and endorsement) public key IDs.
@@ -95,13 +96,11 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
-                                  hmac_digest_t *owner_manifest_measurement,
-                                  uint32_t owner_security_version,
-                                  owner_app_domain_t key_domain,
-                                  cert_key_id_pair_t *key_ids,
-                                  ecdsa_p256_public_key_t *cdi_1_pubkey,
-                                  uint8_t *cert, size_t *cert_size);
+rom_error_t dice_cdi_1_cert_build(
+    hmac_digest_t *owner_measurement, hmac_digest_t *owner_manifest_measurement,
+    hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
+    owner_app_domain_t key_domain, cert_key_id_pair_t *key_ids,
+    ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert, size_t *cert_size);
 
 /**
  * Check if a subject pubkey ID (serial number) or subject pubkey match the

--- a/sw/device/silicon_creator/lib/cert/dice_chain.c
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.c
@@ -404,8 +404,8 @@ static rom_error_t dice_chain_attestation_check_cdi_0(void) {
 
 rom_error_t dice_chain_attestation_owner(
     const manifest_t *owner_manifest, keymgr_binding_value_t *bl0_measurement,
-    hmac_digest_t *owner_measurement, keymgr_binding_value_t *sealing_binding,
-    owner_app_domain_t key_domain) {
+    hmac_digest_t *owner_measurement, hmac_digest_t *owner_history_hash,
+    keymgr_binding_value_t *sealing_binding, owner_app_domain_t key_domain) {
   // Handles the certificates from the immutable rom_ext first.
   RETURN_IF_ERROR(dice_chain_attestation_check_uds());
   RETURN_IF_ERROR(dice_chain_attestation_check_cdi_0());
@@ -442,7 +442,7 @@ rom_error_t dice_chain_attestation_owner(
     // Update the cert page buffer.
     size_t updated_cert_size = kScratchCertSizeBytes;
     HARDENED_RETURN_IF_ERROR(dice_cdi_1_cert_build(
-        (hmac_digest_t *)bl0_measurement, owner_measurement,
+        (hmac_digest_t *)bl0_measurement, owner_measurement, owner_history_hash,
         owner_manifest->security_version, key_domain, &dice_chain.key_ids,
         &dice_chain.subject_pubkey, dice_chain.scratch_cert,
         &updated_cert_size));

--- a/sw/device/silicon_creator/lib/cert/dice_chain.h
+++ b/sw/device/silicon_creator/lib/cert/dice_chain.h
@@ -58,8 +58,8 @@ rom_error_t dice_chain_attestation_creator(
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_chain_attestation_owner(
     const manifest_t *owner_manifest, keymgr_binding_value_t *bl0_measurement,
-    hmac_digest_t *owner_measurement, keymgr_binding_value_t *sealing_binding,
-    owner_app_domain_t key_domain);
+    hmac_digest_t *owner_measurement, hmac_digest_t *owner_history_hash,
+    keymgr_binding_value_t *sealing_binding, owner_app_domain_t key_domain);
 
 /**
  * Write back the certificate chain to flash if changed.

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -322,13 +322,14 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
   return kErrorOk;
 }
 
-rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
-                                  hmac_digest_t *owner_manifest_measurement,
-                                  uint32_t owner_security_version,
-                                  owner_app_domain_t key_domain,
-                                  cert_key_id_pair_t *key_ids,
-                                  ecdsa_p256_public_key_t *cdi_1_pubkey,
-                                  uint8_t *cert, size_t *cert_size) {
+rom_error_t dice_cdi_1_cert_build(
+    hmac_digest_t *owner_measurement, hmac_digest_t *owner_manifest_measurement,
+    hmac_digest_t *owner_history_hash, uint32_t owner_security_version,
+    owner_app_domain_t key_domain, cert_key_id_pair_t *key_ids,
+    ecdsa_p256_public_key_t *cdi_1_pubkey, uint8_t *cert, size_t *cert_size) {
+  // TODO: The ownership history is currently not included in the CWT
+  // certificate.
+  OT_DISCARD(owner_history_hash);
   // Build Subject public key structure
   size_t cose_key_size = sizeof(cose_key_buffer);
   cwt_cose_key_values_t cwt_cose_key_params = {

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
@@ -15,7 +15,7 @@ rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
                                                signature, message, len);
 }
 
-rom_error_t ownership_seal_init() {
+rom_error_t ownership_seal_init(void) {
   return MockOwnershipKey::Instance().seal_init();
 }
 
@@ -27,8 +27,10 @@ rom_error_t ownership_seal_check(size_t page) {
   return MockOwnershipKey::Instance().seal_check(page);
 }
 
-rom_error_t ownership_secret_new() {
-  return MockOwnershipKey::Instance().secret_new();
+rom_error_t ownership_secret_new(uint32_t prior_key_alg,
+                                 const owner_keydata_t *prior_owner_key) {
+  return MockOwnershipKey::Instance().secret_new(prior_key_alg,
+                                                 prior_owner_key);
 }
 
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
@@ -23,7 +23,7 @@ class MockOwnershipKey : public global_mock::GlobalMock<MockOwnershipKey> {
   MOCK_METHOD(rom_error_t, seal_init, ());
   MOCK_METHOD(rom_error_t, seal_page, (size_t));
   MOCK_METHOD(rom_error_t, seal_check, (size_t));
-  MOCK_METHOD(rom_error_t, secret_new, ());
+  MOCK_METHOD(rom_error_t, secret_new, (uint32_t, const owner_keydata_t *));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -80,6 +80,10 @@ static rom_error_t activate_handler(boot_svc_msg_t *msg,
     return kErrorOwnershipInvalidDin;
   }
 
+  // Copy the prior owner's key so we can save it in the key history.
+  uint32_t prior_key_alg = owner_page[0].ownership_key_alg;
+  owner_keydata_t prior_owner_key = owner_page[0].owner_key;
+
   HARDENED_RETURN_IF_ERROR(
       ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolTrue));
 
@@ -98,7 +102,8 @@ static rom_error_t activate_handler(boot_svc_msg_t *msg,
   } else {
     // All other activations are transfers and need to regenerate entropy stored
     // in the OwnerSecret page.
-    HARDENED_RETURN_IF_ERROR(ownership_secret_new());
+    HARDENED_RETURN_IF_ERROR(
+        ownership_secret_new(prior_key_alg, &prior_owner_key));
     bootdata->ownership_transfers += 1;
   }
 

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -270,7 +270,7 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
       .WillOnce(Return(kErrorOk));
 
   if (state != kOwnershipStateUnlockedSelf) {
-    EXPECT_CALL(ownership_key_, secret_new()).WillOnce(Return(kErrorOk));
+    EXPECT_CALL(ownership_key_, secret_new(_, _)).WillOnce(Return(kErrorOk));
   }
 
   // The nonce will be regenerated.
@@ -340,7 +340,7 @@ TEST_P(OwnershipActivateValidStateTest, UpdateBootdataBl0) {
       .WillOnce(Return(kErrorOk));
 
   if (state != kOwnershipStateUnlockedSelf) {
-    EXPECT_CALL(ownership_key_, secret_new()).WillOnce(Return(kErrorOk));
+    EXPECT_CALL(ownership_key_, secret_new(_, _)).WillOnce(Return(kErrorOk));
   }
 
   // The nonce will be regenerated.

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -87,9 +87,12 @@ rom_error_t ownership_seal_check(size_t page);
 /**
  * Replace the owner secret with new entropy and update the ownership history.
  *
+ * @param prior_key_alg The key algorithm of the prior owner_key.
+ * @param prior_owner_key The prior owner key.
  * @return Success or error code.
  */
-rom_error_t ownership_secret_new(void);
+rom_error_t ownership_secret_new(uint32_t prior_key_alg,
+                                 const owner_keydata_t *prior_owner_key);
 
 /**
  * Retrieve the owner history digest from the OwnerSecret page.

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -573,9 +573,9 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
                               /*max_key_version=*/0));
   TRY(otbn_boot_cert_ecc_p256_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id,
                                      &curr_pubkey));
-  TRY(dice_cdi_1_cert_build(&kZeroDigest, &kZeroDigest, 0, kOwnerAppDomainProd,
-                            &cdi_1_key_ids, &curr_pubkey, all_certs,
-                            &curr_cert_size));
+  TRY(dice_cdi_1_cert_build(&kZeroDigest, &kZeroDigest, &kZeroDigest, 0,
+                            kOwnerAppDomainProd, &cdi_1_key_ids, &curr_pubkey,
+                            all_certs, &curr_cert_size));
   cdi_1_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -82,6 +82,9 @@ owner_config_t owner_config;
 // Owner application keys.
 owner_application_keyring_t keyring;
 
+// Hash chain of all previous owners.
+hmac_digest_t owner_history_hash;
+
 // Verifying key index
 size_t verify_key;
 
@@ -315,8 +318,8 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
 
   // Generate CDI_1 attestation keys and certificate.
   HARDENED_RETURN_IF_ERROR(dice_chain_attestation_owner(
-      manifest, &boot_measurements.bl0, &owner_measurement, &sealing_binding,
-      key->key_domain));
+      manifest, &boot_measurements.bl0, &owner_measurement, &owner_history_hash,
+      &sealing_binding, key->key_domain));
 
   // Write the DICE certs to flash if they have been updated.
   HARDENED_RETURN_IF_ERROR(dice_chain_flush_flash());
@@ -671,6 +674,12 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 
   // Configure SRAM execution as the owner requested.
   rom_ext_sram_exec(owner_config.sram_exec);
+
+  // Get the ownership history.  We discard the error because there is no
+  // meaningful action we could take in the event of an error.  If there
+  // was an error, ownership_history_get will default history hash result to
+  // all ones.
+  OT_DISCARD(ownership_history_get(&owner_history_hash));
 
   // Handle any pending boot_svc commands.
   uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;

--- a/sw/host/tests/attestation/attestation_test.rs
+++ b/sw/host/tests/attestation/attestation_test.rs
@@ -89,7 +89,7 @@ fn check_public_key(key: &SubjectPublicKeyInfo, id: &[u8], subject: &Name) -> Re
     Ok(keyid == id && &hex::encode(keyid) == name)
 }
 
-fn attestation_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+fn attestation_test(opts: &Opts, transport: &TransportWrapper, owner_history: &[u8]) -> Result<()> {
     let uart = transport.uart("console")?;
     let capture = UartConsole::wait_for(
         &*uart,
@@ -159,9 +159,10 @@ fn attestation_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     assert_eq!(dice.vendor.get_value(), "OpenTitan");
     assert_eq!(dice.layer.get_value(), &BigUint::from(2u8));
     let fw_ids = dice.fw_ids.as_ref().expect("list of fw_ids");
-    assert_eq!(fw_ids.len(), 2);
+    assert_eq!(fw_ids.len(), 3);
     assert_eq!(fw_ids[0].digest.get_value(), &measurements[1].as_ref());
     assert_eq!(fw_ids[1].digest.get_value(), &owner_measurements[0]);
+    assert_eq!(fw_ids[2].digest.get_value(), &owner_history);
     Ok(())
 }
 
@@ -169,6 +170,7 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
-    attestation_test(&opts, &transport)?;
+    // If there haven't been any ownership transfers, the owner history will be all ones.
+    attestation_test(&opts, &transport, &[255u8; 32])?;
     Ok(())
 }


### PR DESCRIPTION
1. Add a `fw_ids` member that contains the ownership history information.  The ownership history is a hash chain of all owner_keys: `owner_history = HASH(owner_history || owner_key)`.
2. Initialize the owner_history hash in `sku_creator_owner_init`. The beginning of the hash chain is just `HASH(owner_key)`.
3. Check the owner_history element in the attestation test.

A follow-up PR will add tests to check the owner_history after an ownership transfer.