### PR TITLE
[individualize] use SPI console GPIO TX-indicator pin and remove done indication print

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -102,10 +102,19 @@ static status_t spi_device_getc(void *io) {
   return OK_STATUS(info.data[index++]);
 }
 
-static void spi_device_wait_for_sync(dif_spi_device_handle_t *spi_device) {
-  const uint8_t kBootMagicPattern[4] = {0x02, 0xb0, 0xfe, 0xca};
+static void spi_device_clear_flash_buffer(dif_spi_device_handle_t *spi_device) {
   const uint8_t kEmptyPattern[4] = {0};
+  for (size_t i = 0; i < SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH; i++) {
+    CHECK_DIF_OK(dif_spi_device_write_flash_buffer(
+        spi_device, kDifSpiDeviceFlashBufferTypeEFlash,
+        i * ARRAYSIZE(kEmptyPattern), ARRAYSIZE(kEmptyPattern), kEmptyPattern));
+  }
+  CHECK_DIF_OK(dif_spi_device_set_flash_status_registers(spi_device, 0x00));
+}
 
+static void spi_device_wait_for_sync(dif_spi_device_handle_t *spi_device) {
+  // Write the boot synchronization data to the flash buffer.
+  const uint8_t kBootMagicPattern[4] = {0x02, 0xb0, 0xfe, 0xca};
   for (size_t i = 0; i < SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH; i++) {
     CHECK_DIF_OK(dif_spi_device_write_flash_buffer(
         spi_device, kDifSpiDeviceFlashBufferTypeEFlash,
@@ -113,15 +122,12 @@ static void spi_device_wait_for_sync(dif_spi_device_handle_t *spi_device) {
         kBootMagicPattern));
   }
 
+  // Wait for host to read out the boot synchronization data.
   upload_info_t info = {0};
   CHECK_STATUS_OK(spi_device_testutils_wait_for_upload(spi_device, &info));
-  // Clear the boot magic in the read buffer.
-  for (size_t i = 0; i < SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH; i++) {
-    CHECK_DIF_OK(dif_spi_device_write_flash_buffer(
-        spi_device, kDifSpiDeviceFlashBufferTypeEFlash,
-        i * ARRAYSIZE(kEmptyPattern), ARRAYSIZE(kEmptyPattern), kEmptyPattern));
-  }
-  CHECK_DIF_OK(dif_spi_device_set_flash_status_registers(spi_device, 0x00));
+
+  // Clear the boot magic data in the flash buffer that the host echoed back.
+  spi_device_clear_flash_buffer(spi_device);
 }
 
 void ottf_console_init(void) {
@@ -275,6 +281,7 @@ void ottf_console_configure_spi_device(uintptr_t base_addr) {
         true));
     base_spi_device_set_gpio_tx_indicator(
         &gpio, kOttfTestConfig.console_tx_indicator.spi_console_tx_ready_gpio);
+    spi_device_clear_flash_buffer(&ottf_console_spi_device);
   } else {
     spi_device_wait_for_sync(&ottf_console_spi_device);
   }

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -194,6 +194,7 @@ opentitan_test(
             "//sw/device/lib/dif:gpio",
             "//sw/device/lib/dif:otp_ctrl",
             "//sw/device/lib/dif:pinmux",
+            "//sw/device/lib/runtime:print",
             "//sw/device/lib/testing:pinmux_testutils",
             "//sw/device/lib/testing/json:provisioning_data",
             "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -165,8 +165,6 @@ static status_t provision(ujson_t *uj) {
   TRY(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
   TRY(manuf_individualize_device_creator_sw_cfg(&otp_ctrl, &flash_ctrl_state));
 
-  base_printf("FT SRAM provisioning done.");
-
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/flash_ctrl_testutils.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
@@ -28,11 +29,6 @@
 #include "ast_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
-                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
-                        .console.test_may_clobber = false,
-                        .silence_console_prints = true);
-
 static dif_flash_ctrl_state_t flash_ctrl_state;
 static dif_gpio_t gpio;
 static dif_otp_ctrl_t otp_ctrl;
@@ -44,7 +40,18 @@ static manuf_ft_individualize_data_t in_data;
 static const dif_gpio_pin_t kGpioPinTestStart = 0;
 static const dif_gpio_pin_t kGpioPinTestDone = 1;
 static const dif_gpio_pin_t kGpioPinTestError = 2;
+static const dif_gpio_pin_t kGpioPinSpiConsoleTxReady = 3;
 static const dif_gpio_pin_t kGpioPinSpiConsoleRxReady = 4;
+
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false,
+                        .silence_console_prints = true,
+                        .console_tx_indicator.enable = true,
+                        .console_tx_indicator.spi_console_tx_ready_mio =
+                            kTopEarlgreyPinmuxMioOutIoa5,
+                        .console_tx_indicator.spi_console_tx_ready_gpio =
+                            kGpioPinSpiConsoleTxReady);
 
 /**
  * Initializes all DIF handles used in this SRAM program.
@@ -69,6 +76,10 @@ static status_t configure_ate_gpio_indicators(void) {
   TRY(dif_pinmux_output_select(
       &pinmux, kTopEarlgreyPinmuxMioOutIoa6,
       kTopEarlgreyPinmuxOutselGpioGpio0 + kGpioPinSpiConsoleRxReady));
+  // IOA5 / GPIO3 is for SPI console TX ready signal.
+  TRY(dif_pinmux_output_select(
+      &pinmux, kTopEarlgreyPinmuxMioOutIoa5,
+      kTopEarlgreyPinmuxOutselGpioGpio0 + kGpioPinSpiConsoleTxReady));
   // IOA0 / GPIO2 is for error reporting.
   TRY(dif_pinmux_output_select(
       &pinmux, kTopEarlgreyPinmuxMioOutIoa0,
@@ -138,7 +149,7 @@ static status_t provision(ujson_t *uj) {
   // Perform OTP writes.
 #ifndef ATE
   // Get host data.
-  LOG_INFO("Waiting for FT SRAM provisioning data ...");
+  base_printf("Waiting for FT SRAM provisioning data ...");
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
   TRY(ujson_deserialize_manuf_ft_individualize_data_t(uj, &in_data));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
@@ -154,7 +165,7 @@ static status_t provision(ujson_t *uj) {
   TRY(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
   TRY(manuf_individualize_device_creator_sw_cfg(&otp_ctrl, &flash_ctrl_state));
 
-  LOG_INFO("FT SRAM provisioning done.");
+  base_printf("FT SRAM provisioning done.");
 
   return OK_STATUS();
 }

--- a/sw/host/opentitanlib/src/console/spi.rs
+++ b/sw/host/opentitanlib/src/console/spi.rs
@@ -50,6 +50,11 @@ impl<'a> SpiConsoleDevice<'a> {
         })
     }
 
+    pub fn reset_frame_counter(&self) {
+        self.console_next_frame_number.set(0);
+        self.next_read_address.set(0);
+    }
+
     fn check_device_boot_up(&self, buf: &[u8]) -> Result<usize> {
         for i in (0..buf.len()).step_by(4) {
             let pattern: u32 = u32::from_le_bytes(buf[i..i + 4].try_into().unwrap());
@@ -59,8 +64,7 @@ impl<'a> SpiConsoleDevice<'a> {
         }
         // Set busy bit and wait for the device to clear the boot magic.
         self.flash.program(self.spi, 0, buf)?;
-        self.console_next_frame_number.set(0);
-        self.next_read_address.set(0);
+        self.reset_frame_counter();
         Ok(0)
     }
 

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -98,6 +98,10 @@ struct Opts {
     #[arg(long, default_value = "BOOTSTRAP")]
     console_spi: String,
 
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "IOA5")]
+    console_tx_indicator_pin: String,
+
     /// Owner's firmware string indicating successful start up.
     #[arg(long)]
     owner_success_text: Option<String>,
@@ -241,6 +245,7 @@ fn main() -> Result<()> {
                 &opts.sram_program,
                 &ft_individualize_data_in,
                 &opts.console_spi,
+                &opts.console_tx_indicator_pin,
                 opts.timeout,
                 &mut ujson_payloads,
             )?;

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -240,7 +240,7 @@ fn main() -> Result<()> {
                 opts.init.bootstrap.options.reset_delay,
                 &opts.sram_program,
                 &ft_individualize_data_in,
-                &spi_console_device,
+                &opts.console_spi,
                 opts.timeout,
                 &mut ujson_payloads,
             )?;

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run_sram_ft_individualize(
     device_console_tx_ready_pin.set_mode(PinMode::Input)?;
     device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
     let spi_console = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
+    spi_console.reset_frame_counter();
 
     // Set CPU TAP straps, reset, and connect to the JTAG interface.
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -13,13 +13,14 @@ use anyhow::{bail, Result};
 use arrayvec::ArrayVec;
 use zerocopy::AsBytes;
 
+use bindgen::sram_program::SRAM_MAGIC_SP_EXECUTION_DONE;
 use cert_lib::{parse_and_endorse_x509_cert, validate_cert_chain, CaConfig, CaKey, EndorsedCert};
 use ft_ext_lib::ft_ext;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::console::spi::SpiConsoleDevice;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
 use opentitanlib::io::gpio::{PinMode, PullMode};
-use opentitanlib::io::jtag::{JtagParams, JtagTap};
+use opentitanlib::io::jtag::{JtagParams, JtagTap, RiscvGpr, RiscvReg};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
 use opentitanlib::test_utils::load_sram_program::{
@@ -87,13 +88,14 @@ pub fn run_sram_ft_individualize(
     reset_delay: Duration,
     sram_program: &SramProgramParams,
     ft_individualize_data_in: &ManufFtIndividualizeData,
-    console_spi: &String,
+    console_spi: &str,
+    console_tx_indicator_pin: &str,
     timeout: Duration,
     ujson_payloads: &mut UjsonPayloads,
 ) -> Result<()> {
     // Setup the SPI console with the GPIO TX indicator pin.
     let spi = transport.spi(console_spi)?;
-    let device_console_tx_ready_pin = &transport.gpio_pin("IOA5")?;
+    let device_console_tx_ready_pin = &transport.gpio_pin(console_tx_indicator_pin)?;
     device_console_tx_ready_pin.set_mode(PinMode::Input)?;
     device_console_tx_ready_pin.set_pull_mode(PullMode::None)?;
     let spi_console = SpiConsoleDevice::new(&*spi, Some(device_console_tx_ready_pin))?;
@@ -114,12 +116,6 @@ pub fn run_sram_ft_individualize(
         _ => panic!("SRAM program load/execution failed: {:?}.", result),
     }
 
-    // Switch TAP straps to LC TAP (without resetting) to aid debugging if there are OTP issues.
-    // TAP straps are continuously sampled in TEST_UNLOCKED* LC states.
-    jtag.disconnect()?;
-    transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
-    transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
-
     // Wait for SRAM program to complete execution.
     let _ = UartConsole::wait_for(
         &spi_console,
@@ -134,7 +130,20 @@ pub fn run_sram_ft_individualize(
     );
 
     // Wait for provisioning operations to complete.
-    let _ = UartConsole::wait_for(&spi_console, r"FT SRAM provisioning done.", timeout)?;
+    jtag.wait_halt(timeout)?;
+    jtag.halt()?;
+    let sp = jtag.read_riscv_reg(&RiscvReg::Gpr(RiscvGpr::SP))?;
+    log::info!("after timeout, sp = {:x}", sp);
+    match sp {
+        SRAM_MAGIC_SP_EXECUTION_DONE => {}
+        _ => panic!("SRAM program load/execution failed: sp = {:?}.", sp),
+    }
+
+    // Switch TAP straps to LC TAP (without resetting) to aid debugging if there are OTP issues.
+    // TAP straps are continuously sampled in TEST_UNLOCKED* LC states.
+    jtag.disconnect()?;
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
+    transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
 
     Ok(())
 }


### PR DESCRIPTION
This contains two commits that:
1. updates the individualization firmware to use the SPI console GPIO TX-indicator pin to reduce the amount of traffic on the SPI console to simplify ATE integrations, and
2. remove SRAM execution done print.

Regarding the second item/commit, when SRAM programs complete execution they set the stack pointer to a magic value. We can detect this magic value instead of requiring the host to wait until a message is printed over the console. This eliminate more unneeded traffic on the SPI console.

Note this depends on #26982, only review the last two commits.