### PR TITLE
[opentitantool] Configure IOA2 with OpenDrain mode PullDown

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw340.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw340.json
@@ -48,6 +48,12 @@
       "mode": "Alternate",
       "pull_mode": "PullUp",
       "alias_of": "IOA7"
+    },
+    {
+      "name": "IOA2",
+      "mode": "OpenDrain",
+      "level": false,
+      "pull_mode": "PullDown"
     }
   ],
   "strappings": [


### PR DESCRIPTION
This introduces a configuration change to configure IOA2 pin with OpenDrain mode and PullDown by default to prevent the SPI rescue signal being unintentionally triggered.