### PR TITLE
[opentitanlib,manuf] apply #27011 to hyper310 and decrease FT timeout

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
@@ -223,6 +223,12 @@
     {
       "name": "CC2",
       "alias_of": "CN7_10"
+    },
+    {
+      "name": "IOA2",
+      "mode": "OpenDrain",
+      "level": false,
+      "pull_mode": "PullDown"
     }
   ],
   "spi": [

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw340.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw340.json
@@ -48,12 +48,6 @@
       "mode": "Alternate",
       "pull_mode": "PullUp",
       "alias_of": "IOA7"
-    },
-    {
-      "name": "IOA2",
-      "mode": "OpenDrain",
-      "level": false,
-      "pull_mode": "PullDown"
     }
   ],
   "strappings": [

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -91,7 +91,7 @@ struct Opts {
     second_bootstrap: PathBuf,
 
     /// Console receive timeout.
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "20s")]
     timeout: Duration,
 
     /// Name of the SPI interface to connect to the OTTF console.


### PR DESCRIPTION
PR #27011 updated the default configuration of IOA2 to prevent provisioning flows accidentally entering SPI rescue. This applies the fix to both hyper310 and hyper340 boards.

Additionally, this decreases the default FT timeout to reduce CI times.