### PR TITLE
[rom_ctrl,doc] Correct a padding width

### DIFF
--- a/hw/ip/rom_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/rom_ctrl/doc/theory_of_operation.md
@@ -61,7 +61,7 @@ We expect to use the `cSHAKE256` algorithm, with prefix "ROM_CTRL".
 The [Application Interface](../../kmac/README.md#application-interface) section of the KMAC documentation details the parameters used.
 
 The checker reads the ROM contents in address order, resulting in a scattered access pattern on the ROM itself because of the address scrambling.
-Each read produces 39 bits of data, which are padded with zeros to 64 bits to match the interface expected by the KMAC block.
+Each read produces 39 bits of data, which are padded with a zero to 40 bits to match the interface expected by the KMAC block.
 The checker FSM loops through almost all the words in ROM (from bottom to top), passing each to the KMAC block with the ready/valid interface and setting the `kmac_data_o.last` bit for the last word that is sent.
 Once the last word has been sent, the FSM releases the multiplexer; this now switches over permanently to allow access through the TL-UL SRAM adapter.
 


### PR DESCRIPTION
The text was documenting the original design (which padded up from 39 bits to 64 bits), but this changed in 2022 with commit 5d4d4e5 and started only padding up to 40 bits, which is rather more efficient.

Update the document to match.