### PR TITLE
[topgen] Repeat default intermodule signals

### DIFF
--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -1003,9 +1003,19 @@ def im_netname(sig: OrderedDict, suffix: str = "", default_name=False) -> str:
             # custom default has been specified
             if obj["default"]:
                 return obj["default"]
-            if isinstance(sig["width"], Parameter):
-                return "{{{param}{{{package}::{struct}_DEFAULT}}}}".format(
-                    param=sig["width"].name_top,
+            repetitions = 1
+            if sig["width"]:
+                if isinstance(sig["width"], Parameter):
+                    repetitions = sig["width"].name_top
+                elif isinstance(sig["width"], str):
+                    repetitions = int(sig["width"])
+                elif isinstance(sig["width"], int):
+                    repetitions = sig["width"]
+                else:
+                    raise ValueError(f"Invalid inter-module signal width {sig['width']}")
+            if repetitions != 1:
+                return "{{{repetitions}{{{package}::{struct}_DEFAULT}}}}".format(
+                    repetitions=repetitions,
                     package=obj["package"],
                     struct=obj["struct"].upper())
             else:


### PR DESCRIPTION
The "width" value hadn't been respected if it wasn't a parameter. Fixes #27053.