### PR TITLE
[hw,ac_range,rtl] Log RACL hit on denied accesses

### DIFF
--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -303,13 +303,15 @@ module ${module_instance_name}
   assign hw2reg.log_status.denied_no_match.de = log_first_deny | clear_log;
   assign hw2reg.log_status.denied_no_match.d = log_first_deny ? ~(|addr_hit) : 1'b0;
 
-  // TODO(#25454): RACL status gets implemented once RACL is in
+  // Log if denied range lacks a valid READ RACL hit
   assign hw2reg.log_status.denied_racl_read.de = log_first_deny | clear_log;
-  assign hw2reg.log_status.denied_racl_read.d  = '0;
+  assign hw2reg.log_status.denied_racl_read.d  =
+    log_first_deny ? ((read_access | execute_access) & ~racl_read_hit[deny_index]) : '0;
 
-  // TODO(#25454): RACL status gets implemented once RACL is in
+  // Log if denied range lacks a valid WRITE RACL hit
   assign hw2reg.log_status.denied_racl_write.de = log_first_deny | clear_log;
-  assign hw2reg.log_status.denied_racl_write.d  = '0;
+  assign hw2reg.log_status.denied_racl_write.d  =
+    log_first_deny ? (write_access & ~racl_write_hit[deny_index]) : '0;
 
   assign hw2reg.log_status.denied_source_role.de = log_first_deny | clear_log;
   assign hw2reg.log_status.denied_source_role.d  = log_first_deny ? racl_role : '0;

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -303,13 +303,15 @@ module ac_range_check
   assign hw2reg.log_status.denied_no_match.de = log_first_deny | clear_log;
   assign hw2reg.log_status.denied_no_match.d = log_first_deny ? ~(|addr_hit) : 1'b0;
 
-  // TODO(#25454): RACL status gets implemented once RACL is in
+  // Log if denied range lacks a valid READ RACL hit
   assign hw2reg.log_status.denied_racl_read.de = log_first_deny | clear_log;
-  assign hw2reg.log_status.denied_racl_read.d  = '0;
+  assign hw2reg.log_status.denied_racl_read.d  =
+    log_first_deny ? ((read_access | execute_access) & ~racl_read_hit[deny_index]) : '0;
 
-  // TODO(#25454): RACL status gets implemented once RACL is in
+  // Log if denied range lacks a valid WRITE RACL hit
   assign hw2reg.log_status.denied_racl_write.de = log_first_deny | clear_log;
-  assign hw2reg.log_status.denied_racl_write.d  = '0;
+  assign hw2reg.log_status.denied_racl_write.d  =
+    log_first_deny ? (write_access & ~racl_write_hit[deny_index]) : '0;
 
   assign hw2reg.log_status.denied_source_role.de = log_first_deny | clear_log;
   assign hw2reg.log_status.denied_source_role.d  = log_first_deny ? racl_role : '0;


### PR DESCRIPTION
This PR adds the ability to log an RACL violation as part of a denied access, which was previously missing in the implementation.

Closes #25454