### PR TITLE
[sw/crypto] use hardened mem copy

### DIFF
--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -211,7 +211,6 @@ static status_t get_block(otcrypto_const_byte_buf_t input,
     HARDENED_CHECK_LT(index, num_full_blocks);
     // No need to worry about padding, just copy the data into the output
     // block.
-    // TODO(#17711) Change to `hardened_memcpy`.
     memcpy(block->data, &input.data[index * kAesBlockNumBytes],
            kAesBlockNumBytes);
     return OTCRYPTO_OK;
@@ -352,7 +351,6 @@ otcrypto_status_t otcrypto_aes(const otcrypto_blinded_key_t *key,
   for (i = block_offset; launder32(i) < input_nblocks; ++i) {
     HARDENED_TRY(get_block(cipher_input, aes_padding, i, &block_in));
     TRY(aes_update(&block_out, &block_in));
-    // TODO(#17711) Change to `hardened_memcpy`.
     memcpy(&cipher_output.data[(i - block_offset) * kAesBlockNumBytes],
            block_out.data, kAesBlockNumBytes);
   }
@@ -363,7 +361,6 @@ otcrypto_status_t otcrypto_aes(const otcrypto_blinded_key_t *key,
   // input).
   for (i = block_offset; launder32(i) > 0; --i) {
     HARDENED_TRY(aes_update(&block_out, /*src=*/NULL));
-    // TODO(#17711) Change to `hardened_memcpy`.
     memcpy(&cipher_output.data[(input_nblocks - i) * kAesBlockNumBytes],
            block_out.data, kAesBlockNumBytes);
   }

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -211,6 +211,7 @@ static status_t get_block(otcrypto_const_byte_buf_t input,
     HARDENED_CHECK_LT(index, num_full_blocks);
     // No need to worry about padding, just copy the data into the output
     // block.
+    // TODO(#17711) Change to `hardened_memcpy`.
     memcpy(block->data, &input.data[index * kAesBlockNumBytes],
            kAesBlockNumBytes);
     return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -26,12 +26,12 @@
  * @return OK or error.
  */
 static otcrypto_status_t seed_material_construct(
-    otcrypto_const_byte_buf_t value, entropy_seed_material_t *seed_material) {
-  if (value.len > kEntropySeedBytes) {
+    otcrypto_const_word32_buf_t value, entropy_seed_material_t *seed_material) {
+  if (value.len > kEntropySeedWords) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  size_t nwords = ceil_div(value.len, sizeof(uint32_t));
+  size_t nwords = value.len;
   seed_material->len = nwords;
 
   // Initialize the set words to zero.
@@ -42,8 +42,7 @@ static otcrypto_status_t seed_material_construct(
   }
 
   // Copy seed data.
-  hardened_memcpy(seed_material->data, (uint32_t *)value.data,
-                  value.len / sizeof(uint32_t));
+  hardened_memcpy(seed_material->data, value.data, value.len);
 
   return OTCRYPTO_OK;
 }
@@ -62,7 +61,7 @@ static otcrypto_status_t seed_material_construct(
  */
 static otcrypto_status_t seed_material_xor(
     otcrypto_const_byte_buf_t value, entropy_seed_material_t *seed_material) {
-  if (value.len > kEntropySeedBytes) {
+  if (value.len > kEntropySeedWords) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (value.len == 0) {
@@ -85,7 +84,7 @@ static otcrypto_status_t seed_material_xor(
 }
 
 otcrypto_status_t otcrypto_drbg_instantiate(
-    otcrypto_const_byte_buf_t perso_string) {
+    otcrypto_const_word32_buf_t perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string.len != 0 && perso_string.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -100,7 +99,7 @@ otcrypto_status_t otcrypto_drbg_instantiate(
 }
 
 otcrypto_status_t otcrypto_drbg_reseed(
-    otcrypto_const_byte_buf_t additional_input) {
+    otcrypto_const_word32_buf_t additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input.len != 0 && additional_input.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
@@ -114,12 +113,13 @@ otcrypto_status_t otcrypto_drbg_reseed(
 }
 
 otcrypto_status_t otcrypto_drbg_manual_instantiate(
-    otcrypto_const_byte_buf_t entropy, otcrypto_const_byte_buf_t perso_string) {
+    otcrypto_const_word32_buf_t entropy,
+    otcrypto_const_byte_buf_t perso_string) {
   // Check for NULL pointers or bad length.
   if (perso_string.len != 0 && perso_string.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (entropy.data == NULL || entropy.len != kEntropySeedBytes) {
+  if (entropy.data == NULL || entropy.len != kEntropySeedWords) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -134,13 +134,13 @@ otcrypto_status_t otcrypto_drbg_manual_instantiate(
 }
 
 otcrypto_status_t otcrypto_drbg_manual_reseed(
-    otcrypto_const_byte_buf_t entropy,
+    otcrypto_const_word32_buf_t entropy,
     otcrypto_const_byte_buf_t additional_input) {
   // Check for NULL pointers or bad length.
   if (additional_input.len != 0 && additional_input.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
-  if (entropy.data == NULL || entropy.len != kEntropySeedBytes) {
+  if (entropy.data == NULL || entropy.len != kEntropySeedWords) {
     return OTCRYPTO_BAD_ARGS;
   }
 
@@ -167,7 +167,7 @@ otcrypto_status_t otcrypto_drbg_manual_reseed(
  * @return Result status; OK or error
  */
 static otcrypto_status_t generate(hardened_bool_t fips_check,
-                                  otcrypto_const_byte_buf_t additional_input,
+                                  otcrypto_const_word32_buf_t additional_input,
                                   otcrypto_word32_buf_t drbg_output) {
   if (drbg_output.len == 0) {
     // Nothing to do.
@@ -187,14 +187,14 @@ static otcrypto_status_t generate(hardened_bool_t fips_check,
 }
 
 otcrypto_status_t otcrypto_drbg_generate(
-    otcrypto_const_byte_buf_t additional_input,
+    otcrypto_const_word32_buf_t additional_input,
     otcrypto_word32_buf_t drbg_output) {
   return generate(/*fips_check=*/kHardenedBoolTrue, additional_input,
                   drbg_output);
 }
 
 otcrypto_status_t otcrypto_drbg_manual_generate(
-    otcrypto_const_byte_buf_t additional_input,
+    otcrypto_const_word32_buf_t additional_input,
     otcrypto_word32_buf_t drbg_output) {
   return generate(/*fips_check=*/kHardenedBoolFalse, additional_input,
                   drbg_output);

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -42,8 +42,8 @@ static otcrypto_status_t seed_material_construct(
   }
 
   // Copy seed data.
-  // TODO(#17711) Change to `hardened_memcpy`.
-  memcpy(seed_material->data, value.data, value.len);
+  hardened_memcpy(seed_material->data, (uint32_t *)value.data,
+                  value.len / sizeof(uint32_t));
 
   return OTCRYPTO_OK;
 }

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -17,7 +17,7 @@
 #define MODULE_ID MAKE_MODULE_ID('k', 't', 'r')
 
 otcrypto_status_t otcrypto_symmetric_keygen(
-    otcrypto_const_byte_buf_t perso_string, otcrypto_blinded_key_t *key) {
+    otcrypto_const_word32_buf_t perso_string, otcrypto_blinded_key_t *key) {
   if (key == NULL || key->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -44,7 +44,7 @@ otcrypto_status_t otcrypto_symmetric_keygen(
 
   // Construct an empty buffer for the "additional input" to the DRBG generate
   // function.
-  otcrypto_const_byte_buf_t empty = {.data = NULL, .len = 0};
+  otcrypto_const_word32_buf_t empty = {.data = NULL, .len = 0};
 
   // Generate each share of the key independently.
   HARDENED_TRY(otcrypto_drbg_instantiate(perso_string));

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -29,7 +29,7 @@ extern "C" {
  * @return Result of the DRBG instantiate operation.
  */
 otcrypto_status_t otcrypto_drbg_instantiate(
-    otcrypto_const_byte_buf_t perso_string);
+    otcrypto_const_word32_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -41,7 +41,7 @@ otcrypto_status_t otcrypto_drbg_instantiate(
  * @return Result of the DRBG reseed operation.
  */
 otcrypto_status_t otcrypto_drbg_reseed(
-    otcrypto_const_byte_buf_t additional_input);
+    otcrypto_const_word32_buf_t additional_input);
 
 /**
  * Instantiates the DRBG system.
@@ -59,7 +59,8 @@ otcrypto_status_t otcrypto_drbg_reseed(
  * @return Result of the DRBG manual instantiation.
  */
 otcrypto_status_t otcrypto_drbg_manual_instantiate(
-    otcrypto_const_byte_buf_t entropy, otcrypto_const_byte_buf_t perso_string);
+    otcrypto_const_word32_buf_t entropy,
+    otcrypto_const_byte_buf_t perso_string);
 
 /**
  * Reseeds the DRBG with fresh entropy.
@@ -73,7 +74,7 @@ otcrypto_status_t otcrypto_drbg_manual_instantiate(
  * @return Result of the manual DRBG reseed operation.
  */
 otcrypto_status_t otcrypto_drbg_manual_reseed(
-    otcrypto_const_byte_buf_t entropy,
+    otcrypto_const_word32_buf_t entropy,
     otcrypto_const_byte_buf_t additional_input);
 
 /**
@@ -95,7 +96,7 @@ otcrypto_status_t otcrypto_drbg_manual_reseed(
  * @return Result of the DRBG generate operation.
  */
 otcrypto_status_t otcrypto_drbg_generate(
-    otcrypto_const_byte_buf_t additional_input,
+    otcrypto_const_word32_buf_t additional_input,
     otcrypto_word32_buf_t drbg_output);
 
 /**
@@ -117,7 +118,7 @@ otcrypto_status_t otcrypto_drbg_generate(
  * @return Result of the DRBG generate operation.
  */
 otcrypto_status_t otcrypto_drbg_manual_generate(
-    otcrypto_const_byte_buf_t additional_input,
+    otcrypto_const_word32_buf_t additional_input,
     otcrypto_word32_buf_t drbg_output);
 
 /**

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_symmetric_keygen(
-    otcrypto_const_byte_buf_t perso_string, otcrypto_blinded_key_t *key);
+    otcrypto_const_word32_buf_t perso_string, otcrypto_blinded_key_t *key);
 
 /**
  * Creates a handle for a hardware-backed key.

--- a/sw/device/tests/crypto/aes_kwp_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_functest.c
@@ -87,7 +87,7 @@ static status_t wrap_unwrap_random_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  otcrypto_const_byte_buf_t personalization = {.data = NULL, .len = 0};
+  otcrypto_const_word32_buf_t personalization = {.data = NULL, .len = 0};
   TRY(otcrypto_symmetric_keygen(personalization, &kmac_key));
 
   // Generate a random AES-KWP key.

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -97,7 +97,7 @@ static status_t wrap_unwrap_random_test(void) {
       .keyblob_length = sizeof(keyblob),
       .keyblob = keyblob,
   };
-  otcrypto_const_byte_buf_t personalization = {.data = NULL, .len = 0};
+  otcrypto_const_word32_buf_t personalization = {.data = NULL, .len = 0};
   TRY(otcrypto_symmetric_keygen(personalization, &kmac_key));
 
   // Construct the sideloaded wrapping key.

--- a/sw/device/tests/crypto/cryptotest/firmware/drbg.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/drbg.c
@@ -21,11 +21,12 @@ status_t handle_drbg(ujson_t *uj) {
   TRY(ujson_deserialize_cryptotest_drbg_input_t(uj, &uj_input));
 
   // Entropy for initialization
-  uint8_t entropy_buf[kEntropySeedBytes];
+  size_t buf_len = ceil_div(kEntropySeedBytes, sizeof(uint32_t));
+  uint32_t entropy_buf[buf_len];
   memset(entropy_buf, 0, kEntropySeedBytes);
-  memcpy(entropy_buf, uj_input.entropy, uj_input.entropy_len);
-  otcrypto_const_byte_buf_t entropy = {
-      .len = kEntropySeedBytes,
+  memcpy((uint8_t *)entropy_buf, uj_input.entropy, uj_input.entropy_len);
+  otcrypto_const_word32_buf_t entropy = {
+      .len = buf_len,
       .data = entropy_buf,
   };
 
@@ -39,12 +40,13 @@ status_t handle_drbg(ujson_t *uj) {
   };
 
   // Reseed entropy
-  uint8_t reseed_entropy_buf[uj_input.reseed_entropy_len];
-  memcpy(reseed_entropy_buf, uj_input.reseed_entropy,
+  buf_len = ceil_div(uj_input.reseed_entropy_len, sizeof(uint32_t));
+  uint32_t reseed_entropy_buf[buf_len];
+  memcpy((uint8_t *)reseed_entropy_buf, uj_input.reseed_entropy,
          uj_input.reseed_entropy_len);
-  otcrypto_const_byte_buf_t reseed_entropy = {
-      .len = uj_input.reseed_entropy_len,
-      .data = uj_input.reseed_entropy,
+  otcrypto_const_word32_buf_t reseed_entropy = {
+      .len = buf_len,
+      .data = reseed_entropy_buf,
   };
 
   // Reseed additional input
@@ -57,21 +59,23 @@ status_t handle_drbg(ujson_t *uj) {
   };
 
   // First additional input
-  uint8_t addl_1_buf[uj_input.additional_input_1_len];
-  memcpy(addl_1_buf, uj_input.additional_input_1,
+  buf_len = ceil_div(uj_input.additional_input_1_len, sizeof(uint32_t));
+  uint32_t addl_1_buf[buf_len];
+  memcpy((uint8_t *)addl_1_buf, uj_input.additional_input_1,
          uj_input.additional_input_1_len);
-  otcrypto_const_byte_buf_t addl_1 = {
-      .len = uj_input.additional_input_1_len,
-      .data = uj_input.additional_input_1,
+  otcrypto_const_word32_buf_t addl_1 = {
+      .len = buf_len,
+      .data = addl_1_buf,
   };
 
   // Second additional input
-  uint8_t addl_2_buf[uj_input.additional_input_2_len];
-  memcpy(addl_2_buf, uj_input.additional_input_2,
+  buf_len = ceil_div(uj_input.additional_input_2_len, sizeof(uint32_t));
+  uint32_t addl_2_buf[buf_len];
+  memcpy((uint8_t *)addl_2_buf, uj_input.additional_input_2,
          uj_input.additional_input_2_len);
-  otcrypto_const_byte_buf_t addl_2 = {
-      .len = uj_input.additional_input_2_len,
-      .data = uj_input.additional_input_2,
+  otcrypto_const_word32_buf_t addl_2 = {
+      .len = buf_len,
+      .data = addl_2_buf,
   };
 
   // Buffer for random output

--- a/sw/device/tests/crypto/drbg_functest.c
+++ b/sw/device/tests/crypto/drbg_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/include/drbg.h"
@@ -26,19 +27,24 @@ static const uint32_t kExpOutput[16] = {
     0x771c619b, 0xdf82ab22, 0x80b1dc2f, 0x2581f391, 0x64f7ac0c, 0x510494b3,
     0xa43c41b7, 0xdb17514c, 0x87b107ae, 0x793e01c5,
 };
-static const otcrypto_const_byte_buf_t kEmptyBuffer = {
+static const otcrypto_const_word32_buf_t kEmptyBuffer = {
+    .data = NULL,
+    .len = 0,
+};
+static const otcrypto_const_byte_buf_t kEmptyByteBuffer = {
     .data = NULL,
     .len = 0,
 };
 
 static status_t kat_test(void) {
-  otcrypto_const_byte_buf_t entropy = {
-      .data = (const unsigned char *)kTestSeed,
-      .len = sizeof(kTestSeed),
+  otcrypto_const_word32_buf_t entropy = {
+      .data = kTestSeed,
+      .len = ceil_div(sizeof(kTestSeed), sizeof(uint32_t)),
   };
 
   // Instantiate DRBG.
-  TRY(otcrypto_drbg_manual_instantiate(entropy, /*perso_string=*/kEmptyBuffer));
+  TRY(otcrypto_drbg_manual_instantiate(entropy,
+                                       /*perso_string=*/kEmptyByteBuffer));
 
   uint32_t actual_output_words[ARRAYSIZE(kExpOutput)];
   otcrypto_word32_buf_t actual_output = {

--- a/sw/device/tests/crypto/symmetric_keygen_functest.c
+++ b/sw/device/tests/crypto/symmetric_keygen_functest.c
@@ -25,10 +25,10 @@ static const randomness_quality_significance_t kSignificance =
     kRandomnessQualitySignificanceOnePercent;
 
 // Personalization data for testing.
-static const uint8_t kPersonalizationData[5] = {0xf0, 0xf1, 0xf2, 0xf3, 0xf4};
-static const otcrypto_const_byte_buf_t kPersonalization = {
+static const uint32_t kPersonalizationData[2] = {0xf3f2f1f0, 0x000000f4};
+static const otcrypto_const_word32_buf_t kPersonalization = {
     .data = kPersonalizationData,
-    .len = sizeof(kPersonalizationData),
+    .len = 2,
 };
 
 // Represents a 192-bit AES-CBC key.


### PR DESCRIPTION
This commit changes unhardened mem copies to the hardened counterpart. To this end the input and output buffers for the hardened memcpy function need to use a word size of 32 bits and the addresses need to be word aligned (32 bit).

Resolves https://github.com/lowRISC/opentitan/issues/17711