### PR TITLE
[topgen,alert_handler] Explicitly specify alert handler connections

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -537,6 +537,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -633,6 +637,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       param_decl:
       {
@@ -770,6 +778,10 @@
           name: spi_device
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       param_decl:
       {
@@ -956,6 +968,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -1096,6 +1112,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
@@ -1153,6 +1173,14 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_macro_error: alert_handler
+        fatal_check_error: alert_handler
+        fatal_bus_integ_error: alert_handler
+        fatal_prim_otp_alert: alert_handler
+        recov_prim_otp_alert: alert_handler
       }
       base_addrs:
       {
@@ -1613,6 +1641,12 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_prog_error: alert_handler
+        fatal_state_error: alert_handler
+        fatal_bus_integ_error: alert_handler
       }
       base_addrs:
       {
@@ -2434,6 +2468,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -2587,6 +2625,10 @@
         Aon
         "0"
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       param_decl:
       {
         EscNumSeverities: AlertHandlerEscNumSeverities
@@ -2944,6 +2986,11 @@
         Aon
         "0"
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+        fatal_cnsty_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -3196,6 +3243,11 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -3462,6 +3514,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -3559,6 +3615,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
@@ -3804,6 +3864,38 @@
         Aon
         "0"
       ]
+      alert_connections:
+      {
+        fatal_alert_intg: alert_handler
+        fatal_alert_external_0: alert_handler
+        fatal_alert_external_1: alert_handler
+        fatal_alert_external_2: alert_handler
+        fatal_alert_external_3: alert_handler
+        fatal_alert_external_4: alert_handler
+        fatal_alert_external_5: alert_handler
+        fatal_alert_external_6: alert_handler
+        fatal_alert_external_7: alert_handler
+        fatal_alert_external_8: alert_handler
+        fatal_alert_external_9: alert_handler
+        fatal_alert_external_10: alert_handler
+        fatal_alert_external_11: alert_handler
+        fatal_alert_external_12: alert_handler
+        fatal_alert_external_13: alert_handler
+        fatal_alert_external_14: alert_handler
+        fatal_alert_external_15: alert_handler
+        fatal_alert_external_16: alert_handler
+        fatal_alert_external_17: alert_handler
+        fatal_alert_external_18: alert_handler
+        fatal_alert_external_19: alert_handler
+        fatal_alert_external_20: alert_handler
+        fatal_alert_external_21: alert_handler
+        fatal_alert_external_22: alert_handler
+        fatal_alert_external_23: alert_handler
+        recov_alert_external_0: alert_handler
+        recov_alert_external_1: alert_handler
+        recov_alert_external_2: alert_handler
+        recov_alert_external_3: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -4205,6 +4297,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_error: alert_handler
+      }
       param_decl:
       {
         InstrExec: "0"
@@ -4555,6 +4651,10 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       base_addrs:
       {
@@ -4926,6 +5026,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -5020,6 +5124,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_ctrl_update_err: alert_handler
+        fatal_fault: alert_handler
       }
       param_decl:
       {
@@ -5250,6 +5359,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_hmac
@@ -5318,6 +5431,11 @@
         clk_edn_i: main
       }
       clock_group: trans
+      alert_connections:
+      {
+        recov_operation_err: alert_handler
+        fatal_fault_err: alert_handler
+      }
       reset_connections:
       {
         rst_ni:
@@ -5617,6 +5735,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal: alert_handler
+        recov: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_otbn
@@ -5908,6 +6031,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_operation_err: alert_handler
+        fatal_fault_err: alert_handler
       }
       clock_connections:
       {
@@ -6213,6 +6341,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure
@@ -6362,6 +6495,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure
@@ -6447,6 +6585,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
       }
       clock_connections:
       {
@@ -6539,6 +6682,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_error: alert_handler
       }
       param_decl:
       {
@@ -6897,6 +7044,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_error: alert_handler
+      }
       param_decl:
       {
         InstrExec: "0"
@@ -7246,6 +7397,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal: alert_handler
+      }
       base_addrs:
       {
         rom:
@@ -7431,6 +7586,10 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal: alert_handler
       }
       base_addrs:
       {
@@ -7618,6 +7777,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
@@ -7782,6 +7945,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
       }
       base_addrs:
       {
@@ -7969,6 +8137,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -8154,6 +8327,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
       }
       base_addrs:
       {
@@ -8341,6 +8519,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -8526,6 +8709,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
       }
       base_addrs:
       {
@@ -8713,6 +8901,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -8898,6 +9091,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
       }
       base_addrs:
       {
@@ -9085,6 +9283,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -9270,6 +9473,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
       }
       base_addrs:
       {
@@ -9457,6 +9665,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -9643,6 +9856,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_ctrl_update_err: alert_handler
+        fatal_fault: alert_handler
+      }
       base_addrs:
       {
         core:
@@ -9824,6 +10042,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+        recov_ctrl_update_err: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -9972,6 +10195,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+        recov_ctrl_update_err: alert_handler
       }
       ipgen_param:
       {
@@ -10389,6 +10617,13 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_sw_err: alert_handler
+        recov_sw_err: alert_handler
+        fatal_hw_err: alert_handler
+        recov_hw_err: alert_handler
       }
       clock_connections:
       {
@@ -17718,6 +17953,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: uart0
       desc: uart0 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -17728,6 +17964,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: gpio
       desc: gpio fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -17738,6 +17975,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: spi_device
       desc: spi_device fatal_fault alert
       lpg_name: peri_spi_device_0
@@ -17748,6 +17986,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: i2c0
       desc: i2c0 fatal_fault alert
       lpg_name: peri_i2c0_0
@@ -17758,6 +17997,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_timer
       desc: rv_timer fatal_fault alert
       lpg_name: timers_lc_io_div4_0
@@ -17768,6 +18008,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_macro_error alert
       lpg_name: secure_lc_io_div4_0
@@ -17778,6 +18019,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_check_error alert
       lpg_name: secure_lc_io_div4_0
@@ -17788,6 +18030,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_bus_integ_error alert
       lpg_name: secure_lc_io_div4_0
@@ -17798,6 +18041,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_prim_otp_alert alert
       lpg_name: secure_lc_io_div4_0
@@ -17808,6 +18052,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl recov_prim_otp_alert alert
       lpg_name: secure_lc_io_div4_0
@@ -17818,6 +18063,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: lc_ctrl
       desc: lc_ctrl fatal_prog_error alert
       lpg_name: secure_lc_io_div4_0
@@ -17828,6 +18074,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: lc_ctrl
       desc: lc_ctrl fatal_state_error alert
       lpg_name: secure_lc_io_div4_0
@@ -17838,6 +18085,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: lc_ctrl
       desc: lc_ctrl fatal_bus_integ_error alert
       lpg_name: secure_lc_io_div4_0
@@ -17848,6 +18096,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: spi_host0
       desc: spi_host0 fatal_fault alert
       lpg_name: peri_spi_host0_0
@@ -17858,6 +18107,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: pwrmgr_aon
       desc: pwrmgr_aon fatal_fault alert
       lpg_name: powerup_por_io_div4_Aon
@@ -17868,6 +18118,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rstmgr_aon
       desc: rstmgr_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -17878,6 +18129,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rstmgr_aon
       desc: rstmgr_aon fatal_cnsty_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -17888,6 +18140,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: clkmgr_aon
       desc: clkmgr_aon recov_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -17898,6 +18151,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: clkmgr_aon
       desc: clkmgr_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -17908,6 +18162,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: pinmux_aon
       desc: pinmux_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -17918,6 +18173,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: aon_timer_aon
       desc: aon_timer_aon fatal_fault alert
       lpg_name: timers_lc_io_div4_Aon
@@ -17928,6 +18184,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_intg alert
       lpg_name: infra_lc_0
@@ -17938,6 +18195,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_0 alert
       lpg_name: infra_lc_0
@@ -17948,6 +18206,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_1 alert
       lpg_name: infra_lc_0
@@ -17958,6 +18217,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_2 alert
       lpg_name: infra_lc_0
@@ -17968,6 +18228,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_3 alert
       lpg_name: infra_lc_0
@@ -17978,6 +18239,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_4 alert
       lpg_name: infra_lc_0
@@ -17988,6 +18250,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_5 alert
       lpg_name: infra_lc_0
@@ -17998,6 +18261,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_6 alert
       lpg_name: infra_lc_0
@@ -18008,6 +18272,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_7 alert
       lpg_name: infra_lc_0
@@ -18018,6 +18283,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_8 alert
       lpg_name: infra_lc_0
@@ -18028,6 +18294,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_9 alert
       lpg_name: infra_lc_0
@@ -18038,6 +18305,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_10 alert
       lpg_name: infra_lc_0
@@ -18048,6 +18316,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_11 alert
       lpg_name: infra_lc_0
@@ -18058,6 +18327,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_12 alert
       lpg_name: infra_lc_0
@@ -18068,6 +18338,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_13 alert
       lpg_name: infra_lc_0
@@ -18078,6 +18349,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_14 alert
       lpg_name: infra_lc_0
@@ -18088,6 +18360,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_15 alert
       lpg_name: infra_lc_0
@@ -18098,6 +18371,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_16 alert
       lpg_name: infra_lc_0
@@ -18108,6 +18382,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_17 alert
       lpg_name: infra_lc_0
@@ -18118,6 +18393,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_18 alert
       lpg_name: infra_lc_0
@@ -18128,6 +18404,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_19 alert
       lpg_name: infra_lc_0
@@ -18138,6 +18415,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_20 alert
       lpg_name: infra_lc_0
@@ -18148,6 +18426,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_21 alert
       lpg_name: infra_lc_0
@@ -18158,6 +18437,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_22 alert
       lpg_name: infra_lc_0
@@ -18168,6 +18448,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy fatal_alert_external_23 alert
       lpg_name: infra_lc_0
@@ -18178,6 +18459,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy recov_alert_external_0 alert
       lpg_name: infra_lc_0
@@ -18188,6 +18470,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy recov_alert_external_1 alert
       lpg_name: infra_lc_0
@@ -18198,6 +18481,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy recov_alert_external_2 alert
       lpg_name: infra_lc_0
@@ -18208,6 +18492,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_proxy
       desc: soc_proxy recov_alert_external_3 alert
       lpg_name: infra_lc_0
@@ -18218,6 +18503,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sram_ctrl_ret_aon
       desc: sram_ctrl_ret_aon fatal_error alert
       lpg_name: infra_lc_io_div4_Aon
@@ -18228,6 +18514,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_dm
       desc: rv_dm fatal_fault alert
       lpg_name: infra_sys_0
@@ -18238,6 +18525,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_plic
       desc: rv_plic fatal_fault alert
       lpg_name: secure_lc_0
@@ -18248,6 +18536,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: aes
       desc: aes recov_ctrl_update_err alert
       lpg_name: aes_trans_lc_0
@@ -18258,6 +18547,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: aes
       desc: aes fatal_fault alert
       lpg_name: aes_trans_lc_0
@@ -18268,6 +18558,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: hmac
       desc: hmac fatal_fault alert
       lpg_name: hmac_trans_lc_0
@@ -18278,6 +18569,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: kmac
       desc: kmac recov_operation_err alert
       lpg_name: kmac_trans_lc_0
@@ -18288,6 +18580,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: kmac
       desc: kmac fatal_fault_err alert
       lpg_name: kmac_trans_lc_0
@@ -18298,6 +18591,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otbn
       desc: otbn fatal alert
       lpg_name: otbn_trans_lc_0
@@ -18308,6 +18602,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otbn
       desc: otbn recov alert
       lpg_name: otbn_trans_lc_0
@@ -18318,6 +18613,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: keymgr_dpe
       desc: keymgr_dpe recov_operation_err alert
       lpg_name: secure_lc_0
@@ -18328,6 +18624,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: keymgr_dpe
       desc: keymgr_dpe fatal_fault_err alert
       lpg_name: secure_lc_0
@@ -18338,6 +18635,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: csrng
       desc: csrng recov_alert alert
       lpg_name: secure_lc_0
@@ -18348,6 +18646,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: csrng
       desc: csrng fatal_alert alert
       lpg_name: secure_lc_0
@@ -18358,6 +18657,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn0
       desc: edn0 recov_alert alert
       lpg_name: secure_lc_0
@@ -18368,6 +18668,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn0
       desc: edn0 fatal_alert alert
       lpg_name: secure_lc_0
@@ -18378,6 +18679,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn1
       desc: edn1 recov_alert alert
       lpg_name: secure_lc_0
@@ -18388,6 +18690,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn1
       desc: edn1 fatal_alert alert
       lpg_name: secure_lc_0
@@ -18398,6 +18701,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sram_ctrl_main
       desc: sram_ctrl_main fatal_error alert
       lpg_name: infra_lc_0
@@ -18408,6 +18712,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sram_ctrl_mbox
       desc: sram_ctrl_mbox fatal_error alert
       lpg_name: infra_lc_0
@@ -18418,6 +18723,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rom_ctrl0
       desc: rom_ctrl0 fatal alert
       lpg_name: infra_lc_0
@@ -18428,6 +18734,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rom_ctrl1
       desc: rom_ctrl1 fatal alert
       lpg_name: infra_lc_0
@@ -18438,6 +18745,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: dma
       desc: dma fatal_fault alert
       lpg_name: infra_lc_0
@@ -18448,6 +18756,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx0
       desc: mbx0 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18458,6 +18767,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx0
       desc: mbx0 recov_fault alert
       lpg_name: infra_lc_0
@@ -18468,6 +18778,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx1
       desc: mbx1 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18478,6 +18789,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx1
       desc: mbx1 recov_fault alert
       lpg_name: infra_lc_0
@@ -18488,6 +18800,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx2
       desc: mbx2 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18498,6 +18811,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx2
       desc: mbx2 recov_fault alert
       lpg_name: infra_lc_0
@@ -18508,6 +18822,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx3
       desc: mbx3 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18518,6 +18833,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx3
       desc: mbx3 recov_fault alert
       lpg_name: infra_lc_0
@@ -18528,6 +18844,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx4
       desc: mbx4 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18538,6 +18855,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx4
       desc: mbx4 recov_fault alert
       lpg_name: infra_lc_0
@@ -18548,6 +18866,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx5
       desc: mbx5 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18558,6 +18877,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx5
       desc: mbx5 recov_fault alert
       lpg_name: infra_lc_0
@@ -18568,6 +18888,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx6
       desc: mbx6 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18578,6 +18899,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx6
       desc: mbx6 recov_fault alert
       lpg_name: infra_lc_0
@@ -18588,6 +18910,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx_jtag
       desc: mbx_jtag fatal_fault alert
       lpg_name: infra_lc_0
@@ -18598,6 +18921,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx_jtag
       desc: mbx_jtag recov_fault alert
       lpg_name: infra_lc_0
@@ -18608,6 +18932,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx_pcie0
       desc: mbx_pcie0 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18618,6 +18943,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx_pcie0
       desc: mbx_pcie0 recov_fault alert
       lpg_name: infra_lc_0
@@ -18628,6 +18954,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx_pcie1
       desc: mbx_pcie1 fatal_fault alert
       lpg_name: infra_lc_0
@@ -18638,6 +18965,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: mbx_pcie1
       desc: mbx_pcie1 recov_fault alert
       lpg_name: infra_lc_0
@@ -18648,6 +18976,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_dbg_ctrl
       desc: soc_dbg_ctrl fatal_fault alert
       lpg_name: secure_lc_io_div4_0
@@ -18658,6 +18987,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: soc_dbg_ctrl
       desc: soc_dbg_ctrl recov_ctrl_update_err alert
       lpg_name: secure_lc_io_div4_0
@@ -18668,6 +18998,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: racl_ctrl
       desc: racl_ctrl fatal_fault alert
       lpg_name: infra_lc_0
@@ -18678,6 +19009,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: racl_ctrl
       desc: racl_ctrl recov_ctrl_update_err alert
       lpg_name: infra_lc_0
@@ -18688,6 +19020,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: ac_range_check
       desc: ac_range_check recov_ctrl_update_err alert
       lpg_name: secure_lc_0
@@ -18698,6 +19031,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: ac_range_check
       desc: ac_range_check fatal_fault alert
       lpg_name: secure_lc_0
@@ -18708,6 +19042,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex fatal_sw_err alert
       lpg_name: infra_lc_0
@@ -18718,6 +19053,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex recov_sw_err alert
       lpg_name: infra_lc_0
@@ -18728,6 +19064,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex fatal_hw_err alert
       lpg_name: infra_lc_0
@@ -18738,6 +19075,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex recov_hw_err alert
       lpg_name: infra_lc_0
@@ -19765,6 +20103,424 @@
     ac_range_check
     rv_core_ibex
   ]
+  alert_connections:
+  {
+    alert_handler:
+    [
+      [
+        uart0
+        fatal_fault
+      ]
+      [
+        gpio
+        fatal_fault
+      ]
+      [
+        spi_device
+        fatal_fault
+      ]
+      [
+        i2c0
+        fatal_fault
+      ]
+      [
+        rv_timer
+        fatal_fault
+      ]
+      [
+        otp_ctrl
+        fatal_macro_error
+      ]
+      [
+        otp_ctrl
+        fatal_check_error
+      ]
+      [
+        otp_ctrl
+        fatal_bus_integ_error
+      ]
+      [
+        otp_ctrl
+        fatal_prim_otp_alert
+      ]
+      [
+        otp_ctrl
+        recov_prim_otp_alert
+      ]
+      [
+        lc_ctrl
+        fatal_prog_error
+      ]
+      [
+        lc_ctrl
+        fatal_state_error
+      ]
+      [
+        lc_ctrl
+        fatal_bus_integ_error
+      ]
+      [
+        spi_host0
+        fatal_fault
+      ]
+      [
+        pwrmgr_aon
+        fatal_fault
+      ]
+      [
+        rstmgr_aon
+        fatal_fault
+      ]
+      [
+        rstmgr_aon
+        fatal_cnsty_fault
+      ]
+      [
+        clkmgr_aon
+        recov_fault
+      ]
+      [
+        clkmgr_aon
+        fatal_fault
+      ]
+      [
+        pinmux_aon
+        fatal_fault
+      ]
+      [
+        aon_timer_aon
+        fatal_fault
+      ]
+      [
+        soc_proxy
+        fatal_alert_intg
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_0
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_1
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_2
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_3
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_4
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_5
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_6
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_7
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_8
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_9
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_10
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_11
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_12
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_13
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_14
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_15
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_16
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_17
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_18
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_19
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_20
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_21
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_22
+      ]
+      [
+        soc_proxy
+        fatal_alert_external_23
+      ]
+      [
+        soc_proxy
+        recov_alert_external_0
+      ]
+      [
+        soc_proxy
+        recov_alert_external_1
+      ]
+      [
+        soc_proxy
+        recov_alert_external_2
+      ]
+      [
+        soc_proxy
+        recov_alert_external_3
+      ]
+      [
+        sram_ctrl_ret_aon
+        fatal_error
+      ]
+      [
+        rv_dm
+        fatal_fault
+      ]
+      [
+        rv_plic
+        fatal_fault
+      ]
+      [
+        aes
+        recov_ctrl_update_err
+      ]
+      [
+        aes
+        fatal_fault
+      ]
+      [
+        hmac
+        fatal_fault
+      ]
+      [
+        kmac
+        recov_operation_err
+      ]
+      [
+        kmac
+        fatal_fault_err
+      ]
+      [
+        otbn
+        fatal
+      ]
+      [
+        otbn
+        recov
+      ]
+      [
+        keymgr_dpe
+        recov_operation_err
+      ]
+      [
+        keymgr_dpe
+        fatal_fault_err
+      ]
+      [
+        csrng
+        recov_alert
+      ]
+      [
+        csrng
+        fatal_alert
+      ]
+      [
+        edn0
+        recov_alert
+      ]
+      [
+        edn0
+        fatal_alert
+      ]
+      [
+        edn1
+        recov_alert
+      ]
+      [
+        edn1
+        fatal_alert
+      ]
+      [
+        sram_ctrl_main
+        fatal_error
+      ]
+      [
+        sram_ctrl_mbox
+        fatal_error
+      ]
+      [
+        rom_ctrl0
+        fatal
+      ]
+      [
+        rom_ctrl1
+        fatal
+      ]
+      [
+        dma
+        fatal_fault
+      ]
+      [
+        mbx0
+        fatal_fault
+      ]
+      [
+        mbx0
+        recov_fault
+      ]
+      [
+        mbx1
+        fatal_fault
+      ]
+      [
+        mbx1
+        recov_fault
+      ]
+      [
+        mbx2
+        fatal_fault
+      ]
+      [
+        mbx2
+        recov_fault
+      ]
+      [
+        mbx3
+        fatal_fault
+      ]
+      [
+        mbx3
+        recov_fault
+      ]
+      [
+        mbx4
+        fatal_fault
+      ]
+      [
+        mbx4
+        recov_fault
+      ]
+      [
+        mbx5
+        fatal_fault
+      ]
+      [
+        mbx5
+        recov_fault
+      ]
+      [
+        mbx6
+        fatal_fault
+      ]
+      [
+        mbx6
+        recov_fault
+      ]
+      [
+        mbx_jtag
+        fatal_fault
+      ]
+      [
+        mbx_jtag
+        recov_fault
+      ]
+      [
+        mbx_pcie0
+        fatal_fault
+      ]
+      [
+        mbx_pcie0
+        recov_fault
+      ]
+      [
+        mbx_pcie1
+        fatal_fault
+      ]
+      [
+        mbx_pcie1
+        recov_fault
+      ]
+      [
+        soc_dbg_ctrl
+        fatal_fault
+      ]
+      [
+        soc_dbg_ctrl
+        recov_ctrl_update_err
+      ]
+      [
+        racl_ctrl
+        fatal_fault
+      ]
+      [
+        racl_ctrl
+        recov_ctrl_update_err
+      ]
+      [
+        ac_range_check
+        recov_ctrl_update_err
+      ]
+      [
+        ac_range_check
+        fatal_fault
+      ]
+      [
+        rv_core_ibex
+        fatal_sw_err
+      ]
+      [
+        rv_core_ibex
+        recov_sw_err
+      ]
+      [
+        rv_core_ibex
+        fatal_hw_err
+      ]
+      [
+        rv_core_ibex
+        recov_hw_err
+      ]
+    ]
+  }
   interrupt_module:
   [
     uart0

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -286,6 +286,8 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      // alert connections names handler for each alert
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30010000",
       },
@@ -296,6 +298,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30000000",
       },
@@ -313,6 +316,7 @@
       clock_srcs: {clk_i: "io_div4", scan_clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30310000",
       },
@@ -325,6 +329,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c0"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30080000",
       },
@@ -334,6 +339,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30100000",
       },
@@ -344,6 +350,13 @@
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
+      alert_connections: {
+        fatal_macro_error: "alert_handler",
+        fatal_check_error: "alert_handler",
+        fatal_bus_integ_error: "alert_handler",
+        fatal_prim_otp_alert: "alert_handler",
+        recov_prim_otp_alert: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x30130000"},
         prim: {hart: "0x30140000"},
@@ -355,6 +368,11 @@
       clock_srcs: {clk_i: "io_div4", clk_kmac_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_kmac_ni: "lc"},
+      alert_connections: {
+        fatal_prog_error: "alert_handler",
+        fatal_state_error: "alert_handler",
+        fatal_bus_integ_error: "alert_handler",
+      },
       base_addrs: {
         regs: {hart: "0x30150000"},
         dmi:  {soc_dbg: "0x3000"},
@@ -397,6 +415,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host0"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30300000",
       },
@@ -441,6 +460,7 @@
         },
       }
       domain: ["Aon", "0"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30400000",
       },
@@ -474,6 +494,10 @@
         },
       }
       domain: ["Aon", "0"],
+      alert_connections: {
+        fatal_fault: "alert_handler",
+        fatal_cnsty_fault: "alert_handler",
+      },
       base_addr: {
         hart: "0x30410000",
       },
@@ -511,6 +535,10 @@
                           rst_root_main_ni: "por",
                          },
       domain: ["Aon"],
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addr: {
         hart: "0x30420000",
       },
@@ -526,6 +554,7 @@
                           rst_sys_ni: "sys_io_div4"
                          },
       domain: ["Aon"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30460000",
       },
@@ -537,6 +566,7 @@
       clock_group: "timers",
       reset_connections: {rst_ni: "lc_io_div4", rst_aon_ni: "lc_aon"},
       domain: ["Aon"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x30470000",
       },
@@ -609,6 +639,37 @@
         },
       },
       domain: ["Aon", "0"],
+      alert_connections: {
+        fatal_alert_intg: "alert_handler",
+        fatal_alert_external_0: "alert_handler",
+        fatal_alert_external_1: "alert_handler",
+        fatal_alert_external_2: "alert_handler",
+        fatal_alert_external_3: "alert_handler",
+        fatal_alert_external_4: "alert_handler",
+        fatal_alert_external_5: "alert_handler",
+        fatal_alert_external_6: "alert_handler",
+        fatal_alert_external_7: "alert_handler",
+        fatal_alert_external_8: "alert_handler",
+        fatal_alert_external_9: "alert_handler",
+        fatal_alert_external_10: "alert_handler",
+        fatal_alert_external_11: "alert_handler",
+        fatal_alert_external_12: "alert_handler",
+        fatal_alert_external_13: "alert_handler",
+        fatal_alert_external_14: "alert_handler",
+        fatal_alert_external_15: "alert_handler",
+        fatal_alert_external_16: "alert_handler",
+        fatal_alert_external_17: "alert_handler",
+        fatal_alert_external_18: "alert_handler",
+        fatal_alert_external_19: "alert_handler",
+        fatal_alert_external_20: "alert_handler",
+        fatal_alert_external_21: "alert_handler",
+        fatal_alert_external_22: "alert_handler",
+        fatal_alert_external_23: "alert_handler",
+        recov_alert_external_0: "alert_handler",
+        recov_alert_external_1: "alert_handler",
+        recov_alert_external_2: "alert_handler",
+        recov_alert_external_3: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22030000"},
         ctn:  {hart: "0x40000000"},
@@ -631,6 +692,7 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "lc_io_div4", rst_otp_ni: "lc_io_div4"}
       domain: ["Aon"],
+      alert_connections: {fatal_error: "alert_handler"},
       param_decl: {
         InstrExec: "0",
         InstSize: 4096
@@ -657,6 +719,7 @@
       clock_srcs: {clk_i: "main", clk_lc_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "sys", rst_lc_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       // Note that this module also contains a bus host.
       base_addrs: {
         mem:  {hart: "0x00040000"},
@@ -679,6 +742,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x28000000",
       },
@@ -689,6 +753,10 @@
       clock_srcs: {clk_i: "main", clk_edn_i: "main"},
       clock_group: "trans",
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc"},
+      alert_connections: {
+        recov_ctrl_update_err: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       param_decl: {
         SecMasking: "1",
         SecSBoxImpl: "aes_pkg::SBoxImplDom"
@@ -702,6 +770,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "trans",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x21110000",
       },
@@ -715,6 +784,10 @@
       }
       clock_srcs: {clk_i: "main", clk_edn_i: "main"}
       clock_group: "trans"
+      alert_connections: {
+        recov_operation_err: "alert_handler",
+        fatal_fault_err: "alert_handler",
+      },
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc"}
       base_addr: {
         hart: "0x21120000",
@@ -738,6 +811,10 @@
       },
       clock_group: "trans",
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        fatal: "alert_handler",
+        recov: "alert_handler",
+      },
       base_addr: {
         hart: "0x21130000",
       },
@@ -747,6 +824,10 @@
       clock_srcs: {clk_i: "main", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc"},
+      alert_connections: {
+        recov_operation_err: "alert_handler",
+        fatal_fault_err: "alert_handler",
+      },
       base_addr: {
         hart: "0x21140000",
       },
@@ -756,6 +837,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x21150000",
       },
@@ -765,6 +850,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x21170000",
       },
@@ -774,6 +863,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x21180000",
       },
@@ -783,6 +876,7 @@
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {fatal_error: "alert_handler"},
       // Note that while it might be useful to allow execution from SRAM for early testing, it can
       // later be permanently disabled using the EN_SRAM_IFETCH switch in OTP.
       param_decl: {
@@ -811,6 +905,7 @@
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {fatal_error: "alert_handler"},
       param_decl: {
         InstrExec: "0",
         InstSize: 4096
@@ -837,6 +932,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal: "alert_handler"},
       base_addrs: {
         rom:  {hart: "0x00008000"},
         regs: {hart: "0x211e0000"},
@@ -861,6 +957,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal: "alert_handler"},
       // TODO(opentitan-integrated/issues/251):
       // This is not the final parameterization for Darjeeling.
       base_addrs: {
@@ -887,6 +984,7 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {hart: "0x22010000"},
     },
     { name: "mbx0",
@@ -894,6 +992,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000000"},
         soc:  {soc_mbx: "0x01465000"},
@@ -907,6 +1009,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000100"},
         soc:  {soc_mbx: "0x01465100"},
@@ -920,6 +1026,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000200"},
         soc:  {soc_mbx: "0x01465200"},
@@ -933,6 +1043,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000300"},
         soc:  {soc_mbx: "0x01465300"},
@@ -946,6 +1060,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000400"},
         soc:  {soc_mbx: "0x01465400"},
@@ -959,6 +1077,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000500"},
         soc:  {soc_mbx: "0x01465500"},
@@ -972,6 +1094,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000600"},
         soc:  {soc_mbx: "0x01496000"},
@@ -985,6 +1111,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22000800"},
         soc:  {soc_dbg: "0x2200"},
@@ -998,6 +1128,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22040000"},
         soc:  {soc_mbx: "0x01460100"},
@@ -1011,6 +1145,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x22040100"},
         soc:  {soc_mbx: "0x01460200"},
@@ -1024,6 +1162,10 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {
+        recov_ctrl_update_err: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addrs: {
         core:  {hart: "0x30170000"},
         jtag:  {soc_dbg: "0x2300"},
@@ -1035,6 +1177,10 @@
       clock_srcs: {clk_i: "main"}
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+          fatal_fault: "alert_handler"
+          recov_ctrl_update_err: "alert_handler"
+      },
       base_addr: {
         soc_mbx: "0x01461f00",
       },
@@ -1046,6 +1192,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+          fatal_fault: "alert_handler"
+          recov_ctrl_update_err: "alert_handler"
+      },
       base_addr: {
         soc_mbx: "0x01464000"
       },
@@ -1108,6 +1258,12 @@
                           rst_edn_ni: "lc",
                           rst_esc_ni: "lc_io_div4",
                           rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        fatal_sw_err: "alert_handler",
+        recov_sw_err: "alert_handler",
+        fatal_hw_err: "alert_handler",
+        recov_hw_err: "alert_handler",
+      },
       base_addr: {
         hart: "0x211f0000",
       },

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -1011,7 +1011,7 @@ module top_darjeeling #(
       .intr_rx_timeout_o    (intr_uart0_rx_timeout),
       .intr_rx_parity_err_o (intr_uart0_rx_parity_err),
       .intr_tx_empty_o      (intr_uart0_tx_empty),
-      // [0]: fatal_fault
+      // alert_handler[0]: fatal_fault
       .alert_tx_o  ( alert_tx[0:0] ),
       .alert_rx_i  ( alert_rx[0:0] ),
 
@@ -1041,7 +1041,7 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_gpio_o (intr_gpio_gpio),
-      // [1]: fatal_fault
+      // alert_handler[1]: fatal_fault
       .alert_tx_o  ( alert_tx[1:1] ),
       .alert_rx_i  ( alert_rx[1:1] ),
 
@@ -1081,7 +1081,7 @@ module top_darjeeling #(
       .intr_tpm_header_not_empty_o     (intr_spi_device_tpm_header_not_empty),
       .intr_tpm_rdfifo_cmd_end_o       (intr_spi_device_tpm_rdfifo_cmd_end),
       .intr_tpm_rdfifo_drop_o          (intr_spi_device_tpm_rdfifo_drop),
-      // [2]: fatal_fault
+      // alert_handler[2]: fatal_fault
       .alert_tx_o  ( alert_tx[2:2] ),
       .alert_rx_i  ( alert_rx[2:2] ),
 
@@ -1137,7 +1137,7 @@ module top_darjeeling #(
       .intr_acq_stretch_o      (intr_i2c0_acq_stretch),
       .intr_unexp_stop_o       (intr_i2c0_unexp_stop),
       .intr_host_timeout_o     (intr_i2c0_host_timeout),
-      // [3]: fatal_fault
+      // alert_handler[3]: fatal_fault
       .alert_tx_o  ( alert_tx[3:3] ),
       .alert_rx_i  ( alert_rx[3:3] ),
 
@@ -1160,7 +1160,7 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_timer_expired_hart0_timer0_o (intr_rv_timer_timer_expired_hart0_timer0),
-      // [4]: fatal_fault
+      // alert_handler[4]: fatal_fault
       .alert_tx_o  ( alert_tx[4:4] ),
       .alert_rx_i  ( alert_rx[4:4] ),
 
@@ -1187,11 +1187,11 @@ module top_darjeeling #(
       // Interrupt
       .intr_otp_operation_done_o (intr_otp_ctrl_otp_operation_done),
       .intr_otp_error_o          (intr_otp_ctrl_otp_error),
-      // [5]: fatal_macro_error
-      // [6]: fatal_check_error
-      // [7]: fatal_bus_integ_error
-      // [8]: fatal_prim_otp_alert
-      // [9]: recov_prim_otp_alert
+      // alert_handler[5]: fatal_macro_error
+      // alert_handler[6]: fatal_check_error
+      // alert_handler[7]: fatal_bus_integ_error
+      // alert_handler[8]: fatal_prim_otp_alert
+      // alert_handler[9]: recov_prim_otp_alert
       .alert_tx_o  ( alert_tx[9:5] ),
       .alert_rx_i  ( alert_rx[9:5] ),
 
@@ -1258,9 +1258,9 @@ module top_darjeeling #(
     .EscNumSeverities(AlertHandlerEscNumSeverities),
     .EscPingCountWidth(AlertHandlerEscPingCountWidth)
   ) u_lc_ctrl (
-      // [10]: fatal_prog_error
-      // [11]: fatal_state_error
-      // [12]: fatal_bus_integ_error
+      // alert_handler[10]: fatal_prog_error
+      // alert_handler[11]: fatal_state_error
+      // alert_handler[12]: fatal_bus_integ_error
       .alert_tx_o  ( alert_tx[12:10] ),
       .alert_rx_i  ( alert_rx[12:10] ),
 
@@ -1371,7 +1371,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_error_o     (intr_spi_host0_error),
       .intr_spi_event_o (intr_spi_host0_spi_event),
-      // [13]: fatal_fault
+      // alert_handler[13]: fatal_fault
       .alert_tx_o  ( alert_tx[13:13] ),
       .alert_rx_i  ( alert_rx[13:13] ),
 
@@ -1396,7 +1396,7 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_wakeup_o (intr_pwrmgr_aon_wakeup),
-      // [14]: fatal_fault
+      // alert_handler[14]: fatal_fault
       .alert_tx_o  ( alert_tx[14:14] ),
       .alert_rx_i  ( alert_rx[14:14] ),
 
@@ -1445,8 +1445,8 @@ module top_darjeeling #(
     .SecCheck(SecRstmgrAonCheck),
     .SecMaxSyncDelay(SecRstmgrAonMaxSyncDelay)
   ) u_rstmgr_aon (
-      // [15]: fatal_fault
-      // [16]: fatal_cnsty_fault
+      // alert_handler[15]: fatal_fault
+      // alert_handler[16]: fatal_cnsty_fault
       .alert_tx_o  ( alert_tx[16:15] ),
       .alert_rx_i  ( alert_rx[16:15] ),
 
@@ -1478,8 +1478,8 @@ module top_darjeeling #(
   clkmgr #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[18:17])
   ) u_clkmgr_aon (
-      // [17]: recov_fault
-      // [18]: fatal_fault
+      // alert_handler[17]: recov_fault
+      // alert_handler[18]: fatal_fault
       .alert_tx_o  ( alert_tx[18:17] ),
       .alert_rx_i  ( alert_rx[18:17] ),
 
@@ -1526,7 +1526,7 @@ module top_darjeeling #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19]),
     .TargetCfg(PinmuxAonTargetCfg)
   ) u_pinmux_aon (
-      // [19]: fatal_fault
+      // alert_handler[19]: fatal_fault
       .alert_tx_o  ( alert_tx[19:19] ),
       .alert_rx_i  ( alert_rx[19:19] ),
 
@@ -1570,7 +1570,7 @@ module top_darjeeling #(
       // Interrupt
       .intr_wkup_timer_expired_o (intr_aon_timer_aon_wkup_timer_expired),
       .intr_wdog_timer_bark_o    (intr_aon_timer_aon_wdog_timer_bark),
-      // [20]: fatal_fault
+      // alert_handler[20]: fatal_fault
       .alert_tx_o  ( alert_tx[20:20] ),
       .alert_rx_i  ( alert_rx[20:20] ),
 
@@ -1604,35 +1604,35 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_external_o (intr_soc_proxy_external),
-      // [21]: fatal_alert_intg
-      // [22]: fatal_alert_external_0
-      // [23]: fatal_alert_external_1
-      // [24]: fatal_alert_external_2
-      // [25]: fatal_alert_external_3
-      // [26]: fatal_alert_external_4
-      // [27]: fatal_alert_external_5
-      // [28]: fatal_alert_external_6
-      // [29]: fatal_alert_external_7
-      // [30]: fatal_alert_external_8
-      // [31]: fatal_alert_external_9
-      // [32]: fatal_alert_external_10
-      // [33]: fatal_alert_external_11
-      // [34]: fatal_alert_external_12
-      // [35]: fatal_alert_external_13
-      // [36]: fatal_alert_external_14
-      // [37]: fatal_alert_external_15
-      // [38]: fatal_alert_external_16
-      // [39]: fatal_alert_external_17
-      // [40]: fatal_alert_external_18
-      // [41]: fatal_alert_external_19
-      // [42]: fatal_alert_external_20
-      // [43]: fatal_alert_external_21
-      // [44]: fatal_alert_external_22
-      // [45]: fatal_alert_external_23
-      // [46]: recov_alert_external_0
-      // [47]: recov_alert_external_1
-      // [48]: recov_alert_external_2
-      // [49]: recov_alert_external_3
+      // alert_handler[21]: fatal_alert_intg
+      // alert_handler[22]: fatal_alert_external_0
+      // alert_handler[23]: fatal_alert_external_1
+      // alert_handler[24]: fatal_alert_external_2
+      // alert_handler[25]: fatal_alert_external_3
+      // alert_handler[26]: fatal_alert_external_4
+      // alert_handler[27]: fatal_alert_external_5
+      // alert_handler[28]: fatal_alert_external_6
+      // alert_handler[29]: fatal_alert_external_7
+      // alert_handler[30]: fatal_alert_external_8
+      // alert_handler[31]: fatal_alert_external_9
+      // alert_handler[32]: fatal_alert_external_10
+      // alert_handler[33]: fatal_alert_external_11
+      // alert_handler[34]: fatal_alert_external_12
+      // alert_handler[35]: fatal_alert_external_13
+      // alert_handler[36]: fatal_alert_external_14
+      // alert_handler[37]: fatal_alert_external_15
+      // alert_handler[38]: fatal_alert_external_16
+      // alert_handler[39]: fatal_alert_external_17
+      // alert_handler[40]: fatal_alert_external_18
+      // alert_handler[41]: fatal_alert_external_19
+      // alert_handler[42]: fatal_alert_external_20
+      // alert_handler[43]: fatal_alert_external_21
+      // alert_handler[44]: fatal_alert_external_22
+      // alert_handler[45]: fatal_alert_external_23
+      // alert_handler[46]: recov_alert_external_0
+      // alert_handler[47]: recov_alert_external_1
+      // alert_handler[48]: recov_alert_external_2
+      // alert_handler[49]: recov_alert_external_3
       .alert_tx_o  ( alert_tx[49:21] ),
       .alert_rx_i  ( alert_rx[49:21] ),
 
@@ -1687,7 +1687,7 @@ module top_darjeeling #(
     .EccCorrection(SramCtrlRetAonEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_ret_aon (
-      // [50]: fatal_error
+      // alert_handler[50]: fatal_error
       .alert_tx_o  ( alert_tx[50:50] ),
       .alert_rx_i  ( alert_rx[50:50] ),
 
@@ -1721,7 +1721,7 @@ module top_darjeeling #(
     .SecVolatileRawUnlockEn(SecRvDmVolatileRawUnlockEn),
     .TlulHostUserRsvdBits(RvDmTlulHostUserRsvdBits)
   ) u_rv_dm (
-      // [51]: fatal_fault
+      // alert_handler[51]: fatal_fault
       .alert_tx_o  ( alert_tx[51:51] ),
       .alert_rx_i  ( alert_rx[51:51] ),
 
@@ -1761,7 +1761,7 @@ module top_darjeeling #(
   rv_plic #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[52:52])
   ) u_rv_plic (
-      // [52]: fatal_fault
+      // alert_handler[52]: fatal_fault
       .alert_tx_o  ( alert_tx[52:52] ),
       .alert_rx_i  ( alert_rx[52:52] ),
 
@@ -1791,8 +1791,8 @@ module top_darjeeling #(
     .RndCnstMaskingLfsrSeed(RndCnstAesMaskingLfsrSeed),
     .RndCnstMaskingLfsrPerm(RndCnstAesMaskingLfsrPerm)
   ) u_aes (
-      // [53]: recov_ctrl_update_err
-      // [54]: fatal_fault
+      // alert_handler[53]: recov_ctrl_update_err
+      // alert_handler[54]: fatal_fault
       .alert_tx_o  ( alert_tx[54:53] ),
       .alert_rx_i  ( alert_rx[54:53] ),
 
@@ -1820,7 +1820,7 @@ module top_darjeeling #(
       .intr_hmac_done_o  (intr_hmac_hmac_done),
       .intr_fifo_empty_o (intr_hmac_fifo_empty),
       .intr_hmac_err_o   (intr_hmac_hmac_err),
-      // [55]: fatal_fault
+      // alert_handler[55]: fatal_fault
       .alert_tx_o  ( alert_tx[55:55] ),
       .alert_rx_i  ( alert_rx[55:55] ),
 
@@ -1851,8 +1851,8 @@ module top_darjeeling #(
       .intr_kmac_done_o  (intr_kmac_kmac_done),
       .intr_fifo_empty_o (intr_kmac_fifo_empty),
       .intr_kmac_err_o   (intr_kmac_kmac_err),
-      // [56]: recov_operation_err
-      // [57]: fatal_fault_err
+      // alert_handler[56]: recov_operation_err
+      // alert_handler[57]: fatal_fault_err
       .alert_tx_o  ( alert_tx[57:56] ),
       .alert_rx_i  ( alert_rx[57:56] ),
 
@@ -1888,8 +1888,8 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_done_o (intr_otbn_done),
-      // [58]: fatal
-      // [59]: recov
+      // alert_handler[58]: fatal
+      // alert_handler[59]: recov
       .alert_tx_o  ( alert_tx[59:58] ),
       .alert_rx_i  ( alert_rx[59:58] ),
 
@@ -1937,8 +1937,8 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_op_done_o (intr_keymgr_dpe_op_done),
-      // [60]: recov_operation_err
-      // [61]: fatal_fault_err
+      // alert_handler[60]: recov_operation_err
+      // alert_handler[61]: fatal_fault_err
       .alert_tx_o  ( alert_tx[61:60] ),
       .alert_rx_i  ( alert_rx[61:60] ),
 
@@ -1978,8 +1978,8 @@ module top_darjeeling #(
       .intr_cs_entropy_req_o  (intr_csrng_cs_entropy_req),
       .intr_cs_hw_inst_exc_o  (intr_csrng_cs_hw_inst_exc),
       .intr_cs_fatal_err_o    (intr_csrng_cs_fatal_err),
-      // [62]: recov_alert
-      // [63]: fatal_alert
+      // alert_handler[62]: recov_alert
+      // alert_handler[63]: fatal_alert
       .alert_tx_o  ( alert_tx[63:62] ),
       .alert_rx_i  ( alert_rx[63:62] ),
 
@@ -2006,8 +2006,8 @@ module top_darjeeling #(
       // Interrupt
       .intr_edn_cmd_req_done_o (intr_edn0_edn_cmd_req_done),
       .intr_edn_fatal_err_o    (intr_edn0_edn_fatal_err),
-      // [64]: recov_alert
-      // [65]: fatal_alert
+      // alert_handler[64]: recov_alert
+      // alert_handler[65]: fatal_alert
       .alert_tx_o  ( alert_tx[65:64] ),
       .alert_rx_i  ( alert_rx[65:64] ),
 
@@ -2030,8 +2030,8 @@ module top_darjeeling #(
       // Interrupt
       .intr_edn_cmd_req_done_o (intr_edn1_edn_cmd_req_done),
       .intr_edn_fatal_err_o    (intr_edn1_edn_fatal_err),
-      // [66]: recov_alert
-      // [67]: fatal_alert
+      // alert_handler[66]: recov_alert
+      // alert_handler[67]: fatal_alert
       .alert_tx_o  ( alert_tx[67:66] ),
       .alert_rx_i  ( alert_rx[67:66] ),
 
@@ -2062,7 +2062,7 @@ module top_darjeeling #(
     .EccCorrection(SramCtrlMainEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_main (
-      // [68]: fatal_error
+      // alert_handler[68]: fatal_error
       .alert_tx_o  ( alert_tx[68:68] ),
       .alert_rx_i  ( alert_rx[68:68] ),
 
@@ -2104,7 +2104,7 @@ module top_darjeeling #(
     .EccCorrection(SramCtrlMboxEccCorrection),
     .RaclPolicySelRangesRamNum(SramCtrlMboxRaclPolicySelRangesRamNum)
   ) u_sram_ctrl_mbox (
-      // [69]: fatal_error
+      // alert_handler[69]: fatal_error
       .alert_tx_o  ( alert_tx[69:69] ),
       .alert_rx_i  ( alert_rx[69:69] ),
 
@@ -2139,7 +2139,7 @@ module top_darjeeling #(
     .SecDisableScrambling(SecRomCtrl0DisableScrambling),
     .MemSizeRom(32768)
   ) u_rom_ctrl0 (
-      // [70]: fatal
+      // alert_handler[70]: fatal
       .alert_tx_o  ( alert_tx[70:70] ),
       .alert_rx_i  ( alert_rx[70:70] ),
 
@@ -2166,7 +2166,7 @@ module top_darjeeling #(
     .SecDisableScrambling(SecRomCtrl1DisableScrambling),
     .MemSizeRom(65536)
   ) u_rom_ctrl1 (
-      // [71]: fatal
+      // alert_handler[71]: fatal
       .alert_tx_o  ( alert_tx[71:71] ),
       .alert_rx_i  ( alert_rx[71:71] ),
 
@@ -2198,7 +2198,7 @@ module top_darjeeling #(
       .intr_dma_done_o       (intr_dma_dma_done),
       .intr_dma_chunk_done_o (intr_dma_dma_chunk_done),
       .intr_dma_error_o      (intr_dma_dma_error),
-      // [72]: fatal_fault
+      // alert_handler[72]: fatal_fault
       .alert_tx_o  ( alert_tx[72:72] ),
       .alert_rx_i  ( alert_rx[72:72] ),
 
@@ -2231,8 +2231,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx0_mbx_ready),
       .intr_mbx_abort_o (intr_mbx0_mbx_abort),
       .intr_mbx_error_o (intr_mbx0_mbx_error),
-      // [73]: fatal_fault
-      // [74]: recov_fault
+      // alert_handler[73]: fatal_fault
+      // alert_handler[74]: recov_fault
       .alert_tx_o  ( alert_tx[74:73] ),
       .alert_rx_i  ( alert_rx[74:73] ),
 
@@ -2267,8 +2267,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx1_mbx_ready),
       .intr_mbx_abort_o (intr_mbx1_mbx_abort),
       .intr_mbx_error_o (intr_mbx1_mbx_error),
-      // [75]: fatal_fault
-      // [76]: recov_fault
+      // alert_handler[75]: fatal_fault
+      // alert_handler[76]: recov_fault
       .alert_tx_o  ( alert_tx[76:75] ),
       .alert_rx_i  ( alert_rx[76:75] ),
 
@@ -2303,8 +2303,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx2_mbx_ready),
       .intr_mbx_abort_o (intr_mbx2_mbx_abort),
       .intr_mbx_error_o (intr_mbx2_mbx_error),
-      // [77]: fatal_fault
-      // [78]: recov_fault
+      // alert_handler[77]: fatal_fault
+      // alert_handler[78]: recov_fault
       .alert_tx_o  ( alert_tx[78:77] ),
       .alert_rx_i  ( alert_rx[78:77] ),
 
@@ -2339,8 +2339,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx3_mbx_ready),
       .intr_mbx_abort_o (intr_mbx3_mbx_abort),
       .intr_mbx_error_o (intr_mbx3_mbx_error),
-      // [79]: fatal_fault
-      // [80]: recov_fault
+      // alert_handler[79]: fatal_fault
+      // alert_handler[80]: recov_fault
       .alert_tx_o  ( alert_tx[80:79] ),
       .alert_rx_i  ( alert_rx[80:79] ),
 
@@ -2375,8 +2375,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx4_mbx_ready),
       .intr_mbx_abort_o (intr_mbx4_mbx_abort),
       .intr_mbx_error_o (intr_mbx4_mbx_error),
-      // [81]: fatal_fault
-      // [82]: recov_fault
+      // alert_handler[81]: fatal_fault
+      // alert_handler[82]: recov_fault
       .alert_tx_o  ( alert_tx[82:81] ),
       .alert_rx_i  ( alert_rx[82:81] ),
 
@@ -2411,8 +2411,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx5_mbx_ready),
       .intr_mbx_abort_o (intr_mbx5_mbx_abort),
       .intr_mbx_error_o (intr_mbx5_mbx_error),
-      // [83]: fatal_fault
-      // [84]: recov_fault
+      // alert_handler[83]: fatal_fault
+      // alert_handler[84]: recov_fault
       .alert_tx_o  ( alert_tx[84:83] ),
       .alert_rx_i  ( alert_rx[84:83] ),
 
@@ -2447,8 +2447,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx6_mbx_ready),
       .intr_mbx_abort_o (intr_mbx6_mbx_abort),
       .intr_mbx_error_o (intr_mbx6_mbx_error),
-      // [85]: fatal_fault
-      // [86]: recov_fault
+      // alert_handler[85]: fatal_fault
+      // alert_handler[86]: recov_fault
       .alert_tx_o  ( alert_tx[86:85] ),
       .alert_rx_i  ( alert_rx[86:85] ),
 
@@ -2483,8 +2483,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx_jtag_mbx_ready),
       .intr_mbx_abort_o (intr_mbx_jtag_mbx_abort),
       .intr_mbx_error_o (intr_mbx_jtag_mbx_error),
-      // [87]: fatal_fault
-      // [88]: recov_fault
+      // alert_handler[87]: fatal_fault
+      // alert_handler[88]: recov_fault
       .alert_tx_o  ( alert_tx[88:87] ),
       .alert_rx_i  ( alert_rx[88:87] ),
 
@@ -2519,8 +2519,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx_pcie0_mbx_ready),
       .intr_mbx_abort_o (intr_mbx_pcie0_mbx_abort),
       .intr_mbx_error_o (intr_mbx_pcie0_mbx_error),
-      // [89]: fatal_fault
-      // [90]: recov_fault
+      // alert_handler[89]: fatal_fault
+      // alert_handler[90]: recov_fault
       .alert_tx_o  ( alert_tx[90:89] ),
       .alert_rx_i  ( alert_rx[90:89] ),
 
@@ -2555,8 +2555,8 @@ module top_darjeeling #(
       .intr_mbx_ready_o (intr_mbx_pcie1_mbx_ready),
       .intr_mbx_abort_o (intr_mbx_pcie1_mbx_abort),
       .intr_mbx_error_o (intr_mbx_pcie1_mbx_error),
-      // [91]: fatal_fault
-      // [92]: recov_fault
+      // alert_handler[91]: fatal_fault
+      // alert_handler[92]: recov_fault
       .alert_tx_o  ( alert_tx[92:91] ),
       .alert_rx_i  ( alert_rx[92:91] ),
 
@@ -2581,8 +2581,8 @@ module top_darjeeling #(
   soc_dbg_ctrl #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[94:93])
   ) u_soc_dbg_ctrl (
-      // [93]: fatal_fault
-      // [94]: recov_ctrl_update_err
+      // alert_handler[93]: fatal_fault
+      // alert_handler[94]: recov_ctrl_update_err
       .alert_tx_o  ( alert_tx[94:93] ),
       .alert_rx_i  ( alert_rx[94:93] ),
 
@@ -2614,8 +2614,8 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_racl_error_o (intr_racl_ctrl_racl_error),
-      // [95]: fatal_fault
-      // [96]: recov_ctrl_update_err
+      // alert_handler[95]: fatal_fault
+      // alert_handler[96]: recov_ctrl_update_err
       .alert_tx_o  ( alert_tx[96:95] ),
       .alert_rx_i  ( alert_rx[96:95] ),
 
@@ -2641,8 +2641,8 @@ module top_darjeeling #(
 
       // Interrupt
       .intr_deny_cnt_reached_o (intr_ac_range_check_deny_cnt_reached),
-      // [97]: recov_ctrl_update_err
-      // [98]: fatal_fault
+      // alert_handler[97]: recov_ctrl_update_err
+      // alert_handler[98]: fatal_fault
       .alert_tx_o  ( alert_tx[98:97] ),
       .alert_rx_i  ( alert_rx[98:97] ),
 
@@ -2699,10 +2699,10 @@ module top_darjeeling #(
     .PipeLine(RvCoreIbexPipeLine),
     .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
   ) u_rv_core_ibex (
-      // [99]: fatal_sw_err
-      // [100]: recov_sw_err
-      // [101]: fatal_hw_err
-      // [102]: recov_hw_err
+      // alert_handler[99]: fatal_sw_err
+      // alert_handler[100]: recov_sw_err
+      // alert_handler[101]: fatal_hw_err
+      // alert_handler[102]: recov_hw_err
       .alert_tx_o  ( alert_tx[102:99] ),
       .alert_rx_i  ( alert_rx[102:99] ),
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -642,6 +642,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -732,6 +736,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       clock_connections:
       {
@@ -824,6 +832,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -914,6 +926,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       clock_connections:
       {
@@ -1006,6 +1022,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       param_decl:
       {
@@ -1137,6 +1157,10 @@
           name: spi_device
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       clock_connections:
       {
@@ -1308,6 +1332,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -1436,6 +1464,10 @@
           name: i2c1
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       clock_connections:
       {
@@ -1566,6 +1598,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -1695,6 +1731,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -1745,6 +1785,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       clock_connections:
       {
@@ -1803,6 +1847,14 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_macro_error: alert_handler
+        fatal_check_error: alert_handler
+        fatal_bus_integ_error: alert_handler
+        fatal_prim_otp_alert: alert_handler
+        recov_prim_otp_alert: alert_handler
       }
       base_addrs:
       {
@@ -2257,6 +2309,12 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_prog_error: alert_handler
+        fatal_state_error: alert_handler
+        fatal_bus_integ_error: alert_handler
       }
       base_addrs:
       {
@@ -3085,6 +3143,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_peri
@@ -3199,6 +3261,10 @@
           name: spi_host1
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       clock_connections:
       {
@@ -3318,6 +3384,10 @@
           name: usb_aon
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
       }
       param_decl:
       {
@@ -3673,6 +3743,10 @@
         Aon
         "0"
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       param_decl:
       {
         EscNumSeverities: AlertHandlerEscNumSeverities
@@ -4017,6 +4091,11 @@
         Aon
         "0"
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+        fatal_cnsty_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -4285,6 +4364,11 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        recov_fault: alert_handler
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -4546,6 +4630,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
@@ -4628,6 +4716,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -4713,6 +4805,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -4804,6 +4900,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       param_decl:
       {
@@ -5251,6 +5351,10 @@
           domain: Aon
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       domain:
       [
         Aon
@@ -5510,6 +5614,11 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
+      }
       attr: reggen_top
       clock_connections:
       {
@@ -5651,6 +5760,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_error: alert_handler
+      }
       param_decl:
       {
         InstrExec: "0"
@@ -5999,6 +6112,14 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_err: alert_handler
+        fatal_std_err: alert_handler
+        fatal_err: alert_handler
+        fatal_prim_flash_alert: alert_handler
+        recov_prim_flash_alert: alert_handler
       }
       base_addrs:
       {
@@ -6454,6 +6575,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       param_decl:
       {
         IdcodeValue: jtag_id_pkg::RV_DM_JTAG_IDCODE
@@ -6815,6 +6940,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       attr: ipgen
       clock_connections:
       {
@@ -6909,6 +7038,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_ctrl_update_err: alert_handler
+        fatal_fault: alert_handler
       }
       param_decl:
       {
@@ -7139,6 +7273,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_hmac
@@ -7211,6 +7349,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_operation_err: alert_handler
+        fatal_fault_err: alert_handler
       }
       clock_connections:
       {
@@ -7492,6 +7635,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal: alert_handler
+        recov: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_otbn
@@ -7769,6 +7917,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_operation_err: alert_handler
+        fatal_fault_err: alert_handler
       }
       clock_connections:
       {
@@ -8139,6 +8292,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure
@@ -8290,6 +8448,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
       }
       clock_connections:
       {
@@ -8463,6 +8626,11 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure
@@ -8548,6 +8716,11 @@
           name: lc
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_alert: alert_handler
+        fatal_alert: alert_handler
       }
       clock_connections:
       {
@@ -8640,6 +8813,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_error: alert_handler
       }
       param_decl:
       {
@@ -8990,6 +9167,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal: alert_handler
+      }
       base_addrs:
       {
         rom:
@@ -9240,6 +9421,13 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_sw_err: alert_handler
+        recov_sw_err: alert_handler
+        fatal_hw_err: alert_handler
+        recov_hw_err: alert_handler
       }
       clock_connections:
       {
@@ -15358,6 +15546,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: uart0
       desc: uart0 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -15368,6 +15557,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: uart1
       desc: uart1 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -15378,6 +15568,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: uart2
       desc: uart2 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -15388,6 +15579,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: uart3
       desc: uart3 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -15398,6 +15590,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: gpio
       desc: gpio fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -15408,6 +15601,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: spi_device
       desc: spi_device fatal_fault alert
       lpg_name: peri_spi_device_0
@@ -15418,6 +15612,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: i2c0
       desc: i2c0 fatal_fault alert
       lpg_name: peri_i2c0_0
@@ -15428,6 +15623,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: i2c1
       desc: i2c1 fatal_fault alert
       lpg_name: peri_i2c1_0
@@ -15438,6 +15634,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: i2c2
       desc: i2c2 fatal_fault alert
       lpg_name: peri_i2c2_0
@@ -15448,6 +15645,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: pattgen
       desc: pattgen fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -15458,6 +15656,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_timer
       desc: rv_timer fatal_fault alert
       lpg_name: timers_lc_io_div4_0
@@ -15468,6 +15667,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_macro_error alert
       lpg_name: secure_lc_io_div4_0
@@ -15478,6 +15678,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_check_error alert
       lpg_name: secure_lc_io_div4_0
@@ -15488,6 +15689,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_bus_integ_error alert
       lpg_name: secure_lc_io_div4_0
@@ -15498,6 +15700,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl fatal_prim_otp_alert alert
       lpg_name: secure_lc_io_div4_0
@@ -15508,6 +15711,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otp_ctrl
       desc: otp_ctrl recov_prim_otp_alert alert
       lpg_name: secure_lc_io_div4_0
@@ -15518,6 +15722,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: lc_ctrl
       desc: lc_ctrl fatal_prog_error alert
       lpg_name: secure_lc_io_div4_0
@@ -15528,6 +15733,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: lc_ctrl
       desc: lc_ctrl fatal_state_error alert
       lpg_name: secure_lc_io_div4_0
@@ -15538,6 +15744,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: lc_ctrl
       desc: lc_ctrl fatal_bus_integ_error alert
       lpg_name: secure_lc_io_div4_0
@@ -15548,6 +15755,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: spi_host0
       desc: spi_host0 fatal_fault alert
       lpg_name: peri_spi_host0_0
@@ -15558,6 +15766,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: spi_host1
       desc: spi_host1 fatal_fault alert
       lpg_name: peri_spi_host1_0
@@ -15568,6 +15777,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: usbdev
       desc: usbdev fatal_fault alert
       lpg_name: peri_usb_0
@@ -15578,6 +15788,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: pwrmgr_aon
       desc: pwrmgr_aon fatal_fault alert
       lpg_name: powerup_por_io_div4_Aon
@@ -15588,6 +15799,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rstmgr_aon
       desc: rstmgr_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -15598,6 +15810,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rstmgr_aon
       desc: rstmgr_aon fatal_cnsty_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -15608,6 +15821,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: clkmgr_aon
       desc: clkmgr_aon recov_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -15618,6 +15832,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: clkmgr_aon
       desc: clkmgr_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -15628,6 +15843,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sysrst_ctrl_aon
       desc: sysrst_ctrl_aon fatal_fault alert
       lpg_name: secure_lc_io_div4_Aon
@@ -15638,6 +15854,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: adc_ctrl_aon
       desc: adc_ctrl_aon fatal_fault alert
       lpg_name: peri_lc_io_div4_Aon
@@ -15648,6 +15865,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: pwm_aon
       desc: pwm_aon fatal_fault alert
       lpg_name: peri_lc_io_div4_Aon
@@ -15658,6 +15876,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: pinmux_aon
       desc: pinmux_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -15668,6 +15887,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: aon_timer_aon
       desc: aon_timer_aon fatal_fault alert
       lpg_name: timers_lc_io_div4_Aon
@@ -15678,6 +15898,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sensor_ctrl_aon
       desc: sensor_ctrl_aon recov_alert alert
       lpg_name: secure_lc_io_div4_Aon
@@ -15688,6 +15909,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sensor_ctrl_aon
       desc: sensor_ctrl_aon fatal_alert alert
       lpg_name: secure_lc_io_div4_Aon
@@ -15698,6 +15920,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sram_ctrl_ret_aon
       desc: sram_ctrl_ret_aon fatal_error alert
       lpg_name: infra_lc_io_div4_Aon
@@ -15708,6 +15931,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: flash_ctrl
       desc: flash_ctrl recov_err alert
       lpg_name: infra_lc_0
@@ -15718,6 +15942,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: flash_ctrl
       desc: flash_ctrl fatal_std_err alert
       lpg_name: infra_lc_0
@@ -15728,6 +15953,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: flash_ctrl
       desc: flash_ctrl fatal_err alert
       lpg_name: infra_lc_0
@@ -15738,6 +15964,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: flash_ctrl
       desc: flash_ctrl fatal_prim_flash_alert alert
       lpg_name: infra_lc_0
@@ -15748,6 +15975,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: flash_ctrl
       desc: flash_ctrl recov_prim_flash_alert alert
       lpg_name: infra_lc_0
@@ -15758,6 +15986,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_dm
       desc: rv_dm fatal_fault alert
       lpg_name: infra_sys_0
@@ -15768,6 +15997,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_plic
       desc: rv_plic fatal_fault alert
       lpg_name: secure_lc_0
@@ -15778,6 +16008,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: aes
       desc: aes recov_ctrl_update_err alert
       lpg_name: aes_trans_lc_0
@@ -15788,6 +16019,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: aes
       desc: aes fatal_fault alert
       lpg_name: aes_trans_lc_0
@@ -15798,6 +16030,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: hmac
       desc: hmac fatal_fault alert
       lpg_name: hmac_trans_lc_0
@@ -15808,6 +16041,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: kmac
       desc: kmac recov_operation_err alert
       lpg_name: kmac_trans_lc_0
@@ -15818,6 +16052,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: kmac
       desc: kmac fatal_fault_err alert
       lpg_name: kmac_trans_lc_0
@@ -15828,6 +16063,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otbn
       desc: otbn fatal alert
       lpg_name: otbn_trans_lc_0
@@ -15838,6 +16074,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: otbn
       desc: otbn recov alert
       lpg_name: otbn_trans_lc_0
@@ -15848,6 +16085,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: keymgr
       desc: keymgr recov_operation_err alert
       lpg_name: secure_lc_0
@@ -15858,6 +16096,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: keymgr
       desc: keymgr fatal_fault_err alert
       lpg_name: secure_lc_0
@@ -15868,6 +16107,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: csrng
       desc: csrng recov_alert alert
       lpg_name: secure_lc_0
@@ -15878,6 +16118,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: csrng
       desc: csrng fatal_alert alert
       lpg_name: secure_lc_0
@@ -15888,6 +16129,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: entropy_src
       desc: entropy_src recov_alert alert
       lpg_name: secure_lc_0
@@ -15898,6 +16140,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: entropy_src
       desc: entropy_src fatal_alert alert
       lpg_name: secure_lc_0
@@ -15908,6 +16151,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn0
       desc: edn0 recov_alert alert
       lpg_name: secure_lc_0
@@ -15918,6 +16162,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn0
       desc: edn0 fatal_alert alert
       lpg_name: secure_lc_0
@@ -15928,6 +16173,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn1
       desc: edn1 recov_alert alert
       lpg_name: secure_lc_0
@@ -15938,6 +16184,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: edn1
       desc: edn1 fatal_alert alert
       lpg_name: secure_lc_0
@@ -15948,6 +16195,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: sram_ctrl_main
       desc: sram_ctrl_main fatal_error alert
       lpg_name: infra_lc_0
@@ -15958,6 +16206,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rom_ctrl
       desc: rom_ctrl fatal alert
       lpg_name: infra_lc_0
@@ -15968,6 +16217,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex fatal_sw_err alert
       lpg_name: infra_lc_0
@@ -15978,6 +16228,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex recov_sw_err alert
       lpg_name: infra_lc_0
@@ -15988,6 +16239,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex fatal_hw_err alert
       lpg_name: infra_lc_0
@@ -15998,6 +16250,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: alert_handler
       module_name: rv_core_ibex
       desc: rv_core_ibex recov_hw_err alert
       lpg_name: infra_lc_0
@@ -17592,6 +17845,272 @@
     rom_ctrl
     rv_core_ibex
   ]
+  alert_connections:
+  {
+    alert_handler:
+    [
+      [
+        uart0
+        fatal_fault
+      ]
+      [
+        uart1
+        fatal_fault
+      ]
+      [
+        uart2
+        fatal_fault
+      ]
+      [
+        uart3
+        fatal_fault
+      ]
+      [
+        gpio
+        fatal_fault
+      ]
+      [
+        spi_device
+        fatal_fault
+      ]
+      [
+        i2c0
+        fatal_fault
+      ]
+      [
+        i2c1
+        fatal_fault
+      ]
+      [
+        i2c2
+        fatal_fault
+      ]
+      [
+        pattgen
+        fatal_fault
+      ]
+      [
+        rv_timer
+        fatal_fault
+      ]
+      [
+        otp_ctrl
+        fatal_macro_error
+      ]
+      [
+        otp_ctrl
+        fatal_check_error
+      ]
+      [
+        otp_ctrl
+        fatal_bus_integ_error
+      ]
+      [
+        otp_ctrl
+        fatal_prim_otp_alert
+      ]
+      [
+        otp_ctrl
+        recov_prim_otp_alert
+      ]
+      [
+        lc_ctrl
+        fatal_prog_error
+      ]
+      [
+        lc_ctrl
+        fatal_state_error
+      ]
+      [
+        lc_ctrl
+        fatal_bus_integ_error
+      ]
+      [
+        spi_host0
+        fatal_fault
+      ]
+      [
+        spi_host1
+        fatal_fault
+      ]
+      [
+        usbdev
+        fatal_fault
+      ]
+      [
+        pwrmgr_aon
+        fatal_fault
+      ]
+      [
+        rstmgr_aon
+        fatal_fault
+      ]
+      [
+        rstmgr_aon
+        fatal_cnsty_fault
+      ]
+      [
+        clkmgr_aon
+        recov_fault
+      ]
+      [
+        clkmgr_aon
+        fatal_fault
+      ]
+      [
+        sysrst_ctrl_aon
+        fatal_fault
+      ]
+      [
+        adc_ctrl_aon
+        fatal_fault
+      ]
+      [
+        pwm_aon
+        fatal_fault
+      ]
+      [
+        pinmux_aon
+        fatal_fault
+      ]
+      [
+        aon_timer_aon
+        fatal_fault
+      ]
+      [
+        sensor_ctrl_aon
+        recov_alert
+      ]
+      [
+        sensor_ctrl_aon
+        fatal_alert
+      ]
+      [
+        sram_ctrl_ret_aon
+        fatal_error
+      ]
+      [
+        flash_ctrl
+        recov_err
+      ]
+      [
+        flash_ctrl
+        fatal_std_err
+      ]
+      [
+        flash_ctrl
+        fatal_err
+      ]
+      [
+        flash_ctrl
+        fatal_prim_flash_alert
+      ]
+      [
+        flash_ctrl
+        recov_prim_flash_alert
+      ]
+      [
+        rv_dm
+        fatal_fault
+      ]
+      [
+        rv_plic
+        fatal_fault
+      ]
+      [
+        aes
+        recov_ctrl_update_err
+      ]
+      [
+        aes
+        fatal_fault
+      ]
+      [
+        hmac
+        fatal_fault
+      ]
+      [
+        kmac
+        recov_operation_err
+      ]
+      [
+        kmac
+        fatal_fault_err
+      ]
+      [
+        otbn
+        fatal
+      ]
+      [
+        otbn
+        recov
+      ]
+      [
+        keymgr
+        recov_operation_err
+      ]
+      [
+        keymgr
+        fatal_fault_err
+      ]
+      [
+        csrng
+        recov_alert
+      ]
+      [
+        csrng
+        fatal_alert
+      ]
+      [
+        entropy_src
+        recov_alert
+      ]
+      [
+        entropy_src
+        fatal_alert
+      ]
+      [
+        edn0
+        recov_alert
+      ]
+      [
+        edn0
+        fatal_alert
+      ]
+      [
+        edn1
+        recov_alert
+      ]
+      [
+        edn1
+        fatal_alert
+      ]
+      [
+        sram_ctrl_main
+        fatal_error
+      ]
+      [
+        rom_ctrl
+        fatal
+      ]
+      [
+        rv_core_ibex
+        fatal_sw_err
+      ]
+      [
+        rv_core_ibex
+        recov_sw_err
+      ]
+      [
+        rv_core_ibex
+        fatal_hw_err
+      ]
+      [
+        rv_core_ibex
+        recov_hw_err
+      ]
+    ]
+  }
   interrupt_module:
   [
     uart0

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -292,6 +292,8 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      // alert connections names handler for each alert
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40000000",
       },
@@ -309,6 +311,8 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      // alert connections defines the port to alert domain
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40010000",
       },
@@ -326,6 +330,8 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      // alert connections defines the port to alert domain
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40020000",
       },
@@ -343,6 +349,8 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      // alert connections defines the port to alert domain
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40030000",
       },
@@ -353,6 +361,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40040000",
       },
@@ -367,6 +376,7 @@
       clock_srcs: {clk_i: "io_div4", scan_clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40050000",
       },
@@ -376,6 +386,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c0"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40080000",
       },
@@ -385,6 +396,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c1"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40090000",
       },
@@ -394,6 +406,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "i2c2"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x400A0000",
       },
@@ -403,6 +416,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x400E0000",
       },
@@ -412,6 +426,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40100000",
       },
@@ -422,6 +437,13 @@
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},
+      alert_connections: {
+        fatal_macro_error: "alert_handler",
+        fatal_check_error: "alert_handler",
+        fatal_bus_integ_error: "alert_handler",
+        fatal_prim_otp_alert: "alert_handler",
+        recov_prim_otp_alert: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x40130000"},
         prim: {hart: "0x40138000"},
@@ -433,6 +455,11 @@
       clock_srcs: {clk_i: "io_div4", clk_kmac_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_kmac_ni: "lc"},
+      alert_connections: {
+        fatal_prog_error: "alert_handler",
+        fatal_state_error: "alert_handler",
+        fatal_bus_integ_error: "alert_handler",
+      },
       base_addrs: {
         regs: {hart: "0x40140000"},
         dmi:  {hart: "0x0"}, // DMI is not used in EarlGrey
@@ -472,6 +499,7 @@
       clock_srcs: {clk_i: "io"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host0"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40300000",
       },
@@ -481,6 +509,7 @@
       clock_srcs: {clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host1"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40310000",
       },
@@ -490,6 +519,7 @@
       clock_srcs: {clk_i: "usb", clk_aon_i: "aon"},
       clock_group: "peri",
       reset_connections: {rst_ni: "usb", rst_aon_ni: "usb_aon"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40320000",
       },
@@ -533,6 +563,7 @@
         },
       },
       domain: ["Aon", "0"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40400000",
       },
@@ -565,6 +596,10 @@
         },
       },
       domain: ["Aon", "0"],
+      alert_connections: {
+        fatal_fault: "alert_handler",
+        fatal_cnsty_fault: "alert_handler",
+      },
       base_addr: {
         hart: "0x40410000",
       },
@@ -608,6 +643,10 @@
                           rst_root_usb_ni: "por_usb",
                          },
       domain: ["Aon"],
+      alert_connections: {
+        recov_fault: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       base_addr: {
         hart: "0x40420000",
       },
@@ -619,6 +658,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_aon_ni: "lc_aon"},
       domain: ["Aon"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40430000",
       }
@@ -629,6 +669,7 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "lc_io_div4", rst_aon_ni: "lc_aon"},
       domain: ["Aon"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40440000",
       }
@@ -640,6 +681,7 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "lc_io_div4", rst_core_ni: "lc_aon"},
       domain: ["Aon"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40450000",
       },
@@ -655,6 +697,7 @@
                           rst_sys_ni: "sys_io_div4"
                          },
       domain: ["Aon"],
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x40460000",
       },
@@ -671,6 +714,7 @@
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
       clock_group: "timers",
       reset_connections: {rst_ni: "lc_io_div4", rst_aon_ni: "lc_aon"},
+      alert_connections: {fatal_fault: "alert_handler"},
       domain: ["Aon"],
       base_addr: {
         hart: "0x40470000",
@@ -743,6 +787,10 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_aon_ni: "lc_aon"},
       domain: ["Aon"],
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x40490000",
       },
@@ -754,6 +802,7 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "lc_io_div4", rst_otp_ni: "lc_io_div4"},
       domain: ["Aon"],
+      alert_connections: {fatal_error: "alert_handler"},
       param_decl: {
         InstrExec: "0",
         InstSize: "4096",
@@ -781,6 +830,13 @@
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        recov_err: "alert_handler",
+        fatal_std_err: "alert_handler",
+        fatal_err: "alert_handler",
+        fatal_prim_flash_alert: "alert_handler",
+        recov_prim_flash_alert: "alert_handler",
+      },
       base_addrs: {
         core: {hart: "0x41000000"},
         prim: {hart: "0x41008000"},
@@ -811,6 +867,7 @@
       clock_srcs: {clk_i: "main", clk_lc_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "sys", rst_lc_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       param_decl: {
         IdcodeValue: "jtag_id_pkg::RV_DM_JTAG_IDCODE",
       },
@@ -828,6 +885,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x48000000",
       },
@@ -838,6 +896,10 @@
       clock_srcs: {clk_i: "main", clk_edn_i: "main"},
       clock_group: "trans",
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc"},
+      alert_connections: {
+        recov_ctrl_update_err: "alert_handler",
+        fatal_fault: "alert_handler",
+      },
       param_decl: {
         SecMasking: "1",
         SecSBoxImpl: "aes_pkg::SBoxImplDom"
@@ -851,6 +913,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "trans",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal_fault: "alert_handler"},
       base_addr: {
         hart: "0x41110000",
       },
@@ -863,6 +926,10 @@
       clock_srcs: {clk_i: "main", clk_edn_i: "main"}
       clock_group: "trans"
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc"}
+      alert_connections: {
+        recov_operation_err: "alert_handler",
+        fatal_fault_err: "alert_handler",
+      },
       base_addr: {
         hart: "0x41120000",
       }
@@ -885,6 +952,10 @@
       },
       clock_group: "trans",
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        fatal: "alert_handler",
+        recov: "alert_handler",
+      },
       base_addr: {
         hart: "0x41130000",
       },
@@ -894,6 +965,10 @@
       clock_srcs: {clk_i: "main", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc", rst_edn_ni: "lc"},
+      alert_connections: {
+        recov_operation_err: "alert_handler",
+        fatal_fault_err: "alert_handler",
+      },
       base_addr: {
         hart: "0x41140000",
       },
@@ -903,6 +978,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x41150000",
       },
@@ -912,6 +991,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x41160000",
       },
@@ -921,6 +1004,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x41170000",
       },
@@ -930,6 +1017,10 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {
+        recov_alert: "alert_handler",
+        fatal_alert: "alert_handler",
+      },
       base_addr: {
         hart: "0x41180000",
       },
@@ -939,6 +1030,7 @@
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {fatal_error: "alert_handler"},
       param_decl: {
         InstrExec: "1",
         NumPrinceRoundsHalf: "2",
@@ -966,6 +1058,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      alert_connections: {fatal: "alert_handler"},
       base_addrs: {
         rom:  {hart: "0x00008000"},
         regs: {hart: "0x411e0000"}
@@ -1038,6 +1131,12 @@
                           rst_edn_ni: "lc",
                           rst_esc_ni: "lc_io_div4",
                           rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        fatal_sw_err: "alert_handler",
+        recov_sw_err: "alert_handler",
+        fatal_hw_err: "alert_handler",
+        recov_hw_err: "alert_handler",
+      },
       base_addr: {
         hart: "0x411F0000",
       },

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -502,6 +502,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -592,6 +596,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: null
       }
       clock_connections:
       {
@@ -684,6 +692,10 @@
           name: sys_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: null
       }
       param_decl:
       {
@@ -814,6 +826,10 @@
           name: spi_device
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: null
       }
       clock_connections:
       {
@@ -981,6 +997,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_peri
@@ -1096,6 +1116,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
@@ -1152,6 +1176,10 @@
           name: sys_aon
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_fault: null
       }
       clock_connections:
       {
@@ -1492,6 +1520,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       attr: ipgen
       clock_connections:
       {
@@ -1809,6 +1841,11 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: null
+        fatal_cnsty_fault: null
+      }
       param_decl:
       {
         SecCheck: "0"
@@ -2078,6 +2115,11 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        recov_fault: null
+        fatal_fault: null
+      }
       attr: ipgen
       clock_connections:
       {
@@ -2336,6 +2378,10 @@
       [
         Aon
       ]
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       attr: ipgen
       clock_connections:
       {
@@ -2763,6 +2809,10 @@
           domain: Aon
         }
       }
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       domain:
       [
         Aon
@@ -2989,6 +3039,14 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_err: null
+        fatal_std_err: null
+        fatal_err: null
+        fatal_prim_flash_alert: null
+        recov_prim_flash_alert: null
       }
       base_addrs:
       {
@@ -3401,6 +3459,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal_fault: null
+      }
       attr: ipgen
       clock_connections:
       {
@@ -3495,6 +3557,11 @@
           name: sys
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        recov_ctrl_update_err: null
+        fatal_fault: null
       }
       param_decl:
       {
@@ -3725,6 +3792,10 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_error: null
       }
       param_decl:
       {
@@ -4065,6 +4136,10 @@
           domain: "0"
         }
       }
+      alert_connections:
+      {
+        fatal: null
+      }
       base_addrs:
       {
         rom:
@@ -4285,6 +4360,13 @@
           name: lc_io_div4
           domain: "0"
         }
+      }
+      alert_connections:
+      {
+        fatal_sw_err: null
+        recov_sw_err: null
+        fatal_hw_err: null
+        recov_hw_err: null
       }
       clock_connections:
       {
@@ -7847,6 +7929,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: uart0
       desc: uart0 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -7857,6 +7940,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: uart1
       desc: uart1 fatal_fault alert
       lpg_name: peri_lc_io_div4_0
@@ -7867,6 +7951,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: gpio
       desc: gpio fatal_fault alert
       lpg_name: peri_sys_io_div4_0
@@ -7877,6 +7962,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: spi_device
       desc: spi_device fatal_fault alert
       lpg_name: peri_spi_device_0
@@ -7887,6 +7973,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: spi_host0
       desc: spi_host0 fatal_fault alert
       lpg_name: peri_spi_host0_0
@@ -7897,6 +7984,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rv_timer
       desc: rv_timer fatal_fault alert
       lpg_name: timers_sys_io_div4_0
@@ -7907,6 +7995,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: usbdev
       desc: usbdev fatal_fault alert
       lpg_name: peri_usb_0
@@ -7917,6 +8006,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: pwrmgr_aon
       desc: pwrmgr_aon fatal_fault alert
       lpg_name: powerup_por_io_div4_Aon
@@ -7927,6 +8017,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rstmgr_aon
       desc: rstmgr_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -7937,6 +8028,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rstmgr_aon
       desc: rstmgr_aon fatal_cnsty_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -7947,6 +8039,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: clkmgr_aon
       desc: clkmgr_aon recov_fault alert
       lpg_name: powerup_por_io_div4_Aon
@@ -7957,6 +8050,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: clkmgr_aon
       desc: clkmgr_aon fatal_fault alert
       lpg_name: powerup_por_io_div4_Aon
@@ -7967,6 +8061,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: pinmux_aon
       desc: pinmux_aon fatal_fault alert
       lpg_name: powerup_lc_io_div4_Aon
@@ -7977,6 +8072,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: aon_timer_aon
       desc: aon_timer_aon fatal_fault alert
       lpg_name: timers_sys_io_div4_Aon
@@ -7987,6 +8083,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: flash_ctrl
       desc: flash_ctrl recov_err alert
       lpg_name: infra_lc_0
@@ -7997,6 +8094,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: flash_ctrl
       desc: flash_ctrl fatal_std_err alert
       lpg_name: infra_lc_0
@@ -8007,6 +8105,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: flash_ctrl
       desc: flash_ctrl fatal_err alert
       lpg_name: infra_lc_0
@@ -8017,6 +8116,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: flash_ctrl
       desc: flash_ctrl fatal_prim_flash_alert alert
       lpg_name: infra_lc_0
@@ -8027,6 +8127,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: flash_ctrl
       desc: flash_ctrl recov_prim_flash_alert alert
       lpg_name: infra_lc_0
@@ -8037,6 +8138,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rv_plic
       desc: rv_plic fatal_fault alert
       lpg_name: secure_sys_0
@@ -8047,6 +8149,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: aes
       desc: aes recov_ctrl_update_err alert
       lpg_name: aes_trans_sys_0
@@ -8057,6 +8160,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: aes
       desc: aes fatal_fault alert
       lpg_name: aes_trans_sys_0
@@ -8067,6 +8171,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: sram_ctrl_main
       desc: sram_ctrl_main fatal_error alert
       lpg_name: secure_sys_0
@@ -8077,6 +8182,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rom_ctrl
       desc: rom_ctrl fatal alert
       lpg_name: infra_sys_0
@@ -8087,6 +8193,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rv_core_ibex
       desc: rv_core_ibex fatal_sw_err alert
       lpg_name: infra_sys_0
@@ -8097,6 +8204,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rv_core_ibex
       desc: rv_core_ibex recov_sw_err alert
       lpg_name: infra_sys_0
@@ -8107,6 +8215,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rv_core_ibex
       desc: rv_core_ibex fatal_hw_err alert
       lpg_name: infra_sys_0
@@ -8117,6 +8226,7 @@
       width: 1
       type: alert
       async: "1"
+      handler: null
       module_name: rv_core_ibex
       desc: rv_core_ibex recov_hw_err alert
       lpg_name: infra_sys_0
@@ -8708,6 +8818,124 @@
     rom_ctrl
     rv_core_ibex
   ]
+  alert_connections:
+  {
+    null:
+    [
+      [
+        uart0
+        fatal_fault
+      ]
+      [
+        uart1
+        fatal_fault
+      ]
+      [
+        gpio
+        fatal_fault
+      ]
+      [
+        spi_device
+        fatal_fault
+      ]
+      [
+        spi_host0
+        fatal_fault
+      ]
+      [
+        rv_timer
+        fatal_fault
+      ]
+      [
+        usbdev
+        fatal_fault
+      ]
+      [
+        pwrmgr_aon
+        fatal_fault
+      ]
+      [
+        rstmgr_aon
+        fatal_fault
+      ]
+      [
+        rstmgr_aon
+        fatal_cnsty_fault
+      ]
+      [
+        clkmgr_aon
+        recov_fault
+      ]
+      [
+        clkmgr_aon
+        fatal_fault
+      ]
+      [
+        pinmux_aon
+        fatal_fault
+      ]
+      [
+        aon_timer_aon
+        fatal_fault
+      ]
+      [
+        flash_ctrl
+        recov_err
+      ]
+      [
+        flash_ctrl
+        fatal_std_err
+      ]
+      [
+        flash_ctrl
+        fatal_err
+      ]
+      [
+        flash_ctrl
+        fatal_prim_flash_alert
+      ]
+      [
+        flash_ctrl
+        recov_prim_flash_alert
+      ]
+      [
+        rv_plic
+        fatal_fault
+      ]
+      [
+        aes
+        recov_ctrl_update_err
+      ]
+      [
+        aes
+        fatal_fault
+      ]
+      [
+        sram_ctrl_main
+        fatal_error
+      ]
+      [
+        rom_ctrl
+        fatal
+      ]
+      [
+        rv_core_ibex
+        fatal_sw_err
+      ]
+      [
+        rv_core_ibex
+        recov_sw_err
+      ]
+      [
+        rv_core_ibex
+        fatal_hw_err
+      ]
+      [
+        rv_core_ibex
+        recov_hw_err
+      ]
+    ]
+  }
   outgoing_alert_module: {}
   alert_lpgs:
   [

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -268,6 +268,8 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      // alert connections names handler for each alert
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40000000",
       },
@@ -285,6 +287,7 @@
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
       reset_connections: {rst_ni: "lc_io_div4"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40010000",
       },
@@ -295,6 +298,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "sys_io_div4"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40040000",
       },
@@ -308,6 +312,7 @@
       clock_srcs: {clk_i: "io_div4", scan_clk_i: "io_div2"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40050000",
       },
@@ -317,6 +322,7 @@
       clock_srcs: {clk_i: "io"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host0"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40060000",
       },
@@ -326,6 +332,7 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
       reset_connections: {rst_ni: "sys_io_div4"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40100000",
       },
@@ -335,6 +342,7 @@
       clock_srcs: {clk_i: "usb", clk_aon_i: "aon"},
       clock_group: "peri",
       reset_connections: {rst_ni: "usb", rst_aon_ni: "sys_aon"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40320000",
       },
@@ -352,6 +360,7 @@
         rst_slow_ni: "por_aon"
       },
       domain: ["Aon"],
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40400000",
       },
@@ -366,6 +375,10 @@
       clock_group: "powerup",
       reset_connections: {rst_ni: "lc_io_div4", rst_por_ni: "por_io_div4"},
       domain: ["Aon"],
+      alert_connections: {
+        fatal_fault: null,
+        fatal_cnsty_fault: null,
+      },
       base_addr: {
         hart: "0x40410000",
       },
@@ -412,6 +425,10 @@
                           rst_root_usb_ni: "por_usb",
                          },
       domain: ["Aon"],
+      alert_connections: {
+        recov_fault: null,
+        fatal_fault: null,
+      },
       base_addr: {
         hart: "0x40420000",
       },
@@ -427,6 +444,7 @@
                           rst_sys_ni: "sys_io_div4"
                          },
       domain: ["Aon"],
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x40460000",
       },
@@ -437,6 +455,7 @@
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
       clock_group: "timers",
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
+      alert_connections: {fatal_fault: null},
       domain: ["Aon"],
       base_addr: {
         hart: "0x40470000",
@@ -475,6 +494,13 @@
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        recov_err: null,
+        fatal_std_err: null,
+        fatal_err: null,
+        fatal_prim_flash_alert: null,
+        recov_prim_flash_alert: null,
+      },
       base_addrs: {
         core: {hart: "0x41000000"},
         prim: {hart: "0x41008000"},
@@ -505,6 +531,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
+      alert_connections: {fatal_fault: null},
       base_addr: {
         hart: "0x48000000",
       },
@@ -515,6 +542,10 @@
       clock_srcs: {clk_i: "main", clk_edn_i: "main"},
       clock_group: "trans",
       reset_connections: {rst_ni: "sys", rst_edn_ni: "sys"},
+      alert_connections: {
+        recov_ctrl_update_err: null,
+        fatal_fault: null,
+      },
       param_decl: {
         SecMasking: "1",
         SecSBoxImpl: "aes_pkg::SBoxImplDom"
@@ -528,6 +559,7 @@
       clock_srcs: {clk_i: "main", clk_otp_i: "io_div4"},
       clock_group: "secure",
       reset_connections: {rst_ni: "sys", rst_otp_ni: "lc_io_div4"},
+      alert_connections: {fatal_error: null},
       param_decl: {
         InstrExec: "1",
       }
@@ -552,6 +584,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "sys"},
+      alert_connections: {fatal: null},
       base_addrs: {
         rom:  {hart: "0x00008000"},
         regs: {hart: "0x411e0000"},
@@ -605,6 +638,12 @@
                           rst_edn_ni: "sys",
                           rst_esc_ni: "lc_io_div4",
                           rst_otp_ni: "lc_io_div4"},
+      alert_connections: {
+        fatal_sw_err: null,
+        recov_sw_err: null,
+        fatal_hw_err: null,
+        recov_hw_err: null,
+      },
       base_addr: {
         hart: "0x411F0000",
       },

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -666,3 +666,9 @@ class IpBlock:
                           f"register block: {', '.join(unused_regwens)}")
                 status = False
         return status
+
+    def get_alert_by_name(self, name: str) -> Alert:
+        for alert in self.alerts:
+            if alert.name == name:
+                return alert
+        return None

--- a/util/topgen/c_test.py
+++ b/util/topgen/c_test.py
@@ -222,9 +222,11 @@ class TopGenCTest(TopGenC):
             return alert_peripherals
         all_device_regions = self.all_device_regions()
         all_direct_regions = all_device_regions[addr_space]
+        alerting_modules = self.top["alert_module"]
+
         for entry in self.top['module']:
             inst_name = entry['name']
-            if inst_name not in self.top["alert_module"]:
+            if inst_name not in alerting_modules:
                 continue
 
             if not entry['generate_dif']:

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -366,6 +366,7 @@ alert_required = {
     'width': ['d', 'the number of alerts in this signal, typically 1'],
     'async': ['s', 'string interpreted as boolean'],
     'module_name': ['s', 'The module name of the source'],
+    'handler': ['s', 'alert handler managing this alert'],
 }
 alert_optional = {
     'desc': ['s', 'the description of the alert'],
@@ -586,6 +587,8 @@ def check_alerts(top: ConfigT, ip_name_to_block: IpBlocksT, prefix: str) -> int:
     if 'alert' not in top:
         return 0
     error = 0
+
+    # Check alert keys
     for alert in top['alert']:
         error += check_keys(alert, alert_required, alert_optional, alert_added,
                             prefix + ' Alert')

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -12,6 +12,7 @@ from reggen.ip_block import IpBlock
 from reggen.validate import check_keys
 from topgen.resets import Resets, UnmanagedResets
 from topgen.typing import IpBlocksT
+from topgen.lib import find_modules
 
 # For the reference
 # val_types = {
@@ -286,6 +287,7 @@ module_optional = {
         'represent a dict that associates all interfaces with the given '
         'mapping. It is an error to specify both this and racl_mappings.'
     ],
+    'alert_connections': ['g', 'dict specifying handler for each alert'],
 }
 
 module_added = {
@@ -580,13 +582,21 @@ def check_pad(top: ConfigT, pad: Dict, known_pad_names: Dict,
     return error
 
 
-def check_alerts(top: ConfigT, prefix: str) -> int:
+def check_alerts(top: ConfigT, ip_name_to_block: IpBlocksT, prefix: str) -> int:
     if 'alert' not in top:
         return 0
     error = 0
     for alert in top['alert']:
         error += check_keys(alert, alert_required, alert_optional, alert_added,
                             prefix + ' Alert')
+
+    # Check alert_connections for all IPs
+    alert_handlers = find_modules(top['module'], "alert_handler",
+                                  use_base_template_type=True)
+    for module in top['module']:
+        log.info(f'Checking alerts for {module["name"]}')
+        block = ip_name_to_block[module['type']]
+        error += validate_alert(module, block, alert_handlers)
     return error
 
 
@@ -1066,6 +1076,45 @@ def validate_clock(top: ConfigT,
     return error
 
 
+# Checks the following:
+# - that each alert in the IP's alert_list is named in alert_connections
+# - that each alert in alert_connections names a valid handler
+def validate_alert(top, block, handlers):
+    errors = 0
+    name = top.name if isinstance(top, IpBlock) else top['name']
+    handler_names = [handler['name'] for handler in handlers]
+    if block.alerts:
+        alert_names = [alert.name for alert in block.alerts]
+        unused_alerts = set(alert_names)
+        if 'alert_connections' in top:
+            alert_connections = top['alert_connections']
+            for alert, handler in alert_connections.items():
+                if alert not in alert_names:
+                    errors += 1
+                    log.error(f'{name} does not have an alert called {alert}')
+                else:
+                    if alert not in unused_alerts:
+                        errors += 1
+                        log.error(f'{name} has more than one alert connection for {alert}')
+                    unused_alerts.remove(alert)
+
+                if handler is not None and handler not in handler_names:
+                    errors += 1
+                    log.error(f"{name} specifies handler {handler} for alert {alert} "
+                              f"but the handler doesn't exist")
+        if unused_alerts:
+            errors += 1
+            log.error(f'module {name} did not assign handlers for these alerts: '
+                      f'{unused_alerts}')
+    else:
+        # No actual alerts to connect
+        if 'alert_connections' in top and len(top['alert_connections']):
+            errors += 1
+            log.error(f'{name} contains entries in alert_connections but there are no alerts')
+
+    return errors
+
+
 def check_flash(top: ConfigT):
 
     for mem in top['memory']:
@@ -1209,7 +1258,7 @@ def validate_top(top: ConfigT, ip_name_to_block: IpBlocksT,
     error += check_pinmux(top, component)
     error += check_implementation_targets(top, component)
 
-    error += check_alerts(top, component)
+    error += check_alerts(top, ip_name_to_block, component)
     error += check_incoming_alerts(top, component)
     error += check_outgoing_alerts(top, component)
     error += check_interrupts(top, component)


### PR DESCRIPTION
Currently, each IP block's HJSON defines some number of alerts in its alert_list, and these are all implicitly connected to the top's alert handler instance, if present.

With an eye towards more flexible alert topologies, with potentially multiple alert handlers, this PR makes alert handler connections explicit by having each toplevel HJSON module define an `alert_connections` dictionary naming each alert and its handler, for example:

```
...
    { name: "csrng",
      type: "csrng",
      clock_srcs: {clk_i: "main"},
      clock_group: "secure",
      reset_connections: {rst_ni: "lc"},
+     alert_connections: {
+       recov_alert: "alert_handler",
+       fatal_alert: "alert_handler",
+     },
      base_addr: {
        hart: "0x21150000",
      },
    }
...
```

While not implemented yet, it's easy to extend to [incoming/outgoing alerts](https://github.com/lowRISC/opentitan/pull/25179), e.g. for outgoing alerts, specifying "outgoing:top1" routes alerts to the "top1" outgoing alert group. Incoming alerts can be handled [as the RFC does](https://docs.google.com/document/d/1LGQjasiB6WJ1dL42hTKbzScmEmRQDXurdG6n8ORtJQk/edit?tab=t.0#heading=h.ly4mwumf0y6l) or have another dictionary explicitly breaking out its alerts.

Inviting discussion on the following questions and more:
* Should we support the implicit mapping when there is zero or one alert handler?
* Should we express alert handler connectivity on a block level instead of the alert level?