### PR TITLE
[rv_core_ibex, ibex, rtl] Re-vendor Ibex and pass mvendorid/mimpid to Ibex

### DIFF
--- a/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
+++ b/hw/ip_templates/rv_core_ibex/data/rv_core_ibex.hjson.tpl
@@ -519,6 +519,28 @@
       local:   "false"
       expose:  "true"
     },
+    { name:  "CsrMvendorId"
+      type:  "logic [31:0]"
+      desc: '''
+        mvendorid: encoding of manufacturer/provider
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to set their own JEDEC ID here.
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    },
+    { name:  "CsrMimpId"
+      type:  "logic [31:0]"
+      desc: '''
+        mimpid: encoding of processor implementation version
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    }
   ],
   features: [
     {

--- a/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
+++ b/hw/ip_templates/rv_core_ibex/rtl/rv_core_ibex.sv.tpl
@@ -55,7 +55,9 @@ module ${module_instance_name}
     RaclPolicySelVecCfg[${module_instance_name}_reg_pkg::NumRegsCfg] =
       '{${module_instance_name}_reg_pkg::NumRegsCfg{0}},
 % endif
-  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0,
+  parameter logic [31:0]            CsrMvendorId                   = 32'b0,
+  parameter logic [31:0]            CsrMimpId                      = 32'b0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -432,7 +434,9 @@ module ${module_instance_name}
     .DmBaseAddr                  ( DmBaseAddr               ),
     .DmAddrMask                  ( DmAddrMask               ),
     .DmHaltAddr                  ( DmHaltAddr               ),
-    .DmExceptionAddr             ( DmExceptionAddr          )
+    .DmExceptionAddr             ( DmExceptionAddr          ),
+    .CsrMvendorId                ( CsrMvendorId             ),
+    .CsrMimpId                   ( CsrMimpId                )
   ) u_core (
     .clk_i              (ibex_top_clk_i),
     .rst_ni,

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -10782,6 +10782,34 @@
           expose: "true"
           name_top: RvCoreIbexTlulHostUserRsvdBits
         }
+        {
+          name: CsrMvendorId
+          desc:
+            '''
+            mvendorid: encoding of manufacturer/provider
+            0 indicates this field is not implemented.
+            Ibex implementors may wish to set their own JEDEC ID here.
+            '''
+          type: logic [31:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexCsrMvendorId
+        }
+        {
+          name: CsrMimpId
+          desc:
+            '''
+            mimpid: encoding of processor implementation version
+            0 indicates this field is not implemented.
+            Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+            '''
+          type: logic [31:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexCsrMimpId
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -493,6 +493,28 @@
       local:   "false"
       expose:  "true"
     },
+    { name:  "CsrMvendorId"
+      type:  "logic [31:0]"
+      desc: '''
+        mvendorid: encoding of manufacturer/provider
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to set their own JEDEC ID here.
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    },
+    { name:  "CsrMimpId"
+      type:  "logic [31:0]"
+      desc: '''
+        mimpid: encoding of processor implementation version
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    }
   ],
   features: [
     {

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -48,7 +48,9 @@ module rv_core_ibex
       ibex_pkg::RndCnstIbexNonceDefault,
   parameter int unsigned                    NEscalationSeverities = 4,
   parameter int unsigned                    WidthPingCounter      = 16,
-  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0,
+  parameter logic [31:0]            CsrMvendorId                   = 32'b0,
+  parameter logic [31:0]            CsrMimpId                      = 32'b0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -419,7 +421,9 @@ module rv_core_ibex
     .DmBaseAddr                  ( DmBaseAddr               ),
     .DmAddrMask                  ( DmAddrMask               ),
     .DmHaltAddr                  ( DmHaltAddr               ),
-    .DmExceptionAddr             ( DmExceptionAddr          )
+    .DmExceptionAddr             ( DmExceptionAddr          ),
+    .CsrMvendorId                ( CsrMvendorId             ),
+    .CsrMimpId                   ( CsrMimpId                )
   ) u_core (
     .clk_i              (ibex_top_clk_i),
     .rst_ni,

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -160,7 +160,9 @@ module top_darjeeling #(
   parameter int unsigned RvCoreIbexDmExceptionAddr =
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0],
   parameter bit RvCoreIbexPipeLine = 1,
-  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0,
+  parameter logic [31:0] RvCoreIbexCsrMvendorId = '0,
+  parameter logic [31:0] RvCoreIbexCsrMimpId = '0
 ) (
   // Multiplexed I/O
   input        [11:0] mio_in_i,
@@ -2701,7 +2703,9 @@ module top_darjeeling #(
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
     .PipeLine(RvCoreIbexPipeLine),
-    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
+    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits),
+    .CsrMvendorId(RvCoreIbexCsrMvendorId),
+    .CsrMimpId(RvCoreIbexCsrMimpId)
   ) u_rv_core_ibex (
       // [99]: fatal_sw_err
       // [100]: recov_sw_err

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -9615,6 +9615,34 @@
           expose: "true"
           name_top: RvCoreIbexTlulHostUserRsvdBits
         }
+        {
+          name: CsrMvendorId
+          desc:
+            '''
+            mvendorid: encoding of manufacturer/provider
+            0 indicates this field is not implemented.
+            Ibex implementors may wish to set their own JEDEC ID here.
+            '''
+          type: logic [31:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexCsrMvendorId
+        }
+        {
+          name: CsrMimpId
+          desc:
+            '''
+            mimpid: encoding of processor implementation version
+            0 indicates this field is not implemented.
+            Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+            '''
+          type: logic [31:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexCsrMimpId
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -493,6 +493,28 @@
       local:   "false"
       expose:  "true"
     },
+    { name:  "CsrMvendorId"
+      type:  "logic [31:0]"
+      desc: '''
+        mvendorid: encoding of manufacturer/provider
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to set their own JEDEC ID here.
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    },
+    { name:  "CsrMimpId"
+      type:  "logic [31:0]"
+      desc: '''
+        mimpid: encoding of processor implementation version
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    }
   ],
   features: [
     {

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -48,7 +48,9 @@ module rv_core_ibex
       ibex_pkg::RndCnstIbexNonceDefault,
   parameter int unsigned                    NEscalationSeverities = 4,
   parameter int unsigned                    WidthPingCounter      = 16,
-  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0,
+  parameter logic [31:0]            CsrMvendorId                   = 32'b0,
+  parameter logic [31:0]            CsrMimpId                      = 32'b0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -419,7 +421,9 @@ module rv_core_ibex
     .DmBaseAddr                  ( DmBaseAddr               ),
     .DmAddrMask                  ( DmAddrMask               ),
     .DmHaltAddr                  ( DmHaltAddr               ),
-    .DmExceptionAddr             ( DmExceptionAddr          )
+    .DmExceptionAddr             ( DmExceptionAddr          ),
+    .CsrMvendorId                ( CsrMvendorId             ),
+    .CsrMimpId                   ( CsrMimpId                )
   ) u_core (
     .clk_i              (ibex_top_clk_i),
     .rst_ni,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -149,7 +149,9 @@ module top_earlgrey #(
   parameter int unsigned RvCoreIbexDmExceptionAddr =
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0],
   parameter bit RvCoreIbexPipeLine = 0,
-  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0,
+  parameter logic [31:0] RvCoreIbexCsrMvendorId = '0,
+  parameter logic [31:0] RvCoreIbexCsrMimpId = '0
 ) (
   // Multiplexed I/O
   input        [46:0] mio_in_i,
@@ -2763,7 +2765,9 @@ module top_earlgrey #(
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
     .PipeLine(RvCoreIbexPipeLine),
-    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
+    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits),
+    .CsrMvendorId(RvCoreIbexCsrMvendorId),
+    .CsrMimpId(RvCoreIbexCsrMimpId)
   ) u_rv_core_ibex (
       // [61]: fatal_sw_err
       // [62]: recov_sw_err

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -4634,6 +4634,34 @@
           expose: "true"
           name_top: RvCoreIbexTlulHostUserRsvdBits
         }
+        {
+          name: CsrMvendorId
+          desc:
+            '''
+            mvendorid: encoding of manufacturer/provider
+            0 indicates this field is not implemented.
+            Ibex implementors may wish to set their own JEDEC ID here.
+            '''
+          type: logic [31:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexCsrMvendorId
+        }
+        {
+          name: CsrMimpId
+          desc:
+            '''
+            mimpid: encoding of processor implementation version
+            0 indicates this field is not implemented.
+            Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+            '''
+          type: logic [31:0]
+          default: "'0"
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexCsrMimpId
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/data/rv_core_ibex.hjson
@@ -493,6 +493,28 @@
       local:   "false"
       expose:  "true"
     },
+    { name:  "CsrMvendorId"
+      type:  "logic [31:0]"
+      desc: '''
+        mvendorid: encoding of manufacturer/provider
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to set their own JEDEC ID here.
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    },
+    { name:  "CsrMimpId"
+      type:  "logic [31:0]"
+      desc: '''
+        mimpid: encoding of processor implementation version
+        0 indicates this field is not implemented.
+        Ibex implementors may wish to indicate an RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented commit).
+      '''
+      default: "'0"
+      local:   "false"
+      expose:  "true"
+    }
   ],
   features: [
     {

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -48,7 +48,9 @@ module rv_core_ibex
       ibex_pkg::RndCnstIbexNonceDefault,
   parameter int unsigned                    NEscalationSeverities = 4,
   parameter int unsigned                    WidthPingCounter      = 16,
-  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] TlulHostUserRsvdBits   = 0,
+  parameter logic [31:0]            CsrMvendorId                   = 32'b0,
+  parameter logic [31:0]            CsrMimpId                      = 32'b0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -419,7 +421,9 @@ module rv_core_ibex
     .DmBaseAddr                  ( DmBaseAddr               ),
     .DmAddrMask                  ( DmAddrMask               ),
     .DmHaltAddr                  ( DmHaltAddr               ),
-    .DmExceptionAddr             ( DmExceptionAddr          )
+    .DmExceptionAddr             ( DmExceptionAddr          ),
+    .CsrMvendorId                ( CsrMvendorId             ),
+    .CsrMimpId                   ( CsrMimpId                )
   ) u_core (
     .clk_i              (ibex_top_clk_i),
     .rst_ni,

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast.sv
@@ -84,7 +84,9 @@ module top_englishbreakfast #(
   parameter int unsigned RvCoreIbexDmHaltAddr = 0,
   parameter int unsigned RvCoreIbexDmExceptionAddr = 0,
   parameter bit RvCoreIbexPipeLine = 0,
-  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0
+  parameter logic [tlul_pkg::RsvdWidth-1:0] RvCoreIbexTlulHostUserRsvdBits = '0,
+  parameter logic [31:0] RvCoreIbexCsrMvendorId = '0,
+  parameter logic [31:0] RvCoreIbexCsrMimpId = '0
 ) (
   // Multiplexed I/O
   input        [46:0] mio_in_i,
@@ -1287,7 +1289,9 @@ module top_englishbreakfast #(
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
     .PipeLine(RvCoreIbexPipeLine),
-    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits)
+    .TlulHostUserRsvdBits(RvCoreIbexTlulHostUserRsvdBits),
+    .CsrMvendorId(RvCoreIbexCsrMvendorId),
+    .CsrMimpId(RvCoreIbexCsrMimpId)
   ) u_rv_core_ibex (
       // [24]: fatal_sw_err
       // [25]: recov_sw_err

--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 6e466c1504b61333d1b2ba85c69bff94b65e9284
+    rev: 036943810566e45fe57994912824027f56567820
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/cs_registers.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/cs_registers.rst
@@ -606,7 +606,7 @@ CSR Address: ``0xF11``
 
 Reset Value: ``0x0000_0000``
 
-Use the ``CSR_MVENDORID_VALUE`` parameter in :file:`rtl/ibex_pkg.sv` to change the fixed value.
+Use the top-level parameter ``CsrMvendorId`` in :file:`rtl/ibex_top.sv` to change the fixed value.
 Details of what the ID represents can be found in the RISC-V Privileged Specification.
 
 Machine Architecture ID (marchid)
@@ -628,7 +628,7 @@ CSR Address: ``0xF13``
 
 Reset Value: ``0x0000_0000``
 
-Use the ``CSR_MIMPID_VALUE`` parameter in :file:`rtl/ibex_pkg.sv` to change the fixed value.
+Use the top-level parameter ``CsrMimpId`` in :file:`rtl/ibex_top.sv` to change the fixed value.
 Details of what the ID represents can be found in the RISC-V Privileged Specification.
 
 .. _csr-mhartid:

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -278,6 +278,20 @@
     compare_final_value_only: 1
     verbose: 1
 
+# TODO(#2233): Implement the following test (also note the priorities in the issue).
+#- test: riscv_debug_mode_pmp_test
+#  description: >
+#    When debug mode is enabled, any access to the Debug Module address space should be allowed.
+#    This holds regardless of PMP settings. Thus, this test performs a series of random accesses
+#    (reads, writes, and instruction fetch) in debug mode with a random PMP configuration, and it
+#    checks that all accesses to the Debug Module address space get allowed and that all accesses
+#    outside the Debug Module address space get allowed if and only if the PMP configuration permits
+#    them.
+#    When debug mode is not enabled, accesses to the Debug Module address space are governed by the
+#    PMP configuration. Verifying PMP is the focus of other tests. This test verifies a simple case:
+#    when debug mode is disabled and the PMP does not allow accesses to the Debug Module address
+#    space, a random access to that address space fails.
+
 - test: riscv_dret_test
   description: >
     Dret instructions will be inserted into generated code, ibex should treat these

--- a/hw/vendor/lowrisc_ibex/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
+++ b/hw/vendor/lowrisc_ibex/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
@@ -182,7 +182,6 @@ targets:
           - '-CFLAGS "-std=c++14 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
           - '-LDFLAGS "-pthread -lutil -lelf `pkg-config --libs riscv-riscv riscv-disasm riscv-fdt`"'
           - "-Wall"
-          - "-Wwarn-IMPERFECTSCH"
           # RAM primitives wider than 64bit (required for ECC) fail to build in
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
@@ -175,7 +175,7 @@ module ibex_controller #(
     // print warning in case of decoding errors
     if ((ctrl_fsm_cs == DECODE) && instr_valid_i && !instr_fetch_err_i && illegal_insn_d) begin
       $display("%t: Illegal instruction (hart %0x) at PC 0x%h: 0x%h", $time, u_ibex_core.hart_id_i,
-               pc_id_i, id_stage_i.instr_rdata_i);
+               pc_id_i, instr_is_compressed_i ? {16'b0, instr_compressed_i} : instr_i );
     end
   end
   // synopsys translate_on

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
@@ -47,15 +47,15 @@ module ibex_core import ibex_pkg::*; #(
   parameter int unsigned            DmBaseAddr       = 32'h1A110000,
   parameter int unsigned            DmAddrMask       = 32'h00000FFF,
   parameter int unsigned            DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned            DmExceptionAddr  = 32'h1A110808
+  parameter int unsigned            DmExceptionAddr  = 32'h1A110808,
+  // mvendorid: encoding of manufacturer/provider
+  parameter logic [31:0]            CsrMvendorId     = 32'b0,
+  // marchid: encoding of base microarchitecture
+  parameter logic [31:0]            CsrMimpId        = 32'b0
 ) (
   // Clock and Reset
   input  logic                         clk_i,
-  // Internally generated resets in ibex_lockstep cause IMPERFECTSCH warnings.
-  // TODO: Remove when upgrading Verilator #2134.
-  /* verilator lint_off IMPERFECTSCH */
   input  logic                         rst_ni,
-  /* verilator lint_on IMPERFECTSCH */
 
   input  logic [31:0]                  hart_id_i,
   input  logic [31:0]                  boot_addr_i,
@@ -1065,7 +1065,9 @@ module ibex_core import ibex_pkg::*; #(
     .PMPRstMsecCfg    (PMPRstMsecCfg),
     .RV32E            (RV32E),
     .RV32M            (RV32M),
-    .RV32B            (RV32B)
+    .RV32B            (RV32B),
+    .CsrMvendorId     (CsrMvendorId),
+    .CsrMimpId        (CsrMimpId)
   ) cs_registers_i (
     .clk_i (clk_i),
     .rst_ni(rst_ni),

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -26,7 +26,11 @@ module ibex_cs_registers #(
   parameter ibex_pkg::pmp_mseccfg_t PMPRstMsecCfg     = ibex_pkg::PmpMseccfgRst,
   parameter bit                     RV32E             = 0,
   parameter ibex_pkg::rv32m_e RV32M                   = ibex_pkg::RV32MFast,
-  parameter ibex_pkg::rv32b_e RV32B                   = ibex_pkg::RV32BNone
+  parameter ibex_pkg::rv32b_e RV32B                   = ibex_pkg::RV32BNone,
+  // mvendorid: encoding of manufacturer/provider
+  parameter logic [31:0]            CsrMvendorId      = 32'b0,
+  // mimpid: encoding of processor implementation version
+  parameter logic [31:0]            CsrMimpId         = 32'b0
 ) (
   // Clock and Reset
   input  logic                 clk_i,
@@ -332,11 +336,11 @@ module ibex_cs_registers #(
 
     unique case (csr_addr_i)
       // mvendorid: encoding of manufacturer/provider
-      CSR_MVENDORID: csr_rdata_int = CSR_MVENDORID_VALUE;
+      CSR_MVENDORID: csr_rdata_int = CsrMvendorId;
       // marchid: encoding of base microarchitecture
       CSR_MARCHID: csr_rdata_int = CSR_MARCHID_VALUE;
       // mimpid: encoding of processor implementation version
-      CSR_MIMPID: csr_rdata_int = CSR_MIMPID_VALUE;
+      CSR_MIMPID: csr_rdata_int = CsrMimpId;
       // mhartid: unique hardware thread id
       CSR_MHARTID: csr_rdata_int = hart_id_i;
       // mconfigptr: pointer to configuration data structre

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -433,11 +433,10 @@ module ibex_decoder #(
                   end
                 end
                 5'b0_0001: begin
-                  if (instr[26] == 1'b0) begin                                        // unshfl
-                    illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
-                  end else begin
-                    illegal_insn = 1'b1;
-                  end
+                  // Since instr[26] is known to be 0, this must be the "unshfl" instruction, which
+                  // is part of the RISC-V bitmanip extension. This is supported for the
+                  // RV32BOTEarlGrey and RV32BFull bitmanip configurations.
+                  illegal_insn = (RV32B == RV32BOTEarlGrey || RV32B == RV32BFull) ? 1'b0 : 1'b1;
                 end
 
                 default: illegal_insn = 1'b1;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
@@ -128,7 +128,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   logic [LockstepOffsetW-1:0] rst_shadow_cnt;
   logic                       rst_shadow_cnt_err;
   ibex_mubi_t                 rst_shadow_set_d, rst_shadow_set_q;
-  logic                       rst_shadow_n, rst_shadow_set_single_bit;
+  logic                       rst_shadow_n;
   ibex_mubi_t                 enable_cmp_d, enable_cmp_q;
 
   // This counter primitive starts counting to LockstepOffset after a system
@@ -161,10 +161,6 @@ module ibex_lockstep import ibex_pkg::*; #(
   // Enable lockstep comparison.
   assign enable_cmp_d = rst_shadow_set_q;
 
-  // This assignment is needed in order to avoid "Warning-IMPERFECTSCH" messages.
-  // TODO: Remove when updating Verilator #2134.
-  assign rst_shadow_set_single_bit = rst_shadow_set_q[0];
-
   // The primitives below are used to place size-only constraints in order to prevent
   // synthesis optimizations and preserve anchor points for constraining backend tools.
   prim_flop #(
@@ -190,7 +186,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
   ) u_prim_rst_shadow_n_mux2 (
-    .clk0_i(rst_shadow_set_single_bit),
+    .clk0_i(rst_shadow_set_q[0]),
     .clk1_i(scan_rst_ni),
     .sel_i (test_en_i),
     .clk_o (rst_shadow_n)

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
@@ -617,22 +617,11 @@ package ibex_pkg;
   parameter int unsigned CSR_MSECCFG_MMWP_BIT = 1;
   parameter int unsigned CSR_MSECCFG_RLB_BIT  = 2;
 
-  // Vendor ID
-  // No JEDEC ID has been allocated to lowRISC so the value is 0 to indicate the field is not
-  // implemented
-  localparam logic [31:0] CSR_MVENDORID_VALUE  = 32'b0;
-
   // Architecture ID
   // Top bit is unset to indicate an open source project. The lower bits are an ID allocated by the
   // RISC-V Foundation. Note this is allocated specifically to Ibex, should significant changes be
   // made a different architecture ID should be supplied.
   localparam logic [31:0] CSR_MARCHID_VALUE = {1'b0, 31'd22};
-
-  // Implementation ID
-  // 0 indicates this field is not implemeted. Ibex implementors may wish to indicate an RTL/netlist
-  // version here using their own unique encoding (e.g. 32 bits of the git hash of the implemented
-  // commit).
-  localparam logic [31:0] CSR_MIMPID_VALUE = 32'b0;
 
   // Machine Configuration Pointer
   // 0 indicates the configuration data structure does not eixst. Ibex implementors may wish to

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -43,7 +43,16 @@ module ibex_top import ibex_pkg::*; #(
   parameter int unsigned            DmExceptionAddr              = 32'h1A110808,
   // Default seed and nonce for scrambling
   parameter logic [SCRAMBLE_KEY_W-1:0]   RndCnstIbexKey          = RndCnstIbexKeyDefault,
-  parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce        = RndCnstIbexNonceDefault
+  parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce        = RndCnstIbexNonceDefault,
+  // mvendorid: encoding of manufacturer/provider
+  // 0 indicates this field is not implemented. Ibex implementors may wish to set their
+  // own JEDEC ID here.
+  parameter logic [31:0]            CsrMvendorId                 = 32'b0,
+  // mimpid: encoding of processor implementation version
+  // 0 indicates this field is not implemented. Ibex implementors may wish to indicate an
+  // RTL/netlist version here using their own unique encoding (e.g. 32 bits of the git hash of the
+  // implemented commit).
+  parameter logic [31:0]            CsrMimpId                    = 32'b0
 ) (
   // Clock and Reset
   input  logic                                                         clk_i,
@@ -323,7 +332,9 @@ module ibex_top import ibex_pkg::*; #(
     .DmBaseAddr       (DmBaseAddr),
     .DmAddrMask       (DmAddrMask),
     .DmHaltAddr       (DmHaltAddr),
-    .DmExceptionAddr  (DmExceptionAddr)
+    .DmExceptionAddr  (DmExceptionAddr),
+    .CsrMvendorId     (CsrMvendorId),
+    .CsrMimpId        (CsrMimpId)
   ) u_ibex_core (
     .clk_i(clk),
     .rst_ni,

--- a/hw/vendor/patches/lowrisc_ibex/rtl/0001-PATCH-Change-RAM-DFT-signals.patch
+++ b/hw/vendor/patches/lowrisc_ibex/rtl/0001-PATCH-Change-RAM-DFT-signals.patch
@@ -24,7 +24,7 @@ index a90fee0e..085e80ee 100644
 --- a/ibex_top.sv
 +++ b/ibex_top.sv
 @@ -46,105 +46,110 @@ module ibex_top import ibex_pkg::*; #(
-   parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce        = RndCnstIbexNonceDefault
+   parameter logic [31:0]            CsrMimpId                    = 32'b0
  ) (
    // Clock and Reset
 -  input  logic                         clk_i,


### PR DESCRIPTION
This PR re-vendors Ibex and then adds support for passing the new Ibex parameters for mvendorid/mimpid  from the top. The current parameter selection (0/0) is the same as the current behavior. Integrators may set that to a different value. 