### PR TITLE
Remove rom ctrl base vseq warnings

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -58,6 +58,9 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   rst_shadowed_vif    rst_shadowed_vif;
   virtual clk_rst_if  edn_clk_rst_vif;
 
+  // Default tl_access timeout - override in child classes where necessary
+  uint tl_access_timeout_ns = default_spinwait_timeout_ns;
+
   // If the data intg is passthru for the memory and the data intg value in mem is incorrect, it
   // won't trigger d_error in this mem block and the check is done in the processor
   // User can set this flag to disable the check for d_user.data_intg

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -175,7 +175,7 @@ class cip_base_vseq #(
   virtual task tl_access(input bit [BUS_AW-1:0]  addr,
                          input bit               write,
                          inout bit [BUS_DW-1:0]  data,
-                         input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
+                         input uint              tl_access_timeout_ns = cfg.tl_access_timeout_ns,
                          input bit [BUS_DBW-1:0] mask = '1,
                          input bit               check_rsp = 1'b1,
                          input bit               exp_err_rsp = 1'b0,
@@ -201,7 +201,7 @@ class cip_base_vseq #(
       inout bit [BUS_DW-1:0]  data,
       output bit              completed,
       output bit              saw_err,
-      input uint              tl_access_timeout_ns = default_spinwait_timeout_ns,
+      input uint              tl_access_timeout_ns = cfg.tl_access_timeout_ns,
       input bit [BUS_DBW-1:0] mask = '1,
       input bit               check_rsp = 1'b1,
       input bit               exp_err_rsp = 1'b0,
@@ -231,23 +231,24 @@ class cip_base_vseq #(
     end
   endtask
 
-  virtual task tl_access_sub(input bit [BUS_AW-1:0]  addr,
-                             input bit               write,
-                             inout bit [BUS_DW-1:0]  data,
-                             output bit              completed,
-                             output bit              saw_err,
-                             output                  cip_tl_seq_item rsp,
-                             input                   uint tl_access_timeout_ns = default_spinwait_timeout_ns,
-                             input bit [BUS_DBW-1:0] mask = '1,
-                             input bit               check_rsp = 1'b1,
-                             input bit               exp_err_rsp = 1'b0,
-                             input bit [BUS_DW-1:0]  exp_data = 0,
-                             input bit [BUS_DW-1:0]  compare_mask = '1,
-                             input bit               check_exp_data = 1'b0,
-                             input int               req_abort_pct = 0,
-                             input                   mubi4_t instr_type = MuBi4False,
-                                                     tl_sequencer tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                             input                   tl_intg_err_e tl_intg_err_type = TlIntgErrNone);
+  virtual task tl_access_sub(
+      input bit [BUS_AW-1:0]  addr,
+      input bit               write,
+      inout bit [BUS_DW-1:0]  data,
+      output bit              completed,
+      output bit              saw_err,
+      output                  cip_tl_seq_item rsp,
+      input                   uint tl_access_timeout_ns = cfg.tl_access_timeout_ns,
+      input bit [BUS_DBW-1:0] mask = '1,
+      input bit               check_rsp = 1'b1,
+      input bit               exp_err_rsp = 1'b0,
+      input bit [BUS_DW-1:0]  exp_data = 0,
+      input bit [BUS_DW-1:0]  compare_mask = '1,
+      input bit               check_exp_data = 1'b0,
+      input int               req_abort_pct = 0,
+      input                   mubi4_t instr_type = MuBi4False,
+      tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h,
+      input                   tl_intg_err_e tl_intg_err_type = TlIntgErrNone);
 
     cip_tl_host_single_seq tl_seq;
     `uvm_create_on(tl_seq, tl_sequencer_h)

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -15,10 +15,6 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // ext interfaces
   rom_ctrl_vif rom_ctrl_vif;
 
-  // Default is 10ms (see default_spinwait_timeout_ns in csr_utils_pkg.sv)
-  // We have to increase this here since the ROM check may actually take longer than that,
-  // which sometimes causes blocked TL accesses to time out.
-  uint tl_access_timeout_ns = 40_000_000; // 40ms
 
   // A handle to the scoreboard, used to flag expected errors.
   rom_ctrl_scoreboard scoreboard;
@@ -75,6 +71,12 @@ function void rom_ctrl_env_cfg::initialize(bit [31:0] csr_base_addr = '1);
 
   // Tell the CIP base code what bit gets set if we see a TL fault.
   tl_intg_alert_fields[ral.fatal_alert_cause.integrity_error] = 1;
+
+  // Default is 10ms (see default_spinwait_timeout_ns in csr_utils_pkg.sv, assigned in
+  // cip_base_env_cfg)
+  // We have to increase this here since the ROM check may actually take longer than that,
+  // which sometimes causes blocked TL accesses to time out.
+  tl_access_timeout_ns = 40_000_000; // 40ms
 endfunction
 
 // Override the default implementation in dv_base_env_cfg.

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -21,41 +21,6 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
   extern virtual task do_rand_ops(int num_ops, bit read_only = 0);
   extern virtual task read_digest_regs();
   extern virtual function bit [DIGEST_SIZE-1:0] get_expected_digest();
-  extern virtual task tl_access(
-                          input bit [TL_AW-1:0]  addr,
-                          input bit              write,
-                          inout bit [TL_DW-1:0]  data,
-                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
-                          input bit [TL_DBW-1:0] mask = '1,
-                          input bit              check_rsp = 1'b1,
-                          input bit              exp_err_rsp = 1'b0,
-                          input bit [TL_DW-1:0]  exp_data = 0,
-                          input bit [TL_DW-1:0]  compare_mask = '1,
-                          input bit              check_exp_data = 1'b0,
-                          input bit              blocking = csr_utils_pkg::default_csr_blocking,
-                          input mubi4_t          instr_type = MuBi4False,
-                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone);
-
-  extern virtual task tl_access_w_abort(
-                          input bit [TL_AW-1:0]  addr,
-                          input bit              write,
-                          inout bit [TL_DW-1:0]  data,
-                          output bit             completed,
-                          output bit             saw_err,
-                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
-                          input bit [TL_DBW-1:0] mask = '1,
-                          input bit              check_rsp = 1'b1,
-                          input bit              exp_err_rsp = 1'b0,
-                          input bit [TL_DW-1:0]  exp_data = 0,
-                          input bit [TL_DW-1:0]  compare_mask = '1,
-                          input bit              check_exp_data = 1'b0,
-                          input bit              blocking = csr_utils_pkg::default_csr_blocking,
-                          input mubi4_t          instr_type = MuBi4False,
-                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone,
-                          input int              req_abort_pct = 0);
-
   extern function void set_kmac_digest(bit [DIGEST_SIZE-1:0] value);
   extern function void configure_kmac_digest(bit as_expected);
   extern task wait_for_fatal_alert(bit check_fsm_state = 1'b1,
@@ -164,74 +129,6 @@ function bit [DIGEST_SIZE-1:0] rom_ctrl_base_vseq::get_expected_digest();
   end
   return digest;
 endfunction
-
-// Overrides tl_access in cip_base_vseq to add custom timeout. Timeout overriden to
-// cfg.tl_access_timeout_ns (40ms)
-// The ROM takes a while to be read and otherwise some tests may timeout when using
-// default timeout.
-task rom_ctrl_base_vseq::tl_access(
-                          input bit [TL_AW-1:0]  addr,
-                          input bit              write,
-                          inout bit [TL_DW-1:0]  data,
-                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
-                          input bit [TL_DBW-1:0] mask = '1,
-                          input bit              check_rsp = 1'b1,
-                          input bit              exp_err_rsp = 1'b0,
-                          input bit [TL_DW-1:0]  exp_data = 0,
-                          input bit [TL_DW-1:0]  compare_mask = '1,
-                          input bit              check_exp_data = 1'b0,
-                          input bit              blocking = csr_utils_pkg::default_csr_blocking,
-                          input mubi4_t          instr_type = MuBi4False,
-                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone);
-
-  if (tl_access_timeout_ns < cfg.tl_access_timeout_ns) begin
-    tl_access_timeout_ns = cfg.tl_access_timeout_ns;
-  end
-
-  super.tl_access(.addr(addr), .write(write), .data(data),
-                  .tl_access_timeout_ns(tl_access_timeout_ns),
-                  .mask(mask), .check_rsp(check_rsp), .exp_err_rsp(exp_err_rsp),
-                  .compare_mask(compare_mask), .check_exp_data(check_exp_data),
-                  .blocking(blocking), .instr_type(instr_type), .tl_sequencer_h(tl_sequencer_h),
-                  .tl_intg_err_type(tl_intg_err_type));
-endtask
-
-// Overrides tl_access_w_abort in cip_base_vseq to add custom timeout. Timeout overriden to
-// cfg.tl_access_timeout_ns (40ms)
-// The ROM takes a while to be read and otherwise some tests may timeout when using
-// default timeout.
-task rom_ctrl_base_vseq::tl_access_w_abort(
-                          input bit [TL_AW-1:0]  addr,
-                          input bit              write,
-                          inout bit [TL_DW-1:0]  data,
-                          output bit             completed,
-                          output bit             saw_err,
-                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
-                          input bit [TL_DBW-1:0] mask = '1,
-                          input bit              check_rsp = 1'b1,
-                          input bit              exp_err_rsp = 1'b0,
-                          input bit [TL_DW-1:0]  exp_data = 0,
-                          input bit [TL_DW-1:0]  compare_mask = '1,
-                          input bit              check_exp_data = 1'b0,
-                          input bit              blocking = csr_utils_pkg::default_csr_blocking,
-                          input mubi4_t          instr_type = MuBi4False,
-                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone,
-                          input int              req_abort_pct = 0);
-
-  if (tl_access_timeout_ns < cfg.tl_access_timeout_ns) begin
-    tl_access_timeout_ns = cfg.tl_access_timeout_ns;
-  end
-
-  super.tl_access_w_abort(.addr(addr), .write(write), .data(data), .completed(completed),
-                          .saw_err(saw_err), .tl_access_timeout_ns(tl_access_timeout_ns),
-                          .mask(mask), .check_rsp(check_rsp), .exp_err_rsp(exp_err_rsp),
-                          .exp_data(exp_data), .compare_mask(compare_mask),
-                          .check_exp_data(check_exp_data), .blocking(blocking),
-                          .instr_type(instr_type), .tl_sequencer_h(tl_sequencer_h),
-                          .tl_intg_err_type(tl_intg_err_type), .req_abort_pct(req_abort_pct));
-endtask
 
 // Configure the KMAC agent to respond with a digest matching the given value. This is sent in two
 // shares, which are chosen randomly.


### PR DESCRIPTION
This PR is meant to remove the rom_ctrl warnings which said the arguments in the `tl_access*` task don't match the ones in the parent class.

There's no need to override the method now, instead rom_ctrl_env_cfg overrides the `tl_access_timeout_ns` to the desired value.

The warnings were:
```
Warning-[MDVMO] Multiple default values in method override
../src/lowrisc_dv_rom_ctrl_env_0.1/seq_lib/rom_ctrl_base_vseq.sv, 28
rom_ctrl_env_pkg, "rom_ctrl_env_pkg_rom_ctrl_base_vseq_11_0::tl_access"
  The class method argument 'tl_access_timeout_ns' has different default 
  values specified at the base 
  ("../src/lowrisc_dv_cip_lib_0/seq_lib/cip_base_vseq.sv", 178) and the 
  current definition.
  VCS resolves default arguments of functions at compile time so the current 
  one will be used regardless of virtual override.


Warning-[MDVMO] Multiple default values in method override
../src/lowrisc_dv_rom_ctrl_env_0.1/seq_lib/rom_ctrl_base_vseq.sv, 46
rom_ctrl_env_pkg, "rom_ctrl_env_pkg_rom_ctrl_base_vseq_11_0::tl_access_w_abort"
  The class method argument 'tl_access_timeout_ns' has different default 
  values specified at the base 
  ("../src/lowrisc_dv_cip_lib_0/seq_lib/cip_base_vseq.sv", 204) and the 
  current definition.
  VCS resolves default arguments of functions at compile time so the current 
  one will be used regardless of virtual override.

```