### PR TITLE
[rom_ext_e2e] Test firmware boot with an ISFB present

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:const.bzl", "CONST", "hex")
-load("//rules:manifest.bzl", "manifest")
+load(
+    "//rules:manifest.bzl",
+    "integrator_specific_firmware_binding",
+    "manifest",
+    "product_expr",
+)
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -275,4 +280,41 @@ _KEYS = {
 test_suite(
     name = "keys",
     tests = ["key_{}".format(name) for name in _KEYS],
+)
+
+manifest(d = {
+    "name": "isfb_manifest",
+    "address_translation": hex(CONST.HARDENED_FALSE),
+    "identifier": hex(CONST.OWNER),
+    "visibility": ["//visibility:public"],
+    "integrator_specific_firmware_binding": integrator_specific_firmware_binding(
+        name = "isfb",
+        product_exprs = [
+            product_expr(
+                name = "none",
+                mask = "0xFFFFFFFF",
+                value = "0xFFFFFFFF",
+            ),
+        ],
+        strike_mask = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+    ),
+})
+
+opentitan_test(
+    name = "isfb_boot_test",
+    srcs = [":boot_test"],
+    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(),
+    manifest = ":isfb_manifest",
+    spx_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_spx": "prod_key_0"},
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
 )

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -273,7 +273,12 @@ impl CommandDispatch for ManifestUpdateCommand {
             .iter()
             .filter(|entry_spec| entry_spec.is_signed())
             .map(|e| e.id())
-            .chain(vec![ManifestExtId::spx_key.into()])
+            .chain(vec![
+                ManifestExtId::spx_key.into(),
+                ManifestExtId::secver_write.into(),
+                ManifestExtId::isfb.into(),
+                ManifestExtId::isfb_erase.into(),
+            ])
             .collect::<HashSet<u32>>();
         image.update_signed_region(&signed_ids)?;
 


### PR DESCRIPTION
1. Make opentitantool examine all extensions to set the signed region bounds.
1. Test that firmware boots with an ISFB extension present.  Note that the ISFB extension is not evaluated by this test -- we're only checking that the ROM_EXT will boot firmware with such an extension.