### PR TITLE
[ottf_console] enable use of GPIO TX indicator pin with SPI console to prevent host polling

### DIFF
--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -92,8 +92,10 @@ cc_library(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
     ],
 )
 

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
@@ -295,6 +296,18 @@ size_t base_fhexdump_with(buffer_sink_t out, base_hexdump_fmt_t fmt,
  * @param out the sink to use for "default" printing.
  */
 void base_set_stdout(buffer_sink_t out);
+
+/**
+ * Configures SPI device GPIO TX indicator pin for `base_print.h` to use.
+ *
+ * Note that this function will save `gpio` in a global variable, so the
+ * pointer must have static storage duration.
+ *
+ * @param gpio The GPIO handle to use for the SPI console TX indicator pin.
+ * @param tx_indicator_pin The GPIO pin to use for the SPI console TX indicator.
+ */
+void base_spi_device_set_gpio_tx_indicator(dif_gpio_t *gpio,
+                                           dif_gpio_pin_t tx_indicator_pin);
 
 /**
  * Configures SPI device stdout for `base_print.h` to use.

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -2,18 +2,17 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load("//rules:linker.bzl", "ld_library")
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
-    "cw310_params",
     "fpga_params",
     "opentitan_test",
     "verilator_params",
 )
-load("//rules:linker.bzl", "ld_library")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -317,6 +316,8 @@ dual_cc_library(
             "//sw/device/lib/base:mmio",
             "//sw/device/lib/runtime:print",
             "//sw/device/lib/dif:rv_plic",
+            "//sw/device/lib/dif:gpio",
+            "//sw/device/lib/dif:pinmux",
             "//sw/device/lib/runtime:ibex",
             "//sw/device/lib/runtime:irq",
             "//sw/device/lib/testing:spi_device_testutils",

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -9,6 +9,8 @@
 
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/dif/dif_uart.h"
@@ -47,6 +49,8 @@ enum {
 };
 
 // Potential DIF handles for OTTF console communication.
+static dif_gpio_t gpio;
+static dif_pinmux_t pinmux;
 static dif_spi_device_handle_t ottf_console_spi_device;
 static dif_uart_t ottf_console_uart;
 
@@ -171,6 +175,7 @@ void ottf_console_configure_uart(uintptr_t base_addr) {
 }
 
 void ottf_console_configure_spi_device(uintptr_t base_addr) {
+  // Configure spi_device SPI flash emulation.
   CHECK_DIF_OK(dif_spi_device_init_handle(mmio_region_from_addr(base_addr),
                                           &ottf_console_spi_device));
   CHECK_DIF_OK(dif_spi_device_configure(
@@ -251,7 +256,28 @@ void ottf_console_configure_spi_device(uintptr_t base_addr) {
     CHECK_DIF_OK(dif_spi_device_set_flash_command_slot(
         &ottf_console_spi_device, slot, kDifToggleEnabled, write_commands[i]));
   }
-  spi_device_wait_for_sync(&ottf_console_spi_device);
+
+  // Setup TX GPIO if requested.
+  if (kOttfTestConfig.console_tx_indicator.enable) {
+    CHECK_DIF_OK(dif_gpio_init(
+        mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+    CHECK_DIF_OK(dif_pinmux_init(
+        mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+    CHECK_DIF_OK(dif_pinmux_output_select(
+        &pinmux, kOttfTestConfig.console_tx_indicator.spi_console_tx_ready_mio,
+        kTopEarlgreyPinmuxOutselGpioGpio0 +
+            kOttfTestConfig.console_tx_indicator.spi_console_tx_ready_gpio));
+    CHECK_DIF_OK(dif_gpio_write(
+        &gpio, kOttfTestConfig.console_tx_indicator.spi_console_tx_ready_gpio,
+        false));
+    CHECK_DIF_OK(dif_gpio_output_set_enabled(
+        &gpio, kOttfTestConfig.console_tx_indicator.spi_console_tx_ready_gpio,
+        true));
+    base_spi_device_set_gpio_tx_indicator(
+        &gpio, kOttfTestConfig.console_tx_indicator.spi_console_tx_ready_gpio);
+  } else {
+    spi_device_wait_for_sync(&ottf_console_spi_device);
+  }
   base_spi_device_stdout(&ottf_console_spi_device);
 }
 

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -31,6 +31,25 @@ typedef struct ottf_console {
   bool test_may_clobber;
 } ottf_console_t;
 
+typedef struct ottf_console_tx_indicator {
+  /**
+   * Indicates if the TX indicator GPIO is to be used in conjunction with the
+   * SPI console.
+   */
+  bool enable;
+  /**
+   * Indicates the GPIO to use to signal to the host that the SPI console buffer
+   * is not empty.
+   */
+  uint32_t spi_console_tx_ready_gpio;
+  /**
+   * Indicates the MIO to connect to the GPIO pin above. to signal to the host
+   * that the SPI console buffer is not empty. A value of UINT32_MAX indicates
+   * this feature is unused.
+   */
+  uint32_t spi_console_tx_ready_mio;
+} ottf_console_tx_indicator_t;
+
 /**
  * Configuration variables for an on-device test.
  *
@@ -64,6 +83,13 @@ typedef struct ottf_test_config {
    * communication peripherals may be supported.
    */
   ottf_console_t console;
+
+  /**
+   * The TX indicator GPIO to use in conjunction with the SPI console, if a
+   * polling mechanism is not desireable to use such as in manufacturing ATE
+   * environments.
+   */
+  ottf_console_tx_indicator_t console_tx_indicator;
 
   /**
    * Indicates that this test will utilize the UART to receive commands from

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4313,6 +4313,35 @@ cc_library(
 )
 
 opentitan_test(
+    name = "ottf_console_with_gpio_tx_indicator_test",
+    srcs = ["ottf_console_with_gpio_tx_indicator_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+    },
+    fpga = fpga_params(
+        # We run this as part of the manuf test suite as we want to run it in
+        # the hyper310 exec_env as this is most realistic of a provisioning
+        # scenario where this feature will be used. Without this tag, the test
+        # is not run in CI which causes a CI error ("Verify FPGA Jobs" check
+        # will fail).
+        tags = ["manuf"],
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap="{firmware}"
+            "{firmware:elf}"
+        """,
+        test_harness = "//sw/host/tests/chip/ottf_console_with_gpio_tx_indicator",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "spi_device_ottf_console_test",
     srcs = ["spi_device_ottf_console_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
+++ b/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
@@ -1,0 +1,101 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static const dif_gpio_pin_t kGpioPinSpiConsoleTxReady = 0;
+
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false,
+                        .silence_console_prints = true,
+                        .console_tx_indicator.enable = true,
+                        .console_tx_indicator.spi_console_tx_ready_mio =
+                            kTopEarlgreyPinmuxMioOutIoa5,
+                        .console_tx_indicator.spi_console_tx_ready_gpio =
+                            kGpioPinSpiConsoleTxReady);
+
+static const char kTest4KbDataStr[] =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+bool test_main(void) {
+  // Send a string using the TX-ready GPIO indicator pin. Note, we use
+  // `base_printf()`directly, instead of LOG_INFO(), as we only want to print
+  // the exact string as is, with no additional metadata.
+  base_printf("ABC");
+
+  // Send 4k worth of data to the host using the TX-ready GPIO indicator pin.
+  // 4k is larger than the 2k SPI read buffer size, which excercies the circular
+  // buffer operations.
+  base_printf("%s", kTest4KbDataStr);
+
+  // Repeat the above.
+  base_printf("ABC");
+  base_printf("%s", kTest4KbDataStr);
+
+  abort();
+
+  return true;
+}

--- a/sw/host/opentitanlib/src/console/spi.rs
+++ b/sw/host/opentitanlib/src/console/spi.rs
@@ -5,9 +5,11 @@
 use anyhow::Result;
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
+use std::rc::Rc;
 use std::time::Duration;
 
 use crate::io::console::ConsoleDevice;
+use crate::io::gpio::GpioPin;
 use crate::io::spi::Target;
 use crate::spiflash::flash::SpiFlash;
 
@@ -17,6 +19,7 @@ pub struct SpiConsoleDevice<'a> {
     console_next_frame_number: Cell<u32>,
     rx_buf: RefCell<VecDeque<u8>>,
     next_read_address: Cell<u32>,
+    device_tx_ready: Option<&'a Rc<dyn GpioPin>>,
 }
 
 impl<'a> SpiConsoleDevice<'a> {
@@ -28,7 +31,7 @@ impl<'a> SpiConsoleDevice<'a> {
     const SPI_TX_LAST_CHUNK_MAGIC_ADDRESS: u32 = 0x100;
     const SPI_BOOT_MAGIC_PATTERN: u32 = 0xcafeb002;
 
-    pub fn new(spi: &'a dyn Target) -> Result<Self> {
+    pub fn new(spi: &'a dyn Target, device_tx_ready: Option<&'a Rc<dyn GpioPin>>) -> Result<Self> {
         let flash = SpiFlash {
             ..Default::default()
         };
@@ -38,6 +41,7 @@ impl<'a> SpiConsoleDevice<'a> {
             rx_buf: RefCell::new(VecDeque::new()),
             console_next_frame_number: Cell::new(0),
             next_read_address: Cell::new(0),
+            device_tx_ready,
         })
     }
 

--- a/sw/host/opentitanlib/src/io/console.rs
+++ b/sw/host/opentitanlib/src/io/console.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 
 use super::nonblocking_help::{NoNonblockingHelp, NonblockingHelp};
 use crate::impl_serializable_error;
+use crate::io::gpio::GpioPin;
 
 /// Errors related to the console interface.
 #[derive(Error, Debug, Serialize, Deserialize)]
@@ -34,6 +35,11 @@ pub trait ConsoleDevice {
 
     fn set_break(&self, _enable: bool) -> Result<()> {
         Err(ConsoleError::GenericError("break unsupported".into()).into())
+    }
+
+    /// Query if TX-ready pin non-polling mode is supported.
+    fn get_tx_ready_pin(&self) -> Result<Option<&Rc<dyn GpioPin>>> {
+        Ok(None)
     }
 
     /// Query if nonblocking mio mode is supported.

--- a/sw/host/provisioning/cp/src/main.rs
+++ b/sw/host/provisioning/cp/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
     let spi = transport.spi(&opts.console_spi)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
 
     let provisioning_data = ManufCpProvisioningData {
         wafer_auth_secret: hex_string_to_u32_arrayvec::<8>(

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -115,7 +115,7 @@ fn main() -> Result<()> {
     let transport = backend::create(&opts.init.backend_opts)?;
     transport.apply_default_configuration(None)?;
     let spi = transport.spi(&opts.console_spi)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     InitializeTest::print_result("load_bitstream", opts.init.load_bitstream.init(&transport))?;
 
     // Parse and format tokens.

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "ottf_console_with_gpio_tx_indicator",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:clap",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:log",
+        "@crate_index//:object",
+    ],
+)

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::io::gpio::{PinMode, PullMode};
+use opentitanlib::test_utils;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "20s")]
+    timeout: Duration,
+
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "BOOTSTRAP")]
+    console_spi: String,
+
+    /// Path to the firmware's ELF file, for querying symbol addresses.
+    #[arg(value_name = "FIRMWARE_ELF")]
+    firmware_elf: PathBuf,
+}
+
+fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    // Setup the SPI console with the GPIO TX indicator pin.
+    let spi = transport.spi(&opts.console_spi)?;
+    let device_console_tx_ready_pin = &transport.gpio_pin("IOA5")?;
+    device_console_tx_ready_pin.set_mode(PinMode::Input)?;
+    device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
+
+    // Load the ELF binary and get the expect data.
+    let elf_binary = fs::read(&opts.firmware_elf)?;
+    let object = object::File::parse(&*elf_binary)?;
+
+    for _ in 0..2 {
+        // Receive simple string from the device.
+        _ = UartConsole::wait_for(&spi_console_device, "ABC", opts.timeout)?;
+
+        // Receive 4K of data from the device.
+        let data = test_utils::object::symbol_data(&object, "kTest4KbDataStr")?;
+        let data_str = std::str::from_utf8(&data)?.trim_matches(char::from(0));
+        _ = UartConsole::wait_for(&spi_console_device, data_str, opts.timeout)?;
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+    execute_test!(spi_device_console_test, &opts, &transport);
+    Ok(())
+}

--- a/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
@@ -48,7 +48,7 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     let mut stdout = std::io::stdout();
     let spi = transport.spi(&opts.console_spi)?;
 
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     /* Load the ELF binary and get the expect data.*/

--- a/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
 
     let transport = opts.init.init_target()?;
     let spi = transport.spi(&opts.console_spi)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     execute_test!(test_perso_blob_strcut, &opts, &spi_console_device);

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -130,7 +130,7 @@ fn run_aes_testcase(
 
 fn test_aes(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -128,7 +128,7 @@ fn run_drbg_testcase(
 
 fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -220,7 +220,7 @@ fn run_ecdh_testcase(
 
 fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -511,7 +511,7 @@ fn run_ecdsa_testcase(
 
 fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -158,7 +158,7 @@ fn run_hash_testcase(
 
 fn test_hash(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -126,7 +126,7 @@ fn run_hmac_testcase(
 
 fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -141,7 +141,7 @@ fn run_kmac_testcase(
 
 fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
+++ b/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
@@ -126,7 +126,7 @@ fn run_sphincsplus_testcase(
 
 fn test_sphincsplus(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let spi = transport.spi("BOOTSTRAP")?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
     let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;

--- a/sw/host/tests/manuf/cp_provision_functest/src/main.rs
+++ b/sw/host/tests/manuf/cp_provision_functest/src/main.rs
@@ -221,7 +221,7 @@ fn main() -> Result<()> {
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
     let spi = transport.spi(&opts.console_spi)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
 
     // Transition from RAW to TEST_UNLOCKED0.
     unlock_raw(


### PR DESCRIPTION
This PR has two commits that enables the use of a GPIO TX-ready indicator pin in conjunction with the SPI console to eliminate the need for the host to constantly poll the SPI egress buffer for data.

The first commit adds an TX-ready indicator GPIO pin to the SpiConsoleDevice in opentitanlib that can alternatively be sampled by the SpiConsoleDevice to determine when the host should attempt to read out data from the device.

The second commit updates the OTTF console to enable the device to drive this TX-ready GPIO indicator pin when data is added to the egress buffer.

Both of these commits will enable capturing waveforms of the SPI console during the personalization flow to develop ATE test patterns. See the below waveform captured during the newly added test. See how the host only clocks out data from the spi_device console when the GPIO indicator on IOA5 toggles from L-->H (note the first blob of SPI traffic is bootstrap; the remaining spurts of traffic are the console activity).

<img width="2528" alt="Screenshot 2025-04-11 at 1 17 07 PM" src="https://github.com/user-attachments/assets/ac4a7df8-dd99-4ab0-9aea-1d7b265c8a2e" />


