### PR TITLE
[ottf_console] buffer SPI console data in SW

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -17,8 +17,6 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 
-#include "spi_device_regs.h"  // Generated.
-
 // This is declared as an enum to force the values to be
 // compile-time constants, but the type is otherwise not
 // used for anything.
@@ -81,15 +79,6 @@ void base_set_stdout(buffer_sink_t out) {
   base_stdout = out;
 }
 
-static const size_t kSpiDeviceReadBufferSizeBytes =
-    SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH * sizeof(uint32_t);
-static const size_t kSpiDeviceFrameHeaderSizeBytes = 12;
-static const size_t kSpiDeviceBufferPreservedSizeBytes =
-    kSpiDeviceFrameHeaderSizeBytes;
-static const size_t kSpiDeviceMaxFramePayloadSizeBytes =
-    kSpiDeviceReadBufferSizeBytes - kSpiDeviceFrameHeaderSizeBytes -
-    kSpiDeviceBufferPreservedSizeBytes - 4;
-static const uint32_t kSpiDeviceFrameMagicNumber = 0xa5a5beef;
 static uint32_t spi_device_frame_num = 0;
 
 static status_t spi_device_send_data(dif_spi_device_handle_t *spi_device,

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -12,6 +12,8 @@
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/dif/dif_uart.h"
 
+#include "spi_device_regs.h"  // Generated.
+
 /**
  * @file
  * @brief Libc-like printing facilities.
@@ -48,6 +50,20 @@ typedef struct buffer_sink {
   void *data;
   sink_func_ptr sink;
 } buffer_sink_t;
+
+/**
+ * SPI console buffer management constants.
+ */
+enum {
+  kSpiDeviceReadBufferSizeBytes =
+      SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH * sizeof(uint32_t),
+  kSpiDeviceFrameHeaderSizeBytes = 12,
+  kSpiDeviceBufferPreservedSizeBytes = kSpiDeviceFrameHeaderSizeBytes,
+  kSpiDeviceMaxFramePayloadSizeBytes = kSpiDeviceReadBufferSizeBytes -
+                                       kSpiDeviceFrameHeaderSizeBytes -
+                                       kSpiDeviceBufferPreservedSizeBytes - 4,
+  kSpiDeviceFrameMagicNumber = 0xa5a5beef,
+};
 
 /**
  * Returns a function pointer to the spi device sink function.

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -64,6 +64,10 @@ static status_t (*getc)(void *);
 static volatile ottf_console_flow_control_t flow_control_state;
 static volatile uint32_t flow_control_irqs;
 
+// Staging buffer for the SPI console implementation.
+static char spi_buf[kSpiDeviceMaxFramePayloadSizeBytes];
+static size_t spi_buf_end;
+
 void *ottf_console_get(void) {
   switch (kOttfTestConfig.console.type) {
     case kOttfConsoleSpiDevice:
@@ -150,6 +154,8 @@ void ottf_console_init(void) {
       ottf_console_configure_spi_device(base_addr);
       sink = get_spi_device_sink();
       getc = spi_device_getc;
+      spi_buf_end = 0;
+      memset(spi_buf, 0, kSpiDeviceMaxFramePayloadSizeBytes);
       break;
     default:
       CHECK(false, "unsupported OTTF console interface.");
@@ -419,12 +425,65 @@ size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf) {
   return received_data_len;
 }
 
-status_t ottf_console_putbuf(void *io, const char *buf, size_t len) {
+static status_t ottf_spi_console_flushbuf(void *io) {
+  size_t written_len = 0;
+  if (spi_buf_end > 0) {
+    written_len = sink(io, spi_buf, spi_buf_end);
+    if (spi_buf_end != written_len) {
+      return DATA_LOSS((int32_t)(spi_buf_end - written_len));
+    }
+    spi_buf_end = 0;
+  }
+  return OK_STATUS((int32_t)written_len);
+}
+
+static status_t ottf_spi_console_putbuf(void *io, const char *buf, size_t len) {
+  if (len > sizeof(spi_buf)) {
+    // Flush and skip the staging buffer if the payload is already the max size.
+    TRY(ottf_spi_console_flushbuf(io));
+    size_t written_len = sink(io, buf, len);
+    if (len != written_len) {
+      return DATA_LOSS((int32_t)(len - written_len));
+    }
+  } else if ((spi_buf_end + len) <= sizeof(spi_buf)) {
+    // There is room for the data in the staging buffer, copy it over.
+    memcpy(&spi_buf[spi_buf_end], buf, len);
+    spi_buf_end += len;
+  } else {
+    // The staging buffer is almost full; flush it before staging more data.
+    TRY(ottf_spi_console_flushbuf(io));
+    memcpy(&spi_buf[spi_buf_end], buf, len);
+    spi_buf_end += len;
+  }
+  return OK_STATUS((int32_t)len);
+}
+
+static status_t ottf_uart_console_putbuf(void *io, const char *buf,
+                                         size_t len) {
   size_t written_len = sink(io, buf, len);
   if (len != written_len) {
     return DATA_LOSS((int32_t)(len - written_len));
   }
   return OK_STATUS((int32_t)len);
+}
+
+status_t ottf_console_putbuf(void *io, const char *buf, size_t len) {
+  switch (kOttfTestConfig.console.type) {
+    case kOttfConsoleSpiDevice:
+      return ottf_spi_console_putbuf(io, buf, len);
+    default:
+      return ottf_uart_console_putbuf(io, buf, len);
+  }
+}
+
+status_t ottf_console_flushbuf(void *io) {
+  switch (kOttfTestConfig.console.type) {
+    case kOttfConsoleSpiDevice:
+      return ottf_spi_console_flushbuf(io);
+    default:
+      // Only the SPI console requires flushing a staging buffer.
+      return OK_STATUS(0);
+  }
 }
 
 status_t ottf_console_getc(void *io) { return getc(io); }

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -425,9 +425,9 @@ size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf) {
   return received_data_len;
 }
 
-static status_t ottf_spi_console_flushbuf(void *io) {
+status_t ottf_console_flushbuf(void *io) {
   size_t written_len = 0;
-  if (spi_buf_end > 0) {
+  if (kOttfTestConfig.console.putbuf_buffered && spi_buf_end > 0) {
     written_len = sink(io, spi_buf, spi_buf_end);
     if (spi_buf_end != written_len) {
       return DATA_LOSS((int32_t)(spi_buf_end - written_len));
@@ -437,10 +437,10 @@ static status_t ottf_spi_console_flushbuf(void *io) {
   return OK_STATUS((int32_t)written_len);
 }
 
-static status_t ottf_spi_console_putbuf(void *io, const char *buf, size_t len) {
+static status_t ottf_buffered_putbuf(void *io, const char *buf, size_t len) {
   if (len > sizeof(spi_buf)) {
     // Flush and skip the staging buffer if the payload is already the max size.
-    TRY(ottf_spi_console_flushbuf(io));
+    TRY(ottf_console_flushbuf(io));
     size_t written_len = sink(io, buf, len);
     if (len != written_len) {
       return DATA_LOSS((int32_t)(len - written_len));
@@ -451,14 +451,14 @@ static status_t ottf_spi_console_putbuf(void *io, const char *buf, size_t len) {
     spi_buf_end += len;
   } else {
     // The staging buffer is almost full; flush it before staging more data.
-    TRY(ottf_spi_console_flushbuf(io));
+    TRY(ottf_console_flushbuf(io));
     memcpy(&spi_buf[spi_buf_end], buf, len);
     spi_buf_end += len;
   }
   return OK_STATUS((int32_t)len);
 }
 
-static status_t ottf_uart_console_putbuf(void *io, const char *buf,
+static status_t ottf_non_buffered_putbuf(void *io, const char *buf,
                                          size_t len) {
   size_t written_len = sink(io, buf, len);
   if (len != written_len) {
@@ -468,21 +468,10 @@ static status_t ottf_uart_console_putbuf(void *io, const char *buf,
 }
 
 status_t ottf_console_putbuf(void *io, const char *buf, size_t len) {
-  switch (kOttfTestConfig.console.type) {
-    case kOttfConsoleSpiDevice:
-      return ottf_spi_console_putbuf(io, buf, len);
-    default:
-      return ottf_uart_console_putbuf(io, buf, len);
-  }
-}
-
-status_t ottf_console_flushbuf(void *io) {
-  switch (kOttfTestConfig.console.type) {
-    case kOttfConsoleSpiDevice:
-      return ottf_spi_console_flushbuf(io);
-    default:
-      // Only the SPI console requires flushing a staging buffer.
-      return OK_STATUS(0);
+  if (kOttfTestConfig.console.putbuf_buffered) {
+    return ottf_buffered_putbuf(io, buf, len);
+  } else {
+    return ottf_non_buffered_putbuf(io, buf, len);
   }
 }
 

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -120,6 +120,14 @@ size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf);
 status_t ottf_console_putbuf(void *io, const char *buf, size_t len);
 
 /**
+ * Flush remaining buffered data to the OTTF console.
+ *
+ * @param context An IO context
+ * @return OK or an error.
+ */
+status_t ottf_console_flushbuf(void *io);
+
+/**
  * Get a single character from the OTTF console.
  *
  * @return The next character or an error.

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -29,6 +29,15 @@ typedef struct ottf_console {
    * reconfigure it before printing the test status.
    */
   bool test_may_clobber;
+  /**
+   * Indicates if SW buffering should be turned on for `ottf_console_putbuf()`
+   * to increase the transmit performance when using a peripheral backend like
+   * SPI that has a frame overhead associated with each packet transmission.
+   *
+   * Set this option to true if you are using the SPI console device with UJSON
+   * transmissions.
+   */
+  bool putbuf_buffered;
 } ottf_console_t;
 
 typedef struct ottf_console_tx_indicator {

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -10,5 +10,6 @@
 #include "sw/device/lib/ujson/ujson.h"
 
 ujson_t ujson_ottf_console(void) {
-  return ujson_init(ottf_console_get(), ottf_console_getc, ottf_console_putbuf);
+  return ujson_init(ottf_console_get(), ottf_console_getc, ottf_console_putbuf,
+                    ottf_console_flushbuf);
 }

--- a/sw/device/lib/testing/test_framework/ujson_ottf.h
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.h
@@ -73,6 +73,7 @@ ujson_t ujson_ottf_console(void);
     TRY(ujson_putbuf(uj_ctx_, " CRC:", 5));       \
     TRY(ujson_serialize_uint32_t(uj_ctx_, &crc)); \
     TRY(ujson_putbuf(uj_ctx_, "\n", 1));          \
+    TRY(ujson_flushbuf(uj));                      \
     OK_STATUS();                                  \
   })
 

--- a/sw/device/lib/ujson/example_roundtrip.c
+++ b/sw/device/lib/ujson/example_roundtrip.c
@@ -34,7 +34,7 @@ status_t check_crc32(ujson_t *uj) {
 }
 
 status_t roundtrip(const char *name) {
-  ujson_t uj = ujson_init(NULL, stdio_getc, stdio_putbuf);
+  ujson_t uj = ujson_init(NULL, stdio_getc, stdio_putbuf, NULL);
   if (!strcmp(name, "foo")) {
     foo x = {0};
     TRY(ujson_deserialize_foo(&uj, &x));

--- a/sw/device/lib/ujson/test_helpers.h
+++ b/sw/device/lib/ujson/test_helpers.h
@@ -19,7 +19,8 @@ class SourceSink {
   const std::string &Sink() { return sink_; }
 
   ujson_t UJson() {
-    return ujson_init((void *)this, &SourceSink::getc, &SourceSink::putbuf);
+    return ujson_init((void *)this, &SourceSink::getc, &SourceSink::putbuf,
+                      nullptr);
   }
 
   void Reset() {

--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -17,8 +17,9 @@
 static bool is_space(int c) { return c == ' ' || (c >= '\t' && c < '\t' + 5); }
 
 ujson_t ujson_init(void *context, status_t (*getc)(void *),
-                   status_t (*putbuf)(void *, const char *, size_t)) {
-  ujson_t u = UJSON_INIT(context, getc, putbuf);
+                   status_t (*putbuf)(void *, const char *, size_t),
+                   status_t (*flushbuf)(void *)) {
+  ujson_t u = UJSON_INIT(context, getc, putbuf, flushbuf);
   return u;
 }
 
@@ -30,6 +31,8 @@ status_t ujson_putbuf(ujson_t *uj, const char *buf, size_t len) {
   crc32_add(&uj->crc32, buf, len);
   return uj->putbuf(uj->io_context, buf, len);
 }
+
+status_t ujson_flushbuf(ujson_t *uj) { return uj->flushbuf(uj->io_context); }
 
 status_t ujson_getc(ujson_t *uj) {
   int16_t buffer = uj->buffer;

--- a/sw/device/lib/ujson/ujson.h
+++ b/sw/device/lib/ujson/ujson.h
@@ -19,6 +19,8 @@ typedef struct ujson {
   void *io_context;
   /** A pointer to an IO function for writing data to the output. */
   status_t (*putbuf)(void *, const char *, size_t);
+  /** A pointer to an IO function for flusing buffered data to the output. */
+  status_t (*flushbuf)(void *);
   /** A pointer to an IO function for reading data from the input. */
   status_t (*getc)(void *);
   /** An internal single character buffer for ungetting a character. */
@@ -28,13 +30,14 @@ typedef struct ujson {
 } ujson_t;
 
 // clang-format off
-#define UJSON_INIT(context_, getc_, putbuf_) \
-  {                                          \
-    .io_context = (void*)(context_),         \
-    .putbuf_ = (putbuf_),                    \
-    .getc = (getc_),                         \
-    .buffer = -1,                            \
-    .crc32 = UINT32_MAX,                     \
+#define UJSON_INIT(context_, getc_, putbuf_, flushbuf_) \
+  {                                                     \
+      .io_context = (void *)(context_),                 \
+      .putbuf_ = (putbuf_),                             \
+      .flushbuf_ = (flushbuf_),                         \
+      .getc = (getc_),                                  \
+      .buffer = -1,                                     \
+      .crc32 = UINT32_MAX,                              \
   }
 // clang-format on
 
@@ -47,7 +50,8 @@ typedef struct ujson {
  * @return An initialized ujson_t context.
  */
 ujson_t ujson_init(void *context, status_t (*getc)(void *),
-                   status_t (*putbuf)(void *, const char *, size_t));
+                   status_t (*putbuf)(void *, const char *, size_t),
+                   status_t (*flushbuf)(void *));
 
 /**
  * Gets a single character from the input.
@@ -75,6 +79,19 @@ status_t ujson_ungetc(ujson_t *uj, char ch);
  * @return OK or an error.
  */
 status_t ujson_putbuf(ujson_t *uj, const char *buf, size_t len);
+
+/**
+ * Flush a UJSON buffer to the output.
+ *
+ * Some console implementations, e.g., the SPI console, stages data in a
+ * software buffer before flushing it out to the low-level printf driver, as the
+ * driver code uses a framing protocol that is more efficient if used with bulk
+ * data transfers as opposed to being used with single character writes.
+ *
+ * @param uj A ujson IO context.
+ * @return OK or an error.
+ */
+status_t ujson_flushbuf(ujson_t *uj);
 
 /**
  * Resets the CRC32 calculation to an initial state.

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -242,7 +242,7 @@ cc_library(
     deps = [
         ":personalize_ext",
         "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing/test_framework:status",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/silicon_creator/lib:attestation",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4349,7 +4349,9 @@ opentitan_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
     ],
 )
 

--- a/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
+++ b/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
@@ -17,6 +17,7 @@ static const dif_gpio_pin_t kGpioPinSpiConsoleTxReady = 0;
 OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
                         .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
                         .console.test_may_clobber = false,
+                        .console.putbuf_buffered = true,
                         .silence_console_prints = true,
                         .console_tx_indicator.enable = true,
                         .console_tx_indicator.spi_console_tx_ready_mio =

--- a/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
+++ b/sw/device/tests/ottf_console_with_gpio_tx_indicator_test.c
@@ -4,9 +4,11 @@
 
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -80,7 +82,9 @@ static const char kTest4KbDataStr[] =
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     "bbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-bool test_main(void) {
+static perso_blob_t perso_blob_to_host;
+
+static status_t test_base_printf(void) {
   // Send a string using the TX-ready GPIO indicator pin. Note, we use
   // `base_printf()`directly, instead of LOG_INFO(), as we only want to print
   // the exact string as is, with no additional metadata.
@@ -95,7 +99,26 @@ bool test_main(void) {
   base_printf("ABC");
   base_printf("%s", kTest4KbDataStr);
 
-  abort();
+  return OK_STATUS();
+}
 
+static status_t test_large_ujson_tx(ujson_t *uj) {
+  // Note: this should match the size of the "body" field in
+  // `sw/device/lib/testing/json/provisioning_data.h`.
+  const size_t kPayloadSize = 5120;
+  for (size_t i = 0; i < kPayloadSize; ++i) {
+    perso_blob_to_host.body[i] = (uint8_t)(i % 256);
+  }
+  perso_blob_to_host.num_objs = 1;
+  perso_blob_to_host.next_free = kPayloadSize;
+  RESP_OK(ujson_serialize_perso_blob_t, uj, &perso_blob_to_host);
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  ujson_t uj = ujson_ottf_console();
+  CHECK_STATUS_OK(test_base_printf());
+  CHECK_STATUS_OK(test_large_ujson_tx(&uj));
+  abort();
   return true;
 }

--- a/sw/host/opentitanlib/src/uart/console.rs
+++ b/sw/host/opentitanlib/src/uart/console.rs
@@ -43,7 +43,7 @@ impl<T: Read + AsFd> ReadAsFd for T {}
 impl UartConsole {
     const CTRL_B: u8 = 2;
     const CTRL_C: u8 = 3;
-    const BUFFER_LEN: usize = 16384;
+    const BUFFER_LEN: usize = 32768;
 
     // Runs an interactive console until CTRL_C is received.
     pub fn interact<T>(

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/BUILD
@@ -13,6 +13,7 @@ rust_binary(
     ],
     deps = [
         "//sw/host/opentitanlib",
+        "//sw/host/provisioning/ujson_lib",
         "//third_party/rust/crates:anyhow",
         "//third_party/rust/crates:clap",
         "//third_party/rust/crates:humantime",

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
@@ -14,7 +14,9 @@ use opentitanlib::execute_test;
 use opentitanlib::io::gpio::{PinMode, PullMode};
 use opentitanlib::test_utils;
 use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::ConsoleRecv;
 use opentitanlib::uart::console::UartConsole;
+use ujson_lib::provisioning_data::PersoBlob;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -46,6 +48,7 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     let elf_binary = fs::read(&opts.firmware_elf)?;
     let object = object::File::parse(&*elf_binary)?;
 
+    // Wait for generic strings to be transmitted.
     for _ in 0..2 {
         // Receive simple string from the device.
         _ = UartConsole::wait_for(&spi_console_device, "ABC", opts.timeout)?;
@@ -54,6 +57,12 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
         let data = test_utils::object::symbol_data(&object, "kTest4KbDataStr")?;
         let data_str = std::str::from_utf8(&data)?.trim_matches(char::from(0));
         _ = UartConsole::wait_for(&spi_console_device, data_str, opts.timeout)?;
+    }
+
+    // Receive the UJSON string transmitted and verify its contents.
+    let perso_blob = PersoBlob::recv(&spi_console_device, opts.timeout, true)?;
+    for i in 0..perso_blob.body.len() {
+        assert_eq!(perso_blob.body[i], (i % 256) as u8);
     }
 
     Ok(())


### PR DESCRIPTION
When using the spi_device transport for the OTTF console, a header is attached to every data payload before writing the data payload to the spi_device flash buffer (to be later read out by the host). This creates a large overhead (12-bytes) when the data payload is small (e.g., only a single character).

Moreover, the way the UJSON message transmit macros are implemented, results in writing several small strings, or even single characters, to the printf (console) sink function. This created an unncessarily large number of SPI console frames when sending the `perso_blob_t` UJSON struct to the host.

This commit adds a SW buffering mechanism to the OTTF SPI console to collect all small strings / single character writes into a single large SPI console transaction. This greatly improves the efficiency in sending large UJSON structs over the SPI OTTF console.