### PR TITLE
[rescue, rom_ext_e2e] Test rescue with a restricted command set

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -71,6 +71,8 @@
   (owner_keydata_t) { .ecdsa = UNLOCK_ECDSA_P256 }
 #endif
 
+// The following preprocessor symbols are only relevant when
+// WITH_RESCUE_PROTOCOL is defined.
 #ifndef WITH_RESCUE_GPIO_PARAM
 #define WITH_RESCUE_GPIO_PARAM 0
 #endif
@@ -82,6 +84,15 @@
 #endif
 #ifndef WITH_RESCUE_TRIGGER
 #define WITH_RESCUE_TRIGGER 1 /* default to UartBreak */
+#endif
+#ifndef WITH_RESCUE_COMMAND_ALLOW
+#define WITH_RESCUE_COMMAND_ALLOW                                            \
+  kRescueModeBootLog, kRescueModeBootSvcRsp, kRescueModeBootSvcReq,          \
+      kRescueModeOwnerBlock, kRescueModeOwnerPage0, kRescueModeOwnerPage1,   \
+      kRescueModeOpenTitanID, kRescueModeFirmware, kRescueModeFirmwareSlotB, \
+      kBootSvcEmptyReqType, kBootSvcNextBl0SlotReqType,                      \
+      kBootSvcMinBl0SecVerReqType, kBootSvcOwnershipActivateReqType,         \
+      kBootSvcOwnershipUnlockReqType,
 #endif
 
 rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
@@ -233,22 +244,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
       .start = 32,
       .size = 224,
   };
-  const uint32_t commands[] = {
-      kRescueModeBootLog,
-      kRescueModeBootSvcRsp,
-      kRescueModeBootSvcReq,
-      kRescueModeOwnerBlock,
-      kRescueModeOwnerPage0,
-      kRescueModeOwnerPage1,
-      kRescueModeOpenTitanID,
-      kRescueModeFirmware,
-      kRescueModeFirmwareSlotB,
-      kBootSvcEmptyReqType,
-      kBootSvcNextBl0SlotReqType,
-      kBootSvcMinBl0SecVerReqType,
-      kBootSvcOwnershipActivateReqType,
-      kBootSvcOwnershipUnlockReqType,
-  };
+  const uint32_t commands[] = {WITH_RESCUE_COMMAND_ALLOW};
   memcpy(&rescue->command_allow, commands, sizeof(commands));
   rescue->header.length += sizeof(commands);
   end = (uintptr_t)rescue + rescue->header.length;

--- a/sw/device/silicon_creator/lib/rescue/rescue.h
+++ b/sw/device/silicon_creator/lib/rescue/rescue.h
@@ -49,6 +49,8 @@ typedef enum {
   kRescueModeReboot = 0x5245424f,
   /** `WAIT` */
   kRescueModeWait = 0x57414954,
+  /** `NOOP` */
+  kRescueModeNoOp = 0x4e4f4f50,
 } rescue_mode_t;
 
 typedef enum {
@@ -67,7 +69,10 @@ typedef enum {
 } rescue_baud_t;
 
 typedef struct RescueState {
+  // Current rescue mode.
   rescue_mode_t mode;
+  // Default rescue mode.
+  rescue_mode_t default_mode;
   // Inactivity deadline.
   uint64_t inactivity_deadline;
   // Current xmodem frame.

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -65,7 +65,7 @@ static rom_error_t handle_send_modes(rescue_state_t *state) {
   if (error == kErrorRescueSendStart && state->staged_len > 0) {
     error = xmodem_send(iohandle, state->data, state->staged_len);
     state->staged_len = 0;
-    validate_mode(kRescueModeFirmware, state);
+    validate_mode(state->default_mode, state);
   }
   return error;
 }
@@ -84,7 +84,7 @@ static rom_error_t protocol(rescue_state_t *state) {
   uint8_t command;
   uint32_t next_mode = 0;
 
-  validate_mode(kRescueModeFirmware, state);
+  validate_mode(state->default_mode, state);
 
   xmodem_recv_start(iohandle);
   while (true) {
@@ -95,7 +95,9 @@ static rom_error_t protocol(rescue_state_t *state) {
 
     HARDENED_RETURN_IF_ERROR(rescue_inactivity(state));
     if (state->frame == 1 && result == kErrorXModemTimeoutStart) {
-      xmodem_recv_start(iohandle);
+      if (state->mode != kRescueModeNoOp) {
+        xmodem_recv_start(iohandle);
+      }
       continue;
     }
 

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -86,4 +86,34 @@ TEST_OWNER_CONFIGS = {
         ],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
     },
+    "xmodem_restricted_commands": {
+        # Enable Xmodem rescue with enter-on-fail and a timeout.
+        "owner_defines": [
+            # 0x58 is 'X'modem.
+            "WITH_RESCUE_PROTOCOL=0x58",
+            # Restrict rescue to only one command
+            "WITH_RESCUE_COMMAND_ALLOW=kRescueModeOpenTitanID",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_xmodem"],
+    },
+    "spidfu_restricted_commands": {
+        # Enable USB-DFU triggered by SW_STRAPS value 3.
+        "owner_defines": [
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_GPIO_PARAM=3",
+            # Timeout: 0x80=enter_on_fail, 0x00 = No timeout.
+            "WITH_RESCUE_TIMEOUT=0x80",
+            # Restrict rescue to only one command
+            "WITH_RESCUE_COMMAND_ALLOW=kRescueModeOpenTitanID",
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -360,6 +360,74 @@ opentitan_test(
     ],
 )
 
+# Check that xmodem rescue is functional when the `RESQ` mode is disabled.
+opentitan_test(
+    name = "xmodem_restricted_commands",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        exit_failure = "ok: ",
+        exit_success = "error: mode not allowed",
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_restricted_commands",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            # Trigger rescue and make sure we can get the device ID.
+            --exec="rescue get-device-id --reboot=false"
+            # Try the `RESQ` mode and make sure we get an error message.
+            --exec="console --non-interactive --send='RESQ\r' --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+            no-op
+        """,
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+# Check that DFU rescue is functional when the `RESQ` mode is disabled.
+# TODO: Add a test to try to perform a firmware rescue and ensure that it fails.
+opentitan_test(
+    name = "spidfu_restricted_commands",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_restricted_commands",
+        setup = "--exec=\"gpio set --mode OpenDrain Ioa2\"",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            {setup}
+            --exec="bootstrap --clear-uart=true {firmware}"
+            # Trigger rescue and make sure we can get the device ID.
+            --exec="rescue {params} get-device-id --reboot=false"
+            no-op
+        """,
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
 [
     opentitan_test(
         name = "rescue_enter_on_fail_{}".format(name),

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -37,7 +37,7 @@ pub struct Firmware {
     offset: Option<usize>,
     #[arg(long, default_value_t = false, help = "Upload the file contents as-is")]
     raw: bool,
-    #[arg(long, default_value_t = true, help = "Reboot after upload")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(
         long,
@@ -101,7 +101,7 @@ pub struct GetBootLog {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(long, short, default_value = "false")]
     raw: bool,
@@ -139,7 +139,7 @@ pub struct GetBootSvc {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(long, short, default_value = "false")]
     raw: bool,
@@ -177,7 +177,7 @@ pub struct GetDeviceId {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(long, short, default_value = "false")]
     raw: bool,
@@ -229,7 +229,7 @@ pub struct SetNextBl0Slot {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(
         long,
@@ -273,7 +273,7 @@ pub struct OwnershipUnlock {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(
         long,
@@ -328,7 +328,7 @@ pub struct OwnershipActivate {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(
         long,
@@ -383,7 +383,7 @@ pub struct SetOwnerConfig {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(help = "A signed owner configuration block")]
     input: PathBuf,
@@ -416,7 +416,7 @@ pub struct GetOwnerConfig {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(long, short, default_value = "false", conflicts_with = "output")]
     raw: bool,
@@ -498,7 +498,7 @@ pub struct EraseOwner {
         help = "Method to reset for rescue mode",
     )]
     reset_target: EntryMode,
-    #[arg(long, default_value_t = true, help = "Reboot after the rescue command")]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Reboot after the rescue command")]
     reboot: bool,
     #[arg(long, default_value_t = false, help = "Really erase the owner config")]
     really: bool,


### PR DESCRIPTION
1. Add a `no-op` mode to rescue so that the xmodem protocol is functional if the owner disables the `RescueFirwmare` command.
2. Make the `no-op` mode the default if `RescueFirmware` is absent from the allowed commands list.
3. Test that the rescue protocol is functional when the `RescueFirmware` mode is not in the list of allowed commands.