### PR TITLE
[perso] remove UJSON CRC when sending RMA token

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -332,12 +332,10 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
   // and DICE keygen seeds).
   if (!status_ok(manuf_personalize_device_secrets_check(&otp_ctrl))) {
     lc_token_hash_t token_hash;
-    // Wait for host the host generated RMA unlock token hash to arrive over the
-    // console.
+    // Wait for the host to send the RMA unlock token hash over the console.
     LOG_INFO("Waiting For RMA Unlock Token Hash ...");
     TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-    CHECK_STATUS_OK(
-        UJSON_WITH_CRC(ujson_deserialize_lc_token_hash_t, uj, &token_hash));
+    TRY(ujson_deserialize_lc_token_hash_t(uj, &token_hash));
     TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
     TRY(manuf_personalize_device_secrets(&flash_ctrl_state, &lc_ctrl, &otp_ctrl,

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -187,7 +187,7 @@ fn send_rma_unlock_token_hash(
     )?;
     ujson_payloads.dut_in.insert(
         "FT_PERSO_RMA_TOKEN_HASH".to_string(),
-        rma_token_hash.send_with_crc(spi_console)?,
+        rma_token_hash.send(spi_console)?,
     );
     Ok(())
 }
@@ -543,7 +543,6 @@ pub fn run_ft_personalize(
     let t0 = Instant::now();
     let _ = UartConsole::wait_for(spi_console, r"Bootstrap requested.", timeout)?;
     response.stats.log_elapsed_time("first-bootstrap-done", t0);
-
     let t0 = Instant::now();
     init.bootstrap.load(transport, &second_bootstrap)?;
     response.stats.log_elapsed_time("second-bootstrap", t0);


### PR DESCRIPTION
This updates the perso flow to remove the UJSON CRC from the RMA token hash payload to facilitate development of ATE flows.