### PR TITLE
[rv_plic, fpv] Interrupts are level triggered

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
@@ -18,3 +18,12 @@ check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance\
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance\
  {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}
+
+# Since the interrupts are level triggered, we don't use scr_q register in rv_plic_gateway. So,
+# even if this logic is broken, nobody (in the assertions world) cares.
+check_cov -waiver -add -start_line 33 -end_line 33 -type {branch} -instance {dut.u_gateway}\
+ -comment {Interrupts are level triggered and this assignment would not affect any assertions}
+
+# To support the waivers above, this assertion is added. So, if interrupts are no longer level
+# triggered, this will fail.
+assert -name InterruptsLevelTriggered_A {!$rose(dut.u_gateway.le_i)}

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -15,3 +15,11 @@ check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {
 
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}
+
+# Since the interrupts are level triggered, we don't use scr_q register in rv_plic_gateway. So,
+# even if this logic is broken, nobody (in the assertions world) cares.
+check_cov -waiver -add -start_line 33 -end_line 33 -type {branch} -instance {dut.u_gateway} -comment {Interrupts are level triggered and this assignment would not affect any assertions}
+
+# To support the waivers above, this assertion is added. So, if interrupts are no longer level
+# triggered, this will fail.
+assert -name InterruptsLevelTriggered_A {!$rose(dut.u_gateway.le_i)}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -15,3 +15,11 @@ check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {
 
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}
+
+# Since the interrupts are level triggered, we don't use scr_q register in rv_plic_gateway. So,
+# even if this logic is broken, nobody (in the assertions world) cares.
+check_cov -waiver -add -start_line 33 -end_line 33 -type {branch} -instance {dut.u_gateway} -comment {Interrupts are level triggered and this assignment would not affect any assertions}
+
+# To support the waivers above, this assertion is added. So, if interrupts are no longer level
+# triggered, this will fail.
+assert -name InterruptsLevelTriggered_A {!$rose(dut.u_gateway.le_i)}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -15,3 +15,11 @@ check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {
 
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 81 -type {statement} -instance {dut.u_reg.u_chk.u_chk} -comment {data_o is untied}
+
+# Since the interrupts are level triggered, we don't use scr_q register in rv_plic_gateway. So,
+# even if this logic is broken, nobody (in the assertions world) cares.
+check_cov -waiver -add -start_line 33 -end_line 33 -type {branch} -instance {dut.u_gateway} -comment {Interrupts are level triggered and this assignment would not affect any assertions}
+
+# To support the waivers above, this assertion is added. So, if interrupts are no longer level
+# triggered, this will fail.
+assert -name InterruptsLevelTriggered_A {!$rose(dut.u_gateway.le_i)}


### PR DESCRIPTION
Since the interrupts are level triggered, we don't use scr_q register in rv_plic_gateway. So, even if this logic is broken, nobody (in the assertions world) cares.