### PR TITLE
[RACL] Fix up RACL ranges support

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -29,7 +29,7 @@
 
   bus_interfaces: [
     { protocol: "tlul", direction: "device", name: "regs", racl_support: true }
-    { protocol: "tlul", direction: "device", name: "ram" , racl_support: true }
+    { protocol: "tlul", direction: "device", name: "ram" , racl_support: true, racl_range_support: true }
   ],
 
   ///////////////////////////
@@ -120,13 +120,6 @@
       local:     "false",
       expose:    "true",
       default:   "0"
-    },
-    { name:      "RaclPolicySelRangesRamNum",
-      desc:      "Number of Racl Policy Selection Ranges for the Ram interface",
-      type:      "int",
-      local:     "false",
-      expose:    "true",
-      default:   "1"
     },
   ]
 
@@ -244,16 +237,6 @@
         RACL error log information of this module.
       '''
     },
-    { struct:  "racl_range_t",
-      type:    "uni",
-      name:    "racl_policy_sel_ranges_ram",
-      act:     "rcv",
-      width:   "RaclPolicySelRangesRamNum"
-      package: "top_racl_pkg",
-      desc:    '''
-        Incoming array of RACL policy ranges.
-      '''
-    }
     { struct:  "sram_error_t",
       package: "sram_ctrl_pkg",
       width:   "1"

--- a/hw/ip/sram_ctrl/doc/interfaces.md
+++ b/hw/ip/sram_ctrl/doc/interfaces.md
@@ -27,20 +27,19 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name                  | Package::Struct                 | Type    | Act   | Width                     | Description                                                                                                                          |
-|:---------------------------|:--------------------------------|:--------|:------|:--------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| sram_otp_key               | otp_ctrl_pkg::sram_otp_key      | req_rsp | req   | 1                         |                                                                                                                                      |
-| cfg                        | prim_ram_1p_pkg::ram_1p_cfg     | uni     | rcv   | NumRamInst                |                                                                                                                                      |
-| cfg_rsp                    | prim_ram_1p_pkg::ram_1p_cfg_rsp | uni     | req   | NumRamInst                |                                                                                                                                      |
-| lc_escalate_en             | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1                         |                                                                                                                                      |
-| lc_hw_debug_en             | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1                         |                                                                                                                                      |
-| otp_en_sram_ifetch         | prim_mubi_pkg::mubi8            | uni     | rcv   | 1                         |                                                                                                                                      |
-| racl_policies              | top_racl_pkg::racl_policy_vec   | uni     | rcv   | 1                         | Incoming RACL policy vector from a racl_ctrl instance. The policy selection vector (parameter) selects the policy for each register. |
-| racl_error                 | top_racl_pkg::racl_error_log    | uni     | req   | 1                         | RACL error log information of this module.                                                                                           |
-| racl_policy_sel_ranges_ram | top_racl_pkg::racl_range_t      | uni     | rcv   | RaclPolicySelRangesRamNum | Incoming array of RACL policy ranges.                                                                                                |
-| sram_rerror                | sram_ctrl_pkg::sram_error_t     | uni     | req   | 1                         | SRAM read error indicating correctable and uncorrectable ECC errors.                                                                 |
-| regs_tl                    | tlul_pkg::tl                    | req_rsp | rsp   | 1                         |                                                                                                                                      |
-| ram_tl                     | tlul_pkg::tl                    | req_rsp | rsp   | 1                         |                                                                                                                                      |
+| Port Name          | Package::Struct                 | Type    | Act   | Width      | Description                                                                                                                          |
+|:-------------------|:--------------------------------|:--------|:------|:-----------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| sram_otp_key       | otp_ctrl_pkg::sram_otp_key      | req_rsp | req   | 1          |                                                                                                                                      |
+| cfg                | prim_ram_1p_pkg::ram_1p_cfg     | uni     | rcv   | NumRamInst |                                                                                                                                      |
+| cfg_rsp            | prim_ram_1p_pkg::ram_1p_cfg_rsp | uni     | req   | NumRamInst |                                                                                                                                      |
+| lc_escalate_en     | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1          |                                                                                                                                      |
+| lc_hw_debug_en     | lc_ctrl_pkg::lc_tx              | uni     | rcv   | 1          |                                                                                                                                      |
+| otp_en_sram_ifetch | prim_mubi_pkg::mubi8            | uni     | rcv   | 1          |                                                                                                                                      |
+| racl_policies      | top_racl_pkg::racl_policy_vec   | uni     | rcv   | 1          | Incoming RACL policy vector from a racl_ctrl instance. The policy selection vector (parameter) selects the policy for each register. |
+| racl_error         | top_racl_pkg::racl_error_log    | uni     | req   | 1          | RACL error log information of this module.                                                                                           |
+| sram_rerror        | sram_ctrl_pkg::sram_error_t     | uni     | req   | 1          | SRAM read error indicating correctable and uncorrectable ECC errors.                                                                 |
+| regs_tl            | tlul_pkg::tl                    | req_rsp | rsp   | 1          |                                                                                                                                      |
+| ram_tl             | tlul_pkg::tl                    | req_rsp | rsp   | 1          |                                                                                                                                      |
 
 ## Security Alerts
 

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -32,7 +32,7 @@ module sram_ctrl
   parameter bit                         EnableRacl       = 1'b0,
   parameter bit                         RaclErrorRsp     = EnableRacl,
   parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVecRegs[NumRegsRegs] = '{NumRegsRegs{0}},
-  parameter int unsigned                RaclPolicySelRangesRamNum = 1,
+  parameter int unsigned                RaclPolicySelNumRangesRam = 1,
   // Random netlist constants
   parameter  otp_ctrl_pkg::sram_key_t   RndCnstSramKey   = RndCnstSramKeyDefault,
   parameter  otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce = RndCnstSramNonceDefault,
@@ -57,7 +57,7 @@ module sram_ctrl
   // RACL interface
   input  top_racl_pkg::racl_policy_vec_t                     racl_policies_i,
   output top_racl_pkg::racl_error_log_t                      racl_error_o,
-  input  top_racl_pkg::racl_range_t [RaclPolicySelRangesRamNum-1:0] racl_policy_sel_ranges_ram_i,
+  input  top_racl_pkg::racl_range_t [RaclPolicySelNumRangesRam-1:0] racl_policy_sel_ranges_ram_i,
   // Life-cycle escalation input (scraps the scrambling keys)
   // SEC_CM: LC_ESCALATE_EN.INTERSIG.MUBI
   input  lc_ctrl_pkg::lc_tx_t                                lc_escalate_en_i,
@@ -536,7 +536,7 @@ module sram_ctrl
     .EnableReadback  (1), // SEC_CM: MEM.READBACK
     .EnableRacl(EnableRacl),
     .RaclErrorRsp(RaclErrorRsp),
-    .RaclPolicySelNumRanges(RaclPolicySelRangesRamNum)
+    .RaclPolicySelNumRanges(RaclPolicySelNumRangesRam)
   ) u_tlul_adapter_sram_racl (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -4341,15 +4341,6 @@
           expose: "true"
           name_top: SramCtrlRetAonEccCorrection
         }
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          type: int
-          default: 1
-          local: "false"
-          expose: "true"
-          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
-        }
       ]
       inter_signal_list:
       [
@@ -4470,27 +4461,6 @@
           type: uni
           act: req
           width: 1
-          inst_name: sram_ctrl_ret_aon
-          index: -1
-        }
-        {
-          name: racl_policy_sel_ranges_ram
-          desc: Incoming array of RACL policy ranges.
-          struct: racl_range_t
-          package: top_racl_pkg
-          type: uni
-          act: rcv
-          width:
-          {
-            name: RaclPolicySelRangesRamNum
-            desc: Number of Racl Policy Selection Ranges for the Ram interface
-            param_type: int
-            unpacked_dimensions: null
-            default: 1
-            local: false
-            expose: true
-            name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
-          }
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -6676,15 +6646,6 @@
           expose: "true"
           name_top: SramCtrlMainEccCorrection
         }
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          type: int
-          default: 1
-          local: "false"
-          expose: "true"
-          name_top: SramCtrlMainRaclPolicySelRangesRamNum
-        }
       ]
       inter_signal_list:
       [
@@ -6807,27 +6768,6 @@
           type: uni
           act: req
           width: 1
-          inst_name: sram_ctrl_main
-          index: -1
-        }
-        {
-          name: racl_policy_sel_ranges_ram
-          desc: Incoming array of RACL policy ranges.
-          struct: racl_range_t
-          package: top_racl_pkg
-          type: uni
-          act: rcv
-          width:
-          {
-            name: RaclPolicySelRangesRamNum
-            desc: Number of Racl Policy Selection Ranges for the Ram interface
-            param_type: int
-            unpacked_dimensions: null
-            default: 1
-            local: false
-            expose: true
-            name_top: SramCtrlMainRaclPolicySelRangesRamNum
-          }
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -7033,15 +6973,6 @@
           expose: "true"
           name_top: SramCtrlMboxEccCorrection
         }
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          type: int
-          default: 1
-          local: "false"
-          expose: "true"
-          name_top: SramCtrlMboxRaclPolicySelRangesRamNum
-        }
       ]
       inter_signal_list:
       [
@@ -7162,27 +7093,6 @@
           type: uni
           act: req
           width: 1
-          inst_name: sram_ctrl_mbox
-          index: -1
-        }
-        {
-          name: racl_policy_sel_ranges_ram
-          desc: Incoming array of RACL policy ranges.
-          struct: racl_range_t
-          package: top_racl_pkg
-          type: uni
-          act: rcv
-          width:
-          {
-            name: RaclPolicySelRangesRamNum
-            desc: Number of Racl Policy Selection Ranges for the Ram interface
-            param_type: int
-            unpacked_dimensions: null
-            default: 1
-            local: false
-            expose: true
-            name_top: SramCtrlMboxRaclPolicySelRangesRamNum
-          }
           inst_name: sram_ctrl_mbox
           index: -1
         }
@@ -22772,27 +22682,6 @@
         index: -1
       }
       {
-        name: racl_policy_sel_ranges_ram
-        desc: Incoming array of RACL policy ranges.
-        struct: racl_range_t
-        package: top_racl_pkg
-        type: uni
-        act: rcv
-        width:
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          param_type: int
-          unpacked_dimensions: null
-          default: 1
-          local: false
-          expose: true
-          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
-        }
-        inst_name: sram_ctrl_ret_aon
-        index: -1
-      }
-      {
         name: sram_rerror
         desc: SRAM read error indicating correctable and uncorrectable ECC errors.
         struct: sram_error_t
@@ -23954,27 +23843,6 @@
         index: -1
       }
       {
-        name: racl_policy_sel_ranges_ram
-        desc: Incoming array of RACL policy ranges.
-        struct: racl_range_t
-        package: top_racl_pkg
-        type: uni
-        act: rcv
-        width:
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          param_type: int
-          unpacked_dimensions: null
-          default: 1
-          local: false
-          expose: true
-          name_top: SramCtrlMainRaclPolicySelRangesRamNum
-        }
-        inst_name: sram_ctrl_main
-        index: -1
-      }
-      {
         name: sram_rerror
         desc: SRAM read error indicating correctable and uncorrectable ECC errors.
         struct: sram_error_t
@@ -24128,27 +23996,6 @@
         type: uni
         act: req
         width: 1
-        inst_name: sram_ctrl_mbox
-        index: -1
-      }
-      {
-        name: racl_policy_sel_ranges_ram
-        desc: Incoming array of RACL policy ranges.
-        struct: racl_range_t
-        package: top_racl_pkg
-        type: uni
-        act: rcv
-        width:
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          param_type: int
-          unpacked_dimensions: null
-          default: 1
-          local: false
-          expose: true
-          name_top: SramCtrlMboxRaclPolicySelRangesRamNum
-        }
         inst_name: sram_ctrl_mbox
         index: -1
       }

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -53,7 +53,6 @@ module top_darjeeling #(
   parameter bit SramCtrlRetAonInstrExec = 0,
   parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
   parameter bit SramCtrlRetAonEccCorrection = 0,
-  parameter int SramCtrlRetAonRaclPolicySelRangesRamNum = 1,
   // parameters for rv_dm
   parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
   parameter bit RvDmUseDmiInterface = 1,
@@ -95,14 +94,12 @@ module top_darjeeling #(
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
   parameter bit SramCtrlMainEccCorrection = 0,
-  parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for sram_ctrl_mbox
   parameter int SramCtrlMboxInstSize = 4096,
   parameter int SramCtrlMboxNumRamInst = 1,
   parameter bit SramCtrlMboxInstrExec = 0,
   parameter int SramCtrlMboxNumPrinceRoundsHalf = 3,
   parameter bit SramCtrlMboxEccCorrection = 0,
-  parameter int SramCtrlMboxRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl0
   parameter RomCtrl0BootRomInitFile = "",
   parameter bit SecRomCtrl0DisableScrambling = 1'b0,
@@ -1684,12 +1681,12 @@ module top_darjeeling #(
     .InstrExec(SramCtrlRetAonInstrExec),
     .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf),
     .Outstanding(SramCtrlRetAonOutstanding),
-    .EccCorrection(SramCtrlRetAonEccCorrection),
-    .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
+    .EccCorrection(SramCtrlRetAonEccCorrection)
   ) u_sram_ctrl_ret_aon (
       // [50]: fatal_error
       .alert_tx_o  ( alert_tx[50:50] ),
       .alert_rx_i  ( alert_rx[50:50] ),
+      .racl_policy_sel_ranges_ram_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
 
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[1]),
@@ -1701,7 +1698,6 @@ module top_darjeeling #(
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
-      .racl_policy_sel_ranges_ram_i({SramCtrlRetAonRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
@@ -2059,12 +2055,12 @@ module top_darjeeling #(
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMainOutstanding),
-    .EccCorrection(SramCtrlMainEccCorrection),
-    .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
+    .EccCorrection(SramCtrlMainEccCorrection)
   ) u_sram_ctrl_main (
       // [68]: fatal_error
       .alert_tx_o  ( alert_tx[68:68] ),
       .alert_rx_i  ( alert_rx[68:68] ),
+      .racl_policy_sel_ranges_ram_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
 
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[0]),
@@ -2076,7 +2072,6 @@ module top_darjeeling #(
       .otp_en_sram_ifetch_i(sram_ctrl_main_otp_en_sram_ifetch),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
-      .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),
@@ -2101,12 +2096,12 @@ module top_darjeeling #(
     .InstrExec(SramCtrlMboxInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMboxNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMboxOutstanding),
-    .EccCorrection(SramCtrlMboxEccCorrection),
-    .RaclPolicySelRangesRamNum(SramCtrlMboxRaclPolicySelRangesRamNum)
+    .EccCorrection(SramCtrlMboxEccCorrection)
   ) u_sram_ctrl_mbox (
       // [69]: fatal_error
       .alert_tx_o  ( alert_tx[69:69] ),
       .alert_rx_i  ( alert_rx[69:69] ),
+      .racl_policy_sel_ranges_ram_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
 
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[2]),
@@ -2118,7 +2113,6 @@ module top_darjeeling #(
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
-      .racl_policy_sel_ranges_ram_i({SramCtrlMboxRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_mbox_regs_tl_req),
       .regs_tl_o(sram_ctrl_mbox_regs_tl_rsp),

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -494,7 +494,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
 %>\
   % if m["param_list"] or block.alerts:
   ${m["type"]} #(
-<%include file="/toplevel_racl.tpl" args="m=m,top=top"/>\
+<%include file="/toplevel_racl_parameters.tpl" args="module=m,top=top,block=block"/>\
   % if block.alerts:
 <%
 w = len(block.alerts)
@@ -567,6 +567,7 @@ slice = f"{lo+w-1}:{lo}"
       .alert_rx_i  ( alert_rx[${slice}] ),
       % endif
     % endif
+<%include file="/toplevel_racl_signals.tpl" args="module=m,top=top,block=block"/>\
     ## TODO: Inter-module Connection
     % if m.get('inter_signal_list'):
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5787,15 +5787,6 @@
           expose: "true"
           name_top: SramCtrlRetAonEccCorrection
         }
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          type: int
-          default: 1
-          local: "false"
-          expose: "true"
-          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
-        }
       ]
       inter_signal_list:
       [
@@ -5913,27 +5904,6 @@
           type: uni
           act: req
           width: 1
-          inst_name: sram_ctrl_ret_aon
-          index: -1
-        }
-        {
-          name: racl_policy_sel_ranges_ram
-          desc: Incoming array of RACL policy ranges.
-          struct: racl_range_t
-          package: top_racl_pkg
-          type: uni
-          act: rcv
-          width:
-          {
-            name: RaclPolicySelRangesRamNum
-            desc: Number of Racl Policy Selection Ranges for the Ram interface
-            param_type: int
-            unpacked_dimensions: null
-            default: 1
-            local: false
-            expose: true
-            name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
-          }
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -8778,15 +8748,6 @@
           expose: "true"
           name_top: SramCtrlMainEccCorrection
         }
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          type: int
-          default: 1
-          local: "false"
-          expose: "true"
-          name_top: SramCtrlMainRaclPolicySelRangesRamNum
-        }
       ]
       inter_signal_list:
       [
@@ -8906,27 +8867,6 @@
           type: uni
           act: req
           width: 1
-          inst_name: sram_ctrl_main
-          index: -1
-        }
-        {
-          name: racl_policy_sel_ranges_ram
-          desc: Incoming array of RACL policy ranges.
-          struct: racl_range_t
-          package: top_racl_pkg
-          type: uni
-          act: rcv
-          width:
-          {
-            name: RaclPolicySelRangesRamNum
-            desc: Number of Racl Policy Selection Ranges for the Ram interface
-            param_type: int
-            unpacked_dimensions: null
-            default: 1
-            local: false
-            expose: true
-            name_top: SramCtrlMainRaclPolicySelRangesRamNum
-          }
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -21570,27 +21510,6 @@
         index: -1
       }
       {
-        name: racl_policy_sel_ranges_ram
-        desc: Incoming array of RACL policy ranges.
-        struct: racl_range_t
-        package: top_racl_pkg
-        type: uni
-        act: rcv
-        width:
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          param_type: int
-          unpacked_dimensions: null
-          default: 1
-          local: false
-          expose: true
-          name_top: SramCtrlRetAonRaclPolicySelRangesRamNum
-        }
-        inst_name: sram_ctrl_ret_aon
-        index: -1
-      }
-      {
         name: sram_rerror
         desc: SRAM read error indicating correctable and uncorrectable ECC errors.
         struct: sram_error_t
@@ -23136,27 +23055,6 @@
         type: uni
         act: req
         width: 1
-        inst_name: sram_ctrl_main
-        index: -1
-      }
-      {
-        name: racl_policy_sel_ranges_ram
-        desc: Incoming array of RACL policy ranges.
-        struct: racl_range_t
-        package: top_racl_pkg
-        type: uni
-        act: rcv
-        width:
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          param_type: int
-          unpacked_dimensions: null
-          default: 1
-          local: false
-          expose: true
-          name_top: SramCtrlMainRaclPolicySelRangesRamNum
-        }
         inst_name: sram_ctrl_main
         index: -1
       }

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -67,7 +67,6 @@ module top_earlgrey #(
   parameter bit SramCtrlRetAonInstrExec = 0,
   parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
   parameter bit SramCtrlRetAonEccCorrection = 0,
-  parameter int SramCtrlRetAonRaclPolicySelRangesRamNum = 1,
   // parameters for flash_ctrl
   parameter bit SecFlashCtrlScrambleEn = 1,
   parameter int FlashCtrlProgFifoDepth = 4,
@@ -115,7 +114,6 @@ module top_earlgrey #(
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 2,
   parameter bit SramCtrlMainEccCorrection = 0,
-  parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b0,
@@ -2175,12 +2173,12 @@ module top_earlgrey #(
     .InstrExec(SramCtrlRetAonInstrExec),
     .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf),
     .Outstanding(SramCtrlRetAonOutstanding),
-    .EccCorrection(SramCtrlRetAonEccCorrection),
-    .RaclPolicySelRangesRamNum(SramCtrlRetAonRaclPolicySelRangesRamNum)
+    .EccCorrection(SramCtrlRetAonEccCorrection)
   ) u_sram_ctrl_ret_aon (
       // [34]: fatal_error
       .alert_tx_o  ( alert_tx[34:34] ),
       .alert_rx_i  ( alert_rx[34:34] ),
+      .racl_policy_sel_ranges_ram_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
 
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[1]),
@@ -2192,7 +2190,6 @@ module top_earlgrey #(
       .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
-      .racl_policy_sel_ranges_ram_i({SramCtrlRetAonRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
@@ -2667,12 +2664,12 @@ module top_earlgrey #(
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMainOutstanding),
-    .EccCorrection(SramCtrlMainEccCorrection),
-    .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
+    .EccCorrection(SramCtrlMainEccCorrection)
   ) u_sram_ctrl_main (
       // [59]: fatal_error
       .alert_tx_o  ( alert_tx[59:59] ),
       .alert_rx_i  ( alert_rx[59:59] ),
+      .racl_policy_sel_ranges_ram_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
 
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[0]),
@@ -2684,7 +2681,6 @@ module top_earlgrey #(
       .otp_en_sram_ifetch_i(sram_ctrl_main_otp_en_sram_ifetch),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
-      .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -507,7 +507,7 @@ max_intrwidth = (max(len(x.name) for x in block.interrupts)
 %>\
   % if m["param_list"] or block.alerts:
   ${m["type"]} #(
-<%include file="/toplevel_racl.tpl" args="m=m,top=top"/>\
+<%include file="/toplevel_racl_parameters.tpl" args="module=m,top=top,block=block"/>\
   % if block.alerts:
 <%
 w = len(block.alerts)
@@ -580,6 +580,7 @@ slice = f"{lo+w-1}:{lo}"
       .alert_rx_i  ( alert_rx[${slice}] ),
       % endif
     % endif
+<%include file="/toplevel_racl_signals.tpl" args="module=m,top=top,block=block"/>\
     ## TODO: Inter-module Connection
     % if m.get('inter_signal_list'):
 

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3860,15 +3860,6 @@
           expose: "true"
           name_top: SramCtrlMainEccCorrection
         }
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          type: int
-          default: 1
-          local: "false"
-          expose: "true"
-          name_top: SramCtrlMainRaclPolicySelRangesRamNum
-        }
       ]
       inter_signal_list:
       [
@@ -3981,27 +3972,6 @@
           type: uni
           act: req
           width: 1
-          inst_name: sram_ctrl_main
-          index: -1
-        }
-        {
-          name: racl_policy_sel_ranges_ram
-          desc: Incoming array of RACL policy ranges.
-          struct: racl_range_t
-          package: top_racl_pkg
-          type: uni
-          act: rcv
-          width:
-          {
-            name: RaclPolicySelRangesRamNum
-            desc: Number of Racl Policy Selection Ranges for the Ram interface
-            param_type: int
-            unpacked_dimensions: null
-            default: 1
-            local: false
-            expose: true
-            name_top: SramCtrlMainRaclPolicySelRangesRamNum
-          }
           inst_name: sram_ctrl_main
           index: -1
         }
@@ -11176,27 +11146,6 @@
         type: uni
         act: req
         width: 1
-        inst_name: sram_ctrl_main
-        index: -1
-      }
-      {
-        name: racl_policy_sel_ranges_ram
-        desc: Incoming array of RACL policy ranges.
-        struct: racl_range_t
-        package: top_racl_pkg
-        type: uni
-        act: rcv
-        width:
-        {
-          name: RaclPolicySelRangesRamNum
-          desc: Number of Racl Policy Selection Ranges for the Ram interface
-          param_type: int
-          unpacked_dimensions: null
-          default: 1
-          local: false
-          expose: true
-          name_top: SramCtrlMainRaclPolicySelRangesRamNum
-        }
         inst_name: sram_ctrl_main
         index: -1
       }

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -52,7 +52,6 @@ module top_englishbreakfast #(
   parameter bit SramCtrlMainInstrExec = 1,
   parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
   parameter bit SramCtrlMainEccCorrection = 0,
-  parameter int SramCtrlMainRaclPolicySelRangesRamNum = 1,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b1,
@@ -1193,12 +1192,12 @@ module top_englishbreakfast #(
     .InstrExec(SramCtrlMainInstrExec),
     .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf),
     .Outstanding(SramCtrlMainOutstanding),
-    .EccCorrection(SramCtrlMainEccCorrection),
-    .RaclPolicySelRangesRamNum(SramCtrlMainRaclPolicySelRangesRamNum)
+    .EccCorrection(SramCtrlMainEccCorrection)
   ) u_sram_ctrl_main (
       // [22]: fatal_error
       .alert_tx_o  ( alert_tx[22:22] ),
       .alert_rx_i  ( alert_rx[22:22] ),
+      .racl_policy_sel_ranges_ram_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
 
       // Inter-module signals
       .sram_otp_key_o(),
@@ -1210,7 +1209,6 @@ module top_englishbreakfast #(
       .otp_en_sram_ifetch_i(sram_ctrl_main_otp_en_sram_ifetch),
       .racl_policies_i(top_racl_pkg::RACL_POLICY_VEC_DEFAULT),
       .racl_error_o(),
-      .racl_policy_sel_ranges_ram_i({SramCtrlMainRaclPolicySelRangesRamNum{top_racl_pkg::RACL_RANGE_T_DEFAULT}}),
       .sram_rerror_o(),
       .regs_tl_i(sram_ctrl_main_regs_tl_req),
       .regs_tl_o(sram_ctrl_main_regs_tl_rsp),

--- a/util/raclgen.py
+++ b/util/raclgen.py
@@ -116,6 +116,7 @@ def main():
         policy_names=policy_names,
         racl_group=racl_group,
         module_name=ip_block.name,
+        ip_block=ip_block,
         if_name=args.if_name
     ).rstrip())
 

--- a/util/reggen/bus_interfaces.py
+++ b/util/reggen/bus_interfaces.py
@@ -19,15 +19,20 @@ class BusInterfaces:
                  device_async: Dict[Optional[str], str],
                  device_hier_paths: Dict[Optional[str], str],
                  racl_support: Dict[Optional[str], bool],
-                 static_racl_support: Dict[Optional[str], bool]):
+                 static_racl_support: Dict[Optional[str], bool],
+                 racl_range_support: Dict[Optional[str], bool]):
         assert has_unnamed_device or named_devices
         assert len(named_hosts) == len(set(named_hosts))
         assert len(named_devices) == len(set(named_devices))
         # Ensure that for all bus interfaces static and dynamic RACL support are not set at the
         #  same time
-        assert racl_support.keys() == static_racl_support.keys()
+        assert racl_support.keys() == static_racl_support.keys() == racl_range_support.keys()
         for if_name, if_racl_support in racl_support.items():
             assert not (if_racl_support and static_racl_support[if_name])
+        # Ensure that static or dynamic racl support exists when racl_range_support is enabled
+        for if_name, if_racl_range_support in racl_range_support.items():
+            if if_racl_range_support:
+                assert static_racl_support[if_name] or racl_support[if_name]
 
         self.has_unnamed_host = has_unnamed_host
         self.named_hosts = named_hosts
@@ -38,6 +43,7 @@ class BusInterfaces:
         self.device_hier_paths = device_hier_paths
         self.racl_support = racl_support
         self.static_racl_support = static_racl_support
+        self.racl_range_support = racl_range_support
 
     @staticmethod
     def from_raw(raw: object, where: str) -> 'BusInterfaces':
@@ -51,12 +57,13 @@ class BusInterfaces:
         device_hier_paths = {}
         racl_support_map = {}
         static_racl_support_map = {}
+        racl_range_support_map = {}
 
         for idx, raw_entry in enumerate(check_list(raw, where)):
             entry_what = 'entry {} of {}'.format(idx + 1, where)
             ed = check_keys(raw_entry, entry_what, ['protocol', 'direction'], [
                 'name', 'async', 'hier_path', 'racl_support',
-                'static_racl_support'
+                'static_racl_support', 'racl_range_support'
             ])
 
             protocol = check_str(ed['protocol'],
@@ -86,6 +93,9 @@ class BusInterfaces:
             static_racl_support = check_optional_bool(
                 ed.get('static_racl_support'),
                 'static_racl_support field of ' + entry_what)
+            racl_range_support = check_optional_bool(
+                ed.get('racl_range_support'),
+                'racl_range_support field of ' + entry_what)
 
             if direction == 'host':
                 if name is None:
@@ -132,6 +142,7 @@ class BusInterfaces:
 
                 racl_support_map[name] = bool(racl_support)
                 static_racl_support_map[name] = bool(static_racl_support)
+                racl_range_support_map[name] = bool(racl_range_support)
 
         if not (has_unnamed_device or named_devices):
             raise ValueError('No device interface at ' + where)
@@ -139,7 +150,7 @@ class BusInterfaces:
         return BusInterfaces(has_unnamed_host, named_hosts, host_async,
                              has_unnamed_device, named_devices, device_async,
                              device_hier_paths, racl_support_map,
-                             static_racl_support_map)
+                             static_racl_support_map, racl_range_support_map)
 
     def has_host(self) -> bool:
         return bool(self.has_unnamed_host or self.named_hosts)

--- a/util/topgen/templates/toplevel_racl_parameters.tpl
+++ b/util/topgen/templates/toplevel_racl_parameters.tpl
@@ -1,11 +1,11 @@
 ## Copyright lowRISC contributors (OpenTitan project).
 ## Licensed under the Apache License, Version 2.0, see LICENSE for details.
 ## SPDX-License-Identifier: Apache-2.0
-<%page args="m, top"/>\
-% if m.get('racl_mappings'):
+<%page args="module, top, block"/>\
+% if module.get('racl_mappings'):
     .EnableRacl(1'b1),
     .RaclErrorRsp(top_racl_pkg::ErrorRsp),
-  % for if_name, mappings in m['racl_mappings'].items():
+  % for if_name, mappings in module['racl_mappings'].items():
 <%
       register_mapping = mappings.get('register_mapping', {})
       window_mapping   = mappings.get('window_mapping', {})
@@ -14,7 +14,7 @@
       group_suffix = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
       if_suffix = f"_{if_name.upper()}" if if_name else ""
       if_suffix2 = f"{if_name.title()}" if if_name else ""
-      policy_sel_name = f"{m['name'].upper()}{group_suffix}{if_suffix}"
+      policy_sel_name = f"{module['name'].upper()}{group_suffix}{if_suffix}"
 %>\
     % if len(register_mapping) > 0:
     .RaclPolicySelVec${if_suffix2}(RACL_POLICY_SEL_VEC_${policy_sel_name}),
@@ -22,12 +22,11 @@
     % for window_name, policy_idx in window_mapping.items():
     .RaclPolicySelWin${if_suffix2}${window_name.replace("_","").title()}(RACL_POLICY_SEL_WIN_${policy_sel_name}_${window_name.upper()}),
     % endfor
-    % if len(range_mapping) > 0:
+    % if len(range_mapping) > 0 and block.bus_interfaces.racl_range_support.get(if_name):
     .RaclPolicySelNumRanges${if_suffix2}(RACL_POLICY_SEL_NUM_RANGES_${policy_sel_name}),
-    .RaclPolicySelRanges${if_suffix2}(RACL_POLICY_SEL_RANGES_${policy_sel_name}),
     % endif
   % endfor
 % endif
-% if m.get('template_type') == 'racl_ctrl':
+% if module.get('template_type') == 'racl_ctrl':
     .RaclErrorRsp(${"1'b1" if top['racl']['error_response'] else "1'b0"}),
 % endif

--- a/util/topgen/templates/toplevel_racl_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg.sv.tpl
@@ -38,6 +38,7 @@ package top_${topcfg["name"]}_racl_pkg;
         "policy_names"     : policy_names,
         "racl_group"       : racl_group,
         "module_name"      : m['name'],
+        "ip_block"         : name_to_block[m['type']],
         "if_name"          : if_name
       }
 %>\

--- a/util/topgen/templates/toplevel_racl_pkg_parameters.tpl
+++ b/util/topgen/templates/toplevel_racl_pkg_parameters.tpl
@@ -1,7 +1,7 @@
 ## Copyright lowRISC contributors (OpenTitan project).
 ## Licensed under the Apache License, Version 2.0, see LICENSE for details.
 ## SPDX-License-Identifier: Apache-2.0
-<%page args="register_mapping, window_mapping, range_mapping, policy_names, racl_group, module_name, if_name"/>\
+<%page args="register_mapping, window_mapping, range_mapping, policy_names, racl_group, ip_block, module_name, if_name"/>\
 <% import textwrap %>\
 <% import math %>\
 <% policy_idx_len = math.ceil(math.log10(max(1,len(policy_names)+1))) %>\
@@ -12,7 +12,8 @@
 <% window_name_len = max( (len(name) for name in window_mapping.keys()), default=0 ) %>\
 <% policy_sel_name = f"{module_name.upper()}{group_suffix}{if_suffix}" %>\
 <% fmt_sel = "RACL_POLICY_SEL{group_suffix}_{policy}" %>\
-<% policy_sel_len = max( (len(name) for name in policy_names), default=0 ) %>\
+<% policy_sel_len = max( (len(fmt_sel.format(group_suffix=group_suffix, policy=name)) for name in policy_names), default=0 ) %>\
+<% has_ranges = if_name and ip_block.bus_interfaces.racl_range_support.get(if_name) and len(range_mapping) > 0 %>\
 <% verbose = False %>\
   /**
    * Policy selection vector for ${module_name}
@@ -32,7 +33,7 @@
 (Idx ${f"{policy_idx}".rjust(policy_idx_len)})
   % endfor
 % endif
-% if len(range_mapping) > 0 and verbose:
+% if has_ranges and verbose:
    *   Range to policy mapping:
   % for range in range_mapping:
    *     ${f"0x{range['base']:08x}"} -- ${f"0x{(range['base']+range['size']):08x}"} \
@@ -46,7 +47,7 @@ policy: ${policy_names[range['policy']]} (Idx ${f"{range['policy']}".rjust(polic
 <%
     value = fmt_sel.format(group_suffix=group_suffix, policy=policy_names[policy_idx].upper())
     value += ' ' if loop.last else ','
-    value = value.ljust(policy_sel_len + 1 + len(fmt_sel.format(group_suffix=group_suffix, policy="")))
+    value = value.ljust(policy_sel_len + 1)
     comment = " // " + f"{loop.index}".rjust(reg_idx_len) \
             + " " + f"{reg_name}".ljust(reg_name_len) \
             + " : Policy Idx " + f"{policy_idx}".rjust(policy_idx_len)
@@ -58,23 +59,33 @@ policy: ${policy_names[range['policy']]} (Idx ${f"{range['policy']}".rjust(polic
 % for window_name, policy_idx in window_mapping.items():
 <%
     value = fmt_sel.format(group_suffix=group_suffix, policy=policy_names[policy_idx].upper()) + ";"
-    value = value.ljust(policy_sel_len + 1 + len(fmt_sel.format(group_suffix=group_suffix, policy="")))
+    value = value.ljust(policy_sel_len + 1)
     comment = " // Policy Idx " + f"{policy_idx}".rjust(policy_idx_len)
 %>\
   parameter racl_policy_sel_t RACL_POLICY_SEL_WIN_${policy_sel_name}_${window_name.upper()} =
     ${value}${comment}
 % endfor
-% if len(range_mapping) > 0:
+% if has_ranges:
   parameter racl_policy_sel_t RACL_POLICY_SEL_NUM_RANGES_${policy_sel_name} = ${len(range_mapping)};
-<% fmt_range = "'{{base:'h{base:04x},limit:'h{limit:04x},policy:{policy:{policy_sel_len}},enable:1'b1}}" %>\
+<%
+  fmt_range = """'{{
+      base:       'h{base:08x},
+      limit:      'h{limit:08x},
+      policy_sel: {policy} // Policy Idx {policy_idx}
+      enable:     1'b1
+    }}"""
+%>\
   parameter racl_range_t [${len(range_mapping)-1}:0] RACL_POLICY_SEL_RANGES_${policy_sel_name} = '{
 % for range in range_mapping:
 <%
-    value = fmt_range.format(base=range['base'],limit=range['limit'],policy=policy_names[range['policy']],policy_sel_len=policy_sel_len)
-    value += ' ' if loop.last else ','
-    comment = " // Policy Idx " + f"{range['policy']}".rjust(policy_idx_len)
+    policy = fmt_sel.format(group_suffix=group_suffix, policy=policy_names[range['policy']].upper())
+    value = fmt_range.format(base = range['base'],
+                             limit = range['limit'],
+                             policy = f"{policy},".ljust(policy_sel_len + 1),
+                             policy_idx = range['policy'])
+    value += '' if loop.last else ','
 %>\
-    ${value}${comment}
+    ${value}
 % endfor
   };
 % endif

--- a/util/topgen/templates/toplevel_racl_signals.tpl
+++ b/util/topgen/templates/toplevel_racl_signals.tpl
@@ -1,0 +1,21 @@
+## Copyright lowRISC contributors (OpenTitan project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+<%page args="module, top, block"/>\
+% for if_name in (x.get('name') for x in block.bus_interfaces.as_dicts()):
+%   if if_name and block.bus_interfaces.racl_range_support.get(if_name):
+<%
+      mappings        = module.get('racl_mappings', {}).get(if_name, {})
+      range_mapping   = mappings.get('range_mapping', [])
+      racl_group      = mappings.get('racl_group')
+      group_suffix    = f"_{racl_group.upper()}" if racl_group and racl_group != "Null" else ""
+      if_suffix       = f"_{if_name.upper()}" if if_name else ""
+      policy_sel_name = f"{module['name'].upper()}{group_suffix}{if_suffix}"
+%>\
+%     if len(range_mapping) > 0:
+      .racl_policy_sel_ranges_${if_name}_i(RACL_POLICY_SEL_RANGES_${policy_sel_name}),
+%     else:
+      .racl_policy_sel_ranges_${if_name}_i('{top_racl_pkg::RACL_RANGE_T_DEFAULT}),
+%     endif
+%   endif
+% endfor


### PR DESCRIPTION
A previous commit changed RACL ranges from a parameter to a signal, however the topgen templates were not updated.

This commit fixes RACL ranges up such that they are working again with topgen:

* RACL range support was added to bus_interfaces.py such that the template can know which interface uses RACL ranges.

* The parameter RaclPolicySelRangesRamNum was removed from the ip hjson and its name aligned with what the template previously generated. The template now also generates the necessary default value if RACL ranges are disabled.

* toplevel_racl.tpl was split into two files to allow generating the necessary parameters and signals: toplevel_racl_parameters.tpl and toplevel_racl_signals.tpl

* The toplevel_racl_pg.sv.tpl has been updated to only emit RACL range parameters for interfaces that support it. And the format was slightly adjusted to not generate lines that are too long.