### PR TITLE
[rom_ctrl,dv] Use foreach in a vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -199,7 +199,7 @@ task rom_ctrl_corrupt_sig_fatal_chk_vseq::test_fsm_invalid_transitions();
     in_bad_state = 1'b1;
 
     // Since we've jumped from cur_state, delete it from the queue
-    for (int unsigned i = 0; i < states_to_visit.size(); i++) begin
+    foreach (states_to_visit[i]) begin
       if (states_to_visit[i] == cur_state) begin
         states_to_visit.delete(i);
         break;


### PR DESCRIPTION
This is completely equivalent, but a bit shorter. The Verissimo lint tool also raises an error for the more verbose version. Use the shorter one.