### PR TITLE
[sram_ctrl] Bring up of sram_ctrl_scrambled_access in Darjeeling DV

### DIFF
--- a/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_darjeeling/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -50,14 +50,14 @@ class chip_sw_base_vseq extends chip_base_vseq;
     forever begin
       // Await the report of an internal reset request from the power manager.
       if (cfg.chip_vif.aon_clk_por_rst_if.rst_n === 1'b1) begin
-        // No need to check for requests every cycle; the power manager will wait until it observes
-        // the falling edge of the external reset request signal. The exact delay does not matter,
-        // responding with a variable latency improves testing.
-        cfg.chip_vif.aon_clk_por_rst_if.wait_clks(7);
+        // For a software reset request we need in practice to check the `light_reset_req` signal
+        // on every AON clock cycle because as soon as pwrmgr_aon detects the internal reset request
+        // it acknowledges to the rstmgr_aon, which deasserts the software reset request.
+        cfg.chip_vif.aon_clk_por_rst_if.wait_clks(1);
         if (cfg.chip_vif.signal_probe_pwrmgr_light_reset_req(
               .kind(dv_utils_pkg::SignalProbeSample))) begin
           int unsigned clks = $urandom_range(24, 5);
-          `uvm_info(`gfn, $sformatf("Supply external reset request of %0d cycle(s)", clks),
+          `uvm_info(`gfn, $sformatf("Supplying external reset request of %0d cycle(s)", clks),
                     UVM_MEDIUM)
           // Apply an extended reset signal of sufficient duration to pass through the filter.
           apply_soc_reset_request(clks);

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -170,7 +170,7 @@ static noreturn void main_sram_scramble(void) {
       "  andi t0, t0, %[kSramCtrlKeyScrDone]                         \n"
       "  beqz t0, .L_scrambling_busy_loop                            \n"
 
-      // Restore the tests frames addresses after the scrambling .
+      // Restore the tests frames addresses after the scrambling.
       "sw a2, 0(%[mainFrame])                                        \n"
       "sw a3, 0(%[retFrame])                                         \n"
 
@@ -320,7 +320,7 @@ static void check_sram_data(scramble_test_frame *mem_frame) {
 
   if (kDeviceType == kDeviceSimDV) {
     // Reading before comparing just to make sure it will always read all the
-    // words and the right amount of ECC errors will be generated.
+    // words and the right number of ECC errors will be generated.
     LOG_INFO("Checking backdoor  0x%x", mem_frame->backdoor);
     uint32_t kBackdoorExpectedWords[kTestBufferSizeWords];
     memcpy(kBackdoorExpectedWords, kBackdoorExpectedBytes,


### PR DESCRIPTION
This bring up the test `chip_sw_sram_ctrl_scrambed_access` (and should improve/fix related tests) on Darjeeling:

 - The Darjeeling vseq is updated to match the latest software test; in particular the synchronization mechanism has been modified extensively since the integrated_dev branch was forked.
 - The sampling frequencies are adjusted to operate with the real Darjeeling clock frequencies.
 - OTP control request indexes are modified, because there are a different number of request/response channels in Darjeeling.
 - Sampling of the `light_reset_req` signal must be performed more frequently because it is asserted only very briefly in response to a sw reset request.
