### PR TITLE
[spi_device,rtl] Move definition of ValidCmdConfig_A

### DIFF
--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -201,11 +201,6 @@ module spi_readcmd
     cmd_info_i.busy
     };
 
-  `ASSERT(ValidCmdConfig_A,
-          main_st == MainAddress |-> (cmd_info_i.addr_mode != AddrDisabled)
-          && cmd_info_i.payload_dir == PayloadOut
-          && cmd_info_i.valid)
-
   /////////////////
   // Definitions //
   /////////////////
@@ -265,6 +260,11 @@ module spi_readcmd
     MainError
   } main_st_e;
   main_st_e main_st, main_st_d;
+
+  `ASSERT(ValidCmdConfig_A,
+          main_st == MainAddress |-> (cmd_info_i.addr_mode != AddrDisabled &&
+                                      cmd_info_i.payload_dir == PayloadOut &&
+                                      cmd_info_i.valid))
 
   /////////////
   // Signals //


### PR DESCRIPTION
Some tools (Verissimo, at least) generate a lint error because we use the MainAddress symbol before it's defined as part of the main_st_e enum.

Move it to come after that and (since I'm touching the lines anyway) tidy up the indentation to make the structure of the assertion a bit clearer.