### PR TITLE
[ownership, rom_ext_e2e] Add newversion update test for SPX+ owners

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -271,6 +271,27 @@ cc_library(
 )
 
 cc_library(
+    name = "test_owner_hybrid_update_mode_newversion",
+    testonly = True,
+    srcs = ["test_owner.c"],
+    defines = [
+        "TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeNewVersion",
+        "TEST_OWNER_KEY_ALG_HYBRID_SPX_PREHASH=1",
+    ],
+    deps = [
+        ":datatypes",
+        ":owner_block",
+        ":ownership",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
+        "//sw/device/silicon_creator/lib/rescue",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
     name = "test_owner_usbdfu",
     testonly = True,
     srcs = ["test_owner.c"],

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -225,6 +225,7 @@ opentitan_binary(
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
     ],
     extra_bazel_features = [
         "minsize",
@@ -249,6 +250,7 @@ opentitan_binary(
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
     ],
     extra_bazel_features = [
         "minsize",
@@ -267,6 +269,34 @@ opentitan_binary(
     ],
 )
 
+# This binary is a test-only ROM_EXT that has ownership initialized in
+# the "NewVersion" update mode.  Initializing in this mode makes the
+# test flows for the "NewVersion" style of ownership updates easier.
+opentitan_binary(
+    name = "rom_ext_hybrid_owner_update_newversion",
+    testonly = True,
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
+    ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
+    linker_script = ":ld_slot_a",
+    manifest = ":manifest",
+    deps = [
+        ":rom_ext_dice_x509",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership:test_owner_hybrid_update_mode_newversion",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake",
+        "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
+        "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_a",
+    ],
+)
+
 # This binary is a test-only ROM_EXT that has rescue configured
 # for USB-DFU.
 opentitan_binary(
@@ -275,6 +305,7 @@ opentitan_binary(
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
     ],
     extra_bazel_features = [
         "minsize",
@@ -300,6 +331,7 @@ opentitan_binary(
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
     ],
     extra_bazel_features = [
         "minsize",

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -31,6 +31,7 @@ opentitan_binary(
     },
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     deps = [
         "//sw/device/lib/base:status",
@@ -51,6 +52,7 @@ opentitan_binary(
     },
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
@@ -626,6 +628,7 @@ opentitan_binary(
     },
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -748,4 +751,32 @@ ownership_transfer_test(
         "//sw/device/silicon_creator/lib:boot_log",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
+)
+
+ownership_transfer_test(
+    name = "newversion_pq_to_pq_update_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa_pub)
+            --next-key-alg=HybridSpxPrehash
+            --next-owner-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key_spx)
+            --next-unlock-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key_spx)
+            --next-activate-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key_spx)
+            --config-version=2
+            # We expect to see the version updated and the owner key the same.
+            --expect "config_version = 2"
+            --expect "owner_key = 8e3dcb50"
+        """,
+        test_harness = "//sw/host/tests/ownership:newversion_test",
+    ),
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -12,6 +12,7 @@ def ownership_transfer_test(
         srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
         exec_env = {
             "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
         },
         ecdsa_key = {
             "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -27,6 +27,8 @@ struct Opts {
     /// Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
+    #[arg(long, default_value_t = OwnershipKeyAlg::EcdsaP256, help = "Current Owner key algorithm")]
+    next_key_alg: OwnershipKeyAlg,
     #[arg(long, help = "Next Owner private key (ECDSA P256)")]
     next_owner_key: Option<PathBuf>,
     #[arg(long, help = "Next Owner public key (ECDSA P256)")]
@@ -37,6 +39,16 @@ struct Opts {
     next_unlock_key: Option<PathBuf>,
     #[arg(long, help = "Next Owner's application public key (ECDSA P256)")]
     next_application_key: PathBuf,
+
+    #[arg(long, help = "Next Owner private key (SPX)")]
+    next_owner_key_spx: Option<PathBuf>,
+    #[arg(long, help = "Next Owner public key (SPX)")]
+    next_owner_key_spx_pub: Option<PathBuf>,
+    #[arg(long, help = "Next Owner activate private key (SPX)")]
+    next_activate_key_spx: Option<PathBuf>,
+    #[arg(long, help = "Next Owner unlock private key (SPX)")]
+    next_unlock_key_spx: Option<PathBuf>,
+
     #[arg(
         long,
         default_value_t = transfer_lib::TEST_OWNER_CONFIG_VERSION,
@@ -71,17 +83,26 @@ fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     log::info!("###### Get Device Info ######");
     rescue.enter(transport, EntryMode::Reset)?;
-    let devid = rescue.get_device_id()?;
+    let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
 
     log::info!("###### Upload Owner Block ######");
     transfer_lib::create_owner(
         transport,
         &rescue,
-        /*nonce=*/ 0,
-        OwnershipKeyAlg::EcdsaP256,
-        HybridPair::load(opts.next_owner_key.as_deref(), None)?,
-        HybridPair::load(opts.next_activate_key.as_deref(), None)?,
-        HybridPair::load(opts.next_unlock_key.as_deref(), None)?,
+        data.rom_ext_nonce,
+        opts.next_key_alg,
+        HybridPair::load(
+            opts.next_owner_key.as_deref(),
+            opts.next_owner_key_spx.as_deref(),
+        )?,
+        HybridPair::load(
+            opts.next_activate_key.as_deref(),
+            opts.next_activate_key_spx.as_deref(),
+        )?,
+        HybridPair::load(
+            opts.next_unlock_key.as_deref(),
+            opts.next_unlock_key_spx.as_deref(),
+        )?,
         &opts.next_application_key,
         opts.config_kind,
         /*customize=*/


### PR DESCRIPTION
This updates the newversion_test harness to accept the SPX keys and adds an e2e test for the newversion mode update using SPX keys.