### PR TITLE
[rom_ext] Disable the watchdog when entering rescue

### DIFF
--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -183,6 +183,7 @@ ld_library(
             "//sw/device/silicon_creator/lib/drivers:retention_sram",
             "//sw/device/silicon_creator/lib/drivers:rnd",
             "//sw/device/silicon_creator/lib/drivers:uart",
+            "//sw/device/silicon_creator/lib/drivers:watchdog",
             "//sw/device/silicon_creator/lib/ownership",
             "//sw/device/silicon_creator/lib/ownership:owner_verify",
             "//sw/device/silicon_creator/lib/ownership:ownership_activate",

--- a/sw/device/silicon_creator/rom_ext/e2e/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/BUILD
@@ -56,14 +56,15 @@ otp_json(
             name = "OWNER_SW_CFG",
             items = {
                 "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_TRUE),
+                "OWNER_SW_CFG_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES": otp_hex(200000),
             },
         ),
     ],
 )
 
 otp_image(
-    name = "otp_img_secret2_locked_preserve_reset_rma",
-    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    name = "otp_img_secret2_locked_preserve_reset_prod",
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
     overlays = STD_OTP_OVERLAYS + [
         ":otp_json_secret2_locked",
         ":otp_json_reset_reason",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -361,6 +361,15 @@ opentitan_test(
 )
 
 opentitan_test(
+    # This test ensures that the ROM_EXT clears power-on-reset before rebooting
+    # so that the ROM wont re-scrable RET-RAM and destroy the 'skip_once' request.
+    #
+    # This test also ensures that the ROM_EXT disables the watchdog when entering
+    # rescue mode, as the normal watchdog timeout would cause the chip to reset
+    # after one second of idling in rescue.
+    #
+    # If the ROM_EXT were to fail to clear power-on-reset or to disable the
+    # watchdog, this device would boot-loop and this test would fail.
     name = "rescue_inactivity_timeout_preserved_reset_reason",
     srcs = [
         "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
@@ -370,10 +379,9 @@ opentitan_test(
     },
     fpga = fpga_params(
         changes_otp = True,
-        # We configure OTP to preserve the reset reason.  This tests that the
-        # ROM_EXT clears power-on-reset before rebooting so that the ROM wont
-        # re-scramble ret-ram and destroy the 'skip_once' request.
-        otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_rma",
+        # We configure OTP to preserve the reset reason and set the watchdog timeout
+        # to one second.
+        otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_prod",
         # We use the spidfu rom_ext because we can trigger with a GPIO and we
         # want to simulate the trigger being jammed.
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -34,6 +34,7 @@
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
+#include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 #include "sw/device/silicon_creator/lib/epmp_state.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
@@ -715,8 +716,12 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 
   // Handle any pending boot_svc commands.
   uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;
-  uint32_t skip_boot_svc = reset_reasons & (1 << kRstmgrReasonLowPowerExit);
-  if (skip_boot_svc == 0) {
+  hardened_bool_t waking_from_low_power =
+      reset_reasons & (1 << kRstmgrReasonLowPowerExit) ? kHardenedBoolTrue
+                                                       : kHardenedBoolFalse;
+
+  // We don't want to execute boot_svc requests if this is a low-power wakeup.
+  if (waking_from_low_power != kHardenedBoolTrue) {
     error = handle_boot_svc(boot_data, boot_log);
     if (error == kErrorWriteBootdataThenReboot) {
       // Boot services reports errors by writing a status code into the reply
@@ -739,7 +744,10 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // needed.
   HARDENED_RETURN_IF_ERROR(ownership_seal_clear());
 
-  hardened_bool_t want_rescue = rescue_detect_entry(owner_config.rescue);
+  // We don't want to enter rescue mode if this is a low-power wakeup.
+  hardened_bool_t want_rescue = waking_from_low_power != kHardenedBoolTrue
+                                    ? rescue_detect_entry(owner_config.rescue)
+                                    : kHardenedBoolFalse;
   hardened_bool_t boot_attempted = kHardenedBoolFalse;
 
   if (want_rescue == kHardenedBoolFalse) {
@@ -757,6 +765,8 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
       dbg_printf("BFV:%x\r\n", error);
     }
 
+    // Disable the watchdog timer when entering rescue mode.
+    watchdog_disable();
     error = rescue_protocol(boot_data, boot_log, owner_config.rescue);
 
     // If rescue timed out and we didn't attempt to boot, request skipping


### PR DESCRIPTION
1. Detect if we're executing in a low-power-wakeup state.  Do not execute boot_svc or rescue entry when waking from low power.
2. Upon entering rescue, disable the watchdog timer.
3. Update the inactivity timeout test to use the watchdog-enabled OTP configuration.