### PR TITLE
[dv, adc] parameter assoc array lint fix

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
@@ -22,7 +22,7 @@ package adc_ctrl_env_pkg;
   // parameters
   // alerts
   parameter uint NUM_ALERTS = 1;
-  parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
+  parameter string LIST_OF_ALERTS[] = '{0: "fatal_fault"};
   // Number of ADC channels
   parameter int unsigned ADC_CTRL_CHANNELS = ast_pkg::AdcChannels;
   // ADC data width


### PR DESCRIPTION
Using associative array literals (7.9.11 in LRM)  to initialise LIST_OF_ALERTS