### PR TITLE
[dv] Disable certain chip-level tests for Darjeeling

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1748,10 +1748,7 @@
       name: xcelium_ci_1
       tests: ["chip_sw_rv_core_ibex_address_translation",
               "chip_sw_rv_timer_irq",
-              "chip_sw_spi_device_pass_through",
-              "chip_sw_plic_sw_irq",
               "chip_sw_aes_enc",
-              "chip_sw_all_escalation_resets",
               "chip_sw_csrng_kat_test",
               // TODO(#26733): uncomment when these run for Darjeeling.
               // "chip_sw_aes_enc_jitter_en",


### PR DESCRIPTION
These tests are not yet thought to be reliable and we don't want to block on them in CI.

CC @alees24 who told me these tests weren't useful to have copied over from Earlgrey.