### PR TITLE
[sw/cryptolib] Add new ibex driver functions

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -187,6 +187,20 @@ cc_library(
 )
 
 cc_library(
+    name = "ibex",
+    srcs = ["ibex.c"],
+    hdrs = ["ibex.h"],
+    deps = [
+        "//hw/top:rv_core_ibex_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
     name = "otbn",
     srcs = ["otbn.c"],
     hdrs = ["otbn.h"],

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -200,6 +200,27 @@ cc_library(
     ],
 )
 
+opentitan_test(
+    name = "ibex_test",
+    srcs = ["ibex_test.c"],
+    exec_env = EARLGREY_TEST_ENVS,
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":ibex",
+        "//hw/top:rv_core_ibex_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
 cc_library(
     name = "otbn",
     srcs = ["otbn.c"],

--- a/sw/device/lib/crypto/drivers/ibex.c
+++ b/sw/device/lib/crypto/drivers/ibex.c
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/ibex.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"
+
+enum {
+  kBase = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR,
+};
+
+status_t ibex_wait_rnd_valid(void) {
+  while (true) {
+    uint32_t reg = abs_mmio_read32(kBase + RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+    if (bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
+      return OTCRYPTO_OK;
+    }
+  }
+}
+
+status_t ibex_rnd_status_read(uint32_t *rnd_status) {
+  *rnd_status = abs_mmio_read32(kBase + RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+  return OTCRYPTO_OK;
+}
+
+status_t ibex_rnd_data_read(uint32_t *rnd_data) {
+  *rnd_data = abs_mmio_read32(kBase + RV_CORE_IBEX_RND_DATA_REG_OFFSET);
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/drivers/ibex.h
+++ b/sw/device/lib/crypto/drivers/ibex.h
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_IBEX_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_IBEX_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/crypto/impl/status.h"
+
+/**
+ * Wait for random data in the RND_DATA CSR to be valid.
+ *
+ * Returns OTCRYPTO_OK when the random data is valid.
+ *
+ * @return OTCRYPTO_OK.
+ */
+status_t ibex_wait_rnd_valid(void);
+
+/**
+ * Get random data from the EDN0 interface.
+ *
+ * Returns 32 bits of randomness from EDN0.
+ *
+ * @param rnd_data The random data pointer.
+ * @return OTCRYPTO_OK.
+ */
+status_t ibex_rnd_data_read(uint32_t *rnd_data);
+
+/**
+ * Get information on the state of the RND_DATA CSR.
+ *
+ * Returns the status of the randomness interface.
+ *
+ * @param rnd_status The status pointer.
+ * @return OTCRYPTO_OK.
+ */
+status_t ibex_rnd_status_read(uint32_t *rnd_status);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_IBEX_H_

--- a/sw/device/lib/crypto/drivers/ibex_test.c
+++ b/sw/device/lib/crypto/drivers/ibex_test.c
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/lib/crypto/drivers/ibex.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"
+
+enum {
+  kBase = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR,
+};
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static status_t ibex_entropy_test(void) {
+  uint32_t rnd_status;
+  uint32_t rnd_data[2];
+
+  // Read the initial value of the RND_DATA CSR.
+  TRY(ibex_rnd_data_read(rnd_data));
+  // Wait for RND_DATA to be valid again and check if RND_STATUS is as expected.
+  TRY(ibex_wait_rnd_valid());
+  TRY(ibex_rnd_status_read(&rnd_status));
+  TRY_CHECK(bitfield_bit32_read(rnd_status,
+                                RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT));
+  // Read RND_DATA again and check if it changed.
+  TRY(ibex_rnd_data_read(&rnd_data[1]));
+  TRY_CHECK(rnd_data[0] != rnd_data[1]);
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+  // Test RND_DATA and RND_STATUS CSR access.
+  EXECUTE_TEST(result, ibex_entropy_test);
+  return status_ok(result);
+}


### PR DESCRIPTION
This PR adds a new ibex driver to cryptolib for gathering randomness from the RND_DATA CSR.
For further information check the individual commits.