### PR TITLE
[rom_ext] Clear power-on-reset in self-requested reboots

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -160,3 +160,8 @@ void rstmgr_reset(void) {
   }
 #endif
 }
+
+void rstmgr_reboot(void) {
+  rstmgr_reason_clear(1 << kRstmgrReasonPowerOn);
+  rstmgr_reset();
+}

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -126,6 +126,18 @@ noreturn
     rstmgr_reset(void);
 
 /**
+ * Reboot the chip.
+ *
+ * This function clears the power-on-reset reason and then resets the chip.
+ */
+#ifdef OT_PLATFORM_RV32
+// Omit `noreturn` to be able to test this function in off-target tests.
+noreturn
+#endif
+    void
+    rstmgr_reboot(void);
+
+/**
  * Verifies that info collection is initialized properly.
  *
  * In order not to interfere with the operation of other software on the chip,

--- a/sw/device/silicon_creator/lib/rescue/dfu.c
+++ b/sw/device/silicon_creator/lib/rescue/dfu.c
@@ -318,7 +318,7 @@ void dfu_protocol_handler(void *_ctx, uint8_t ep, usb_transfer_flags_t flags,
   if (flags & kUsbTransferFlagsReset) {
     // A USB reset after we've been enumerated means software reset.
     if (ctx->ep0.device_address && ctx->ep0.configuration) {
-      rstmgr_reset();
+      rstmgr_reboot();
     }
   }
 

--- a/sw/device/silicon_creator/lib/rescue/rescue_spi.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_spi.c
@@ -128,7 +128,7 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
       } break;
 
       case kSpiDeviceOpcodeReset:
-        rstmgr_reset();
+        rstmgr_reboot();
         break;
       default:
         dfu_transport_result(&ctx, kErrorUsbBadSetup);

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -154,7 +154,7 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
   rescue_state_init(&rescue_state, bootdata, boot_log, config);
   rom_error_t result = protocol(&rescue_state);
   if (result == kErrorRescueReboot) {
-    rstmgr_reset();
+    rstmgr_reboot();
   }
   return result;
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/BUILD
@@ -3,8 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
+    "//rules:const.bzl",
+    "CONST",
+)
+load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
+    "otp_hex",
     "otp_image",
     "otp_json",
     "otp_partition",
@@ -41,5 +46,26 @@ otp_image(
     src = "//hw/ip/otp_ctrl/data:otp_json_rma",
     overlays = STD_OTP_OVERLAYS + [
         ":otp_json_secret2_locked",
+    ],
+)
+
+otp_json(
+    name = "otp_json_reset_reason",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_TRUE),
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_img_secret2_locked_preserve_reset_rma",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [
+        ":otp_json_secret2_locked",
+        ":otp_json_reset_reason",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -360,6 +360,44 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "rescue_inactivity_timeout_preserved_reset_reason",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
+    ],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        # We configure OTP to preserve the reset reason.  This tests that the
+        # ROM_EXT clears power-on-reset before rebooting so that the ROM wont
+        # re-scramble ret-ram and destroy the 'skip_once' request.
+        otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_rma",
+        # We use the spidfu rom_ext because we can trigger with a GPIO and we
+        # want to simulate the trigger being jammed.
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            # Set the trigger with gpio command to simulate the trigger being jammed.
+            --exec="gpio set --mode PushPull --value true Ioa2"
+            # Check for firmware execution.  We'll enter rescue, timeout,
+            # then reboot and execute firmware.
+            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+            no-op
+        """,
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
 # Check that xmodem rescue is functional when the `RESQ` mode is disabled.
 opentitan_test(
     name = "xmodem_restricted_commands",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -759,7 +759,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     if (error == kErrorRescueInactivity &&
         boot_attempted == kHardenedBoolFalse) {
       rescue_skip_next_boot();
-      rstmgr_reset();
+      rstmgr_reboot();
     }
   }
 


### PR DESCRIPTION
1. Clear power-on-reset in self-requested reboots.
2. Test that the ROM_EXT preserves any boot_svc message sent to itself (e.g. power-on-reset is cleared so that the ROM won't re-scramble RET-RAM).