### PR TITLE
[darjeeling] Update configuration files

### DIFF
--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -74,5 +74,9 @@
       name: vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_alert/data/prim_alert_cover.cfg"
     }
+    {
+      name: xcelium_cov_cfg_file
+      value: ""
+    }
   ]
 }

--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -53,6 +53,7 @@
              // Top level IPs.
              "{proj_root}/hw/top_darjeeling/ip_autogen/ac_range_check/dv/ac_range_check_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
+             "{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/gpio/dv/gpio_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
@@ -64,7 +65,6 @@
              // Top level.
              "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson",
              // TODO(#26733): the smoketests here must be fixed before enabling.
-             //"{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
              //"{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
             ]
 }


### PR DESCRIPTION
This PR addresses two points:

1. The clkmgr smoke test is now okay for inclusion in Darjeeling CI / nightly runs.
2. Darjeeling nightly regression may now be run with xcelium.