### PR TITLE
[alert,dv] Avoid using state_q and PingSt from alert_esc_if directly

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -188,6 +188,15 @@ interface alert_esc_if(input clk, input rst_n);
     end while (cycle_cnt > 1 || rst_n != 1'b1);
   endtask : wait_esc_ping
 
+  // Return true if the current state is PingSt
+  //
+  // This rather trivial function is needed because we want to use the interface through a virtual
+  // interface handle, so cannot refer to PingSt or state_q because they are both defined in terms
+  // of an enum defined inside the interface.
+  function automatic logic in_ping_st();
+    return state_q == PingSt;
+  endfunction
+
   logic alert_sva_active;
   always_comb alert_sva_active = is_alert && rst_n;
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -108,7 +108,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::body();
         // If there's a ping on-flight wait until it's finished. Otherwise, the alert due to the
         // fault injection may be hard to predict since it will come after the ping, but
         // dependant on the exact ping timing
-        if (alert_vif.state_q == alert_vif.PingSt) begin
+        if (alert_vif.in_ping_st()) begin
           // There's 2-cycles sampling delay in the monitor, so if the VIF has already seen the ping
           // Wait for it. Otherwise there may be scenarios where the `active_ping` is not yet set
           // in the monitor due to the 2-cycle delay. Which causes issues predicting the value in


### PR DESCRIPTION
Doing so causes Xcelium to generate an (initially mystifying) error message:

```
  xmelab: *E,DISVIF (...._vseq.sv,111|48):
    Disallowed virtual interface hierarchical reference object type at 'PingSt'.
```

This took me a while to understand, but the point is that the vseq was using e.g. alert_vif.PingSt. What is the type of that expression? Well, it's state_e, but the enum is defined inside the interface (and that enum isn't technically part of the "port list" of the interface).

At least, that's what I *think* is going on. There's a discussion of (I think) the same question at

    https://stackoverflow.com/questions/54627223/