### PR TITLE
[edn,dv] Simplify edn_assert_if and bind it in to shorten paths

### DIFF
--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -476,11 +476,6 @@ class edn_alert_vseq extends edn_base_vseq;
     uvm_reg       csr;
     uvm_reg_field fld;
 
-    if (cfg.use_invalid_mubi) begin
-      // Turn off DUT assertions so that the corresponding alert can fire
-      cfg.edn_assert_vif.assert_off_alert();
-    end
-
     // Depending on the value of cfg.which_invalid_mubi, one of the following ctrl register fields
     // will be set to an invalid MuBI value.
     // Apply the bad settings, and confirm the corresponding alert is fired.
@@ -561,10 +556,6 @@ class edn_alert_vseq extends edn_base_vseq;
     csr_wr(.ptr(ral.recov_alert_sts), .value(32'h0));
     // Check the recov_alert_sts register
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
-
-    // Turn assertions back on
-    cfg.edn_assert_vif.assert_on_alert();
-
   endtask
 
 endclass : edn_alert_vseq

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -56,11 +56,6 @@ class edn_base_vseq extends cip_base_vseq #(
 
     additional_data = 0;
 
-    if (cfg.use_invalid_mubi) begin
-      // Turn off DUT assertions so that the corresponding alert can fire
-      cfg.edn_assert_vif.assert_off_alert();
-    end
-
     if (cfg.boot_req_mode == MuBi4True) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(flags)
       `DV_CHECK_STD_RANDOMIZE_FATAL(glen)

--- a/hw/ip/edn/dv/sva/edn_assert_if.sv
+++ b/hw/ip/edn/dv/sva/edn_assert_if.sv
@@ -2,44 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Interface: edn_assert_if
-// Description: Asserts interface to turn off assertions that have long paths
+// An interface that is bound into the edn_core module and enables/disables assertions embedded in
+// its code.
 
-`define PATH1 \
-    tb.dut.u_edn_core.u_prim_count_max_reqs_cntr
-`define PATH2 \
-    tb.dut.u_edn_core.u_prim_mubi4_sync_edn_enable
-`define PATH3 \
-    tb.dut.u_edn_core.u_prim_mubi4_sync_boot_req_mode
-`define PATH4 \
-    tb.dut.u_edn_core.u_prim_mubi4_sync_auto_req_mode
-`define PATH5 \
-    tb.dut.u_edn_core.u_prim_mubi4_sync_cmd_fifo_rst
-`define PATH6 \
-    tb.dut.u_edn_core.u_edn_main_sm
-`define PATH7 \
-    tb.dut.u_edn_core.gen_ep_blk[0].u_edn_ack_sm_ep
+// These hierarchical paths are all up-references and go up one step (to leave the bound-in
+// interface), then select a block that is a child of the edn_core module.
 
-interface edn_assert_if(input clk, input rst_n);
+`define PATH1 u_prim_count_max_reqs_cntr
+`define PATH2 u_edn_main_sm
+`define PATH3 gen_ep_blk[0].u_edn_ack_sm_ep
+
+interface edn_assert_if();
 
   task automatic assert_off ();
     $assertoff(0, `PATH1.CntErrReported_A);
-    $assertoff(0, `PATH6.u_state_regs_A);
-    $assertoff(0, `PATH7.u_state_regs_A);
-  endtask // assert_off
+    $assertoff(0, `PATH2.u_state_regs_A);
+    $assertoff(0, `PATH3.u_state_regs_A);
+  endtask
 
   task automatic assert_on ();
     $asserton(0, `PATH1.CntErrReported_A);
-    $asserton(0, `PATH6.u_state_regs_A);
-    $asserton(0, `PATH7.u_state_regs_A);
-  endtask // assert_on
-
-  task automatic assert_off_alert ();
-
-  endtask // assert_off_alert
-
-  task automatic assert_on_alert ();
-
-  endtask // assert_on_alert
+    $asserton(0, `PATH2.u_state_regs_A);
+    $asserton(0, `PATH3.u_state_regs_A);
+  endtask
 
 endinterface
+
+`undef PATH3
+`undef PATH2
+`undef PATH1

--- a/hw/ip/edn/dv/tb.sv
+++ b/hw/ip/edn/dv/tb.sv
@@ -30,7 +30,8 @@ module tb;
   push_pull_if#(.HostDataWidth(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH))
        endpoint_if[MAX_NUM_ENDPOINTS](.clk(clk), .rst_n(rst_n));
   edn_if edn_if(.clk(clk), .rst_n(rst_n));
-  edn_assert_if edn_assert_if(.clk(clk), .rst_n(rst_n));
+
+  bind dut.u_edn_core edn_assert_if edn_assert_if ();
 
   `DV_ALERT_IF_CONNECT()
   assign edn_disable_o = edn_if.edn_disable_o;
@@ -78,7 +79,8 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual csrng_if)::set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
     uvm_config_db#(virtual edn_cov_if)::set(null, "*.env", "edn_cov_if", dut.u_edn_cov_if);
-    uvm_config_db#(virtual edn_assert_if)::set(null, "*.env", "edn_assert_vif", edn_assert_if);
+    uvm_config_db#(virtual edn_assert_if)::set(null, "*.env", "edn_assert_vif",
+                                               dut.u_edn_core.edn_assert_if);
     uvm_config_db#(virtual edn_if)::set(null, "*.env", "edn_vif", edn_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
The original motivation was to use up-references to avoid needing "tb.dut" in the hierarchical references. Since I was touching the code anyway, I also:

  - deleted empty functions and their call sites
  - removed the unused defines
  - renamed the used defines to be 1,2,3
  - used `undef to stop the definitions leaving the file