### PR TITLE
[hw,rv_core_ibex,rtl] Add optional RACL support to RV Core Ibex

### DIFF
--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -33,7 +33,11 @@
   bus_interfaces: [
     { protocol: "tlul", direction: "host",   name: "corei" }
     { protocol: "tlul", direction: "host",   name: "cored" }
+  % if racl_support:
+    { protocol: "tlul", direction: "device", name: "cfg", racl_support: true }
+  % else:
     { protocol: "tlul", direction: "device", name: "cfg" }
+  % endif
   ],
   scan: "true",       // Enable `scanmode_i` port
   scan_reset: "true", // Enable `scan_rst_ni` port
@@ -211,6 +215,28 @@
       width:   "32",
       package: "",
     },
+  % if racl_support:
+    { struct:  "racl_policy_vec",
+      type:    "uni",
+      name:    "racl_policies",
+      act:     "rcv",
+      package: "top_racl_pkg",
+      desc:    '''
+        Incoming RACL policy vector from a racl_ctrl instance.
+        The policy selection vector (parameter) selects the policy for each register.
+      '''
+    }
+    { struct:  "racl_error_log",
+      type:    "uni",
+      name:    "racl_error",
+      act:     "req",
+      width:   "1"
+      package: "top_racl_pkg",
+      desc:    '''
+        RACL error log information of this module.
+      '''
+    }
+  % endif
 
   ],
   param_list: [

--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.tpldesc.hjson
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.tpldesc.hjson
@@ -27,5 +27,11 @@
       type: "string"
       default: "rv_core_ibex"
     }
+    {
+      name: "racl_support"
+      desc: "Enable RACL support"
+      type: "bool"
+      default: false
+    }
   ]
 }

--- a/hw/ip_templates/rv_core_ibex/rv_core_ibex.core.tpl
+++ b/hw/ip_templates/rv_core_ibex/rv_core_ibex.core.tpl
@@ -20,6 +20,9 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:tlul:adapter_host
       - lowrisc:ip:rv_core_ibex_pkg
+    % if racl_support:
+      - ${instance_vlnv("lowrisc:constants:top_racl_pkg")}
+    % endif
 
     files:
       - rtl/${module_instance_name}_reg_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/top_darjeeling_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/top_darjeeling_rv_core_ibex.ipconfig.hjson
@@ -5,6 +5,7 @@
   instance_name: top_darjeeling_rv_core_ibex
   param_values:
   {
+    racl_support: false
     num_regions: 32
     module_instance_name: rv_core_ibex
     topname: darjeeling

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/top_earlgrey_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/top_earlgrey_rv_core_ibex.ipconfig.hjson
@@ -5,6 +5,7 @@
   instance_name: top_earlgrey_rv_core_ibex
   param_values:
   {
+    racl_support: false
     num_regions: 2
     module_instance_name: rv_core_ibex
     topname: earlgrey

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/top_englishbreakfast_rv_core_ibex.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/top_englishbreakfast_rv_core_ibex.ipconfig.hjson
@@ -5,6 +5,7 @@
   instance_name: top_englishbreakfast_rv_core_ibex
   param_values:
   {
+    racl_support: false
     num_regions: 2
     module_instance_name: rv_core_ibex
     topname: englishbreakfast

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -807,6 +807,7 @@ def _get_rv_core_ibex_params(topcfg: Dict[str, object]) -> Dict[str, object]:
     uniquified_modules.add_module(module["template_type"], module["type"])
 
     return {
+        "racl_support": module.get("ipgen_param", {}).get("racl_support", False),
         "num_regions": module['ipgen_param']['NumRegions'],
         'module_instance_name': module['type']
     }


### PR DESCRIPTION
This PR adds an optional RACL support to the rv_core_ibex IP. The enablement is gated via an ipgen parameter to not add the logic (even though it is disabled) to rendered IPs that don't use it.