### PR TITLE
[rescue, rom_ext] Lockdown before entering rescue

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/epmp.c
+++ b/sw/device/silicon_creator/lib/drivers/epmp.c
@@ -64,6 +64,19 @@ void epmp_clear_lock_bits(void) {
   }
 }
 
+void epmp_set_lock_bits(void) {
+  const uint32_t mask =
+      ((uint32_t)EPMP_CFG_L << 0 * 8) | ((uint32_t)EPMP_CFG_L << 1 * 8) |
+      ((uint32_t)EPMP_CFG_L << 2 * 8) | ((uint32_t)EPMP_CFG_L << 3 * 8);
+  CSR_SET_BITS(CSR_REG_PMPCFG0, mask);
+  CSR_SET_BITS(CSR_REG_PMPCFG1, mask);
+  CSR_SET_BITS(CSR_REG_PMPCFG2, mask);
+  CSR_SET_BITS(CSR_REG_PMPCFG3, mask);
+  for (int cfgent = 0; cfgent < 4; ++cfgent) {
+    epmp_state.pmpcfg[cfgent] |= mask;
+  }
+}
+
 uint32_t epmp_encode_napot(epmp_region_t region) {
   const uint32_t length = region.end - region.start;
   // The length must be 4 or more.

--- a/sw/device/silicon_creator/lib/drivers/epmp.h
+++ b/sw/device/silicon_creator/lib/drivers/epmp.h
@@ -49,6 +49,11 @@ void epmp_clear(uint8_t entry);
 void epmp_clear_lock_bits(void);
 
 /**
+ * Set the lock bit in all ePMP entries.
+ */
+void epmp_set_lock_bits(void);
+
+/**
  * Encode a start/end address pair to NAPOT address.
  *
  * The region start must have an alignment consistent with the region size.  The

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -298,6 +298,20 @@ rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *sealing_binding,
   return kErrorOk;
 }
 
+void sc_keymgr_disable(void) {
+  uint32_t reg =
+      bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,
+                             KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE);
+  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_SHADOWED_OPERATION_FIELD,
+                               KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_DISABLE);
+  abs_mmio_write32_shadowed(kBase + KEYMGR_CONTROL_SHADOWED_REG_OFFSET, reg);
+  abs_mmio_write32(kBase + KEYMGR_START_REG_OFFSET, 1);
+
+  // According to the documentation for the SIDELOAD_CLEAR register, an invalid
+  // destination will enable continuous clearing of all destinations.
+  abs_mmio_write32(kBase + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET, UINT32_MAX);
+}
+
 extern rom_error_t sc_keymgr_generate_key_otbn(
     sc_keymgr_key_type_t key_type, sc_keymgr_diversification_t diversification);
 extern rom_error_t sc_keymgr_sideload_clear_otbn(void);

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -327,6 +327,11 @@ rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *attest_binding,
                                     keymgr_binding_value_t *sealing_binding,
                                     uint32_t max_key_version);
 
+/**
+ * Disables the keymgr and clears all sideload slots.
+ */
+void sc_keymgr_disable(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -256,6 +256,13 @@ rom_error_t keymgr_rom_ext_test(void) {
   return kErrorOk;
 }
 
+rom_error_t keymgr_disable_test(void) {
+  sc_keymgr_disable();
+  CHECK(sc_keymgr_state_check(kScKeymgrStateDisabled) == kErrorOk,
+        "Keymgr should be in the disabled state.");
+  return kErrorOk;
+}
+
 bool test_main(void) {
   status_t result = OK_STATUS();
   dif_rstmgr_t rstmgr;
@@ -295,6 +302,7 @@ bool test_main(void) {
 
     EXECUTE_TEST(result, keymgr_rom_test);
     EXECUTE_TEST(result, keymgr_rom_ext_test);
+    EXECUTE_TEST(result, keymgr_disable_test);
     return status_ok(result);
   } else {
     LOG_FATAL("Unexpected reset reason unexpected: %08x", info);

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -126,6 +126,10 @@ rom_error_t ownership_seal_init(void) {
   return kErrorOk;
 }
 
+rom_error_t ownership_seal_clear(void) {
+  return sc_keymgr_sideload_clear(kScKeymgrDestKmac);
+}
+
 static rom_error_t seal_generate(const owner_block_t *page, uint32_t *seal) {
   size_t sealed_len = offsetof(owner_block_t, seal);
   HARDENED_RETURN_IF_ERROR(kmac_kmac256_start());

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -69,6 +69,13 @@ rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
 rom_error_t ownership_seal_init(void);
 
 /**
+ * Clear the sideloaded key in the KMAC block.
+ *
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_clear(void);
+
+/**
  * Generate a seal for an ownership page.
  *
  * @param page Owner page for which to generate the sealing value.

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -26,6 +26,7 @@
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
@@ -648,6 +649,22 @@ static void rom_ext_flash_protect_self(uint32_t rom_ext_slot) {
                                  kHardenedBoolTrue);
 }
 
+static void rom_ext_rescue_lockdown(boot_data_t *boot_data) {
+  // Forbid SRAM execution.
+  rom_ext_sram_exec(kOwnerSramExecModeDisabledLocked);
+  // Set the keymgr to disabled and clear all sideloaded keys.
+  sc_keymgr_disable();
+  // Lock out OTP.
+  otp_creator_sw_cfg_lockdown();
+  // Lock the ePMP so it cannot be changed.
+  epmp_set_lock_bits();
+  epmp_clear_rlb();
+  // Disable access to creator-level INFO pages.
+  flash_ctrl_creator_info_pages_lockdown();
+  // Set the OWNER_CONFIG pages for rescue mode (page0=ro, page1=rw).
+  ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolTrue);
+}
+
 static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
   const manifest_t *self = rom_ext_manifest();
@@ -730,8 +747,12 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->bl0_min_sec_ver = boot_data->min_security_version_bl0;
   boot_log_digest_update(boot_log);
 
+  // Now that boot services is finished, the ownership sealing key is no longer
+  // needed.
+  HARDENED_RETURN_IF_ERROR(ownership_seal_clear());
+
   if (rescue_detect_entry(owner_config.rescue) == kHardenedBoolTrue) {
-    ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolTrue);
+    rom_ext_rescue_lockdown(boot_data);
     error = rescue_protocol(boot_data, boot_log, owner_config.rescue);
   } else {
     ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolFalse);


### PR DESCRIPTION
Lockdown the chip before entering rescue mode.
- Forbid SRAM execution.
- Disable keymgr and clear sideload keys.
- Lock out OTP memory-mapped access.
- Lock the ePMP.
- Lock out access to flash INFO pages