### PR TITLE
[perso] implement WAS / TBS HMAC binding

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -285,6 +285,7 @@ manifest(d = {
         manifest = ":manifest_perso",
         spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
         deps = [
+            ":flash_info_permissions",
             ":perso_tlv_data",
             ":personalize_ext",
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -296,7 +297,9 @@ manifest(d = {
             "//sw/device/lib/dif:pinmux",
             "//sw/device/lib/dif:rstmgr",
             "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:flash_ctrl_testutils",
             "//sw/device/lib/testing:lc_ctrl_testutils",
+            "//sw/device/lib/testing:otp_ctrl_testutils",
             "//sw/device/lib/testing:pinmux_testutils",
             "//sw/device/lib/testing:rstmgr_testutils",
             "//sw/device/lib/testing/json:provisioning_data",

--- a/sw/device/silicon_creator/manuf/base/flash_info_permissions.h
+++ b/sw/device/silicon_creator/manuf/base/flash_info_permissions.h
@@ -23,6 +23,9 @@ dif_flash_ctrl_region_properties_t kFlashInfoPage0Permissions = {
 
 /**
  * Access permissions for flash info page 3 (holds wafer_auth_secret).
+ *
+ * Note: scrambling must be disabled as the flash scrambling seeds are not
+ * programmed into OTP until the individualization FW is executed.
  */
 dif_flash_ctrl_region_properties_t kFlashInfoPage3WritePermissions = {
     .ecc_en = kMultiBitBool4True,
@@ -30,6 +33,20 @@ dif_flash_ctrl_region_properties_t kFlashInfoPage3WritePermissions = {
     .erase_en = kMultiBitBool4True,
     .prog_en = kMultiBitBool4True,
     .rd_en = kMultiBitBool4False,
+    .scramble_en = kMultiBitBool4False};
+
+/**
+ * Access permissions for flash info page 3 (holds wafer_auth_secret).
+ *
+ * Note: scrambling must be disabled as it is disabled when the page is written
+ * during CP.
+ */
+dif_flash_ctrl_region_properties_t kFlashInfoPage3ReadPermissions = {
+    .ecc_en = kMultiBitBool4True,
+    .high_endurance_en = kMultiBitBool4False,
+    .erase_en = kMultiBitBool4False,
+    .prog_en = kMultiBitBool4False,
+    .rd_en = kMultiBitBool4True,
     .scramble_en = kMultiBitBool4False};
 
 /**

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -14,8 +14,10 @@
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
@@ -46,10 +48,12 @@
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
+#include "sw/device/silicon_creator/manuf/base/flash_info_permissions.h"
 #include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 #include "sw/device/silicon_creator/manuf/base/personalize_ext.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/personalize.h"
 
 #include "flash_ctrl_regs.h"  // Generated.
@@ -587,6 +591,77 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   return OK_STATUS();
 }
 
+static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
+  // Read out the WAS from flash.
+  hmac_key_t was;
+  static_assert(
+      kFlashInfoFieldWaferAuthSecretSizeIn32BitWords == kHmacKeyNumWords,
+      "WAS size expected to be same size as HMAC-SHA256 key.");
+  TRY(flash_ctrl_testutils_info_region_setup_properties(
+      &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret.page,
+      kFlashInfoFieldWaferAuthSecret.bank,
+      kFlashInfoFieldWaferAuthSecret.partition, kFlashInfoPage3ReadPermissions,
+      /*offset=*/NULL));
+  TRY(manuf_flash_info_field_read(
+      &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret, was.key,
+      kFlashInfoFieldWaferAuthSecretSizeIn32BitWords));
+
+  // Compute HMAC of TBS certs with WAS as the key.
+  // Most HSMs and host tooling will compute an HMAC in big endian format, so we
+  // do the same to make comparison easier.
+  hmac_hmac_sha256_init(was, /*big_endian_digest=*/true);
+  uint8_t *tlv_buf = perso_blob_to_host->body;
+  uint16_t obj_size;
+  perso_tlv_object_type_t obj_type;
+  perso_tlv_cert_obj_t cert_obj;
+  for (size_t i = 0; i < perso_blob_to_host->num_objs; ++i) {
+    // Parse the TLV object header.
+    perso_tlv_object_header_t obj_header = *(uint16_t *)tlv_buf;
+    PERSO_TLV_GET_FIELD(Objh, Type, obj_header, &obj_type);
+    PERSO_TLV_GET_FIELD(Objh, Size, obj_header, &obj_size);
+    if (obj_type == kPersoObjectTypeX509Tbs) {
+      TRY(perso_tlv_get_cert_obj(tlv_buf, obj_size, &cert_obj));
+      hmac_sha256_update(cert_obj.cert_body_p, cert_obj.cert_body_size);
+    }
+    tlv_buf += obj_size;
+  }
+  hmac_sha256_process();
+  hmac_digest_t digest;
+  hmac_sha256_final(&digest);
+
+  // Push hash into perso blob.
+  perso_tlv_object_header_t was_hmac_tlv_header = 0;
+  obj_size = sizeof(perso_tlv_object_header_t) + sizeof(hmac_digest_t);
+  PERSO_TLV_SET_FIELD(Objh, Type, was_hmac_tlv_header,
+                      kPersoObjectTypeWasTbsHmac);
+  PERSO_TLV_SET_FIELD(Objh, Size, was_hmac_tlv_header, obj_size);
+  TRY(perso_tlv_push_to_perso_blob(&was_hmac_tlv_header,
+                                   sizeof(perso_tlv_object_header_t),
+                                   perso_blob_to_host));
+  TRY(perso_tlv_push_to_perso_blob(digest.digest, kHmacDigestNumBytes,
+                                   perso_blob_to_host));
+  perso_blob_to_host->num_objs++;
+
+  // Read complete device ID and push into perso blob. The host will need the
+  // device ID to reconstruct the WAS.
+  uint32_t device_id[kHwCfgDeviceIdSizeIn32BitWords] = {0};
+  TRY(otp_ctrl_testutils_dai_read32_array(&otp_ctrl, kDifOtpCtrlPartitionHwCfg0,
+                                          kHwCfgDeviceIdOffset, device_id,
+                                          ARRAYSIZE(device_id)));
+  perso_tlv_object_header_t device_id_header = 0;
+  obj_size = sizeof(perso_tlv_object_header_t) + kHwCfgDeviceIdSizeInBytes;
+  PERSO_TLV_SET_FIELD(Objh, Type, device_id_header, kPersoObjectTypeDeviceId);
+  PERSO_TLV_SET_FIELD(Objh, Size, device_id_header, obj_size);
+  TRY(perso_tlv_push_to_perso_blob(&device_id_header,
+                                   sizeof(perso_tlv_object_header_t),
+                                   perso_blob_to_host));
+  TRY(perso_tlv_push_to_perso_blob(device_id, kHwCfgDeviceIdSizeInBytes,
+                                   perso_blob_to_host));
+  perso_blob_to_host->num_objs++;
+
+  return OK_STATUS();
+}
+
 static status_t boot_data_cfg_initialize(void) {
   // Configure the boot data OTP word.
   if (!status_ok(manuf_individualize_device_flash_info_boot_data_cfg_check(
@@ -920,8 +995,6 @@ static status_t check_otp_measurement_post_lock(hmac_digest_t *measurement,
 }
 
 static status_t finalize_otp_partitions(void) {
-  // TODO(#21554): Complete the provisioning of the root keys and key policies.
-
   TRY(check_next_slot_bootable());
 
   // Complete the provisioning of OTP OwnerSwCfg partition.
@@ -968,6 +1041,7 @@ bool test_main(void) {
   // This is needed to avoid a watchdog reset if enabled in the ROM.
   watchdog_disable();
 
+  // Initialize all peripherals, GPIO ATE indicators, and UJSON console.
   CHECK_STATUS_OK(peripheral_handles_init());
   pinmux_testutils_init(&pinmux);
   CHECK_STATUS_OK(configure_ate_gpio_indicators());
@@ -984,10 +1058,13 @@ bool test_main(void) {
   }
 
   CHECK_STATUS_OK(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
+
+  // Provision OTP and flash secrets.
   CHECK_STATUS_OK(personalize_otp_and_flash_secrets(&uj));
+
+  // Generate all TBS certs and install the initial owner configuration.
   CHECK_STATUS_OK(personalize_gen_dice_certificates(&uj));
   CHECK_STATUS_OK(install_owner());
-
   personalize_extension_pre_endorse_t pre_endorse = {
       .uj = &uj,
       .certgen_inputs = &certgen_inputs,
@@ -1003,10 +1080,11 @@ bool test_main(void) {
       .otp_rot_creator_auth_state_measurement =
           &otp_rot_creator_auth_state_measurement};
   CHECK_STATUS_OK(personalize_extension_pre_cert_endorse(&pre_endorse));
+  CHECK_STATUS_OK(compute_tbs_was_hmac(pre_endorse.perso_blob_to_host));
 
+  // Endorse TBS certs and install in flash.
   CHECK_STATUS_OK(personalize_endorse_certificates(&uj));
   CHECK_STATUS_OK(hash_all_certs());
-
   personalize_extension_post_endorse_t post_endorse = {
       .uj = &uj,
       .perso_blob_from_host = &perso_blob_from_host,
@@ -1022,7 +1100,9 @@ bool test_main(void) {
            hash.data[7], hash.data[6], hash.data[5], hash.data[4], hash.data[3],
            hash.data[2], hash.data[1], hash.data[0]);
 
+  // Complete OTP programming.
   CHECK_STATUS_OK(finalize_otp_partitions());
+
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
   LOG_INFO("Personalization done.");

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -607,8 +607,8 @@ static status_t compute_tbs_was_hmac(perso_blob_t *perso_blob_to_host) {
       kFlashInfoFieldWaferAuthSecretSizeIn32BitWords));
 
   // Compute HMAC of TBS certs with WAS as the key.
-  // Most HSMs and host tooling will compute an HMAC in big endian format, so we
-  // do the same to make comparison easier.
+  // HSMs and host tooling will compute an HMAC in big endian format, so we do
+  // the same to make the comparison easier.
   hmac_hmac_sha256_init(was, /*big_endian_digest=*/true);
   uint8_t *tlv_buf = perso_blob_to_host->body;
   uint16_t obj_size;

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -26,10 +26,35 @@
  * The following object types have been defined so far:
  */
 typedef enum perso_tlv_object_type {
+  /**
+   * An X.509 TBS certificate to be endorsed during provisioning.
+   */
   kPersoObjectTypeX509Tbs = 0,
+  /**
+   * A fully endorsed X.509 certificate to be written to flash info.
+   */
   kPersoObjectTypeX509Cert = 1,
+  /**
+   * A generic cryptographic seed generated and externall registered during
+   * provisioning. Can be used as a primitive to bootstrap cryptographic
+   * operations post-provisioning/deployment.
+   */
   kPersoObjectTypeDevSeed = 2,
+  /**
+   * A fully endorsed CWT certificate to be written to flash info.
+   */
   kPersoObjectTypeCwtCert = 3,
+  /**
+   * An HMAC-SHA256 over the TBS certificates, using the Wafer Authentication
+   * Secret provisioned during CP as the key, to authenticate the unendorsed
+   * certificates to the provisioning system performing certificate endorsements
+   * during personalization.
+   */
+  kPersoObjectTypeWasTbsHmac = 4,
+  /**
+   * Fully formed (CP + FT) device ID.
+   */
+  kPersoObjectTypeDeviceId = 5,
 } perso_tlv_object_type_t;
 
 typedef uint16_t perso_tlv_object_header_t;

--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
@@ -133,12 +133,11 @@ static status_t flash_info_page_0_read_and_validate(
 
 static status_t wafer_auth_secret_flash_info_page_write(
     manuf_cp_provisioning_data_t *console_in) {
-  uint32_t byte_address = 0;
   TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret.page,
       kFlashInfoFieldWaferAuthSecret.bank,
       kFlashInfoFieldWaferAuthSecret.partition, kFlashInfoPage3WritePermissions,
-      &byte_address));
+      /*offset=*/NULL));
   TRY(manuf_flash_info_field_write(
       &flash_ctrl_state, kFlashInfoFieldWaferAuthSecret,
       console_in->wafer_auth_secret,

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -36,6 +36,10 @@ use util_lib::{
 /// Provisioning data command-line parameters.
 #[derive(Debug, Args, Clone)]
 pub struct ManufFtProvisioningDataInput {
+    /// Wafer Authentication Secret to verify from device.
+    #[arg(long)]
+    pub wafer_auth_secret: String,
+
     /// TestUnlock token; a 128-bit hex string.
     #[arg(long)]
     pub test_unlock_token: String,
@@ -114,7 +118,9 @@ fn main() -> Result<()> {
     let spi_console_device = SpiConsoleDevice::new(&*spi)?;
     InitializeTest::print_result("load_bitstream", opts.init.load_bitstream.init(&transport))?;
 
-    // Parse and format LC tokens.
+    // Parse and format tokens.
+    let wafer_auth_secret =
+        hex_string_to_u8_arrayvec::<32>(opts.provisioning_data.wafer_auth_secret.as_str())?;
     let _test_unlock_token =
         hex_string_to_u32_arrayvec::<4>(opts.provisioning_data.test_unlock_token.as_str())?;
     let _test_exit_token =
@@ -249,6 +255,7 @@ fn main() -> Result<()> {
     run_ft_personalize(
         &transport,
         &opts.init,
+        &wafer_auth_secret,
         &rma_unlock_token,
         ca_cfgs,
         ca_keys,

--- a/sw/host/provisioning/ft_lib/BUILD
+++ b/sw/host/provisioning/ft_lib/BUILD
@@ -28,6 +28,7 @@ package(default_visibility = ["//visibility:public"])
             "@crate_index//:arrayvec",
             "@crate_index//:clap",
             "@crate_index//:hex",
+            "@crate_index//:hmac",
             "@crate_index//:indexmap",
             "@crate_index//:log",
             "@crate_index//:serde",

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -318,16 +319,20 @@ fn provision_certificates(
     response.stats.log_elapsed_time("perso-tbs-export", t0);
 
     // Extract certificate byte vectors, endorse TBS certs, and ensure they parse with OpenSSL.
-    // During the process, both:
+    // During the process:
     //   1. prepare a UJSON payload of endorsed certs to send back to the device,
-    //   2. collect the certs that were endorsed to verify their endorsement signatures with OpenSSL, and
-    //   3. hash all certs to check the integrity of what gets written back to the device.
+    //   2. collect the TBS certs to HMAC them with the WAS,
+    //   3. collect the certs that were endorsed to verify their endorsement signatures with OpenSSL, and
+    //   4. hash all certs to check the integrity of what gets written back to the device.
     let mut cert_hasher = Sha256::new();
     let mut start: usize = 0;
     let mut dice_cert_chain: Vec<EndorsedCert> = Vec::new();
     let mut sku_specific_certs: Vec<EndorsedCert> = Vec::new();
     let mut num_host_endorsed_certs = 0;
     let mut endorsed_cert_concat = ArrayVec::<u8, 4096>::new();
+    let mut device_was_hmac: Vec<u8> = Vec::new();
+    let mut device_id: Vec<u8> = Vec::new();
+    let mut host_was_hmac = Hmac::<Sha256>::new_from_slice(&[0u8; 32])?;
 
     // Extract CAs.
     let dice_ca_cert = &ca_cfgs["dice"].certificate;
@@ -348,6 +353,19 @@ fn provision_certificates(
         start += obj_header_size;
         match header.obj_type {
             ObjType::EndorsedX509Cert | ObjType::UnendorsedX509Cert | ObjType::EndorsedCwtCert => {}
+            ObjType::WasTbsHmac => {
+                let was_tbs_hmac_size = header.obj_size - obj_header_size;
+                device_was_hmac
+                    .extend_from_slice(&perso_blob.body[start..start + was_tbs_hmac_size]);
+                start += was_tbs_hmac_size;
+                continue;
+            }
+            ObjType::DeviceId => {
+                let device_id_size = header.obj_size - obj_header_size;
+                device_id.extend_from_slice(&perso_blob.body[start..start + device_id_size]);
+                start += device_id_size;
+                continue;
+            }
             ObjType::DevSeed => {
                 let dev_seed_size = header.obj_size - obj_header_size;
                 let seeds = &perso_blob.body[start..start + dev_seed_size];
@@ -367,6 +385,7 @@ fn provision_certificates(
 
         // Extract the certificate bytes and endorse the cert if needed.
         let cert_bytes = if header.obj_type == ObjType::UnendorsedX509Cert {
+            host_was_hmac.update(cert.cert_body.as_slice());
             // Endorse the cert and updates its size.
             let cert_bytes = if dice_cert_names.contains(cert.cert_name) {
                 parse_and_endorse_x509_cert(cert.cert_body.clone(), dice_ca_key)?
@@ -426,6 +445,10 @@ fn provision_certificates(
     let t0 = Instant::now();
     endorsed_cert_concat = ft_ext(endorsed_cert_concat)?;
     response.stats.log_elapsed_time("perso-ft-ext", t0);
+
+    // Authenticate WAS HMAC.
+    let host_was_hmac_bytes = host_was_hmac.finalize().into_bytes();
+    assert_eq!(host_was_hmac_bytes[..], device_was_hmac[..]);
 
     // Complete hash of all certs that will be sent back to the device and written to flash. This
     // is used as integrity check on what will be written to flash.

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -291,7 +291,9 @@ fn process_dev_seeds(seeds: &[u8]) -> Result<Vec<Vec<u8>>> {
     Ok(response)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn provision_certificates(
+    wafer_auth_secret: &ArrayVec<u8, 32>,
     ca_cfgs: HashMap<String, CaConfig>,
     ca_keys: HashMap<String, CaKey>,
     perso_certgen_inputs: &ManufCertgenInputs,
@@ -332,7 +334,7 @@ fn provision_certificates(
     let mut endorsed_cert_concat = ArrayVec::<u8, 4096>::new();
     let mut device_was_hmac: Vec<u8> = Vec::new();
     let mut device_id: Vec<u8> = Vec::new();
-    let mut host_was_hmac = Hmac::<Sha256>::new_from_slice(&[0u8; 32])?;
+    let mut host_was_hmac = Hmac::<Sha256>::new_from_slice(wafer_auth_secret.as_slice())?;
 
     // Extract CAs.
     let dice_ca_cert = &ca_cfgs["dice"].certificate;
@@ -520,6 +522,7 @@ fn provision_certificates(
 pub fn run_ft_personalize(
     transport: &TransportWrapper,
     init: &InitializeTest,
+    wafer_auth_secret: &ArrayVec<u8, 32>,
     rma_unlock_token: &ArrayVec<u32, 4>,
     ca_cfgs: HashMap<String, CaConfig>,
     ca_keys: HashMap<String, CaKey>,
@@ -554,6 +557,7 @@ pub fn run_ft_personalize(
     // Provision all device certificates.
     let t0 = Instant::now();
     provision_certificates(
+        wafer_auth_secret,
         ca_cfgs,
         ca_keys,
         perso_certgen_inputs,

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -260,6 +260,7 @@ class OtDut():
             --elf={individ_elf} \
             --bootstrap={perso_bin} \
             --second-bootstrap={fw_bundle_bin} \
+            --wafer-auth-secret="{_ZERO_256BIT_HEXSTR}" \
             --test-unlock-token="{format_hex(self.test_unlock_token, width=32)}" \
             --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
             --target-mission-mode-lc-state="{self.sku_config.target_lc_state}" \

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -12,6 +12,8 @@ pub enum ObjType {
     EndorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Cert as isize,
     DevSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDevSeed as isize,
     EndorsedCwtCert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeCwtCert as isize,
+    WasTbsHmac = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeWasTbsHmac as isize,
+    DeviceId = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDeviceId as isize,
 }
 
 impl ObjType {
@@ -21,6 +23,8 @@ impl ObjType {
             1 => Ok(ObjType::EndorsedX509Cert),
             2 => Ok(ObjType::DevSeed),
             3 => Ok(ObjType::EndorsedCwtCert),
+            4 => Ok(ObjType::WasTbsHmac),
+            5 => Ok(ObjType::DeviceId),
             _ => bail!("incorrect input value of {value} for ObjType"),
         }
     }

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "ftdi-mpsse",
  "heck",
  "hex",
+ "hmac",
  "humantime",
  "humantime-serde",
  "indexmap 2.0.0",

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -47,6 +47,7 @@ ftdi-mpsse = "0.1.1"
 embedded-hal = "1.0.0"
 heck = "0.4.1"
 hex = { version = "0.4.3", features = ["serde"] }
+hmac = "0.12.1"
 humantime = "2.1.0"
 humantime-serde = "1.1"
 indicatif = "0.17.6"

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -212,6 +212,12 @@ alias(
 )
 
 alias(
+    name = "hmac",
+    actual = "@crate_index__hmac-0.12.1//:hmac",
+    tags = ["manual"],
+)
+
+alias(
     name = "humantime",
     actual = "@crate_index__humantime-2.1.0//:humantime",
     tags = ["manual"],

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -326,6 +326,7 @@ _NORMAL_DEPENDENCIES = {
             "ftdi-mpsse": "@crate_index__ftdi-mpsse-0.1.1//:ftdi_mpsse",
             "heck": "@crate_index__heck-0.4.1//:heck",
             "hex": "@crate_index__hex-0.4.3//:hex",
+            "hmac": "@crate_index__hmac-0.12.1//:hmac",
             "humantime": "@crate_index__humantime-2.1.0//:humantime",
             "humantime-serde": "@crate_index__humantime-serde-1.1.1//:humantime_serde",
             "indexmap": "@crate_index__indexmap-2.0.0//:indexmap",


### PR DESCRIPTION
This fixes #22274 by updating the perso firmware and FT test harness to compute and validate an HMAC-SHA256 over the TBS certs.