### PR TITLE
[orchestrator] switch all SKUs to A2 product ID

### DIFF
--- a/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
@@ -4,7 +4,7 @@
 
 {
   name: "emulation",
-  product: "earlgrey_a1",
+  product: "earlgrey_a2",
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation_dice_cwt.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation_dice_cwt.hjson
@@ -4,7 +4,7 @@
 
 {
   name: "emulation_dice_cwt",
-  product: "earlgrey_a1",
+  product: "earlgrey_a2",
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation_tpm.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation_tpm.hjson
@@ -4,7 +4,7 @@
 
 {
   name: "emulation_tpm",
-  product: "earlgrey_a1",
+  product: "earlgrey_a2",
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",

--- a/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
@@ -4,7 +4,7 @@
 
 {
   name: "sival",
-  product: "earlgrey_a1",
+  product: "earlgrey_a2",
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",

--- a/sw/host/provisioning/orchestrator/data/packages/earlgrey_a2.hjson
+++ b/sw/host/provisioning/orchestrator/data/packages/earlgrey_a2.hjson
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Earglrey A2 package identifiers.
+#
+# Mapping of package names to package IDs. These will be encoded in the device
+# ID if required by the SKU. All IDs are encoded as a hex string.
+
+{
+  npcr10: "0x0",
+  npcr11: "0x1",
+  npcr12: "0x2",
+  npcr13: "0x3",
+  npcr1e: "0xE",
+}

--- a/sw/host/provisioning/orchestrator/data/products.hjson
+++ b/sw/host/provisioning/orchestrator/data/products.hjson
@@ -10,6 +10,6 @@
   },
   product_ids: {
     earlgrey_a1: "0x0002",
-    earlgrey_a2: "0x0002",  # A1 and A2 share same product IDs.
+    earlgrey_a2: "0x0003",
   },
 }

--- a/sw/host/provisioning/orchestrator/src/BUILD
+++ b/sw/host/provisioning/orchestrator/src/BUILD
@@ -13,6 +13,7 @@ py_library(
     data = [
         "//sw/host/provisioning/orchestrator/data:products.hjson",
         "//sw/host/provisioning/orchestrator/data/packages:earlgrey_a1.hjson",
+        "//sw/host/provisioning/orchestrator/data/packages:earlgrey_a2.hjson",
     ],
     imports = ["."],
     deps = [
@@ -55,6 +56,7 @@ py_library(
     data = [
         "//sw/host/provisioning/orchestrator/data:products.hjson",
         "//sw/host/provisioning/orchestrator/data/packages:earlgrey_a1.hjson",
+        "//sw/host/provisioning/orchestrator/data/packages:earlgrey_a2.hjson",
     ],
     deps = [
         ":ca_config",

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -13,7 +13,7 @@ from ca_config import CaConfig
 from util import resolve_runfile
 
 _PRODUCT_IDS_HJSON = "sw/host/provisioning/orchestrator/data/products.hjson"
-_PACKAGE_IDS_HJSON = "sw/host/provisioning/orchestrator/data/packages/earlgrey_a1.hjson"
+_PACKAGE_IDS_HJSON = "sw/host/provisioning/orchestrator/data/packages/earlgrey_a2.hjson"
 
 
 @dataclass

--- a/sw/host/provisioning/orchestrator/tests/device_id_test.py
+++ b/sw/host/provisioning/orchestrator/tests/device_id_test.py
@@ -41,7 +41,7 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(expected_field, width=4)))
 
     def test_product_id_field(self):
-        expected_field = 0x0002
+        expected_field = 0x0003
         actual_field = (self.device_id.to_int() >> 16) & 0xffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(


### PR DESCRIPTION
This updates all orchestrator configs to use the updated A2 product ID in the device ID.