### PR TITLE
[signing] Fix file copy automation

### DIFF
--- a/rules/files.bzl
+++ b/rules/files.bzl
@@ -103,7 +103,7 @@ copy_files = rule(
         ),
         "filter": attr.string_list(
             default = [],
-            doc = "Substrings that must match the filename to qualify the file for copying.",
+            doc = "Substrings that must match the filename to qualify the file for copying.  The rule will copy files if any one of the substrings matches.",
         ),
         "workspace_env": attr.string(
             default = "BUILD_WORKSPACE_DIRECTORY",

--- a/rules/scripts/copy_files.template.sh
+++ b/rules/scripts/copy_files.template.sh
@@ -7,13 +7,29 @@
 DEST="__DEST__"
 FILES=(__FILES__)
 
-if [[ ! -z "${__WORKSPACE__+is_set}" ]]; then
-    cd ${__WORKSPACE__} || exit 1
+# Change directory into the root of the project.
+if [[ ! -z "${BUILD_WORKSPACE_DIRECTORY+is_set}" ]]; then
+    cd ${BUILD_WORKSPACE_DIRECTORY} || exit 1
 else
+    echo "BUILD_WORKSPACE_DIRECTORY was not set."
+    echo "This rule should be executable and invoked with 'bazel run'."
+    exit 1
+fi
+
+# Since we may be building resources in an externally attached workspace,
+# determine the real path to that workspace.
+if [[ -z "${__WORKSPACE__+is_set}" ]]; then
     echo "__WORKSPACE__ was not set."
     exit 1
 fi
 
+WORKSPACE="$(realpath "${__WORKSPACE__}")"
+if [[ ! -d "$WORKSPACE" ]]; then
+    echo "$WORKSPACE isn't a directory."
+    exit 1
+fi
+
+# Copy the files from the source (e.g. bazel-out) to the destination.
 for f in "${FILES[@]}"; do
-  cp --no-preserve=mode "$f" "$DEST"
+  cp --no-preserve=mode "$f" "$WORKSPACE/$DEST"
 done


### PR DESCRIPTION
Update the file copying rule to operate in the root of the opentitan repo and be able to copy files into an externally attached repo (e.g. the provisioning skus repo).