### PR TITLE
[ownership] Lock owner INFO pages 

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
@@ -78,6 +78,10 @@ void flash_ctrl_info_cfg_set(const flash_ctrl_info_page_t *info_page,
   MockFlashCtrl::Instance().InfoCfgSet(info_page, cfg);
 }
 
+void flash_ctrl_info_cfg_lock(const flash_ctrl_info_page_t *info_page) {
+  MockFlashCtrl::Instance().InfoCfgLock(info_page);
+}
+
 void flash_ctrl_data_region_protect(flash_ctrl_region_index_t region,
                                     uint32_t page_offset, uint32_t num_pages,
                                     flash_ctrl_perms_t perms,

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
@@ -43,6 +43,7 @@ class MockFlashCtrl : public global_mock::GlobalMock<MockFlashCtrl> {
                flash_ctrl_cfg_t cfg, hardened_bool_t));
   MOCK_METHOD(void, InfoCfgSet,
               (const flash_ctrl_info_page_t *, flash_ctrl_cfg_t));
+  MOCK_METHOD(void, InfoCfgLock, (const flash_ctrl_info_page_t *));
   MOCK_METHOD(void, BankErasePermsSet, (hardened_bool_t));
   MOCK_METHOD(void, ExecSet, (uint32_t));
   MOCK_METHOD(void, CreatorInfoPagesLockdown, ());
@@ -69,6 +70,16 @@ MATCHER_P3(FlashCfg, scrambling, ecc, he, "") {
   return arg.scrambling == static_cast<uint8_t>(scrambling) &&
          arg.ecc == static_cast<uint8_t>(ecc) &&
          arg.he == static_cast<uint8_t>(he);
+}
+
+MATCHER_P(FlashInfoPage, page, "") {
+  return ::testing::Value(
+      arg,
+      ::testing::AllOf(
+          ::testing::Field(&flash_ctrl_info_page_t::base_addr, page.base_addr),
+          ::testing::Field(&flash_ctrl_info_page_t::cfg_wen_addr,
+                           page.cfg_wen_addr),
+          ::testing::Field(&flash_ctrl_info_page_t::cfg_addr, page.cfg_addr)));
 }
 
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -505,6 +505,29 @@ rom_error_t owner_block_info_apply(const owner_flash_info_config_t *info) {
   return kErrorOk;
 }
 
+rom_error_t owner_block_info_lockdown(const owner_flash_info_config_t *info) {
+  if ((hardened_bool_t)info == kHardenedBoolFalse)
+    return kErrorOk;
+  size_t len = (info->header.length - sizeof(owner_flash_info_config_t)) /
+               sizeof(owner_info_page_t);
+  const owner_info_page_t *config = info->config;
+  uint32_t crypt = 0;
+  for (size_t i = 0; i < len; ++i, ++config, crypt += 0x11111111) {
+    if (is_owner_page(config->bank, config->page) == kHardenedBoolTrue) {
+      flash_ctrl_info_page_t page;
+      HARDENED_RETURN_IF_ERROR(flash_ctrl_info_type0_params_build(
+          config->bank, config->page, &page));
+      uint32_t val = config->access ^ crypt;
+      if (bitfield_field32_read(val, FLASH_CONFIG_LOCK) !=
+          kMultiBitBool4False) {
+        flash_ctrl_info_cfg_lock(&page);
+        SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInfoCfgLock);
+      }
+    }
+  }
+  return kErrorOk;
+}
+
 rom_error_t owner_block_rescue_apply(const owner_rescue_config_t *rescue) {
   rescue_detect_t detect = bitfield_field32_read(rescue->detect, RESCUE_DETECT);
   uint32_t index = bitfield_field32_read(rescue->detect, RESCUE_DETECT_INDEX);

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -157,6 +157,14 @@ rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
  */
 rom_error_t owner_block_info_apply(const owner_flash_info_config_t *info);
 
+/**
+ * Lock the flash info configuration parameters as requested by the owner block.
+ *
+ * @param info A pointer to a flash_info configuration.
+ * @return error code.
+ */
+rom_error_t owner_block_info_lockdown(const owner_flash_info_config_t *info);
+
 rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
                                    uint32_t key_id, size_t *index);
 

--- a/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
@@ -21,10 +21,13 @@ namespace {
 #include "sw/device/silicon_creator/lib/ownership/testdata/basic_owner_testdata.h"
 
 using rom_test::FlashCfg;
+using rom_test::FlashInfoPage;
 using rom_test::FlashPerms;
 using rom_test::MockFlashCtrl;
 using ::testing::_;
+using ::testing::DoAll;
 using ::testing::Return;
+using ::testing::SetArgPointee;
 using ::testutil::BinaryBlob;
 
 class OwnerBlockTest : public rom_test::RomTest {
@@ -210,7 +213,7 @@ const owner_flash_info_config_t info_config = {
                     /*program=*/true,
                     /*erase=*/true,
                     /*pwp=*/false,
-                    /*lock=*/false),
+                    /*lock=*/true),
                 .properties = FLASH_PROP(
                     /*index=*/0,
                     /*scramble=*/false,
@@ -579,6 +582,18 @@ TEST_F(OwnerBlockTest, FlashInfoApply) {
                                          kMultiBitBool4True)));
 
   rom_error_t error = owner_block_info_apply(&info_config);
+  EXPECT_EQ(error, kErrorOk);
+}
+
+TEST_F(OwnerBlockTest, FlashInfoLock) {
+  flash_ctrl_info_page_t info_page{
+      .base_addr = 999,
+  };
+  EXPECT_CALL(flash_ctrl_, InfoType0ParamsBuild(0, 6, _))
+      .WillOnce(DoAll(SetArgPointee<2>(info_page), Return(kErrorOk)));
+  EXPECT_CALL(flash_ctrl_, InfoCfgLock(FlashInfoPage(info_page)));
+
+  rom_error_t error = owner_block_info_lockdown(&info_config);
   EXPECT_EQ(error, kErrorOk);
 }
 

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -281,6 +281,7 @@ rom_error_t ownership_flash_lockdown(boot_data_t *bootdata, boot_log_t *bootlog,
     HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(
         config->flash, kBootSlotB,
         /*owner_lockdown=*/bootlog->bl0_slot, &mp_index));
+    HARDENED_RETURN_IF_ERROR(owner_block_info_lockdown(config->info));
   } else {
     HARDENED_CHECK_NE(bootdata->ownership_state, kOwnershipStateLockedOwner);
   }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -645,6 +645,12 @@ static void rom_ext_rescue_lockdown(boot_data_t *boot_data) {
   flash_ctrl_creator_info_pages_lockdown();
   // Set the OWNER_CONFIG pages for rescue mode (page0=ro, page1=rw).
   ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolTrue);
+  // Lock access to owner-level INFO pages.  During normal boot, this
+  // is performed by `ownership_flash_lockdown`, but we can't call that
+  // function when entering rescue because rescue needs the flash DATA
+  // segments to be writable.  Rescue has no need to access the INFO
+  // pages, so we want to lock them for safety.
+  owner_block_info_lockdown(owner_config.info);
 }
 
 static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -131,12 +131,21 @@ fn flash_info_check(info: &[FlashRegion<'_>], unlocked: bool) -> Result<()> {
         FlashRegion("info", 1, 0, 1, "uu-uu-uu-uu-uu-uu", "LK"), // boot data 1
         FlashRegion("info", 1, 0, 2, "RD-xx-xx-SC-EC-xx", "LK"), // owner config 0
         if unlocked {
+            // Owner Config 1 is a creator-level INFO page and is left
+            // writeable when the device is in an unlocked state.
             FlashRegion("info", 1, 0, 3, "RD-WR-ER-SC-EC-xx", "LK") // owner config 1
         } else {
             FlashRegion("info", 1, 0, 3, "RD-xx-xx-SC-EC-xx", "LK") // owner config 1
         },
         FlashRegion("info", 1, 0, 4, "uu-uu-uu-uu-uu-uu", "LK"), // creator reserved
-        FlashRegion("info", 1, 0, 5, "RD-WR-ER-xx-xx-HE", "UN"), // owner reserved
+        // Like DATA pages, owner-level INFO pages are left unlocked
+        // when the device is in an unlocked state and, if so configured,
+        // are locked when in the LockedOwner state.
+        if unlocked {
+            FlashRegion("info", 1, 0, 5, "RD-WR-ER-xx-xx-HE", "UN") // owner reserved
+        } else {
+            FlashRegion("info", 1, 0, 5, "RD-WR-ER-xx-xx-HE", "LK") // owner reserved
+        },
         FlashRegion("info", 1, 0, 6, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved
         FlashRegion("info", 1, 0, 7, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved
         FlashRegion("info", 1, 0, 8, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved


### PR DESCRIPTION
The owner-level INFO pages have a `lock` bit in their configuration that
specifies that their configuration should be locked by the ROM_EXT
before booting the owner firmware.

1. Add a function to lock the so-configured INFO pages.
2. Perform the lockdown before booting owner firmware and before entering rescue mode.
3. Add tests.