### PR TITLE
[dv] add perso sim configuration

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -239,6 +239,24 @@ LC_MISSION_STATES = get_lc_items(
     CONST.LCV.PROD_END,
 )
 
+# Individualized configuration for DV and FPGA testing. Available in all mission
+# mode LC states. This configuration has flash scrambling enabled.
+[
+    otp_image(
+        name = "otp_img_{}_manuf_individualized".format(lc_state),
+        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
+        overlays = [
+            "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
+            ":alert_digest_cfg",
+            ":otp_json_creator_sw_cfg",
+            ":otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg0",
+            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg1",
+        ] + OTP_SIGVERIFY_REAL_KEYS,
+    )
+    for lc_state, _ in LC_MISSION_STATES
+]
+
 # Personalized configuration for FPGA testing. Available on `LC_MISSION_STATES`
 # life cycle states.
 # See sw/device/tests/doc/sival/devguide.md for more details.

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -836,6 +836,21 @@
       ]
       run_timeout_mins: 800
     }
+    {
+      name: rom_e2e_ft_personalize_sival
+      uvm_test_seq: chip_sw_rom_e2e_ft_perso_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival:1:silicon_creator:signed",
+        "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_individualized:4"
+      ]
+      en_run_modes: ["sw_test_mode_mask_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=1000000000",
+        "+use_otp_image=OtpTypeCustom",
+        "+skip_flash_bkdr_load=1",
+      ]
+      run_timeout_mins: 800
+    }
 
     // ROM func tests to be run with test ROM.
     {

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -141,6 +141,7 @@ filesets:
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_ate_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_e2e_ft_perso_vseq extends
+  chip_sw_rom_e2e_base_vseq;
+  `uvm_object_utils(chip_sw_rom_e2e_ft_perso_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    super.body();
+
+    // Drive SW straps for bootstrap.
+    `uvm_info(`gfn, "Driving SW straps high for bootstrap.", UVM_LOW)
+    cfg.chip_vif.sw_straps_if.drive(3'h7);
+    `uvm_info(`gfn, "Initializing SPI flash bootstrap.", UVM_LOW)
+    spi_device_load_bootstrap({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"});
+    `uvm_info(`gfn, "SPI flash bootstrap done.", UVM_LOW)
+
+    // Wait for SRAM initialization to complete a second time (after bootstrap).
+    `uvm_info(`gfn, "Waiting for SRAM initialization to complete (after bootstrap).", UVM_LOW)
+    `DV_WAIT(cfg.chip_vif.sram_ret_init_done == 1,
+             $sformatf({"Timeout occurred when waiting for SRAM initialization; ",
+                        "Current sram_ret_init_done = 1'%0b, Timeout value = %0dns"},
+                        cfg.chip_vif.sram_ret_init_done,
+                        cfg.sw_test_timeout_ns),
+             cfg.sw_test_timeout_ns)
+    `uvm_info(`gfn, "ROM SRAM initialization done.", UVM_LOW)
+
+    // Wait for IOA1 (perso done GPIO indicator) to toggle on.
+    `DV_WAIT(cfg.chip_vif.mios[top_earlgrey_pkg::MioPadIoa1] == '1,
+             $sformatf("Timed out waiting for IOA1 to go high."),
+             cfg.sw_test_timeout_ns)
+
+    // Set test passed.
+    override_test_status_and_finish(.passed(1'b1));
+  endtask
+
+endclass : chip_sw_rom_e2e_ft_perso_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -98,6 +98,7 @@
 `include "chip_padctrl_attributes_vseq.sv"
 `include "chip_sw_rom_e2e_base_vseq.sv"
 `include "chip_sw_rom_e2e_ate_smoke_vseq.sv"
+`include "chip_sw_rom_e2e_ft_perso_vseq.sv"
 `include "chip_sw_rom_e2e_shutdown_exception_c_vseq.sv"
 `include "chip_sw_rom_e2e_shutdown_output_vseq.sv"
 `include "chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv"

--- a/sw/device/silicon_creator/manuf/base/binaries/BUILD
+++ b/sw/device/silicon_creator/manuf/base/binaries/BUILD
@@ -2,6 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load(
+    "//rules:opentitan.bzl",
+    "bin_to_vmem",
+    "scramble_flash_vmem",
+)
 load("//rules/opentitan:cc.bzl", "exec_env_filegroup")
 load("//rules:files.bzl", "copy_files")
 
@@ -33,4 +38,39 @@ exec_env_filegroup(
         "ft_personalize_sival_fpga_cw340_rom_with_fake_keys.signed.bin": "cw340",
         "ft_personalize_sival_silicon_creator.signed.bin": "silicon",
     },
+)
+
+# The below rule sets (bin_to_vmem, scramble_flash_vmem, and filegroup)
+# are needed to run the perso bin in sim.
+bin_to_vmem(
+    name = "ft_personalize_sival_silicon_creator_vmem64_signed",
+    testonly = True,
+    bin = ":ft_personalize_sival_silicon_creator.signed.bin",
+    word_size = 64,  # Backdoor-load VMEM image uses 64-bit words
+)
+
+scramble_flash_vmem(
+    name = "ft_personalize_sival_silicon_creator_scr_vmem64_signed",
+    testonly = True,
+    vmem = ":ft_personalize_sival_silicon_creator_vmem64_signed",
+)
+
+filegroup(
+    name = "ft_personalize_sival_dv_files",
+    testonly = True,
+    srcs = [
+        ":ft_personalize_sival_silicon_creator{}".format(file_type)
+        for file_type in [
+            ".signed.bin",
+            "_vmem64_signed",
+            "_scr_vmem64_signed",
+        ]
+    ],
+)
+
+# This alias is required for the DV testbench to locate these files.
+filegroup(
+    name = "ft_personalize_sival_silicon_creator",
+    testonly = True,
+    srcs = [":ft_personalize_sival_silicon_creator_vmem64_signed"],
 )


### PR DESCRIPTION
This adds the perso simulation configuration to enable ATE itegration of the personalization flow.