### PR TITLE
[RACL, raclgen] Allow mixing * and non-* in racl mappings

### DIFF
--- a/util/raclgen/lib.py
+++ b/util/raclgen/lib.py
@@ -201,15 +201,17 @@ def parse_racl_mapping(
         raise SystemExit('RACL Mapping is missing the field: windows')
 
     # translate star mappings:
-    if list(mapping.get('registers', {}).keys()) == ["*"]:
+    if "*" in mapping.get('registers', {}):
         policy_name = mapping['registers'].pop("*")
         for reg in reg_block.flat_regs:
-            mapping['registers'][reg.name] = policy_name
+            if reg.name not in mapping['registers']:
+                mapping['registers'][reg.name] = policy_name
 
-    if list(mapping.get('windows', {}).keys()) == ["*"]:
+    if "*" in mapping.get('windows', {}):
         policy_name = mapping['windows'].pop("*")
         for window in reg_block.windows:
-            mapping['windows'][window.name] = policy_name
+            if window.name not in mapping['windows']:
+                mapping['windows'][window.name] = policy_name
 
     # Assign all registers to a given policy
     for reg in reg_block.flat_regs:


### PR DESCRIPTION
Previously racl mappings allowed either `*` mappings or non-`*` mappings.
But especially for out of tree modules, it can be beneficial to allow mixing both types.
This PR changes raclgen, such that it's possible to specify policies to some specific registers/windows while also allowing to set all other registers/windows (that are not explicitly named) to another policy using the `*` mapping.

This behavior was previously under specified and will be added to the documentation after #26592 is merged. In the meantime this change is tracked in #26720.