### PR TITLE
[rv_plic, fpv] Rsp and Data intg undetectable in reg_if

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -163,15 +163,20 @@ module tlul_adapter_reg
     d_error:  error
   };
 
-  // outgoing integrity generation
-  tlul_rsp_intg_gen #(
-    .EnableRspIntgGen(EnableRspIntgGen),
-    .EnableDataIntgGen(EnableDataIntgGen),
-    .UserInIsZero(1'b1)
-  ) u_rsp_intg_gen (
-    .tl_i(tl_o_pre),
-    .tl_o(tl_o)
-  );
+  if (!EnableRspIntgGen && !EnableDataIntgGen) begin: gen_no_rsp_intg
+    assign tl_o = tl_o_pre;
+  end
+  else begin: gen_rsp_intg
+    // outgoing integrity generation
+    tlul_rsp_intg_gen #(
+      .EnableRspIntgGen(EnableRspIntgGen),
+      .EnableDataIntgGen(EnableDataIntgGen),
+      .UserInIsZero(1'b1)
+    ) u_rsp_intg_gen (
+      .tl_i(tl_o_pre),
+      .tl_o(tl_o)
+    );
+  end
 
   if (CmdIntgCheck) begin : gen_cmd_intg_check
     logic intg_error_q;


### PR DESCRIPTION
rv_plic_reg_top instantiates tlul_adapter_reg with EnableDataIntgGen and EnableRspIntgGen as 0. So, rsp_intg and data_intg is always zero and jasper recognize that undetectable.

Tweak the instantiation of tlul_adapter_reg in a way applied in the PR will allow jasper to not look at the piece of unneccessary code and mark it as undetectable.