### PR TITLE
[csrng,dv] Use up-references to avoid putting "dut" in paths

### DIFF
--- a/hw/ip/csrng/dv/sva/csrng_assert_if.sv
+++ b/hw/ip/csrng/dv/sva/csrng_assert_if.sv
@@ -2,13 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Interface: csrng_assert_if
-// Description: Asserts interface to turn off assertions that have long paths
+// An interface that is bound into the csrng module and enables/disables assertions embedded in its
+// code.
 
+// These hierarchical paths are all up-references and go up one step (to leave the bound-in
+// interface), then select a block that is a child of the csrng module.
 `define PATH1 \
-    tb.dut.u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage
+    u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage
 `define PATH2 \
-    tb.dut.u_csrng_core.u_csrng_block_encrypt.u_aes_cipher_core.u_aes_cipher_control
+    u_csrng_core.u_csrng_block_encrypt.u_aes_cipher_core.u_aes_cipher_control
 `define PATH2_1 \
     gen_fsm[0].gen_fsm_p.u_aes_cipher_control_fsm_i.u_aes_cipher_control_fsm
 `define PATH2_2 \
@@ -16,17 +18,17 @@
 `define PATH2_3 \
     gen_fsm[2].gen_fsm_n.u_aes_cipher_control_fsm_i.u_aes_cipher_control_fsm
 `define PATH3 \
-    tb.dut.u_csrng_core.u_prim_mubi4_sync_cs_enable
+    u_csrng_core.u_prim_mubi4_sync_cs_enable
 `define PATH4 \
-    tb.dut.u_csrng_core.u_prim_mubi4_sync_sw_app_enable
+    u_csrng_core.u_prim_mubi4_sync_sw_app_enable
 `define PATH5 \
-    tb.dut.u_csrng_core.u_prim_mubi4_sync_read_int_state
+    u_csrng_core.u_prim_mubi4_sync_read_int_state
 `define PATH6 \
-    tb.dut.u_csrng_core.u_csrng_ctr_drbg_upd
+    u_csrng_core.u_csrng_ctr_drbg_upd
 `define PATH7 \
-    tb.dut.u_csrng_core.u_csrng_ctr_drbg_gen
+    u_csrng_core.u_csrng_ctr_drbg_gen
 `define PATH8 \
-    tb.dut.u_csrng_core.u_csrng_main_sm
+    u_csrng_core.u_csrng_main_sm
 
 interface csrng_assert_if
 (
@@ -68,3 +70,15 @@ interface csrng_assert_if
   task automatic assert_on_alert ();
   endtask // assert_on_alert
 endinterface
+
+`undef PATH8
+`undef PATH7
+`undef PATH6
+`undef PATH5
+`undef PATH4
+`undef PATH3
+`undef PATH2_3
+`undef PATH2_2
+`undef PATH2_1
+`undef PATH2
+`undef PATH1

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -38,7 +38,8 @@ module tb;
       entropy_src_if(.clk(clk), .rst_n(entropy_src_disable === 1'b1 ? 1'b0 : rst_n));
   push_pull_if#(.HostDataWidth(1))   aes_halt_if(.clk(clk), .rst_n(rst_n));
   csrng_path_if csrng_path_if (.csrng_cmd_i(csrng_cmd_i));
-  csrng_assert_if csrng_assert_if (.csrng_cmd_i(csrng_cmd_i));
+
+  bind dut csrng_assert_if csrng_assert_if (.csrng_cmd_i(csrng_cmd_i));
 
   // All CSRNG-EDN interfaces (and therefore EDN agents) can currently only be disabled together.
   assign edn_disable = csrng_agents_if.edn_disable;
@@ -113,7 +114,7 @@ module tb;
         (null, "*.env.m_aes_halt_agent*", "vif", aes_halt_if);
     uvm_config_db#(virtual csrng_cov_if)::set(null, "*.env", "csrng_cov_if", dut.u_csrng_cov_if);
     uvm_config_db#(virtual csrng_assert_if)::set(null, "*.env", "csrng_assert_vif",
-                                                 csrng_assert_if);
+                                                 dut.csrng_assert_if);
     uvm_config_db#(virtual csrng_path_if)::set(null, "*.env", "csrng_path_vif", csrng_path_if);
     uvm_config_db#(virtual csrng_agents_if)::set(null, "*.env", "csrng_agents_vif",
                                                  csrng_agents_if);


### PR DESCRIPTION
This feels slightly more clear than the code that was there before. I've also added some documentation comments and used `undef to avoid leaking the macros into other files.