### PR TITLE
[opentitanlib] Configure IOA2 for testing

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_chipwhisperer.json
@@ -30,6 +30,8 @@
     },
     {
       "name": "IOA2",
+      "mode": "PushPull",
+      "level": false,
       "alias_of": "CN9_29"
     },
     {
@@ -223,12 +225,6 @@
     {
       "name": "CC2",
       "alias_of": "CN7_10"
-    },
-    {
-      "name": "IOA2",
-      "mode": "OpenDrain",
-      "level": false,
-      "pull_mode": "PullDown"
     }
   ],
   "spi": [

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -48,6 +48,8 @@
     },
     {
       "name": "IOA2",
+      "mode": "PushPull",
+      "level": false,
       "alias_of": "CN9_29"
     },
     {


### PR DESCRIPTION
Configure IOA2 as a push-pull output with a default level of logic-low. Currently, we use IOA2 as a trigger for SPI rescue in some configurations.  This change prevents errant triggering of SPI resuce and regularizes the configuration across hyperdebug configurations.