### PR TITLE
[ownership] Check key alg during endorsed transfer

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.c
@@ -7,12 +7,15 @@
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-void boot_svc_ownership_unlock_req_init(uint32_t unlock_mode, nonce_t nonce,
+void boot_svc_ownership_unlock_req_init(uint32_t unlock_mode,
+                                        uint32_t next_owner_key_alg,
+                                        nonce_t nonce,
                                         const owner_keydata_t *next_owner_key,
                                         const owner_signature_t *signature,
                                         boot_svc_ownership_unlock_req_t *msg) {
   msg->unlock_mode = unlock_mode;
   memset(msg->reserved, 0, sizeof(msg->reserved));
+  msg->next_owner_key_alg = next_owner_key_alg;
   msg->nonce = nonce;
   msg->next_owner_key = *next_owner_key;
   msg->signature = *signature;

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
@@ -53,7 +53,13 @@ typedef struct boot_svc_ownership_unlock_req {
   /**
    * Reserved for future use.
    */
-  uint32_t reserved[8];
+  uint32_t reserved[7];
+  /**
+   * Algorithm identifier of the next owner (for endorsed mode).
+   *
+   * It should be one of the `ownership_key_alg_t` enum.
+   */
+  uint32_t next_owner_key_alg;
   /**
    * The current ownership nonce.
    */
@@ -76,6 +82,8 @@ OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, din,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, reserved,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 12);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, next_owner_key_alg,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 40);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, nonce,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 44);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, next_owner_key,
@@ -108,7 +116,9 @@ OT_ASSERT_SIZE(boot_svc_ownership_unlock_res_t, 48);
  *
  * @param[out] msg Output buffer for the message.
  */
-void boot_svc_ownership_unlock_req_init(uint32_t unlock_mode, nonce_t nonce,
+void boot_svc_ownership_unlock_req_init(uint32_t unlock_mode,
+                                        uint32_t next_owner_key_alg,
+                                        nonce_t nonce,
                                         const owner_keydata_t *next_owner_key,
                                         const owner_signature_t *signature,
                                         boot_svc_ownership_unlock_req_t *msg);

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock_unittest.cc
@@ -23,6 +23,7 @@ TEST_F(BootSvcOwnershipUnlockTest, ReqInit) {
   boot_svc_ownership_unlock_req_t msg{};
   constexpr uint32_t unlock_mode = kBootSvcUnlockAny;
   constexpr nonce_t nonce = {0x55555555, 0xAAAAAAAA};
+  constexpr uint32_t next_owner_key_alg = 0x36353250;
   constexpr owner_keydata_t next_owner_key = {
       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}};
   constexpr owner_signature_t signature = {{100, 101, 102, 103, 104, 105, 106,
@@ -31,10 +32,11 @@ TEST_F(BootSvcOwnershipUnlockTest, ReqInit) {
   EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcOwnershipUnlockReqType,
                                          sizeof(msg), &msg.header));
 
-  boot_svc_ownership_unlock_req_init(unlock_mode, nonce, &next_owner_key,
-                                     &signature, &msg);
+  boot_svc_ownership_unlock_req_init(unlock_mode, next_owner_key_alg, nonce,
+                                     &next_owner_key, &signature, &msg);
 
   EXPECT_EQ(msg.unlock_mode, unlock_mode);
+  EXPECT_EQ(msg.next_owner_key_alg, next_owner_key_alg);
   EXPECT_EQ(msg.nonce.value[0], nonce.value[0]);
   EXPECT_EQ(msg.nonce.value[1], nonce.value[1]);
   EXPECT_EQ(

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -85,10 +85,13 @@ hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata) {
       case kOwnershipStateUnlockedEndorsed:
         // In UnlockedEndorsed, the owner key must match the key endorsed by the
         // next_owner field in bootdata.  If not, skip parsing owner page 1.
-        //
-        // FIXME: Mix in the key algorithm identifier.
-        hmac_sha256(owner_page[1].owner_key.raw,
-                    sizeof(owner_page[1].owner_key.raw), &digest);
+        hmac_sha256_init();
+        hmac_sha256_update(&owner_page[1].ownership_key_alg,
+                           sizeof(owner_page[1].ownership_key_alg));
+        hmac_sha256_update(owner_page[1].owner_key.raw,
+                           sizeof(owner_page[1].owner_key.raw));
+        hmac_sha256_process();
+        hmac_sha256_final(&digest);
         if (hardened_memeq(bootdata->next_owner, digest.digest,
                            ARRAYSIZE(digest.digest)) == kHardenedBoolTrue) {
           return kHardenedBoolTrue;

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -56,8 +56,12 @@ class OwnershipActivateTest : public rom_test::RomTest {
       case kOwnershipStateUnlockedEndorsed:
         // In UnlockedEndorsed, the hash of the owner key in page1 must be equal
         // to the value stored in boot_data.
-        EXPECT_CALL(hmac_, sha256(_, _, _))
-            .WillOnce(SetArgPointee<2>((hmac_digest_t){{
+        EXPECT_CALL(hmac_, sha256_init());
+        EXPECT_CALL(hmac_, sha256_update(_, _));
+        EXPECT_CALL(hmac_, sha256_update(_, _));
+        EXPECT_CALL(hmac_, sha256_process());
+        EXPECT_CALL(hmac_, sha256_final(_))
+            .WillOnce(SetArgPointee<0>((hmac_digest_t){{
                 bootdata_.next_owner[0] + modifier,
                 bootdata_.next_owner[1],
                 bootdata_.next_owner[2],

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -40,8 +40,13 @@ static rom_error_t do_unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
 
   if (msg->ownership_unlock_req.unlock_mode == kBootSvcUnlockEndorsed) {
     hmac_digest_t digest;
-    hmac_sha256(&msg->ownership_unlock_req.next_owner_key,
-                sizeof(msg->ownership_unlock_req.next_owner_key), &digest);
+    hmac_sha256_init();
+    hmac_sha256_update(&msg->ownership_unlock_req.next_owner_key_alg,
+                       sizeof(msg->ownership_unlock_req.next_owner_key_alg));
+    hmac_sha256_update(&msg->ownership_unlock_req.next_owner_key,
+                       sizeof(msg->ownership_unlock_req.next_owner_key));
+    hmac_sha256_process();
+    hmac_sha256_final(&digest);
     memcpy(&bootdata->next_owner, &digest, sizeof(digest));
     bootdata->ownership_state = kOwnershipStateUnlockedEndorsed;
   } else if (msg->ownership_unlock_req.unlock_mode == kBootSvcUnlockAny) {

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
@@ -199,12 +199,15 @@ TEST_F(OwnershipUnlockTest, UnlockEndorsed) {
       .WillOnce(Return(kErrorOk));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
-  EXPECT_CALL(hmac_, sha256(_, _, _))
-      .WillOnce([&](const void *, size_t, hmac_digest_t *digest) {
-        for (size_t i = 0; i < ARRAYSIZE(digest->digest); ++i) {
-          digest->digest[i] = i;
-        }
-      });
+  EXPECT_CALL(hmac_, sha256_init());
+  EXPECT_CALL(hmac_, sha256_update(_, _));
+  EXPECT_CALL(hmac_, sha256_update(_, _));
+  EXPECT_CALL(hmac_, sha256_process());
+  EXPECT_CALL(hmac_, sha256_final(_)).WillOnce([&](hmac_digest_t *digest) {
+    for (size_t i = 0; i < ARRAYSIZE(digest->digest); ++i) {
+      digest->digest[i] = i;
+    }
+  });
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(5));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 

--- a/sw/device/silicon_creator/rom_ext/doc/ownership.md
+++ b/sw/device/silicon_creator/rom_ext/doc/ownership.md
@@ -402,7 +402,9 @@ typedef struct boot_svc_ownership_unlock_req {
   /** The 64-bit DIN subfield of the full 256-bit device ID.  */
   uint32_t din[2];
   /** Reserved for future use.  */
-  uint32_t reserved[8];
+  uint32_t reserved[7];
+  /** Algorithm identifier of the next owner (for endorsed mode).  */
+  owner_key_t next_owner_key;
   /** The current ownership nonce.  */
   nonce_t nonce;
   /** The public key of the next owner (for endorsed mode).  */

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -365,15 +365,22 @@ TEST_F(RomExtBootServicesTest, BootSvcOwnershipActivate) {
 
   owner_page[0].owner_key = {{1}};
   memset(boot_data.next_owner, 0, sizeof(boot_data.next_owner));
-  boot_data.next_owner[0] = 0x1234;
+  boot_data.next_owner[0] = 0x5678;
 
   MakePage1Valid(true);
 
   EXPECT_CALL(mock_hmac_, sha256)
-      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+      .WillOnce(SetArgPointee<2>(
+          hmac_digest_t{boot_svc_msg.header.digest.digest[0]}));
 
-  EXPECT_CALL(mock_hmac_, sha256)
-      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+  // In UnlockedEndorsed, the hash of the owner key in page1 must be equal
+  // to the value stored in boot_data.
+  EXPECT_CALL(mock_hmac_, sha256_init());
+  EXPECT_CALL(mock_hmac_, sha256_update(_, _));
+  EXPECT_CALL(mock_hmac_, sha256_update(_, _));
+  EXPECT_CALL(mock_hmac_, sha256_process());
+  EXPECT_CALL(mock_hmac_, sha256_final(_))
+      .WillOnce(SetArgPointee<0>((hmac_digest_t){{boot_data.next_owner[0]}}));
 
   EXPECT_CALL(mock_ownership_key_,
               validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
@@ -414,7 +421,7 @@ TEST_F(RomExtBootServicesTest, BootSvcOwnershipActivate) {
   EXPECT_CALL(mock_rnd_, Uint32()).WillRepeatedly(Return(99));
 
   EXPECT_CALL(mock_hmac_, sha256)
-      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0xdeadbeef}));
 
   EXPECT_EQ(
       boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,

--- a/sw/host/opentitanlib/src/chip/boot_svc.rs
+++ b/sw/host/opentitanlib/src/chip/boot_svc.rs
@@ -136,6 +136,8 @@ pub struct OwnershipUnlockRequest {
     /// The ROM_EXT nonce.
     #[annotate(format=hex)]
     pub nonce: u64,
+    /// The algorithm of next owner's key (for unlock Endorsed mode).
+    pub next_owner_alg: OwnershipKeyAlg,
     /// The next owner's key (for unlock Endorsed mode).
     pub next_owner_key: EcdsaRawPublicKey,
     // TODO(cfrantz): Hybrid key material
@@ -471,6 +473,7 @@ impl TryFrom<&[u8]> for OwnershipUnlockRequest {
         val.din = reader.read_u64::<LittleEndian>()?;
         val.reserved.resize(Self::RESERVED_SIZE, 0);
         reader.read_exact(&mut val.reserved)?;
+        val.next_owner_alg = OwnershipKeyAlg(reader.read_u32::<LittleEndian>()?);
         val.nonce = reader.read_u64::<LittleEndian>()?;
         val.next_owner_key = EcdsaRawPublicKey::read(&mut reader).map_err(ChipDataError::Anyhow)?;
 
@@ -484,7 +487,7 @@ impl TryFrom<&[u8]> for OwnershipUnlockRequest {
 }
 impl OwnershipUnlockRequest {
     pub const SIZE: usize = 212;
-    const RESERVED_SIZE: usize = 8 * std::mem::size_of::<u32>();
+    const RESERVED_SIZE: usize = 7 * std::mem::size_of::<u32>();
     const SIGNATURE_OFFSET: usize = 148;
     pub fn write(&self, dest: &mut impl Write) -> Result<()> {
         dest.write_u32::<LittleEndian>(u32::from(self.unlock_mode))?;
@@ -493,6 +496,7 @@ impl OwnershipUnlockRequest {
             let p = self.reserved.get(i).unwrap_or(&0x00);
             dest.write_all(std::slice::from_ref(p))?;
         }
+        dest.write_u32::<LittleEndian>(u32::from(self.next_owner_alg))?;
         dest.write_u64::<LittleEndian>(self.nonce)?;
         self.next_owner_key.write(dest)?;
 

--- a/sw/host/opentitanlib/src/chip/helper.rs
+++ b/sw/host/opentitanlib/src/chip/helper.rs
@@ -51,6 +51,8 @@ impl OwnershipUnlockParams {
         }
         if let Some(next_owner) = &self.next_owner {
             let key = EcdsaPublicKey::load(next_owner)?;
+            // TODO: Support transferring to a different algorithm.
+            unlock.next_owner_alg = self.algorithm;
             unlock.next_owner_key = EcdsaRawPublicKey::try_from(&key)?;
         }
         if let Some(signature) = &self.signature {


### PR DESCRIPTION
This PR fixes an issue in endorsed ownership transfers, where attackers could downgrade an endorsed SPX+ECDSA transfer to ECDSA-only after ECDSA is broken.

The fix involves endorsing the key algorithm with the public key, ensuring transfers only complete with the designated algorithm.