### PR TITLE
[dv, rom_ctrl] Moving ROM_BYTE_ADDR_WIDTH to the env pkg

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -30,6 +30,12 @@ package rom_ctrl_env_pkg;
   parameter string LIST_OF_ALERTS[] = {"fatal"};
   parameter uint   NUM_ALERTS = 1;
 
+  // The exact number of word address bits.
+  // Will be set to 15 for ROM0 and 16 for ROM1.
+  `ifndef ROM_BYTE_ADDR_WIDTH
+   `define ROM_BYTE_ADDR_WIDTH 32
+  `endif
+
   // The top bytes in memory hold the digest
   // KMAC's max digest size is larger than what is required, so declare the size here.
   parameter uint DIGEST_SIZE    = 256;

--- a/hw/ip/rom_ctrl/dv/tb.sv
+++ b/hw/ip/rom_ctrl/dv/tb.sv
@@ -37,11 +37,6 @@ module tb;
   assign rom_ctrl_if.pwrmgr_data   = pwrmgr_data;
   assign rom_ctrl_if.keymgr_data   = keymgr_data;
 
-  // The exact number of word address bits.
-  // Will be set to 15 for ROM0 and 16 for ROM1.
-`ifndef ROM_BYTE_ADDR_WIDTH
-  `define ROM_BYTE_ADDR_WIDTH 32
-`endif
 
   // dut
   rom_ctrl #(


### PR DESCRIPTION
Moving the parameter definition to the env package. 