### PR TITLE
[rescue] Implement enter-on-fail and timeouts

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue.c
@@ -6,7 +6,9 @@
 
 #include "sw/device/silicon_creator/lib/error.h"
 
-void boot_svc_enter_rescue_req_init(boot_svc_enter_rescue_req_t *msg) {
+void boot_svc_enter_rescue_req_init(uint32_t skip_once,
+                                    boot_svc_enter_rescue_req_t *msg) {
+  msg->skip_once = skip_once;
   boot_svc_header_finalize(kBootSvcEnterRescueReqType,
                            sizeof(boot_svc_enter_rescue_req_t), &msg->header);
 }

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue.h
@@ -30,10 +30,16 @@ typedef struct boot_svc_enter_rescue_req {
    * Boot services message header.
    */
   boot_svc_header_t header;
+  /**
+   * Command rescue to ignore the rescue trigger one time.
+   */
+  uint32_t skip_once;
 } boot_svc_enter_rescue_req_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_svc_enter_rescue_req_t, header, 0);
-OT_ASSERT_SIZE(boot_svc_enter_rescue_req_t, CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_enter_rescue_req_t, skip_once,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 0);
+OT_ASSERT_SIZE(boot_svc_enter_rescue_req_t, CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
 
 /**
  * An Enter Rescue response.
@@ -57,9 +63,11 @@ OT_ASSERT_SIZE(boot_svc_enter_rescue_res_t, 48);
 /**
  * Initialize an enter rescue request.
  *
+ * @param skip_once Ignore the rescue trigger on the next boot.
  * @param[out] msg Output buffer for the message.
  */
-void boot_svc_enter_rescue_req_init(boot_svc_enter_rescue_req_t *msg);
+void boot_svc_enter_rescue_req_init(uint32_t skip_once,
+                                    boot_svc_enter_rescue_req_t *msg);
 
 /**
  * Initialize an enter rescue response.

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue_unittest.cc
@@ -24,7 +24,8 @@ TEST_F(BootSvcEnterRescueTest, ReqInit) {
   EXPECT_CALL(boot_svc_header_,
               Finalize(kBootSvcEnterRescueReqType, sizeof(msg), &msg.header));
 
-  boot_svc_enter_rescue_req_init(&msg);
+  boot_svc_enter_rescue_req_init(kHardenedBoolFalse, &msg);
+  EXPECT_EQ(msg.skip_once, kHardenedBoolFalse);
 }
 
 TEST_F(BootSvcEnterRescueTest, ResInit) {

--- a/sw/device/silicon_creator/lib/bootstrap.c
+++ b/sw/device/silicon_creator/lib/bootstrap.c
@@ -209,7 +209,7 @@ static rom_error_t bootstrap_handle_erase(bootstrap_state_t *state) {
   HARDENED_CHECK_EQ(*state, kBootstrapStateErase);
 
   spi_device_cmd_t cmd;
-  RETURN_IF_ERROR(spi_device_cmd_get(&cmd));
+  RETURN_IF_ERROR(spi_device_cmd_get(&cmd, /*blocking=*/true));
   // Erase requires WREN, ignore if WEL is not set.
   if (!bitfield_bit32_read(spi_device_flash_status_get(), kSpiDeviceWelBit)) {
     return kErrorOk;
@@ -275,7 +275,7 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
   HARDENED_CHECK_EQ(*state, kBootstrapStateProgram);
 
   spi_device_cmd_t cmd;
-  RETURN_IF_ERROR(spi_device_cmd_get(&cmd));
+  RETURN_IF_ERROR(spi_device_cmd_get(&cmd, /*blocking=*/true));
   // Erase and program require WREN, ignore if WEL is not set.
   if (cmd.opcode != kSpiDeviceOpcodeReset &&
       !bitfield_bit32_read(spi_device_flash_status_get(), kSpiDeviceWelBit)) {

--- a/sw/device/silicon_creator/lib/bootstrap_fuzzer_util.cc
+++ b/sw/device/silicon_creator/lib/bootstrap_fuzzer_util.cc
@@ -71,8 +71,8 @@ void AbstractBootstrapMockGroup::ConfigureMocks() {
                : stream_.ParseIntOr<uint32_t>("flash_status", 0);
   });
 
-  ON_CALL(spi_device_, CmdGet(testing::NotNull()))
-      .WillByDefault([&](spi_device_cmd_t *cmd) -> rom_error_t {
+  ON_CALL(spi_device_, CmdGet(testing::NotNull(), true))
+      .WillByDefault([&](spi_device_cmd_t *cmd, bool blocking) -> rom_error_t {
         spi_cmd_count_++;
 
         if (spi_cmd_count_ < max_spi_cmd_count_) {

--- a/sw/device/silicon_creator/lib/bootstrap_unittest_util.cc
+++ b/sw/device/silicon_creator/lib/bootstrap_unittest_util.cc
@@ -40,7 +40,7 @@ void BootstrapTest::ExpectBootstrapRequestCheck(bool requested) {
 }
 
 void BootstrapTest::ExpectSpiCmd(spi_device_cmd_t cmd) {
-  EXPECT_CALL(spi_device_, CmdGet(NotNull()))
+  EXPECT_CALL(spi_device_, CmdGet(NotNull(), true))
       .WillOnce(DoAll(SetArgPointee<0>(cmd), Return(kErrorOk)));
 }
 

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
@@ -16,8 +16,8 @@ void spi_device_init_bootstrap(void) {
   MockSpiDevice::Instance().InitBootstrap();
 }
 
-rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
-  return MockSpiDevice::Instance().CmdGet(cmd);
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd, bool blocking) {
+  return MockSpiDevice::Instance().CmdGet(cmd, blocking);
 }
 
 void spi_device_flash_status_clear(void) {

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
@@ -18,7 +18,7 @@ class MockSpiDevice : public global_mock::GlobalMock<MockSpiDevice> {
  public:
   MOCK_METHOD(void, Init, (uint8_t /*log2_density*/, const void *, size_t));
   MOCK_METHOD(void, InitBootstrap, ());
-  MOCK_METHOD(rom_error_t, CmdGet, (spi_device_cmd_t *));
+  MOCK_METHOD(rom_error_t, CmdGet, (spi_device_cmd_t *, bool));
   MOCK_METHOD(void, FlashStatusClear, ());
   MOCK_METHOD(uint32_t, FlashStatusGet, ());
 };

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -601,15 +601,18 @@ void spi_device_init(uint8_t log2_density, const void *sfdp_table,
   abs_mmio_write32(kBase + SPI_DEVICE_CMD_INFO_WRDI_REG_OFFSET, reg);
 }
 
-rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
-  uint32_t reg = 0;
-  bool cmd_pending = false;
-  while (!cmd_pending) {
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd, bool blocking) {
+  uint32_t reg;
+  bool cmd_pending;
+  do {
     // Note: Using INTR_STATE.UPLOAD_CMDFIFO_NOT_EMPTY because
     // UPLOAD_STATUS.CMDFIFO_NOTEMPTY is set before the SPI transaction ends.
     reg = abs_mmio_read32(kBase + SPI_DEVICE_INTR_STATE_REG_OFFSET);
     cmd_pending = bitfield_bit32_read(
         reg, SPI_DEVICE_INTR_COMMON_UPLOAD_CMDFIFO_NOT_EMPTY_BIT);
+  } while (!cmd_pending && blocking);
+  if (!cmd_pending) {
+    return kErrorNoData;
   }
   abs_mmio_write32(kBase + SPI_DEVICE_INTR_STATE_REG_OFFSET, UINT32_MAX);
   if (bitfield_bit32_read(reg,

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -365,9 +365,10 @@ typedef struct spi_device_cmd {
  * next word boundary.
  *
  * @param[out] cmd SPI flash command.
+ * @param blocking Whether or not to block until a command is received.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd);
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd, bool blocking);
 
 /**
  * Clears the SPI flash status register.

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -197,7 +197,7 @@ TEST_F(CmdGetTest, PayloadOverflow) {
                      std::numeric_limits<uint32_t>::max());
 
   spi_device_cmd_t cmd;
-  EXPECT_EQ(spi_device_cmd_get(&cmd), kErrorSpiDevicePayloadOverflow);
+  EXPECT_EQ(spi_device_cmd_get(&cmd, true), kErrorSpiDevicePayloadOverflow);
 }
 
 TEST_P(CmdGetTest, CmdGet) {
@@ -234,7 +234,7 @@ TEST_P(CmdGetTest, CmdGet) {
   }
 
   spi_device_cmd_t cmd;
-  EXPECT_EQ(spi_device_cmd_get(&cmd), kErrorOk);
+  EXPECT_EQ(spi_device_cmd_get(&cmd, true), kErrorOk);
   EXPECT_EQ(cmd.opcode, GetParam().opcode);
   EXPECT_EQ(cmd.address, GetParam().address);
   EXPECT_EQ(cmd.payload_byte_count, GetParam().payload.size());

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -206,6 +206,7 @@ enum module_ {
   X(kErrorRescueBadMode,              ERROR_(1, kModuleRescue, kInvalidArgument)), \
   X(kErrorRescueImageTooBig,          ERROR_(2, kModuleRescue, kFailedPrecondition)), \
   X(kErrorRescueSendStart,            ERROR_(4, kModuleRescue, kInternal)), \
+  X(kErrorRescueInactivity,           ERROR_(5, kModuleRescue, kDeadlineExceeded)), \
   \
   X(kErrorCertInternal,               ERROR_(0, kModuleCert, kInternal)), \
   X(kErrorCertInvalidArgument,        ERROR_(1, kModuleCert, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -86,6 +86,7 @@ enum module_ {
 #define DEFINE_ERRORS(X) \
   X(kErrorOk,                         0x739), \
   X(kErrorWriteBootdataThenReboot,    0x2ea), \
+  X(kErrorNoData,                     0x4d7), \
   X(kErrorUnknown,                    0xffffffff), \
   \
   X(kErrorSigverifyBadRsaSignature,   ERROR_(1, kModuleSigverify, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -11,6 +11,10 @@ load(
     "//rules/opentitan:defs.bzl",
     "opentitan_test",
 )
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "TEST_OWNER_CONFIGS",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -231,98 +235,26 @@ cc_library(
     alwayslink = True,
 )
 
-cc_library(
-    name = "test_owner_hybrid",
-    testonly = True,
-    srcs = ["test_owner.c"],
-    defines = [
-        "TEST_OWNER_KEY_ALG_HYBRID_SPX_PURE=1",
-    ],
-    deps = [
-        ":datatypes",
-        ":owner_block",
-        ":ownership",
-        "//sw/device/silicon_creator/lib:boot_data",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
-        "//sw/device/silicon_creator/lib/rescue",
-    ],
-    alwayslink = True,
-)
-
-cc_library(
-    name = "test_owner_update_mode_newversion",
-    testonly = True,
-    srcs = ["test_owner.c"],
-    defines = [
-        "TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeNewVersion",
-    ],
-    deps = [
-        ":datatypes",
-        ":owner_block",
-        ":ownership",
-        "//sw/device/silicon_creator/lib:boot_data",
-        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
-        "//sw/device/silicon_creator/lib/rescue",
-    ],
-    alwayslink = True,
-)
-
-cc_library(
-    name = "test_owner_usbdfu",
-    testonly = True,
-    srcs = ["test_owner.c"],
-    defines = [
-        # 0x55 is 'U'sb.
-        "WITH_RESCUE_PROTOCOL=0x55",
-        # Trigger 2 is strap pins combination.
-        "WITH_RESCUE_TRIGGER=2",
-        # Strapping value of 3.
-        "WITH_RESCUE_INDEX=3",
-    ],
-    deps = [
-        ":datatypes",
-        ":owner_block",
-        ":ownership",
-        "//sw/device/silicon_creator/lib:boot_data",
-        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
-        "//sw/device/silicon_creator/lib/rescue",
-    ],
-    alwayslink = True,
-)
-
-cc_library(
-    name = "test_owner_spidfu",
-    testonly = True,
-    srcs = ["test_owner.c"],
-    defines = [
-        # 0x53 is 'S'pi.
-        "WITH_RESCUE_PROTOCOL=0x53",
-        # Trigger 3 is GPIO pin.
-        "WITH_RESCUE_TRIGGER=3",
-        # When the trigger is GPIO, the index is the MuxedPad to us as the sense
-        # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
-        "WITH_RESCUE_INDEX=2",
-        # GPIO param 3 means enable the internal pull resistor and trigger
-        # rescue when the GPIO is high.
-        "WITH_RESCUE_GPIO_PARAM=3",
-    ],
-    deps = [
-        ":datatypes",
-        ":owner_block",
-        ":ownership",
-        "//sw/device/silicon_creator/lib:boot_data",
-        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
-        "//sw/device/silicon_creator/lib/rescue",
-    ],
-    alwayslink = True,
-)
+[
+    cc_library(
+        name = "test_owner_{}".format(name),
+        testonly = True,
+        srcs = ["test_owner.c"],
+        defines = param["owner_defines"],
+        deps = [
+            ":datatypes",
+            ":owner_block",
+            ":ownership",
+            "//sw/device/silicon_creator/lib:boot_data",
+            "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
+            "//sw/device/silicon_creator/lib/rescue",
+        ],
+        alwayslink = True,
+    )
+    for name, param in TEST_OWNER_CONFIGS.items()
+]
 
 cc_library(
     name = "owner_verify",

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -400,10 +400,10 @@ typedef struct owner_rescue_config {
   /**
    * The timeout configuration (not implemented yet).
    *
-   *     7        6  5               0
-   * +-----+--------+-----------------+
-   * | EoF | Enable |         Timeout |
-   * +-----+--------+-----------------+
+   *     7  6                        0
+   * +-----+--------------------------+
+   * | EoF |                  Timeout |
+   * +-----+--------------------------+
    */
   uint8_t timeout;
   /**
@@ -442,8 +442,7 @@ OT_ASSERT_MEMBER_OFFSET(owner_rescue_config_t, command_allow, 16);
 OT_ASSERT_SIZE(owner_rescue_config_t, 16);
 
 #define RESCUE_ENTER_ON_FAIL_BIT 7
-#define RESCUE_TIMEOUT_ENABLED_BIT 6
-#define RESCUE_TIMEOUT_SECONDS ((bitfield_field32_t){.mask = 0x3F, .index = 06})
+#define RESCUE_TIMEOUT_SECONDS ((bitfield_field32_t){.mask = 0x7F, .index = 0})
 #define RESCUE_GPIO_PULL_EN_BIT 1
 #define RESCUE_GPIO_VALUE_BIT 0
 #define RESCUE_DETECT ((bitfield_field32_t){.mask = 0x03, .index = 6})

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -74,11 +74,14 @@
 #ifndef WITH_RESCUE_GPIO_PARAM
 #define WITH_RESCUE_GPIO_PARAM 0
 #endif
-#ifndef WITH_RESCUE_TRIGGER
-#define WITH_RESCUE_TRIGGER 1 /* default to UartBreak */
-#endif
 #ifndef WITH_RESCUE_INDEX
 #define WITH_RESCUE_INDEX 0
+#endif
+#ifndef WITH_RESCUE_TIMEOUT
+#define WITH_RESCUE_TIMEOUT 0 /* No timeout, no enter-on-fail */
+#endif
+#ifndef WITH_RESCUE_TRIGGER
+#define WITH_RESCUE_TRIGGER 1 /* default to UartBreak */
 #endif
 
 rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
@@ -225,6 +228,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
           },
       .protocol = WITH_RESCUE_PROTOCOL,
       .gpio = WITH_RESCUE_GPIO_PARAM,
+      .timeout = WITH_RESCUE_TIMEOUT,
       .detect = (WITH_RESCUE_TRIGGER << 6) | WITH_RESCUE_INDEX,
       .start = 32,
       .size = 224,

--- a/sw/device/silicon_creator/lib/rescue/BUILD
+++ b/sw/device/silicon_creator/lib/rescue/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:ibex",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
     ],
 )

--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -139,10 +139,6 @@ rom_error_t rescue_validate_mode(uint32_t mode, rescue_state_t *state) {
       dbg_printf("ok: reboot\r\n");
       state->mode = (rescue_mode_t)mode;
       goto exitproc;
-    case kRescueModeWait:
-      dbg_printf("ok: wait after upload\r\n");
-      state->reboot = false;
-      goto exitproc;
 #ifdef ROM_EXT_KLOBBER_ALLOWED
     case kRescueModeKlobber:
       ownership_erase();

--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -8,9 +8,11 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_enter_rescue.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
@@ -22,7 +24,13 @@
 
 #include "flash_ctrl_regs.h"
 
-static hardened_bool_t rescue_requested;
+typedef enum rescue_request {
+  kRescueRequestNone = 0,
+  kRescueRequestEnter = 0x739,
+  kRescueRequestSkip = 0x1d4,
+} rescue_request_t;
+
+static rescue_request_t rescue_requested;
 
 const uint32_t kFlashPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE;
 const uint32_t kFlashBankSize =
@@ -311,22 +319,56 @@ void rescue_state_init(rescue_state_t *state, boot_data_t *bootdata,
     // after the ROM_EXT and ends at the end of the flash bank.
     state->flash_start = CHIP_ROM_EXT_SIZE_MAX;
     state->flash_limit = kFlashBankSize;
+    state->inactivity_deadline = 0;
   } else {
     state->flash_start = (uint32_t)config->start * kFlashPageSize;
     state->flash_limit =
         (uint32_t)(config->start + config->size) * kFlashPageSize;
+    uint32_t timeout =
+        bitfield_field32_read(config->timeout, RESCUE_TIMEOUT_SECONDS);
+    state->inactivity_deadline =
+        timeout ? ibex_mcycle() + ibex_time_to_cycles(1000000 * timeout) : 0;
   }
 }
 
 rom_error_t rescue_enter_handler(boot_svc_msg_t *msg) {
-  rescue_requested = kHardenedBoolTrue;
+  rescue_requested = msg->enter_rescue_req.skip_once == kHardenedBoolTrue
+                         ? kRescueRequestSkip
+                         : kRescueRequestEnter;
   boot_svc_enter_rescue_res_init(kErrorOk, &msg->enter_rescue_res);
   return kErrorOk;
 }
 
+rom_error_t rescue_inactivity(rescue_state_t *state) {
+  if (state->inactivity_deadline &&
+      ibex_mcycle() > state->inactivity_deadline) {
+    return kErrorRescueInactivity;
+  }
+  return kErrorOk;
+}
+
+hardened_bool_t rescue_enter_on_fail(const owner_rescue_config_t *config) {
+  if ((hardened_bool_t)config != kHardenedBoolFalse) {
+    if (bitfield_bit32_read(config->timeout, RESCUE_ENTER_ON_FAIL_BIT)) {
+      return kHardenedBoolTrue;
+    }
+  }
+  return kHardenedBoolFalse;
+}
+
+void rescue_skip_next_boot(void) {
+  boot_svc_msg_t *msg = &retention_sram_get()->creator.boot_svc_msg;
+  boot_svc_enter_rescue_req_init(kHardenedBoolTrue, &msg->enter_rescue_req);
+}
+
 hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config) {
-  if (rescue_requested == kHardenedBoolTrue) {
-    return kHardenedBoolTrue;
+  switch (rescue_requested) {
+    case kRescueRequestEnter:
+      return kHardenedBoolTrue;
+    case kRescueRequestSkip:
+      return kHardenedBoolFalse;
+    default:
+        /* do nothing and continue with trigger detection */;
   }
   rescue_detect_t detect = kRescueDetectBreak;
   uint32_t index = 0;

--- a/sw/device/silicon_creator/lib/rescue/rescue.h
+++ b/sw/device/silicon_creator/lib/rescue/rescue.h
@@ -68,8 +68,6 @@ typedef enum {
 
 typedef struct RescueState {
   rescue_mode_t mode;
-  // Whether to reboot automatically after an xmodem upload.
-  bool reboot;
   // Current xmodem frame.
   uint32_t frame;
   // Current data offset.

--- a/sw/device/silicon_creator/lib/rescue/rescue.h
+++ b/sw/device/silicon_creator/lib/rescue/rescue.h
@@ -68,6 +68,8 @@ typedef enum {
 
 typedef struct RescueState {
   rescue_mode_t mode;
+  // Inactivity deadline.
+  uint64_t inactivity_deadline;
   // Current xmodem frame.
   uint32_t frame;
   // Current data offset.
@@ -144,6 +146,15 @@ void rescue_state_init(rescue_state_t *state, boot_data_t *bootdata,
 rom_error_t rescue_enter_handler(boot_svc_msg_t *msg);
 
 /**
+ * Return an error if the inactivity deadline has passed.
+ *
+ * @param state Rescue state
+ * @return kErrorOk if the deadline has not passed,
+ *         kErrorRescueInactivity if it has.
+ */
+rom_error_t rescue_inactivity(rescue_state_t *state);
+
+/**
  * Perform the rescue protocol.
  *
  * @param bootdata Boot data
@@ -153,6 +164,18 @@ rom_error_t rescue_enter_handler(boot_svc_msg_t *msg);
  */
 rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
                             const owner_rescue_config_t *config);
+
+/**
+ * Enter rescue mode on boot failure.
+ * @param config The ownership rescue config (if any).
+ * @return whether to enter rescue mode.
+ */
+hardened_bool_t rescue_enter_on_fail(const owner_rescue_config_t *config);
+
+/**
+ * Send ourself a message to skip rescue entry on the next boot.
+ */
+void rescue_skip_next_boot(void);
 
 /**
  * Detect rescue entry.

--- a/sw/device/silicon_creator/lib/rescue/rescue_spi.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_spi.c
@@ -90,9 +90,15 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
   spi_device_cmd_t cmd;
   uint32_t length;
   while (true) {
-    rom_error_t result = spi_device_cmd_get(&cmd);
-    if (result != kErrorOk) {
-      break;
+    RETURN_IF_ERROR(rescue_inactivity(&ctx.state));
+    rom_error_t result = spi_device_cmd_get(&cmd, /*blocking=*/false);
+    switch (result) {
+      case kErrorOk:
+        break;
+      case kErrorNoData:
+        continue;
+      default:
+        return result;
     }
     switch (cmd.opcode) {
       case kSpiDeviceOpcodePageProgram: {
@@ -128,5 +134,4 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
         dfu_transport_result(&ctx, kErrorUsbBadSetup);
     }
   }
-  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/rescue/rescue_usb.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_usb.c
@@ -171,6 +171,7 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
   usb_ep_init(0, kUsbEpTypeControl, 0x40, dfu_protocol_handler, &ctx);
   usb_enable(true);
   while (true) {
+    RETURN_IF_ERROR(rescue_inactivity(&ctx.state));
     usb_poll();
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -92,13 +92,17 @@ static rom_error_t protocol(rescue_state_t *state) {
     result = xmodem_recv_frame(
         iohandle, state->frame, state->data + state->offset,
         sizeof(state->data) - state->offset, &rxlen, &command);
+
+    HARDENED_RETURN_IF_ERROR(rescue_inactivity(state));
     if (state->frame == 1 && result == kErrorXModemTimeoutStart) {
       xmodem_recv_start(iohandle);
       continue;
     }
+
     switch (result) {
       case kErrorOk:
-        // Packet ok.
+        // Packet ok. Cancel the inactivity deadline.
+        state->inactivity_deadline = 0;
         state->offset += rxlen;
         HARDENED_RETURN_IF_ERROR(handle_recv_modes(state));
         xmodem_ack(iohandle, true);
@@ -125,6 +129,8 @@ static rom_error_t protocol(rescue_state_t *state) {
       case kErrorXModemUnknown:
         if (state->frame == 1) {
           if (command == '\r') {
+            // Mode change request.  Cancel the inactivity deadline.
+            state->inactivity_deadline = 0;
             validate_mode(next_mode, state);
             next_mode = 0;
           } else {

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -84,8 +84,6 @@ static rom_error_t protocol(rescue_state_t *state) {
   uint8_t command;
   uint32_t next_mode = 0;
 
-  // TODO: remove automatic reboots.
-  state->reboot = false;
   validate_mode(kRescueModeFirmware, state);
 
   xmodem_recv_start(iohandle);
@@ -115,13 +113,10 @@ static rom_error_t protocol(rescue_state_t *state) {
           HARDENED_RETURN_IF_ERROR(handle_recv_modes(state));
         }
         xmodem_ack(iohandle, true);
-        if (!state->reboot) {
-          state->frame = 1;
-          state->offset = 0;
-          state->flash_offset = 0;
-          continue;
-        }
-        return kErrorRescueReboot;
+        state->frame = 1;
+        state->offset = 0;
+        state->flash_offset = 0;
+        continue;
       case kErrorXModemCrc:
         xmodem_ack(iohandle, false);
         continue;

--- a/sw/device/silicon_creator/rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/rom/bootstrap_unittest.cc
@@ -66,7 +66,7 @@ TEST_F(BootstrapTest, RequestedEnabled) {
 TEST_F(BootstrapTest, PayloadOverflowErase) {
   ExpectBootstrapRequestCheck(true);
   EXPECT_CALL(spi_device_, InitBootstrap());
-  EXPECT_CALL(spi_device_, CmdGet(NotNull()))
+  EXPECT_CALL(spi_device_, CmdGet(NotNull(), true))
       .WillOnce(Return(kErrorSpiDevicePayloadOverflow));
 
   EXPECT_EQ(bootstrap(), kErrorSpiDevicePayloadOverflow);
@@ -83,7 +83,7 @@ TEST_F(BootstrapTest, PayloadOverflowProgram) {
   ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
   EXPECT_CALL(spi_device_, FlashStatusClear());
   // Program
-  EXPECT_CALL(spi_device_, CmdGet(NotNull()))
+  EXPECT_CALL(spi_device_, CmdGet(NotNull(), true))
       .WillOnce(Return(kErrorSpiDevicePayloadOverflow));
 
   EXPECT_EQ(bootstrap(), kErrorSpiDevicePayloadOverflow);

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -12,6 +12,7 @@ load(
     "ROM_EXT_VARIATIONS",
     "ROM_EXT_VERSION",
     "SLOTS",
+    "TEST_OWNER_CONFIGS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -216,107 +217,31 @@ manifest(d = {
     for slot in SLOTS
 ]
 
-# This binary is a test-only ROM_EXT that has ownership initialized in
-# the "NewVersion" update mode.  Initializing in this mode makes the
-# test flows for the "NewVersion" style of ownership updates easier.
-opentitan_binary(
-    name = "rom_ext_owner_update_newversion",
-    testonly = True,
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-    ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
-    linker_script = ":ld_slot_a",
-    manifest = ":manifest",
-    deps = [
-        ":rom_ext_dice_x509",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner_update_mode_newversion",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-        "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
-        "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
-    ],
-)
-
-opentitan_binary(
-    name = "rom_ext_hybrid_owner_keys",
-    testonly = True,
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-    ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
-    linker_script = ":ld_slot_a",
-    manifest = ":manifest",
-    deps = [
-        ":rom_ext_dice_x509",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner_hybrid",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-        "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
-        "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
-    ],
-)
-
-# This binary is a test-only ROM_EXT that has rescue configured
-# for USB-DFU.
-opentitan_binary(
-    name = "rom_ext_usbdfu",
-    testonly = True,
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-    ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
-    linker_script = ":ld_slot_a",
-    manifest = ":manifest",
-    deps = [
-        ":rom_ext_dice_x509",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner_usbdfu",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-        "//sw/device/silicon_creator/lib/rescue:rescue_usbdfu",
-        "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
-    ],
-)
-
-# This binary is a test-only ROM_EXT that has rescue configured for USB-DFU.
-opentitan_binary(
-    name = "rom_ext_spidfu",
-    testonly = True,
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-    ],
-    extra_bazel_features = [
-        "minsize",
-        "use_lld",
-    ],
-    linker_script = ":ld_slot_a",
-    manifest = ":manifest",
-    deps = [
-        ":rom_ext_dice_x509",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner_spidfu",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-        "//sw/device/silicon_creator/lib/rescue:rescue_spidfu",
-        "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
-    ],
-)
+[
+    opentitan_binary(
+        name = "rom_ext_{}".format(name),
+        testonly = True,
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310",
+        ],
+        extra_bazel_features = [
+            "minsize",
+            "use_lld",
+        ],
+        linker_script = ":ld_slot_a",
+        manifest = ":manifest",
+        deps = [
+            ":rom_ext_dice_x509",
+            "//sw/device/lib/crt",
+            "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:test_owner_{}".format(name),
+            "//sw/device/silicon_creator/lib/ownership/keys/fake",
+            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
+        ] + param["rescue_module"],
+    )
+    for name, param in TEST_OWNER_CONFIGS.items()
+]
 
 manifest(d = {
     "name": "manifest_bad_address_translation",

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -25,3 +25,57 @@ SLOTS = [
     "b",
     "virtual",
 ]
+
+TEST_OWNER_CONFIGS = {
+    "hybrid_owner_keys": {
+        # Enable hybrid ECDSA/SPX+ ownership.
+        "owner_defines": ["TEST_OWNER_KEY_ALG_HYBRID_SPX_PURE=1"],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
+    "owner_update_newversion": {
+        # Enable the NewVersion update mode of ownership.
+        "owner_defines": ["TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeNewVersion"],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
+    "usbdfu": {
+        # Enable USB-DFU triggered by SW_STRAPS value 3.
+        "owner_defines": [
+            # 0x55 is 'U'sb.
+            "WITH_RESCUE_PROTOCOL=0x55",
+            # Trigger 2 is strap pins combination.
+            "WITH_RESCUE_TRIGGER=2",
+            # Strapping value of 3.
+            "WITH_RESCUE_INDEX=3",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_usbdfu"],
+    },
+    "spidfu": {
+        "owner_defines": [
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_GPIO_PARAM=3",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
+    "xmodem_timeout": {
+        # Enable Xmodem rescue with enter-on-fail and a timeout.
+        "owner_defines": [
+            # 0x58 is 'X'modem.
+            "WITH_RESCUE_PROTOCOL=0x58",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
+}

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_enter_rescue_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_enter_rescue_test.c
@@ -15,7 +15,8 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
   boot_svc_msg_t msg = {0};
-  boot_svc_enter_rescue_req_init(&msg.enter_rescue_req);
+  boot_svc_enter_rescue_req_init(/*skip_once=*/kHardenedBoolFalse,
+                                 &msg.enter_rescue_req);
   retram->creator.boot_svc_msg = msg;
   state->state = kBootSvcTestStateEnterRescue;
   rstmgr_reset();

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -46,6 +46,8 @@ _RESCUE_ROMEXT_RESULTS = {
 _CONFIGS = {
     "xmodem": {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
+        # This alternate rom_ext has enter-on-fail and a timeout enabled.
+        "alt_rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_timeout",
         "params": "",
         "setup": "",
         "tags": [],
@@ -102,6 +104,7 @@ _CONFIGS = {
             binaries = {
                 ":boot_test_{}".format(name): "payload",
             },
+            changes_otp = True,
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
@@ -160,6 +163,7 @@ genrule(
                 ":boot_test_{}".format(name): "payload",
                 ":bad_rom_ext": "bad_rom_ext",
             },
+            changes_otp = True,
             exit_failure = _RESCUE_ROMEXT_RESULTS[name == rxslot]["failure"],
             exit_success = _RESCUE_ROMEXT_RESULTS[name == rxslot]["success"].format(slot = name),
             image_name = "/tmp/rescue_rom_ext_{}.img".format(name),
@@ -198,6 +202,7 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
+            changes_otp = True,
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
@@ -216,7 +221,6 @@ genrule(
                 --exec="gpio apply RESET"
                 --exec="gpio remove RESET"
                 --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
-                --exec="fpga clear-bitstream"
                 no-op
             """,
         ),
@@ -236,6 +240,7 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
+            changes_otp = True,
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
@@ -258,7 +263,6 @@ genrule(
                 --exec="rescue {params} boot-svc set-next-bl0-slot --primary=SlotA --get-response=false"
                 --exec="no-op --info='##### Check for firmware execution in slot A'"
                 --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
-                --exec="fpga clear-bitstream"
                 no-op
             """,
         ),
@@ -276,6 +280,7 @@ opentitan_test(
         binaries = {
             ":boot_test_slot_a": "payload",
         },
+        changes_otp = True,
         test_cmd = """
             --exec="transport init"
             --exec="fpga load-bitstream {bitstream}"
@@ -283,7 +288,7 @@ opentitan_test(
             # First make sure the ROM_EXT is faulting because there is no firmware
             --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
             # Load firmware via rescue
-            --exec="rescue firmware --rate=230400 {payload:signed_bin}"
+            --exec="rescue firmware --rate=115200 {payload:signed_bin}"
             # Check for firmware execution
             --exec="console --baudrate=115200 --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
@@ -306,6 +311,7 @@ opentitan_test(
         binaries = {
             ":boot_test_slot_a": "payload",
         },
+        changes_otp = True,
         rom_ext = "//sw/device/silicon_creator/rom_ext/e2e/rescue/testdata:rom_ext_rescue_protocol_0",
         test_cmd = """
             --exec="transport init"
@@ -321,3 +327,67 @@ opentitan_test(
         """,
     ),
 )
+
+opentitan_test(
+    name = "rescue_inactivity_timeout",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_timeout",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            # Trigger rescue and do nothing.  We expect the inactivity timer to
+            # cause rescue to exit and then boot the firmware.
+            --exec="rescue no-op"
+            # Check for firmware execution
+            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+            no-op
+        """,
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+[
+    opentitan_test(
+        name = "rescue_enter_on_fail_{}".format(name),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        },
+        fpga = fpga_params(
+            assemble = "",
+            changes_otp = True,
+            exit_success = "BFV:05525304\r\n",
+            rom_ext = config.get(
+                "alt_rom_ext",
+                config["rom_ext"],
+            ),
+            setup = config["setup"],
+            tags = config["tags"],
+            test_cmd = """
+                --exec="transport init"
+                --exec="fpga clear-bitstream"
+                --exec="fpga load-bitstream {bitstream}"
+                {setup}
+                # Load only the ROM_EXT so the boot will fail because of no firmware.
+                --exec="bootstrap --clear-uart=true {rom_ext}"
+                # Check that the final boot-fault is "kErrorRescueInactivity".
+                --exec="console --non-interactive --exit-success='{exit_success}' --timeout=10s"
+                no-op
+            """,
+        ),
+    )
+    for name, config in _CONFIGS.items()
+]

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -414,6 +414,8 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   // Lock the flash according to the ownership configuration.
   HARDENED_RETURN_IF_ERROR(
       ownership_flash_lockdown(boot_data, boot_log, &owner_config));
+  // Lock the ownership info pages.
+  ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolFalse);
 
   // Verify expectations before jumping to owner code.
   // TODO: we really want to call rnd_uint32 here to select a random starting
@@ -751,13 +753,36 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // needed.
   HARDENED_RETURN_IF_ERROR(ownership_seal_clear());
 
-  if (rescue_detect_entry(owner_config.rescue) == kHardenedBoolTrue) {
-    rom_ext_rescue_lockdown(boot_data);
-    error = rescue_protocol(boot_data, boot_log, owner_config.rescue);
-  } else {
-    ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolFalse);
+  hardened_bool_t want_rescue = rescue_detect_entry(owner_config.rescue);
+  hardened_bool_t boot_attempted = kHardenedBoolFalse;
+
+  if (want_rescue == kHardenedBoolFalse) {
+    // If rescue wasn't triggered, try booting the next stage.
     error = rom_ext_try_next_stage(boot_data, boot_log);
+    boot_attempted = kHardenedBoolTrue;
   }
+
+  // If we haven't already entered rescue and rescue is requested (either by
+  // the rescue trigger or by a boot failure), then enter rescue.
+  if (want_rescue == kHardenedBoolTrue ||
+      rescue_enter_on_fail(owner_config.rescue) == kHardenedBoolTrue) {
+    rom_ext_rescue_lockdown(boot_data);
+    if (error != kErrorOk) {
+      dbg_printf("BFV:%x\r\n", error);
+    }
+
+    error = rescue_protocol(boot_data, boot_log, owner_config.rescue);
+
+    // If rescue timed out and we didn't attempt to boot, request skipping
+    // rescue on the next boot.  This will permit booting owner code if
+    // the rescue trigger is stuck for some reason.
+    if (error == kErrorRescueInactivity &&
+        boot_attempted == kHardenedBoolFalse) {
+      rescue_skip_next_boot();
+      rstmgr_reset();
+    }
+  }
+
   return error;
 }
 

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -587,6 +587,8 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
         trigger_index: 0,
         gpio_pull_en: false,
         gpio_value: false,
+        enter_on_failure: false,
+        timeout: 0,
         start: 32,
         size: 224,
         command_allow: [

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -52,10 +52,6 @@ with_unknown! {
     }
 }
 
-fn is_default<T: Default + Eq>(val: &T) -> bool {
-    *val == T::default()
-}
-
 /// Describes the configuration of the rescue feature of the ROM_EXT.
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub struct OwnerRescueConfig {
@@ -80,15 +76,10 @@ pub struct OwnerRescueConfig {
     /// The GPIO trigger value (only if trigger is GPIO).
     #[serde(default)]
     pub gpio_value: bool,
-    /// Enter rescue mode if boot fails (not implemented yet).
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub _enter_on_failure: bool,
-    /// Enable a timeout (rescue exits after a period of no activity; not implemented yet).
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub _timeout_enable: bool,
-    /// The timeout in seconds (not implemented yet).
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub _timeout: u8,
+    /// Enter rescue mode if boot fails.
+    pub enter_on_failure: bool,
+    /// The inactivity timeout in seconds (zero means disabled).
+    pub timeout: u8,
     /// The start of the rescue flash region (in pages).
     pub start: u16,
     /// The size of the rescue flash region (in pages).
@@ -104,9 +95,8 @@ impl Default for OwnerRescueConfig {
             protocol: RescueProtocol::default(),
             gpio_pull_en: false,
             gpio_value: false,
-            _enter_on_failure: false,
-            _timeout_enable: false,
-            _timeout: 0,
+            enter_on_failure: false,
+            timeout: 0,
             trigger: RescueTrigger::default(),
             trigger_index: 0,
             start: 0u16,
@@ -121,8 +111,7 @@ impl OwnerRescueConfig {
     const GPIO_PULL_BIT: u8 = 0x02;
     const GPIO_VALUE_BIT: u8 = 0x01;
     const ENTER_ON_FAIL_BIT: u8 = 0x80;
-    const TIMEOUT_EN_BIT: u8 = 0x40;
-    const TIMEOUT_MASK: u8 = 0x3f;
+    const TIMEOUT_MASK: u8 = 0x7f;
     const TRIGGER_SHIFT: u8 = 6;
     const INDEX_MASK: u8 = 0x3f;
 
@@ -146,9 +135,8 @@ impl OwnerRescueConfig {
             protocol,
             gpio_pull_en: gpio & Self::GPIO_PULL_BIT != 0,
             gpio_value: gpio & Self::GPIO_VALUE_BIT != 0,
-            _enter_on_failure: timeout & Self::ENTER_ON_FAIL_BIT != 0,
-            _timeout_enable: timeout & Self::TIMEOUT_EN_BIT != 0,
-            _timeout: timeout & Self::TIMEOUT_MASK,
+            enter_on_failure: timeout & Self::ENTER_ON_FAIL_BIT != 0,
+            timeout: timeout & Self::TIMEOUT_MASK,
             trigger: RescueTrigger(trigger >> Self::TRIGGER_SHIFT),
             trigger_index: trigger & Self::INDEX_MASK,
             start,
@@ -176,13 +164,8 @@ impl OwnerRescueConfig {
             },
         )?;
         dest.write_u8(
-            self._timeout & Self::TIMEOUT_MASK
-                | if self._timeout_enable {
-                    Self::TIMEOUT_EN_BIT
-                } else {
-                    0
-                }
-                | if self._enter_on_failure {
+            self.timeout & Self::TIMEOUT_MASK
+                | if self.enter_on_failure {
                     Self::ENTER_ON_FAIL_BIT
                 } else {
                     0
@@ -248,6 +231,8 @@ mod test {
   trigger_index: 0,
   gpio_pull_en: false,
   gpio_value: false,
+  enter_on_failure: false,
+  timeout: 0,
   start: 32,
   size: 100,
   command_allow: [

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -465,6 +465,31 @@ impl CommandDispatch for GetOwnerConfig {
 }
 
 #[derive(Debug, Args)]
+/// Rescue No-op.
+pub struct NoOp {
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = EntryMode::Reset,
+        help = "Method to reset for rescue mode",
+    )]
+    reset_target: EntryMode,
+}
+
+impl CommandDispatch for NoOp {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let context = context.downcast_ref::<RescueCommand>().unwrap();
+        let rescue = context.params.create(transport)?;
+        rescue.enter(transport, self.reset_target)?;
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Args)]
 pub struct EraseOwner {
     #[arg(
         long,
@@ -518,6 +543,7 @@ pub enum InternalRescueCommand {
     Firmware(Firmware),
     SetOwnerConfig(SetOwnerConfig),
     GetOwnerConfig(GetOwnerConfig),
+    NoOp(NoOp),
 }
 
 #[derive(Debug, Args)]


### PR DESCRIPTION
Implement enter-on-fail and timeouts for rescue mode.

1. Give the spi_device the capability to operate in a non-blocking fashion.  This allows us to exit the SPI rescue main loop after a period of inactivity.
2. Implement timeout functionality in rescue.  Timeouts are cancelled if there is any rescue activity at all.  "Rescue activity" means slightly different things for each of the modes:
   - For uart/xmodem, starting firmware update or changing the rescue mode cancels the timeout.
   - For DFU modes, any DFU class command cancels the timeout.
   - For DFU modes, a USB `SetInterface` also cancels the timeout if and only if it actually changes the alt-setting.  This is because it is a common default behavior of a USB host to `SetInterface` to alt-setting zero, and standard enumeration behavior should not count as rescue activity.
3. Restructure rescue trigger detection.
   - Rescue can be triggered via the boot-services `RescueEnter` command.
   - Rescue can be skipped one time via the boot-services `RescueEnter(skip_once=true)` command.
   - Rescue can be triggered via the user-configured trigger.
   - Rescue can be triggered by failing to boot the owner payload.
4. If we enter rescue and time out without ever having tried to boot, we consider that the trigger might be stuck and reboot with `RescueEnter(skip_once=true)` to attempt booting.