### PR TITLE
[topgen,otp_flash_keys] Deduce if flash_keys are needed in otp_ctrl

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1161,10 +1161,6 @@
       name: otp_ctrl
       type: otp_ctrl
       template_type: otp_ctrl
-      ipgen_param:
-      {
-        enable_flash_key: false
-      }
       clock_srcs:
       {
         clk_i: io_div4

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -341,9 +341,6 @@
     { name: "otp_ctrl",
       type: "otp_ctrl",
       template_type: "otp_ctrl",
-      ipgen_param: {
-        enable_flash_key: false
-      }
       clock_srcs: {clk_i: "io_div4", clk_edn_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "lc"},


### PR DESCRIPTION
The otp_ctrl interface to export the flash_keys is only needed if the otp secret1 partition holds flash_ctrl keys. Darjeeling has no flash and has no keys in otp.

Detect this examining the content of the otp rather than using an ipgen_param.  This assumes the flash keys are in the secret1 partition, and are named "flash*key_seed" (case doesn't matter). If in some future otp mmap the location of these keys changes we can revisit this detection.

Addresses #26553
Fixes #26931