### PR TITLE
[opentitantool] Add `ownership detached-signature` command

### DIFF
--- a/sw/host/opentitanlib/src/ownership/misc.rs
+++ b/sw/host/opentitanlib/src/ownership/misc.rs
@@ -38,6 +38,12 @@ with_unknown! {
         HybridSpxPure = u32::from_le_bytes(*b"H+Pu"),
         HybridSpxPrehash = u32::from_le_bytes(*b"H+S2"),
     }
+    pub enum DetachedSignatureCommand: u32 [default = Self::Unknown] {
+        Unknown = 0,
+        Owner = u32::from_le_bytes(*b"OWNR"),
+        Unlock = u32::from_le_bytes(*b"UNLK"),
+        Activate = u32::from_le_bytes(*b"ACTV"),
+    }
 }
 
 impl OwnershipKeyAlg {

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -17,7 +17,9 @@ pub use application_key::{ApplicationKeyDomain, OwnerApplicationKey};
 pub use flash::{FlashFlags, OwnerFlashConfig, OwnerFlashRegion};
 pub use flash_info::{OwnerFlashInfoConfig, OwnerInfoPage};
 pub use isfb::OwnerIsfbConfig;
-pub use misc::{HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
+pub use misc::{
+    DetachedSignatureCommand, HybridRawPublicKey, KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag,
+};
 pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
 pub use rescue::{CommandTag, OwnerRescueConfig, RescueProtocol};
 pub use signature::DetachedSignature;

--- a/sw/host/opentitanlib/src/ownership/signature.rs
+++ b/sw/host/opentitanlib/src/ownership/signature.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
 use sphincsplus::{SpxDomain, SpxSecretKey};
 use std::io::{Read, Write};
+use std::path::Path;
 
 use super::misc::{OwnershipKeyAlg, TlvHeader, TlvTag};
 use super::GlobalFlags;
@@ -169,6 +170,40 @@ impl DetachedSignature {
             nonce,
             ecdsa,
             spx,
+            ..Default::default()
+        })
+    }
+
+    pub fn from_raw_signatures(
+        command: u32,
+        algorithm: OwnershipKeyAlg,
+        nonce: u64,
+        ecdsa_signature_path: Option<&Path>,
+        spx_signature_path: Option<&Path>,
+    ) -> Result<Self> {
+        let mut ecdsa_sig: Option<EcdsaRawSignature> = None;
+        let mut spx_sig: Option<Vec<u8>> = None;
+
+        if algorithm.is_ecdsa() {
+            let path =
+                ecdsa_signature_path.ok_or_else(|| anyhow!("No ecdsa signature provided"))?;
+            let mut file = std::fs::File::open(path)?;
+            ecdsa_sig = Some(EcdsaRawSignature::read(&mut file)?);
+        }
+
+        if algorithm.is_spx() {
+            let path = spx_signature_path.ok_or_else(|| anyhow!("No spx signature provided"))?;
+            let spx_bytes = std::fs::read(path)?;
+            spx_sig = Some(spx_bytes);
+        }
+
+        Ok(Self {
+            header: Self::default_header(),
+            command,
+            algorithm,
+            nonce,
+            ecdsa: ecdsa_sig,
+            spx: spx_sig,
             ..Default::default()
         })
     }

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -15,7 +15,10 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams};
 use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawSignature};
 use opentitanlib::crypto::sha256::Sha256Digest;
-use opentitanlib::ownership::{GlobalFlags, KeyMaterial, OwnerBlock, OwnershipKeyAlg, TlvHeader};
+use opentitanlib::ownership::{
+    DetachedSignature, DetachedSignatureCommand, GlobalFlags, KeyMaterial, OwnerBlock,
+    OwnershipKeyAlg, TlvHeader,
+};
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
 enum Format {
@@ -291,6 +294,42 @@ impl CommandDispatch for OwnershipDigestCommand {
     }
 }
 
+#[derive(Debug, Args)]
+pub struct OwnershipDetachedSignatureCommand {
+    #[arg(short, long)]
+    command: DetachedSignatureCommand,
+    #[arg(long)]
+    key_alg: OwnershipKeyAlg,
+    #[arg(short, long)]
+    nonce: u64,
+    #[arg(long)]
+    ecdsa_sig: Option<PathBuf>,
+    #[arg(long)]
+    spx_sig: Option<PathBuf>,
+    /// Filename for an output detached signature bin file.
+    output: PathBuf,
+}
+
+impl CommandDispatch for OwnershipDetachedSignatureCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        let detatch_sig = DetachedSignature::from_raw_signatures(
+            self.command.into(),
+            self.key_alg,
+            self.nonce,
+            self.ecdsa_sig.as_deref(),
+            self.spx_sig.as_deref(),
+        )?;
+
+        let mut file = File::create(&self.output)?;
+        detatch_sig.write(&mut file)?;
+        Ok(None)
+    }
+}
+
 #[derive(Debug, Subcommand, CommandDispatch)]
 pub enum OwnershipCommand {
     Config(OwnershipConfigCommand),
@@ -298,4 +337,5 @@ pub enum OwnershipCommand {
     Unlock(OwnershipUnlockCommand),
     Verify(OwnershipVerifyCommand),
     Digest(OwnershipDigestCommand),
+    DetachedSignature(OwnershipDetachedSignatureCommand),
 }


### PR DESCRIPTION
This introduces a new `ownership detached-signature` subcommand to `opentitantool`. This command allows users to generate a detached signature binary from the existing raw signature files