### PR TITLE
[otp_ctrl] Expand overly wide literals (vectors)

### DIFF
--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -566,7 +566,7 @@ package otp_ctrl_part_pkg;
     78784'({
       64'hC469C593E5DC0DA8,
       5184'h0, // unallocated space
-      73536'h0
+      73536'({8000'h0, 65536'h0})
     }),
     8192'({
       8192'h0


### PR DESCRIPTION
LRM 6.9.1 says vectors (constant literals) may not exceed an implementation-defined width, which Verilator defaults to 2^16. Expand overly wide vectors into a concatenation of narrower vectors. Addresses #26883.