### PR TITLE
ownership: add validating of ECDSA owner's signature

### DIFF
--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -11,8 +11,9 @@ use std::path::PathBuf;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams};
-use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaRawSignature};
-use opentitanlib::ownership::{GlobalFlags, OwnerBlock, TlvHeader};
+use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawSignature};
+use opentitanlib::crypto::sha256::Sha256Digest;
+use opentitanlib::ownership::{GlobalFlags, KeyMaterial, OwnerBlock, OwnershipKeyAlg, TlvHeader};
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
 enum Format {
@@ -204,9 +205,60 @@ impl CommandDispatch for OwnershipActivateCommand {
     }
 }
 
+#[derive(Debug, Args)]
+pub struct OwnershipVerifyCommand {
+    #[arg(help = "A file containing a binary ownership config block")]
+    input: PathBuf,
+    #[arg(
+        short,
+        long,
+        help = "File containing the public key to verfify against"
+    )]
+    signer_pub_key: Option<PathBuf>,
+}
+
+impl CommandDispatch for OwnershipVerifyCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let input = std::fs::read(&self.input)?;
+        let mut cursor = std::io::Cursor::new(&input);
+        let header = TlvHeader::read(&mut cursor)?;
+        let parsed_config = OwnerBlock::read(&mut cursor, header)?;
+
+        match parsed_config.ownership_key_alg {
+            OwnershipKeyAlg::EcdsaP256 => (),
+            _ => {
+                return Err(anyhow!(
+                    "The only supported verification algorithm is ECDSA"
+                ))
+            }
+        };
+
+        let ecdsa_key: EcdsaPublicKey = if let Some(key_file) = &self.signer_pub_key {
+            EcdsaPublicKey::load(key_file)?
+        } else {
+            // Retrieve the ECDSA key.
+            let pubk = match parsed_config.owner_key {
+                KeyMaterial::Ecdsa(ref raw_key) => raw_key,
+                _ => return Err(anyhow!("Owner key material does not match key algorithm!")),
+            };
+            pubk.try_into()?
+        };
+        // Digest over the TBS section of the config.
+        let digest = Sha256Digest::hash(&input[..OwnerBlock::SIGNATURE_OFFSET]);
+
+        ecdsa_key.verify(&digest, &parsed_config.signature)?;
+        Ok(None)
+    }
+}
+
 #[derive(Debug, Subcommand, CommandDispatch)]
 pub enum OwnershipCommand {
     Config(OwnershipConfigCommand),
     Activate(OwnershipActivateCommand),
     Unlock(OwnershipUnlockCommand),
+    Verify(OwnershipVerifyCommand),
 }


### PR DESCRIPTION
Validate ECDSA signature of a full 2K binary owner's configuration blob.

The first 1952 bytes are considered the TBS section, the public key location is fixed inside the blob. The embedded key is used to verify the signature unless the key is supplied in a separate file.

TEST=read configuration from a live chip, converted it to binary and
     successfully verified the blob signature using both embedded and
     external keys. Also verified that a signature verification
     failure is reported if a wrong pub key file is passed in.