### PR TITLE
[rv_plic, fpv] Tidying up the branch condition into assertion

### DIFF
--- a/hw/ip/tlul/rtl/tlul_rsp_intg_gen.sv
+++ b/hw/ip/tlul/rtl/tlul_rsp_intg_gen.sv
@@ -79,10 +79,8 @@ module tlul_rsp_intg_gen import tlul_pkg::*; #(
 // but it is intended to be used in simulation and FPV
 `ifndef SYNTHESIS
   always @(tl_i) begin
-    if (tl_i.d_valid) begin
-      `ASSERT_I(RspZero_A, RspIntgInIsZero -> ~|tl_i.d_user.rsp_intg)
-      `ASSERT_I(UserZero_A, UserInIsZero -> ~|tl_i.d_user)
-    end
+    `ASSERT_I(RspZero_A, tl_i.d_valid & RspIntgInIsZero -> ~|tl_i.d_user.rsp_intg)
+    `ASSERT_I(UserZero_A, tl_i.d_valid & UserInIsZero -> ~|tl_i.d_user)
   end
 `endif
 


### PR DESCRIPTION
The branch appeared as undetectable with a jasper description saying "implicit else". Tidying up the branch into the precondition part of the assertion would make it more clean and get rid of the undetectable coverage complain.