### PR TITLE
[ci] remove udev workarounds

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -52,22 +52,12 @@ jobs:
         with:
           job-patterns: ${{ inputs.bitstream }}
 
-      # We run the update command twice to workaround an issue with udev on the container,
-      # where rusb cannot dynamically update its device list in CI (udev is not completely
-      # functional). If the device is in normal mode, the first thing that opentitantool
-      # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
-      # never detected. But if we run the tool another time, the device list is queried again
-      # and opentitantool can finish the update. The device will now reboot in normal mode
-      # and work for the hyperdebug job.
       - name: Update hyperdebug firmware
         if: inputs.interface == 'hyper310'
         run: |
           ./bazelisk.sh run \
               //sw/host/opentitantool:opentitantool -- \
-              --interface=hyperdebug_dfu transport update-firmware \
-          || ./bazelisk.sh run \
-              //sw/host/opentitantool:opentitantool -- \
-              --interface=hyperdebug_dfu transport update-firmware || true
+              --interface=hyperdebug_dfu transport update-firmware
 
       - name: Execute tests
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,16 +41,8 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - name: Update hyperdebug
-        # We run the update command twice to workaround an issue with udev on the container.
-        # Where rusb cannot dynamically update its device list in CI (udev is not completely
-        # functional). If the device is in normal mode, the first thing that opentitantool
-        # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
-        # never detected. But if we run the tool another time, the device list is queried again
-        # and opentitantool can finish the update. The device will now reboot in normal mode
-        # and work for the hyperdebug job.
         run: |
-          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware \
-          || ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
+          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
 
       - name: Run tests after ROM boot stage
         if: success() || failure()
@@ -116,16 +108,8 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - name: Update hyperdebug
-        # We run the update command twice to workaround an issue with udev on the container.
-        # Where rusb cannot dynamically update its device list in CI (udev is not completely
-        # functional). If the device is in normal mode, the first thing that opentitantool
-        # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
-        # never detected. But if we run the tool another time, the device list is queried again
-        # and opentitantool can finish the update. The device will now reboot in normal mode
-        # and work for the hyperdebug job.
         run: |
-          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware \
-          || ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
+          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
 
       - name: Run tests after ROM boot stage
         if: success() || failure()
@@ -191,16 +175,8 @@ jobs:
           service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - name: Update hyperdebug
-        # We run the update command twice to workaround an issue with udev on the container.
-        # Where rusb cannot dynamically update its device list in CI (udev is not completely
-        # functional). If the device is in normal mode, the first thing that opentitantool
-        # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
-        # never detected. But if we run the tool another time, the device list is queried again
-        # and opentitantool can finish the update. The device will now reboot in normal mode
-        # and work for the hyperdebug job.
         run: |
-          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware \
-          || ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
+          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
 
       - name: Run tests
         if: success() || failure()


### PR DESCRIPTION
With https://github.com/lowRISC/container-hotplug/pull/13, containers in our CI infrastructure can now observe udev events properly, therefore the workarounds around stale USB devices can be removed.