### PR TITLE
[tests,e2e] Fix e2e bootstrap rma flakiness

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -29,7 +29,9 @@ otp_json(
             name = "CREATOR_SW_CFG",
             items = {
                 "CREATOR_SW_CFG_RMA_SPIN_EN": otp_hex(CONST.HARDENED_TRUE),
-                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "0x2000000",
+                # Number of Ibex cycles to spin: approximately 5.5s @ 24Mhz
+                # If you change this value, make sure to update the code in the harness.
+                "CREATOR_SW_CFG_RMA_SPIN_CYCLES": "0x8000000",
             },
         ),
         otp_partition(


### PR DESCRIPTION
Now that the "clear RX buffer" issue of CW310 has been fixed (#27078), I have diagnosed the flakiness to the fact that under heavy CI load, the harness will take several seconds to start openocd, connect and do the RMA transition. Since the RMA spin cycles is set to approximately 1.3s, it is very easy to get to a situation where the device resets in the middle of the test. After some experiments, I have seen delays as high 3 seconds between the device connecting and the RMA transition happening. This PR bumps the RMA spin cycle to roughly 5.5s which should give plenty of margin.