### PR TITLE
[manuf] send FT device ID from host to device

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -76,6 +76,17 @@ UJSON_SERDE_STRUCT(LcTokenHash, \
 // clang-format on
 
 /**
+ * Provisioning data imported onto the device in FT during individualization.
+ */
+// clang-format off
+#define STRUCT_MANUF_FT_INDIVIDUALIZE_DATA(field, string) \
+    field(ft_device_id, uint32_t, 4)
+UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
+                   manuf_ft_individualize_data_t, \
+                   STRUCT_MANUF_FT_INDIVIDUALIZE_DATA);
+// clang-format on
+
+/**
  * Inputs needed to generate certificates during personalization.
  */
 // clang-format off

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -170,7 +170,7 @@ opentitan_test(
 
 [
     opentitan_binary(
-        name = "sram_ft_individualize_{}".format(sku),
+        name = "sram_ft_individualize_{}{}".format(sku, variant),
         testonly = True,
         srcs = ["sram_ft_individualize.c"],
         exec_env = {
@@ -181,6 +181,7 @@ opentitan_test(
         },
         kind = "ram",
         linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
+        local_defines = defines,
         deps = [
             ":flash_info_permissions",
             ":ft_device_id_{}_library".format(sku),
@@ -194,9 +195,12 @@ opentitan_test(
             "//sw/device/lib/dif:otp_ctrl",
             "//sw/device/lib/dif:pinmux",
             "//sw/device/lib/testing:pinmux_testutils",
+            "//sw/device/lib/testing/json:provisioning_data",
             "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_console",
             "//sw/device/lib/testing/test_framework:ottf_test_config",
             "//sw/device/lib/testing/test_framework:status",
+            "//sw/device/lib/testing/test_framework:ujson_ottf",
             "//sw/device/silicon_creator/manuf/lib:individualize",
             "//sw/device/silicon_creator/manuf/lib:otp_fields",
             "//sw/device/silicon_creator/manuf/lib:sram_start",
@@ -204,6 +208,10 @@ opentitan_test(
         ],
     )
     for sku, config in EARLGREY_SKUS.items()
+    for variant, defines in {
+        "": [],
+        "_ate": ["ATE=1"],
+    }.items()
 ]
 
 filegroup(

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -11,9 +11,13 @@
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/manuf/base/flash_info_permissions.h"
 #include "sw/device/silicon_creator/manuf/base/ft_device_id.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
@@ -24,17 +28,23 @@
 #include "ast_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-OTTF_DEFINE_TEST_CONFIG();
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false,
+                        .silence_console_prints = true);
 
 static dif_flash_ctrl_state_t flash_ctrl_state;
 static dif_gpio_t gpio;
 static dif_otp_ctrl_t otp_ctrl;
 static dif_pinmux_t pinmux;
 
+static manuf_ft_individualize_data_t in_data;
+
 // ATE Indicator GPIOs.
 static const dif_gpio_pin_t kGpioPinTestStart = 0;
 static const dif_gpio_pin_t kGpioPinTestDone = 1;
 static const dif_gpio_pin_t kGpioPinTestError = 2;
+static const dif_gpio_pin_t kGpioPinSpiConsoleRxReady = 4;
 
 /**
  * Initializes all DIF handles used in this SRAM program.
@@ -55,6 +65,10 @@ static status_t peripheral_handles_init(void) {
  * Configure the ATE GPIO indicator pins.
  */
 static status_t configure_ate_gpio_indicators(void) {
+  // IOA6 / GPIO4 is for SPI console RX ready signal.
+  TRY(dif_pinmux_output_select(
+      &pinmux, kTopEarlgreyPinmuxMioOutIoa6,
+      kTopEarlgreyPinmuxOutselGpioGpio0 + kGpioPinSpiConsoleRxReady));
   // IOA0 / GPIO2 is for error reporting.
   TRY(dif_pinmux_output_select(
       &pinmux, kTopEarlgreyPinmuxMioOutIoa0,
@@ -68,7 +82,7 @@ static status_t configure_ate_gpio_indicators(void) {
       &pinmux, kTopEarlgreyPinmuxMioOutIoa4,
       kTopEarlgreyPinmuxOutselGpioGpio0 + kGpioPinTestStart));
   TRY(dif_gpio_output_set_enabled_all(&gpio,
-                                      0x7));        // Enable first three GPIOs.
+                                      0x1f));       // Enable first 5 GPIOs.
   TRY(dif_gpio_write_all(&gpio, /*write_val=*/0));  // Intialize all to 0.
   return OK_STATUS();
 }
@@ -117,17 +131,30 @@ static status_t patch_ast_config_value(void) {
  * Note: CreatorSwCfg and OwnerSwCfg partitions are not locked yet, as not
  * all fields can be programmed until the personalization stage.
  */
-static status_t provision(void) {
+static status_t provision(ujson_t *uj) {
   // Patch AST config if requested.
   TRY(patch_ast_config_value());
 
   // Perform OTP writes.
+#ifndef ATE
+  // Get host data.
+  LOG_INFO("Waiting for FT SRAM provisioning data ...");
+  TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
+  TRY(ujson_deserialize_manuf_ft_individualize_data_t(uj, &in_data));
+  TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
+  TRY(manuf_individualize_device_hw_cfg(
+      &flash_ctrl_state, &otp_ctrl, kFlashInfoPage0Permissions,
+      (const uint32_t *)in_data.ft_device_id));
+#else
   TRY(manuf_individualize_device_hw_cfg(
       &flash_ctrl_state, &otp_ctrl, kFlashInfoPage0Permissions, kFtDeviceId));
+#endif
   TRY(manuf_individualize_device_rot_creator_auth_codesign(&otp_ctrl));
   TRY(manuf_individualize_device_rot_creator_auth_state(&otp_ctrl));
   TRY(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
   TRY(manuf_individualize_device_creator_sw_cfg(&otp_ctrl, &flash_ctrl_state));
+
+  LOG_INFO("FT SRAM provisioning done.");
 
   return OK_STATUS();
 }
@@ -135,10 +162,12 @@ static status_t provision(void) {
 bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
   CHECK_STATUS_OK(configure_ate_gpio_indicators());
+  ottf_console_init();
+  ujson_t uj = ujson_ottf_console();
 
   // Perform provisioning operations.
   CHECK_DIF_OK(dif_gpio_write(&gpio, kGpioPinTestStart, true));
-  status_t result = provision();
+  status_t result = provision(&uj);
   if (!status_ok(result)) {
     CHECK_DIF_OK(dif_gpio_write(&gpio, kGpioPinTestError, true));
   } else {

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -13,7 +13,6 @@ use anyhow::{bail, Result};
 use arrayvec::ArrayVec;
 use zerocopy::AsBytes;
 
-use bindgen::sram_program::SRAM_MAGIC_SP_EXECUTION_DONE;
 use cert_lib::{parse_and_endorse_x509_cert, validate_cert_chain, CaConfig, CaKey, EndorsedCert};
 use ft_ext_lib::ft_ext;
 use opentitanlib::app::TransportWrapper;
@@ -31,7 +30,9 @@ use ot_certs::x509::parse_certificate;
 use ot_certs::CertFormat;
 use perso_tlv_lib::perso_tlv_get_field;
 use perso_tlv_lib::{CertHeader, CertHeaderType, ObjHeader, ObjHeaderType, ObjType};
-use ujson_lib::provisioning_data::{LcTokenHash, ManufCertgenInputs, PersoBlob, SerdesSha256Hash};
+use ujson_lib::provisioning_data::{
+    LcTokenHash, ManufCertgenInputs, ManufFtIndividualizeData, PersoBlob, SerdesSha256Hash,
+};
 use ujson_lib::UjsonPayloads;
 use util_lib::hash_lc_token;
 
@@ -78,12 +79,16 @@ pub fn test_unlock(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_sram_ft_individualize(
     transport: &TransportWrapper,
     jtag_params: &JtagParams,
     reset_delay: Duration,
     sram_program: &SramProgramParams,
+    ft_individualize_data_in: &ManufFtIndividualizeData,
+    spi_console: &SpiConsoleDevice,
     timeout: Duration,
+    ujson_payloads: &mut UjsonPayloads,
 ) -> Result<()> {
     // Set CPU TAP straps, reset, and connect to the JTAG interface.
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
@@ -95,12 +100,9 @@ pub fn run_sram_ft_individualize(
     jtag.reset(/*run=*/ false)?;
 
     // Load and execute the SRAM program that contains the provisioning code.
-    let result = sram_program.load_and_execute(&mut *jtag, ExecutionMode::JumpAndWait(timeout))?;
+    let result = sram_program.load_and_execute(&mut *jtag, ExecutionMode::Jump)?;
     match result {
-        ExecutionResult::ExecutionDone(sp_val) => match sp_val {
-            SRAM_MAGIC_SP_EXECUTION_DONE => log::info!("SRAM program completed."),
-            _ => panic!("SRAM program load/execution failed: sp = {:?}.", sp_val),
-        },
+        ExecutionResult::Executing => log::info!("SRAM program loaded and is executing."),
         _ => panic!("SRAM program load/execution failed: {:?}.", result),
     }
 
@@ -109,6 +111,22 @@ pub fn run_sram_ft_individualize(
     jtag.disconnect()?;
     transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
     transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+
+    // Wait for SRAM program to complete execution.
+    let _ = UartConsole::wait_for(
+        spi_console,
+        r"Waiting for FT SRAM provisioning data ...",
+        timeout,
+    )?;
+
+    // Inject provisioning data into the device.
+    ujson_payloads.dut_in.insert(
+        "FT_INDIVIDUALIZE_DATA_IN".to_string(),
+        ft_individualize_data_in.send(spi_console)?,
+    );
+
+    // Wait for provisioning operations to complete.
+    let _ = UartConsole::wait_for(spi_console, r"FT SRAM provisioning done.", timeout)?;
 
     Ok(())
 }

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -147,7 +147,7 @@ class DeviceId():
         din_as_int = self.din.to_int()
 
         # Build base unique ID (i.e., CP device ID).
-        self._base_uid = util.bytes_to_int(
+        self.base_uid = util.bytes_to_int(
             struct.pack("<IQI", self._hw_origin, din_as_int, 0))
 
         # Build SKU specific field (i.e., FT device ID).
@@ -175,7 +175,7 @@ class DeviceId():
             ))
 
         # Build full device ID.
-        self.device_id = (self.sku_specific << 128) | self._base_uid
+        self.device_id = (self.sku_specific << 128) | self.base_uid
 
     def update_din(self, other: "DeviceIdentificationNumber") -> None:
         """Updates the DIN component of the device ID with another DIN object.
@@ -188,9 +188,9 @@ class DeviceId():
         self.din = other
 
         # Build base unique ID.
-        self._base_uid = util.bytes_to_int(
+        self.base_uid = util.bytes_to_int(
             struct.pack("<IQI", self._hw_origin, self.din.to_int(), 0))
-        self.device_id = (self.sku_specific << 128) | self._base_uid
+        self.device_id = (self.sku_specific << 128) | self.base_uid
 
     @staticmethod
     def from_hexstr(hexstr: str) -> "DeviceId":
@@ -240,6 +240,10 @@ class DeviceId():
         din = DeviceIdentificationNumber.from_int((base_uid >> 32) & mask_din)
 
         return DeviceId(sku_config, din)
+
+    def base_uid_hexstr(self) -> str:
+        """Returns the Base UID portion of the device ID as a hex string."""
+        return util.format_hex(self.base_uid, width=32)
 
     def sku_specific_hexstr(self) -> str:
         """Returns the SKU specific portion of the device ID as a hex string."""

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
 from dataclasses import dataclass
 
@@ -260,6 +261,7 @@ class OtDut():
             --elf={individ_elf} \
             --bootstrap={perso_bin} \
             --second-bootstrap={fw_bundle_bin} \
+            --ft-device-id="0x{hex(self.device_id.sku_specific)[2:].zfill(32)}" \
             --wafer-auth-secret="{_ZERO_256BIT_HEXSTR}" \
             --test-unlock-token="{format_hex(self.test_unlock_token, width=32)}" \
             --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
@@ -293,15 +295,29 @@ class OtDut():
                                                    stdout_logfile)
 
             # Check device ID from OTP matches one constructed on host.
+            #
+            # The CP portion may not match, but the FT portion should. The CP
+            # portion of the device ID is set in flash before the
+            # orchestrator.py is ever run, so the device's CP portion of the
+            # device ID should be take as the ground truth.
             device_id_in_otp = DeviceId.from_hexstr(self.ft_data["device_id"])
-            if device_id_in_otp != self.device_id:
+            if device_id_in_otp.sku_specific != self.device_id.sku_specific:
                 logging.error(
-                    "Device ID from OTP does not match expected on host. Use OTP variant?"
+                    "FT Device ID from OTP does not match expected on host."
                 )
                 logging.error(
-                    f"Final (device) DeviceId: {device_id_in_otp.to_hexstr()}")
+                    f"Final (device) FT DeviceId: {device_id_in_otp.sku_specific_hexstr()}")
                 logging.error(
-                    f"Final (host)   DeviceId: {self.device_id.to_hexstr()}")
+                    f"Final (host)   FT DeviceId: {self.device_id.sku_specific_hexstr()}")
+                sys.exit(-1)
+            if device_id_in_otp.base_uid != self.device_id.base_uid:
+                logging.warning(
+                    "CP Device ID from OTP does not match expected on host. Use OTP variant?"
+                )
+                logging.warning(
+                    f"Final (device) CP DeviceId: {device_id_in_otp.base_uid_hexstr()}")
+                logging.warning(
+                    f"Final (host)   CP DeviceId: {self.device_id.base_uid_hexstr()}")
                 if self.require_confirmation:
                     confirm()
                 self.device_id = device_id_in_otp

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -80,7 +80,7 @@ sh_test(
     ],
     env = {
         "PYTHON": "$(PYTHON3)",
-        "PACKAGE": "npcr11",
+        "PACKAGE": "npcr12",
     },
     tags = [
         "changes_otp",

--- a/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
@@ -29,7 +29,7 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --package=${PACKAGE} \
   --fpga=hyper310 \
-  --ast-cfg-version=0 \
+  --ast-cfg-version=10 \
   --log-ujson-payloads \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite


### PR DESCRIPTION
This partially reverts #26648 by adding back the injection of the FT device ID during individualization. This is necessary as the orchestrator.py script provides command line switches for orriding the package ID an AST config version fields of the FT (SKU-specific) portion of the device ID. Since these fields can be overridden at runtime, they cannot be precompiled into the FT individualization binary. Thus, data must be transmitted from the host to the device over UJSON during individualization.

To support ATE flows that would like to avoid sending UJSON messages for performances reasons, we also support building individualization binaries where the FT device ID is compiled into the binary. However, these are no used with the orchestrator, which provides the ability to override the fields mentioned above at runtime.

Lastly, this enhances the E2E tests to ensure the orchestrator.py is able to override the package ID and AST config version at runtime.