### PR TITLE
[hw,rv_core_ibex,rtl] Fix NumReg parameter for named config port

### DIFF
--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -51,8 +51,8 @@ module ${module_instance_name}
 % if racl_support:
   parameter bit                             EnableRacl             = 1'b0,
   parameter bit                             RaclErrorRsp           = EnableRacl,
-  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${module_instance_name}_reg_pkg::NumRegs] = 
-    '{${module_instance_name}_reg_pkg::NumRegs{0}},
+  parameter top_racl_pkg::racl_policy_sel_t RaclPolicySelVec[${module_instance_name}_reg_pkg::NumRegsCfg] = 
+    '{${module_instance_name}_reg_pkg::NumRegsCfg{0}},
 % endif
   parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
 ) (


### PR DESCRIPTION
RV Core Ibex has a named TLUL config port, thus also the NumRegs parameter is including that name. Use the proper name when enabling RACL.