### PR TITLE
Cherry-pick to earlgrey_1.0.0: [ci] Bump verilator test runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
 
   verilator_earlgrey:
     name: Verilated Earl Grey
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: quick_lint
     timeout-minutes: 240
     steps:


### PR DESCRIPTION
Manual cherry-pick of #25882

The Ubuntu 20.04 runner is now completed disabled by GitHub, so we need this to fix CI.