### PR TITLE
[dv] Iterate more carefully with foreach loops

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -116,10 +116,8 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
 
     // Default filter configuration
     // This is the one assumed for normal use
-    foreach (filter_cfg[channel]) {
-      foreach (filter_cfg[channel, filter]) {
-        soft filter_cfg[channel][filter] == FILTER_CFG_DEFAULTS[filter];
-      }
+    foreach (filter_cfg[channel, filter]) {
+      soft filter_cfg[channel][filter] == FILTER_CFG_DEFAULTS[filter];
     }
   }
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
@@ -74,11 +74,10 @@ class csrng_cmds_vseq extends csrng_base_vseq;
   endfunction
 
   function void print_cmds_all_apps();
-    for (int i = 0; i < NUM_HW_APPS + 1; i++) begin
-      foreach (cs_item_q[i, j]) begin
-        `uvm_info(`gfn, $sformatf("cs_item_q[%0d][%0d]: %s", i, j,
-            cs_item_q[i][j].convert2string()), UVM_DEBUG)
-      end
+    foreach (cs_item_q[i, j]) begin
+      `uvm_info(`gfn, $sformatf("cs_item_q[%0d][%0d]: %s",
+                                i, j, cs_item_q[i][j].convert2string()),
+                UVM_DEBUG)
     end
   endfunction
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -120,24 +120,23 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
     foreach (mp_info_pages[i, j]) {
 
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+    }
+    foreach (mp_info_pages[i, j, k]) {
 
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
 
-        mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
 
-        mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
 
-        mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
 
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
 
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -159,14 +159,14 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en      == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en      == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -105,18 +105,18 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -155,18 +155,18 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -33,18 +33,18 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
-          MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -65,18 +65,18 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
-          MuBi4True  :/ cfg.seq_cfg.mp_region_he_en_pc
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        MuBi4True  :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -93,40 +93,35 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint mp_info_pages_c {
-
-    foreach (mp_info_pages[i]) {
-      if (cfg.seq_cfg.op_readonly_on_info_partition) {
-        foreach (mp_info_pages[i][0][k]) {
-          mp_info_pages[i][0][k].program_en == MuBi4False;
-          mp_info_pages[i][0][k].erase_en == MuBi4False;
-        }
+    foreach (mp_info_pages[i, j, k]) {
+      if (j == 0 && cfg.seq_cfg.op_readonly_on_info_partition) {
+        mp_info_pages[i][j][k].program_en == MuBi4False;
+        mp_info_pages[i][j][k].erase_en == MuBi4False;
       }
-      if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-        foreach (mp_info_pages[i][1][k]) {
-          mp_info_pages[i][1][k].program_en == MuBi4False;
-          mp_info_pages[i][1][k].erase_en == MuBi4False;
-        }
+      if (j == 1 && cfg.seq_cfg.op_readonly_on_info1_partition) {
+        mp_info_pages[i][j][k].program_en == MuBi4False;
+        mp_info_pages[i][j][k].erase_en == MuBi4False;
       }
     }
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+    }
 
-      foreach (mp_info_pages[i, j, k]) {
-       mp_info_pages[i][j][k].en dist {
-                               MuBi4True := 4,
-                               MuBi4False := 1
-                               };
+    foreach (mp_info_pages[i, j, k]) {
+     mp_info_pages[i][j][k].en dist {
+                             MuBi4True := 4,
+                             MuBi4False := 1
+                             };
 
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
 
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
 
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -70,13 +70,13 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   constraint rand_info_c {
     foreach (rand_info[i, j]) {
       rand_info[i][j].size() == InfoTypeSize[j];
-      foreach (rand_info[i, j, k]) {
-        if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
-        rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
-        if (cfg.en_always_read) rand_info[i][j][k].read_en == MuBi4True;
-        rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
-        rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
-      }
+    }
+    foreach (rand_info[i, j, k]) {
+      if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
+      rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
+      if (cfg.en_always_read) rand_info[i][j][k].read_en == MuBi4True;
+      rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
+      rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
     }
   }
   constraint ctrl_data_num_c {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -183,44 +183,45 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
 
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
-      foreach (mp_info_pages[i, j, k]) {
+    }
 
-        mp_info_pages[i][j][k].en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_en_pc[i][j]
-        };
+    foreach (mp_info_pages[i, j, k]) {
 
-        mp_info_pages[i][j][k].read_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_read_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_read_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].program_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_program_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_program_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].read_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_read_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_read_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].erase_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].program_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_program_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_program_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].scramble_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].erase_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].ecc_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].scramble_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].ecc_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
+      };
 
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
+
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -120,24 +120,23 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
     foreach (mp_info_pages[i, j]) {
 
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+    }
+    foreach (mp_info_pages[i, j, k]) {
 
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
 
-        mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
 
-        mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
 
-        mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
 
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
 
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -159,14 +159,14 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en      == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en      == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -105,18 +105,18 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -155,18 +155,18 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -33,18 +33,18 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
-          MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -65,18 +65,18 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
-          MuBi4True  :/ cfg.seq_cfg.mp_region_he_en_pc
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        MuBi4True  :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -93,40 +93,35 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint mp_info_pages_c {
-
-    foreach (mp_info_pages[i]) {
-      if (cfg.seq_cfg.op_readonly_on_info_partition) {
-        foreach (mp_info_pages[i][0][k]) {
-          mp_info_pages[i][0][k].program_en == MuBi4False;
-          mp_info_pages[i][0][k].erase_en == MuBi4False;
-        }
+    foreach (mp_info_pages[i, j, k]) {
+      if (j == 0 && cfg.seq_cfg.op_readonly_on_info_partition) {
+        mp_info_pages[i][j][k].program_en == MuBi4False;
+        mp_info_pages[i][j][k].erase_en == MuBi4False;
       }
-      if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-        foreach (mp_info_pages[i][1][k]) {
-          mp_info_pages[i][1][k].program_en == MuBi4False;
-          mp_info_pages[i][1][k].erase_en == MuBi4False;
-        }
+      if (j == 1 && cfg.seq_cfg.op_readonly_on_info1_partition) {
+        mp_info_pages[i][j][k].program_en == MuBi4False;
+        mp_info_pages[i][j][k].erase_en == MuBi4False;
       }
     }
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+    }
 
-      foreach (mp_info_pages[i, j, k]) {
-       mp_info_pages[i][j][k].en dist {
-                               MuBi4True := 4,
-                               MuBi4False := 1
-                               };
+    foreach (mp_info_pages[i, j, k]) {
+     mp_info_pages[i][j][k].en dist {
+                             MuBi4True := 4,
+                             MuBi4False := 1
+                             };
 
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
 
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
 
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -70,13 +70,13 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   constraint rand_info_c {
     foreach (rand_info[i, j]) {
       rand_info[i][j].size() == InfoTypeSize[j];
-      foreach (rand_info[i, j, k]) {
-        if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
-        rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
-        if (cfg.en_always_read) rand_info[i][j][k].read_en == MuBi4True;
-        rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
-        rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
-      }
+    }
+    foreach (rand_info[i, j, k]) {
+      if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
+      rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
+      if (cfg.en_always_read) rand_info[i][j][k].read_en == MuBi4True;
+      rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
+      rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
     }
   }
   constraint ctrl_data_num_c {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -183,44 +183,45 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
 
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
-      foreach (mp_info_pages[i, j, k]) {
+    }
 
-        mp_info_pages[i][j][k].en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_en_pc[i][j]
-        };
+    foreach (mp_info_pages[i, j, k]) {
 
-        mp_info_pages[i][j][k].read_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_read_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_read_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].program_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_program_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_program_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].read_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_read_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_read_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].erase_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].program_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_program_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_program_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].scramble_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].erase_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].ecc_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].scramble_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].ecc_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
+      };
 
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
+
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -120,24 +120,23 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
     foreach (mp_info_pages[i, j]) {
 
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+    }
+    foreach (mp_info_pages[i, j, k]) {
 
-      foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
 
-        mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
 
-        mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
 
-        mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
 
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
 
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -159,14 +159,14 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en      == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en      == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -105,18 +105,18 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -155,18 +155,18 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -33,18 +33,18 @@ class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
-          MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mid_op_rst_vseq.sv
@@ -65,18 +65,18 @@ class flash_ctrl_mid_op_rst_vseq extends flash_ctrl_base_vseq;
   constraint mp_info_pages_c {
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
-      foreach (mp_info_pages[i][j][k]) {
-        mp_info_pages[i][j][k].en == MuBi4True;
-        mp_info_pages[i][j][k].read_en == MuBi4True;
-        mp_info_pages[i][j][k].program_en == MuBi4True;
-        mp_info_pages[i][j][k].erase_en == MuBi4True;
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
-          MuBi4True  :/ cfg.seq_cfg.mp_region_he_en_pc
-        };
-      }
+    }
+    foreach (mp_info_pages[i, j, k]) {
+      mp_info_pages[i][j][k].en == MuBi4True;
+      mp_info_pages[i][j][k].read_en == MuBi4True;
+      mp_info_pages[i][j][k].program_en == MuBi4True;
+      mp_info_pages[i][j][k].erase_en == MuBi4True;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        MuBi4True  :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -93,40 +93,35 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint mp_info_pages_c {
-
-    foreach (mp_info_pages[i]) {
-      if (cfg.seq_cfg.op_readonly_on_info_partition) {
-        foreach (mp_info_pages[i][0][k]) {
-          mp_info_pages[i][0][k].program_en == MuBi4False;
-          mp_info_pages[i][0][k].erase_en == MuBi4False;
-        }
+    foreach (mp_info_pages[i, j, k]) {
+      if (j == 0 && cfg.seq_cfg.op_readonly_on_info_partition) {
+        mp_info_pages[i][j][k].program_en == MuBi4False;
+        mp_info_pages[i][j][k].erase_en == MuBi4False;
       }
-      if (cfg.seq_cfg.op_readonly_on_info1_partition) {
-        foreach (mp_info_pages[i][1][k]) {
-          mp_info_pages[i][1][k].program_en == MuBi4False;
-          mp_info_pages[i][1][k].erase_en == MuBi4False;
-        }
+      if (j == 1 && cfg.seq_cfg.op_readonly_on_info1_partition) {
+        mp_info_pages[i][j][k].program_en == MuBi4False;
+        mp_info_pages[i][j][k].erase_en == MuBi4False;
       }
     }
 
     foreach (mp_info_pages[i, j]) {
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
+    }
 
-      foreach (mp_info_pages[i, j, k]) {
-       mp_info_pages[i][j][k].en dist {
-                               MuBi4True := 4,
-                               MuBi4False := 1
-                               };
+    foreach (mp_info_pages[i, j, k]) {
+     mp_info_pages[i][j][k].en dist {
+                             MuBi4True := 4,
+                             MuBi4False := 1
+                             };
 
-        mp_info_pages[i][j][k].scramble_en == MuBi4False;
+      mp_info_pages[i][j][k].scramble_en == MuBi4False;
 
-        mp_info_pages[i][j][k].ecc_en == MuBi4False;
+      mp_info_pages[i][j][k].ecc_en == MuBi4False;
 
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
     }
   }
 

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -70,13 +70,13 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   constraint rand_info_c {
     foreach (rand_info[i, j]) {
       rand_info[i][j].size() == InfoTypeSize[j];
-      foreach (rand_info[i, j, k]) {
-        if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
-        rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
-        if (cfg.en_always_read) rand_info[i][j][k].read_en == MuBi4True;
-        rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
-        rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
-      }
+    }
+    foreach (rand_info[i, j, k]) {
+      if (all_entry_en) rand_info[i][j][k].en == MuBi4True;
+      rand_info[i][j][k].en dist { MuBi4True := 4, MuBi4False :=1};
+      if (cfg.en_always_read) rand_info[i][j][k].read_en == MuBi4True;
+      rand_info[i][j][k].scramble_en dist { MuBi4True := 4, MuBi4False :=1};
+      rand_info[i][j][k].ecc_en dist { MuBi4True := 4, MuBi4False :=1};
     }
   }
   constraint ctrl_data_num_c {

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -183,44 +183,45 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
 
       mp_info_pages[i][j].size() == flash_ctrl_top_specific_pkg::InfoTypeSize[j];
 
-      foreach (mp_info_pages[i, j, k]) {
+    }
 
-        mp_info_pages[i][j][k].en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_en_pc[i][j]
-        };
+    foreach (mp_info_pages[i, j, k]) {
 
-        mp_info_pages[i][j][k].read_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_read_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_read_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].program_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_program_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_program_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].read_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_read_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_read_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].erase_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].program_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_program_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_program_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].scramble_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].erase_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].ecc_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].scramble_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
+      };
 
-        mp_info_pages[i][j][k].he_en dist {
-          MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
-          MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
-        };
+      mp_info_pages[i][j][k].ecc_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
+      };
 
-      }
+      mp_info_pages[i][j][k].he_en dist {
+        MuBi4False :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+        MuBi4True  :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
+      };
+
     }
   }
 


### PR DESCRIPTION
The changes in PR #26908 don't quite do what we want. Before that PR, we had code like
```
  foreach (foo[a]) {
    foreach (foo[a][b]) {
      ...
    }
  }
```
Some lint tools warn that the inner foreach loop is badly formed, and I think they might be correct. The IEEE 1800 spec doesn't seem to allow this syntax. The start of section 12.7.3 (about the foreach loop) says:

> The foreach-loop construct specifies iteration over the elements of
> an array. Its argument is an identifier that designates any type of
> array followed by a comma-separated list of loop variables enclosed
> in square brackets.

This doesn't match the syntax for the inner loop in the example because "foo[a]" is not an identifier.

The changes in the PR converted that example to something like
```
  foreach (foo[a]) {
    foreach (foo[a, b]) {
      ...
    }
  }
```
This is definitely reasonable syntax but Matute correctly points out that it doesn't do the same thing as VCS used to do with the previous code. Now we iterate over "a" twice!

This commit does what I think is probably the correct fix, dropping the outer loop in this example.

There are a few examples where the change isn't completely trivial. These previously looked like
```
  foreach (foo[a, b]) {
    foo[a][b].size() = ...;
    foreach (foo[a][b][c]) {
      foo[a][b][c] = ...;
    }
  }
```
Here the inner loop really does want to iterate over c for some fixed a, b. This commit changes these to look like
```
  foreach (foo[a, b]) {
    foo[a][b].size() = ...;
  }
  foreach (foo[a, b, c]) {
    foo[a][b][c] = ...;
  }
```
The previous code was trying to say "For each array, constrain its size and then iterate over the items of the array, constraining their values." Now it says says "For each array, constrain its size. Now constrain the value of every item of every array."

Equivalent, and avoids the nesting!

Fixes #27030.