### PR TITLE
[sw/base] Make the ibex library top-independent

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -120,8 +120,8 @@ cc_library(
         ":abs_mmio",
         ":csr",
         ":status",
+        "//hw/top:dt",
         "//hw/top:rv_core_ibex_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )
@@ -139,7 +139,6 @@ opentitan_test(
         ":ibex",
         ":status",
         "//hw/top:rv_core_ibex_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/base/ibex.c
+++ b/sw/device/lib/base/ibex.c
@@ -4,22 +4,27 @@
 
 #include "sw/device/lib/base/ibex.h"
 
+#include "dt/dt_rv_core_ibex.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/status.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
 
-enum {
-  kBase = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR,
-};
+static_assert(kDtRvCoreIbexCount == 1,
+              "this code requires exactly one rv_core_ibex");
+const dt_rv_core_ibex_t kRvCoreIbexDt = kDtRvCoreIbexFirst;
+
+static inline uint32_t rv_core_ibex_base(void) {
+  return dt_rv_core_ibex_primary_reg_block(kRvCoreIbexDt);
+}
 
 status_t ibex_wait_rnd_valid(void) {
   while (true) {
-    uint32_t reg = abs_mmio_read32(kBase + RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+    uint32_t reg = abs_mmio_read32(rv_core_ibex_base() +
+                                   RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
     if (bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
       return OK_STATUS();
     }
@@ -27,11 +32,13 @@ status_t ibex_wait_rnd_valid(void) {
 }
 
 status_t ibex_rnd_status_read(uint32_t *rnd_status) {
-  *rnd_status = abs_mmio_read32(kBase + RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+  *rnd_status =
+      abs_mmio_read32(rv_core_ibex_base() + RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
   return OK_STATUS();
 }
 
 status_t ibex_rnd_data_read(uint32_t *rnd_data) {
-  *rnd_data = abs_mmio_read32(kBase + RV_CORE_IBEX_RND_DATA_REG_OFFSET);
+  *rnd_data =
+      abs_mmio_read32(rv_core_ibex_base() + RV_CORE_IBEX_RND_DATA_REG_OFFSET);
   return OK_STATUS();
 }

--- a/sw/device/lib/base/ibex_test.c
+++ b/sw/device/lib/base/ibex_test.c
@@ -11,12 +11,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
-
-enum {
-  kBase = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR,
-};
 
 OTTF_DEFINE_TEST_CONFIG();
 


### PR DESCRIPTION
When this library was moved from the cryptolib to the base libraries, it wasn't ported to multitop. This change is necessary for #26753