### PR TITLE
[multi_top,clkmgr] Configure clock measurement resolution

### DIFF
--- a/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-  all_srcs = src_clks.copy()
-  all_srcs.update(derived_clks)
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
+from ipgen.clkmgr_gen import get_all_srcs, get_rg_srcs
+all_srcs = get_all_srcs(src_clks, derived_clks)
+rg_srcs = get_rg_srcs(typed_clocks)
 %>
 # CLKMGR register template
 #

--- a/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip_templates/clkmgr/data/clkmgr.hjson.tpl
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-from ipgen.clkmgr_gen import get_all_srcs, get_rg_srcs
+from ipgen.clkmgr_gen import config_clk_meas, get_all_srcs, get_rg_srcs
 all_srcs = get_all_srcs(src_clks, derived_clks)
 rg_srcs = get_rg_srcs(typed_clocks)
 %>
@@ -542,7 +542,6 @@ rg_srcs = get_rg_srcs(typed_clocks)
         },
       ]
     },
-<% aon_freq = all_srcs['aon']['freq'] %>\
 % for src in rg_srcs:
     { name: "${src.upper()}_MEAS_CTRL_EN",
       desc: '''
@@ -568,10 +567,7 @@ rg_srcs = get_rg_srcs(typed_clocks)
       tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 <%
-  freq = all_srcs[src]['freq']
-  ratio = int(freq / aon_freq)
-  # Add extra bit to width for margin
-  width = ratio.bit_length() + 1
+  width, _, ratio = config_clk_meas(src, all_srcs)
   max_msb = width - 1
   min_msb = (max_msb + 1) + width - 1
 %>

--- a/hw/ip_templates/clkmgr/dv/README.md.tpl
+++ b/hw/ip_templates/clkmgr/dv/README.md.tpl
@@ -58,7 +58,7 @@ All common types and methods defined at the package level can be found in
   typedef enum int {
 % for clk in [v for v in typed_clocks['sw_clks'].values()]:
 <% sep = "" if loop.last else "," %>\
-    Peri${Name.from_snake_case(clk['src_name']).as_camel_case()}${sep}
+    Peri${Name.to_camel_case(clk['src_name'])}${sep}
 % endfor
   } peri_e;
   typedef enum int {TransAes, TransHmac, TransKmac, TransOtbn} trans_e;

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_csrs_if.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_csrs_if.sv.tpl
@@ -6,8 +6,8 @@
 // to avoid any confusion.
 
 <%
-rg_srcs = list(sorted({sig['src_name'] for sig
-                      in typed_clocks['rg_clks'].values()}))
+from ipgen.clkmgr_gen import get_rg_srcs
+rg_srcs = get_rg_srcs(typed_clocks)
 
 ## The number of recoverable error bits is:
 ## 1 for shadow_update

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env.sv.tpl
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
+from ipgen.clkmgr_gen import get_rg_srcs
 all_src_names = sorted(s['name'] for s in src_clks.values())
-rg_srcs = list(sorted({sig['src_name'] for sig
-                       in typed_clocks['rg_clks'].values()}))
+rg_srcs = get_rg_srcs(typed_clocks)
 %>\
 
 class clkmgr_env extends cip_base_env #(

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env_cov.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env_cov.sv.tpl
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 <%
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
+from ipgen.clkmgr_gen import get_rg_srcs
+rg_srcs = get_rg_srcs(typed_clocks)
 %>\
 /**
  * Covergoups that are dependent on run-time parameters that may be available

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env_pkg.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env_pkg.sv.tpl
@@ -8,10 +8,6 @@ rg_srcs = get_rg_srcs(typed_clocks)
 all_srcs = get_all_srcs(src_clks, derived_clks)
 clk_freqs = {v['name']: v['freq'] for v in all_srcs.values()}
 hint_targets = get_hint_targets(typed_clocks)
-
-def to_camel_case(s: str):
-  return Name.from_snake_case(s).as_camel_case()
-
 %>
 package clkmgr_env_pkg;
   // dep packages
@@ -50,7 +46,7 @@ package clkmgr_env_pkg;
   parameter mubi_hintables_t IdleAllBusy = {NUM_TRANS{prim_mubi_pkg::MuBi4False}};
 
 % for clk, freq in clk_freqs.items():
-  parameter int ${to_camel_case(clk)}ClkHz = ${f"{freq:_}"};
+  parameter int ${Name.to_camel_case(clk)}ClkHz = ${f"{freq:_}"};
 % endfor
   parameter int FakeAonClkHz = 7_000_000;
 
@@ -67,7 +63,7 @@ package clkmgr_env_pkg;
   typedef enum int {
 % for clk in typed_clocks['sw_clks'].values():
 <% sep = "" if loop.last else "," %>\
-    Peri${to_camel_case(clk['src_name'])}${sep}
+    Peri${Name.to_camel_case(clk['src_name'])}${sep}
 % endfor
   } peri_e;
   typedef struct packed {
@@ -97,7 +93,7 @@ package clkmgr_env_pkg;
   // These are ordered per the bits in the recov_err_code register.
   typedef enum int {
 % for src in rg_srcs:
-    ClkMesr${to_camel_case(src)},
+    ClkMesr${Name.to_camel_case(src)},
 % endfor
     ClkMesrSize
   } clk_mesr_e;
@@ -125,14 +121,14 @@ package clkmgr_env_pkg;
   parameter int ClkInHz[ClkMesrSize] = {
 % for src in rg_srcs:
 <% sep = "" if loop.last else "," %>\
-    ${to_camel_case(src)}ClkHz${sep}
+    ${Name.to_camel_case(src)}ClkHz${sep}
 % endfor
   };
 
   parameter int ExpectedCounts[ClkMesrSize] = {
 % for src in rg_srcs:
 <% sep = "" if loop.last else "," %>\
-    ClkInHz[ClkMesr${to_camel_case(src)}] / AonClkHz - 1${sep}
+    ClkInHz[ClkMesr${Name.to_camel_case(src)}] / AonClkHz - 1${sep}
 % endfor
   };
 

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_env_pkg.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_env_pkg.sv.tpl
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-  from topgen.lib import Name
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
-  clk_freqs = {v['name']: v['freq'] for v in src_clks.values()}
-  clk_freqs.update({v['name']: v['freq'] for v in derived_clks.values()})
-  hint_targets = [sig['endpoint_ip'] for sig in typed_clocks['hint_clks'].values()]
+from ipgen.clkmgr_gen import get_all_srcs, get_hint_targets, get_rg_srcs
+from topgen.lib import Name
+rg_srcs = get_rg_srcs(typed_clocks)
+all_srcs = get_all_srcs(src_clks, derived_clks)
+clk_freqs = {v['name']: v['freq'] for v in all_srcs.values()}
+hint_targets = get_hint_targets(typed_clocks)
 
-  def to_camel_case(s: str):
-    return Name.from_snake_case(s).as_camel_case()
+def to_camel_case(s: str):
+  return Name.from_snake_case(s).as_camel_case()
 
 %>
 package clkmgr_env_pkg;

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_if.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_if.sv.tpl
@@ -6,10 +6,6 @@ from ipgen.clkmgr_gen import get_all_srcs, get_hint_targets, get_rg_srcs
 from topgen.lib import Name
 rg_srcs = get_rg_srcs(typed_clocks)
 hint_targets = get_hint_targets(typed_clocks)
-
-def to_camel_case(s: str):
-    return Name.from_snake_case(s).as_camel_case()
-
 %>\
 //
 // clkmgr interface.
@@ -125,7 +121,7 @@ interface clkmgr_if (
 ${spc}slow: `CLKMGR_HIER.u_${src}_meas.u_meas.slow_o,
 ${spc}fast: `CLKMGR_HIER.u_${src}_meas.u_meas.fast_o};
       `uvm_info("clkmgr_if", $sformatf(
-                "Sampled coverage for ClkMesr${to_camel_case(src)} as %p", ${src}_freq_measurement), UVM_HIGH)
+                "Sampled coverage for ClkMesr${Name.to_camel_case(src)} as %p", ${src}_freq_measurement), UVM_HIGH)
     end
   end
   always_comb ${src}_timeout_err = `CLKMGR_HIER.u_${src}_meas.timeout_err_o;
@@ -179,7 +175,7 @@ ${spc}fast: `CLKMGR_HIER.u_${src}_meas.u_meas.fast_o};
     `uvm_info("clkmgr_if", $sformatf("Forcing count of %0s to all 1.", clk.name()), UVM_MEDIUM)
     case (clk)
 % for src in rg_srcs:
-      ClkMesr${to_camel_case(src)}: `CLKMGR_HIER.u_${src}_meas.u_meas.cnt = '1;
+      ClkMesr${Name.to_camel_case(src)}: `CLKMGR_HIER.u_${src}_meas.u_meas.cnt = '1;
 % endfor
       default: ;
     endcase

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_if.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_if.sv.tpl
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-  from topgen.lib import Name
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
-  hint_targets = [sig['endpoint_ip']
-                  for sig in typed_clocks['hint_clks'].values()]
-  def to_camel_case(s: str):
+from ipgen.clkmgr_gen import get_all_srcs, get_hint_targets, get_rg_srcs
+from topgen.lib import Name
+rg_srcs = get_rg_srcs(typed_clocks)
+hint_targets = get_hint_targets(typed_clocks)
+
+def to_camel_case(s: str):
     return Name.from_snake_case(s).as_camel_case()
+
 %>\
 //
 // clkmgr interface.

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-  from itertools import chain
-  from topgen.lib import Name
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
+from itertools import chain
+from ipgen.clkmgr_gen import get_rg_srcs
+from topgen.lib import Name
+rg_srcs = get_rg_srcs(typed_clocks)
 
-  def to_camel_case(s: str):
-    return Name.from_snake_case(s).as_camel_case()
+def to_camel_case(s: str):
+  return Name.from_snake_case(s).as_camel_case()
 %>\
 
 // The scoreboard checks the jitter_an_o output, and processes CSR checks.

--- a/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/clkmgr_scoreboard.sv.tpl
@@ -6,9 +6,6 @@ from itertools import chain
 from ipgen.clkmgr_gen import get_rg_srcs
 from topgen.lib import Name
 rg_srcs = get_rg_srcs(typed_clocks)
-
-def to_camel_case(s: str):
-  return Name.from_snake_case(s).as_camel_case()
 %>\
 
 // The scoreboard checks the jitter_an_o output, and processes CSR checks.
@@ -139,10 +136,10 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
 <%
   spc = " " * (len("            ") +
                len("cov.peri_cg_wrap[Peri") +
-	       len(to_camel_case(clk_name)) +
+	       len(Name.to_camel_case(clk_name)) +
 	       len("].sample("))
 %>\
-            cov.peri_cg_wrap[Peri${to_camel_case(clk_name)}].sample(cfg.clkmgr_vif.peri_${clk_name}_cb.clk_enable,
+            cov.peri_cg_wrap[Peri${Name.to_camel_case(clk_name)}].sample(cfg.clkmgr_vif.peri_${clk_name}_cb.clk_enable,
 ${spc}cfg.clkmgr_vif.peri_${clk_name}_cb.ip_clk_en,
 ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
           end
@@ -196,7 +193,7 @@ ${spc}cfg.clkmgr_vif.scanmode_i == MuBi4True);
       forever
         @(posedge cfg.clkmgr_vif.${src}_freq_measurement.valid or
           posedge cfg.clkmgr_vif.${src}_timeout_err) begin
-          sample_freq_measurement_cov(ClkMesr${to_camel_case(src)}, cfg.clkmgr_vif.${src}_freq_measurement,
+          sample_freq_measurement_cov(ClkMesr${Name.to_camel_case(src)}, cfg.clkmgr_vif.${src}_freq_measurement,
                                       cfg.clkmgr_vif.${src}_timeout_err);
         end
 

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
@@ -206,8 +206,8 @@ ${spc}ral.${src}_meas_ctrl_shadowed.lo};
     csr_wr(.ptr(meas_ctrl_regs[which].en), .value(MuBi4False));
   endtask
 
-  local function int get_meas_ctrl_value(int min_threshold, int max_threshold, uvm_reg_field lo,
-                                         uvm_reg_field hi);
+  protected function int get_meas_ctrl_value(int min_threshold, int max_threshold,
+                                             uvm_reg_field lo, uvm_reg_field hi);
     int lo_mask = (1 << lo.get_n_bits()) - 1;
     int hi_mask = (1 << hi.get_n_bits()) - 1;
 
@@ -282,6 +282,8 @@ ${spc}ral.${src}_meas_ctrl_shadowed.lo};
     root_name = src
 %>\
       ClkMesr${Name.to_camel_case(src)}: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "${root_name}"),
+                  UVM_MEDIUM)
         if (enable) cfg.${root_name}_clk_rst_vif.start_clk();
         else cfg.${root_name}_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesr${Name.to_camel_case(src)}), .enable(enable));

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
@@ -2,18 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
+from ipgen.clkmgr_gen import get_all_srcs, get_rg_srcs
 from topgen.lib import Name
-src_names = sorted(s['name'] for s in src_clks.values())
+all_srcs = get_all_srcs(src_clks, derived_clks)
 non_aon_src_names = sorted(
     s['name'] for s in src_clks.values() if not s['aon'])
-derived_names = sorted(s['name'] for s in derived_clks.values())
-all_src_names = sorted(src_names + derived_names)
+all_src_names = sorted(s['name'] for s in all_srcs.values())
 meas_clks = sorted(
-    [(src['name'], src['freq']) for src in src_clks.values()] +
-    [(src['name'], src['freq']) for src in derived_clks.values()],
-    key=lambda x: x[0])
-rg_srcs = list(sorted({sig['src_name'] for sig
-                       in typed_clocks['rg_clks'].values()}))
+    ((s['name'], s['freq']) for s in all_srcs.values()), key=lambda x: x[0])
+rg_srcs = get_rg_srcs(typed_clocks)
 
 def to_camel_case(s: str):
     return Name.from_snake_case(s).as_camel_case()

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv.tpl
@@ -11,9 +11,6 @@ all_src_names = sorted(s['name'] for s in all_srcs.values())
 meas_clks = sorted(
     ((s['name'], s['freq']) for s in all_srcs.values()), key=lambda x: x[0])
 rg_srcs = get_rg_srcs(typed_clocks)
-
-def to_camel_case(s: str):
-    return Name.from_snake_case(s).as_camel_case()
 %>\
 class clkmgr_base_vseq extends cip_base_vseq #(
   .RAL_T              (clkmgr_reg_block),
@@ -113,10 +110,10 @@ class clkmgr_base_vseq extends cip_base_vseq #(
 % for src in rg_srcs:
 <% spc = " " * (len("    ") +
                 len("meas_ctrl_regs[ClkMesr") +
-                len(to_camel_case(src)) +
+                len(Name.to_camel_case(src)) +
                 len("}] = '{"))
 %>\
-    meas_ctrl_regs[ClkMesr${to_camel_case(src)}] = '{"${src}", ral.${src}_meas_ctrl_en,
+    meas_ctrl_regs[ClkMesr${Name.to_camel_case(src)}] = '{"${src}", ral.${src}_meas_ctrl_en,
 ${spc}ral.${src}_meas_ctrl_shadowed.hi,
 ${spc}ral.${src}_meas_ctrl_shadowed.lo};
 % endfor
@@ -252,7 +249,7 @@ ${spc}ral.${src}_meas_ctrl_shadowed.lo};
               UVM_MEDIUM)
     case (clk)
 % for src in rg_srcs:
-      ClkMesr${to_camel_case(src)}: begin
+      ClkMesr${Name.to_camel_case(src)}: begin
         if (enable) $asserton(0, "tb.dut.u_${src}_meas.u_meas.MaxWidth_A");
         else $assertoff(0, "tb.dut.u_${src}_meas.u_meas.MaxWidth_A");
       end
@@ -264,7 +261,7 @@ ${spc}ral.${src}_meas_ctrl_shadowed.lo};
   local function void control_sync_pulse_assert(clk_mesr_e clk, bit enable);
     case (clk)
 % for src in rg_srcs:
-      ClkMesr${to_camel_case(src)}: begin
+      ClkMesr${Name.to_camel_case(src)}: begin
         if (enable) $asserton(0, "tb.dut.u_${src}_meas.u_meas.u_sync_ref.SrcPulseCheck_M");
         else $assertoff(0, "tb.dut.u_${src}_meas.u_meas.u_sync_ref.SrcPulseCheck_M");
       end
@@ -284,10 +281,10 @@ ${spc}ral.${src}_meas_ctrl_shadowed.lo};
   else:
     root_name = src
 %>\
-      ClkMesr${to_camel_case(src)}: begin
+      ClkMesr${Name.to_camel_case(src)}: begin
         if (enable) cfg.${root_name}_clk_rst_vif.start_clk();
         else cfg.${root_name}_clk_rst_vif.stop_clk();
-        control_sync_pulse_assert(.clk(ClkMesr${to_camel_case(src)}), .enable(enable));
+        control_sync_pulse_assert(.clk(ClkMesr${Name.to_camel_case(src)}), .enable(enable));
       end
 % endfor
       default: `uvm_fatal(`gfn, $sformatf("Unexpected clk '%0d'", clk))

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_timeout_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_timeout_vseq.sv.tpl
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-  from collections import defaultdict
-  from topgen.lib import Name
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
-  def to_camel_case(s: str):
-    return Name.from_snake_case(s).as_camel_case()
+from collections import defaultdict
+from ipgen.clkmgr_gen import get_rg_srcs
+from topgen.lib import Name
+rg_srcs = get_rg_srcs(typed_clocks)
+
+def to_camel_case(s: str):
+  return Name.from_snake_case(s).as_camel_case()
+
 %>\
 
 // The frequency timeout vseq exercises the frequency measurement counters. More details

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_timeout_vseq.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_frequency_timeout_vseq.sv.tpl
@@ -6,10 +6,6 @@ from collections import defaultdict
 from ipgen.clkmgr_gen import get_rg_srcs
 from topgen.lib import Name
 rg_srcs = get_rg_srcs(typed_clocks)
-
-def to_camel_case(s: str):
-  return Name.from_snake_case(s).as_camel_case()
-
 %>\
 
 // The frequency timeout vseq exercises the frequency measurement counters. More details
@@ -112,9 +108,9 @@ for p, cs in parent_child_clks.items():
     childless.append(p)
 %>\
 % for i, (p, cs) in enumerate(multi_children.items()):
-        if (clk_mesr_timeout inside {${', '.join("ClkMesr{}".format(to_camel_case(c)) for c in cs)}}) begin
+        if (clk_mesr_timeout inside {${', '.join("ClkMesr{}".format(Name.to_camel_case(c)) for c in cs)}}) begin
   % for c in cs:
-          expected_recov_timeout_err[ClkMesr${to_camel_case(c)}] = 1;
+          expected_recov_timeout_err[ClkMesr${Name.to_camel_case(c)}] = 1;
   % endfor
   % if i < len(multi_children) - 1:
         end else

--- a/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/ip_templates/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -51,7 +51,10 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       uvm_reg_data_t prev_en;
       mubi4_t new_en = get_rand_mubi4_val(1, 1, 2);
       int prev_ctrl;
-      int new_ctrl = $urandom();
+      int max_threshold = ExpectedCounts[clk] + 2;
+      int min_threshold = ExpectedCounts[clk] - 2;
+      int new_ctrl = get_meas_ctrl_value(min_threshold, max_threshold,
+          meas_ctrl_regs[clk_mesr].ctrl_lo, meas_ctrl_regs[clk_mesr].ctrl_hi);
       int actual_ctrl;
       int lo_mask = ((1 << meas_ctrl_regs[clk_mesr].ctrl_lo.get_n_bits()) - 1) <<
                      meas_ctrl_regs[clk_mesr].ctrl_lo.get_lsb_pos();
@@ -66,11 +69,11 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(new_en));
       csr_rd_check(.ptr(meas_ctrl_regs[clk_mesr].en),
                    .compare_value(mubi4_t'(regwen_enable ? new_en : prev_en)));
+      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
       csr_rd_check(.ptr(ctrl_shadowed), .compare_value(regwen_enable ? new_ctrl : prev_ctrl),
                    .compare_mask(lo_mask | hi_mask));
       `uvm_info(`gfn, $sformatf("Check %0s regwen done", meas_ctrl_regs[clk_mesr].name),
                 UVM_MEDIUM)
-      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
     end
   endtask : check_meas_ctrl_regwen
 

--- a/hw/ip_templates/clkmgr/dv/sva/clkmgr_bind.sv.tpl
+++ b/hw/ip_templates/clkmgr/dv/sva/clkmgr_bind.sv.tpl
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 <%
-  rg_srcs = list(sorted({sig['src_name'] for sig
-                         in typed_clocks['rg_clks'].values()}))
+from ipgen.clkmgr_gen import get_rg_srcs
+rg_srcs = get_rg_srcs(typed_clocks)
 %>\
 
 module clkmgr_bind;

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -6,13 +6,12 @@
 
 <%
 from collections import OrderedDict
+from ipgen.clkmgr_gen import get_all_srcs, get_rg_srcs
 from topgen.lib import Name
 all_derived_srcs = list(sorted(set([dc['src']['name']
                                     for dc in derived_clks.values()])))
-all_srcs = src_clks.copy()
-all_srcs.update(derived_clks)
-rg_srcs = list(sorted({sig['src_name'] for sig
-                       in typed_clocks['rg_clks'].values()}))
+all_srcs = get_all_srcs(src_clks, derived_clks)
+rg_srcs = get_rg_srcs(typed_clocks)
 %>\
 
 `include "prim_assert.sv"

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -360,7 +360,7 @@ rg_srcs = get_rg_srcs(typed_clocks)
   typedef enum logic [${(len(rg_srcs) + 1).bit_length() - 1}:0] {
     BaseIdx,
 % for src in rg_srcs:
-    Clk${Name.from_snake_case(src).as_camel_case()}Idx,
+    Clk${Name.to_camel_case(src)}Idx,
 % endfor
     CalibRdyLastIdx
   } clkmgr_calib_idx_e;
@@ -394,7 +394,7 @@ rg_srcs = get_rg_srcs(typed_clocks)
  # One bit margin, same bit width as in the reg top
  bit_width = int(freq / aon_freq).bit_length() + 1
  cnt = 2**bit_width
- sel_idx = f"Clk{Name.from_snake_case(src).as_camel_case()}Idx"
+ sel_idx = f"Clk{Name.to_camel_case(src)}Idx"
 %>
   clkmgr_meas_chk #(
     .Cnt(${cnt}),
@@ -502,8 +502,7 @@ rg_srcs = get_rg_srcs(typed_clocks)
 
   logic [${len(typed_clocks['hint_clks'])-1}:0] idle_cnt_err;
 % for clk, sig in typed_clocks['hint_clks'].items():
-<%assert_name = Name.from_snake_case(clk)
-%>
+
   clkmgr_trans #(
 % if clk == "clk_main_kmac":
     .FpgaBufGlobal(1'b1) // KMAC is getting too big for a single clock region.
@@ -534,7 +533,7 @@ rg_srcs = get_rg_srcs(typed_clocks)
     .reg_cnt_err_o(idle_cnt_err[${hint_names[clk]}])
   );
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(
-    ${assert_name.as_camel_case()}CountCheck_A,
+    ${Name.to_camel_case(clk)}CountCheck_A,
     u_${clk}_trans.u_idle_cnt,
     alert_tx_o[1])
 % endfor

--- a/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
+++ b/hw/ip_templates/clkmgr/rtl/clkmgr.sv.tpl
@@ -6,7 +6,7 @@
 
 <%
 from collections import OrderedDict
-from ipgen.clkmgr_gen import get_all_srcs, get_rg_srcs
+from ipgen.clkmgr_gen import config_clk_meas, get_all_srcs, get_rg_srcs
 from topgen.lib import Name
 all_derived_srcs = list(sorted(set([dc['src']['name']
                                     for dc in derived_clks.values()])))
@@ -387,18 +387,14 @@ rg_srcs = get_rg_srcs(typed_clocks)
       hw2reg.measure_ctrl_regwen.d = 1'b1;
     end
   end
-<% aon_freq = src_clks['aon']['freq'] %>\
 % for i, src in enumerate(rg_srcs):
 <%
- freq = all_srcs[src]['freq']
- # One bit margin, same bit width as in the reg top
- bit_width = int(freq / aon_freq).bit_length() + 1
- cnt = 2**bit_width
+ width, ref_cnt, _ = config_clk_meas(src, all_srcs)
  sel_idx = f"Clk{Name.to_camel_case(src)}Idx"
 %>
   clkmgr_meas_chk #(
-    .Cnt(${cnt}),
-    .RefCnt(1)
+    .Cnt(${2**width}),
+    .RefCnt(${ref_cnt})
   ) u_${src}_meas (
     .clk_i,
     .rst_ni,

--- a/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
+++ b/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
@@ -38,7 +38,7 @@ extern "C" {
 typedef enum dif_otp_ctrl_partition {
 % for part in parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
+  part_name_camel = Name.to_camel_case(part["name"])
   short_desc = part["desc"].split(".")[0].strip().replace("\n", " ")
   long_desc_lines = part["desc"].split(".", 1)[1].strip().splitlines()
   long_desc = "\n".join(["   *" + (" " if line else "") + line for
@@ -51,7 +51,7 @@ typedef enum dif_otp_ctrl_partition {
 ${long_desc}
   %endif
    */
-  kDifOtpCtrlPartition${part_name.as_camel_case()},
+  kDifOtpCtrlPartition${part_name_camel},
 % endfor
 } dif_otp_ctrl_partition_t;
 
@@ -104,8 +104,7 @@ typedef enum dif_otp_ctrl_status_code {
   // their values should not be randomized.
 % for part in parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   /**
    * Indicates an error occurred in the `${part_name_camel}` partition.

--- a/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
+++ b/hw/ip_templates/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
@@ -232,8 +232,7 @@ TEST_F(ReadLockTest, NotLockablePartitions) {
   bool flag;
 % for part in [p for p in parts if p not in read_locked_csr_parts]:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   EXPECT_DIF_BADARG(
       dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartition${part_name_camel}));
@@ -250,8 +249,7 @@ TEST_F(ReadLockTest, NullArgs) {
   bool flag;
 % for part in read_locked_csr_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
   lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartition{part_name_camel}));"
 %>\
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(

--- a/hw/ip_templates/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -198,8 +198,7 @@ otp_size_as_uint32 = otp_size_as_bytes // 4
     },
 % for part in otp_mmap["partitions"]:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     { name: "${part_name_camel}Offset",
       desc: "Offset of the ${part["name"]} partition",
@@ -215,8 +214,7 @@ otp_size_as_uint32 = otp_size_as_bytes // 4
     },
   % for item in part["items"]:
 <%
-  item_name = Name.from_snake_case(item["name"])
-  item_name_camel = item_name.as_camel_case()
+  item_name_camel = Name.to_camel_case(item["name"])
 %>\
     { name: "${item_name_camel}Offset",
       desc: "Offset of ${item["name"]}",

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cov.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_cov.sv.tpl
@@ -236,8 +236,8 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
     }
     partition: coverpoint part_idx {
 % for part in otp_mmap["partitions"]:
-<% part_name = Name.from_snake_case(part["name"]) %>\
-      bins ${part["name"].lower()} = {${part_name.as_camel_case()}Idx};
+<% part_name_camel = Name.to_camel_case(part["name"]) %>\
+      bins ${part["name"].lower()} = {${part_name_camel}Idx};
 % endfor
       bins illegal_idx    = default;
     }
@@ -338,8 +338,8 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
                                      int access_part_idx = DaiIdx);
     case (part_idx)
 % for part in otp_mmap["partitions"]:
-<% part_name = Name.from_snake_case(part["name"]) %>\
-      Otp${part_name.as_camel_case()}ErrIdx: begin
+<% part_name_camel = Name.to_camel_case(part["name"]) %>\
+      Otp${part_name_camel}ErrIdx: begin
   % if part in unbuffered_parts:
         unbuf_err_code_cg_wrap[part_idx].unbuf_err_code_cg.sample(val);
   % elif part in buffered_parts:

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv.tpl
@@ -82,8 +82,7 @@ package otp_ctrl_env_pkg;
   parameter int PART_BASE_ADDRS [NumPart-1] = {
 % for part in parts_without_lc:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     ${part_name_camel}Offset${"" if loop.last else ","}
 % endfor
@@ -93,8 +92,7 @@ package otp_ctrl_env_pkg;
   parameter int PART_OTP_DIGEST_ADDRS [NumPart-1] = {
 % for part in parts_without_lc:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
 % if part["sw_digest"] or part["hw_digest"]:
     ${part_name_camel}DigestOffset >> 2${"" if loop.last else ","}
@@ -114,8 +112,7 @@ package otp_ctrl_env_pkg;
   typedef enum bit [5:0] {
 % for part in otp_mmap["partitions"]:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     Otp${part_name_camel}ErrIdx,
 % endfor

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_if.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_if.sv.tpl
@@ -171,8 +171,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     @(posedge clk_i);
 % for part in unbuf_parts_with_digest:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     if (fail_idx[${part_name_camel}Idx]) begin
       force tb.dut.gen_partitions[${part_name_camel}Idx].gen_unbuffered.
@@ -186,8 +185,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     @(posedge clk_i);
 % for part in unbuf_parts_with_digest:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     if (force_sw_parts_ecc_reg[${part_name_camel}Idx]) begin
       release tb.dut.gen_partitions[${part_name_camel}Idx].gen_unbuffered.
@@ -214,8 +212,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     case (part_idx)
 % for part in buf_parts_without_lc:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
       ${part_name_camel}Idx: force `BUF_PART_OTP_CMD_PATH(${part_name_camel}Idx) = prim_otp_pkg::cmd_e'(2'b10);
 % endfor
@@ -232,8 +229,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     case (part_idx)
 % for part in buf_parts_without_lc:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
       ${part_name_camel}Idx: release `BUF_PART_OTP_CMD_PATH(${part_name_camel}Idx);
 % endfor
@@ -252,8 +248,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     @(posedge clk_i);
 % for part in parts_without_lc:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     `FORCE_OTP_PART_LOCK_WITH_RAND_NON_MUBI_VAL(${part_name_camel}Idx)
 % endfor

--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -114,8 +114,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
         otp_lc_data  = '{default:0};
 % for part in secret_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
         // secret partitions have been scrambled before writing to OTP.
         // here calculate the pre-srambled raw data when clearing internal OTP to all 0s.
@@ -228,8 +227,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
             exp_keymgr_data = '0;
 % for part in otp_mmap["partitions"]:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   % if part["iskeymgr_creator"] or part["iskeymgr_owner"]:
     % for item in part["items"]:
@@ -1235,8 +1233,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     case (part_idx)
 % for part in buf_parts_without_lc:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
       ${part_name_camel}Idx: mem_q = otp_a[${part_name_camel}Offset / TL_SIZE : ${part_name_camel}DigestOffset / TL_SIZE - 1];
 % endfor

--- a/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv.tpl
@@ -266,8 +266,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW*2-1:0] wdata;
   % for part in unbuf_parts_with_digest:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     if (wr_digest[${part_name_camel}Idx]) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
@@ -279,8 +278,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   virtual task write_sw_rd_locks(bit [NumPartUnbuf-1:0] do_rd_lock= $urandom());
 % for part in read_locked_csr_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
     if (do_rd_lock[${part_name_camel}Idx]) csr_wr(ral.${part["name"].lower()}_read_lock, 0);
 % endfor
@@ -306,8 +304,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
       // Digest write locks
 % for part in write_locked_digest_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
       if ((`gmv(ral.${part["name"].lower()}_digest[0]) ||
            `gmv(ral.${part["name"].lower()}_digest[1])) &&
@@ -319,8 +316,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
       // CSR read locks
 % for part in read_locked_csr_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
       if ((`gmv(ral.${part["name"].lower()}_read_lock) == 0) && !$urandom_range(0, 4)) begin
         forced_mubi_part_access[${part_name_camel}Idx].read_lock = 1;
@@ -331,8 +327,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
       // Digest read locks
 % for part in secret_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
       if ((`gmv(ral.${part["name"].lower()}_digest[0]) ||
            `gmv(ral.${part["name"].lower()}_digest[1])) &&

--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
@@ -140,7 +140,7 @@ package otp_ctrl_part_pkg;
 
   typedef enum {
 % for part in otp_mmap["partitions"]:
-    ${Name.from_snake_case(part["name"]).as_camel_case()}Idx,
+    ${Name.to_camel_case(part["name"])}Idx,
 % endfor
     // These are not "real partitions", but in terms of implementation it is convenient to
     // add these at the end of certain arrays.
@@ -243,8 +243,7 @@ package otp_ctrl_part_pkg;
     hw2reg = '0;
 % for k, part in enumerate(otp_mmap["partitions"]):
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   % if part["sw_digest"] or part["hw_digest"]:
     hw2reg.${part["name"].lower()}_digest = part_digest[${part_name_camel}Idx];
@@ -266,8 +265,7 @@ package otp_ctrl_part_pkg;
   % if part["read_lock"] == "CSR":
     // ${part["name"]}
     if (!reg2hw.${part["name"].lower()}_read_lock) begin
-<% part_name = Name.from_snake_case(part["name"]) %>\
-      part_access_pre[${part_name.as_camel_case()}Idx].read_lock = prim_mubi_pkg::MuBi8True;
+      part_access_pre[${Name.to_camel_case(part["name"])}Idx].read_lock = prim_mubi_pkg::MuBi8True;
     end
   % endif
 % endfor
@@ -284,8 +282,7 @@ package otp_ctrl_part_pkg;
 % for part in otp_mmap["partitions"]:
     // ${part["name"]}
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   % if part["bkout_type"]:
     valid &= part_init_done[${part_name_camel}Idx];
@@ -313,15 +310,13 @@ package otp_ctrl_part_pkg;
 % for part in otp_mmap["partitions"]:
     // ${part["name"]}
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   % if part["iskeymgr_creator"] or part["iskeymgr_owner"]:
     valid = (part_digest[${part_name_camel}Idx] != 0);
     % for item in part["items"]:
 <%
-  item_name = Name.from_snake_case(item["name"])
-  item_name_camel = item_name.as_camel_case()
+  item_name_camel = Name.to_camel_case(item["name"])
 %>\
       % if item["iskeymgr_creator"] or item["iskeymgr_owner"]:
     otp_keymgr_key.${item["name"].lower()}_valid = valid;

--- a/hw/ip_templates/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv.tpl
+++ b/hw/ip_templates/rstmgr/dv/sva/rstmgr_rst_en_track_sva_if.sv.tpl
@@ -21,8 +21,7 @@ interface rstmgr_rst_en_track_sva_if (
 
 % for rst in output_rsts:
 <%
-  rst_name = Name.from_snake_case(rst['name'])
-  rst_camel_name = rst_name.as_camel_case()
+  rst_camel_name = Name.to_camel_case(rst['name'])
 %>\
   % for domain in rst['domains']:
     % if rst['shadowed']:

--- a/hw/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
+++ b/hw/ip_templates/rstmgr/rtl/rstmgr.sv.tpl
@@ -302,7 +302,7 @@ module rstmgr
   // Power Domains: ${rst['domains']}
   // Shadowed: ${rst['shadowed']}
   % for j, name in enumerate(names):
-<%rst_name = Name.from_snake_case(name)
+<% rst_name_camel = Name.to_camel_case(name)
 %>\
     % for domain in power_domains:
        % if domain in rst['domains']:
@@ -339,7 +339,7 @@ module rstmgr
   % if names[0]!=rst_ni:
   if (SecCheck) begin : gen_d${domain.lower()}_${name}_assert
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
-    D${domain.capitalize()}${rst_name.as_camel_case()}FsmCheck_A,
+    D${domain.capitalize()}${rst_name_camel}FsmCheck_A,
     u_d${domain.lower()}_${name}.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/clkmgr.hjson
@@ -628,17 +628,17 @@
       storage_err_alert: "fatal_fault",
       fields: [
         {
-          bits: "3:0",
+          bits: "8:0",
           name: "HI",
           desc: "Max threshold for io_div4 measurement",
-          resval: "14"
+          resval: "138"
         },
 
         {
-          bits: "7:4",
+          bits: "17:9",
           name: "LO",
           desc: "Min threshold for io_div4 measurement",
-          resval: "0"
+          resval: "118"
         },
       ]
     },
@@ -682,17 +682,17 @@
       storage_err_alert: "fatal_fault",
       fields: [
         {
-          bits: "5:0",
+          bits: "8:0",
           name: "HI",
           desc: "Max threshold for main measurement",
-          resval: "26"
+          resval: "138"
         },
 
         {
-          bits: "11:6",
+          bits: "17:9",
           name: "LO",
           desc: "Min threshold for main measurement",
-          resval: "6"
+          resval: "118"
         },
       ]
     },

--- a/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/doc/registers.md
@@ -277,21 +277,21 @@ Configuration controls for io_div4 measurement.
 The threshold fields are made wider than required (by 1 bit) to ensure
 there is room to adjust for measurement inaccuracies.
 - Offset: `0x2c`
-- Reset default: `0xe`
-- Reset mask: `0xff`
+- Reset default: `0xec8a`
+- Reset mask: `0x3ffff`
 - Register enable: [`MEASURE_CTRL_REGWEN`](#measure_ctrl_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "HI", "bits": 4, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 4, "attr": ["rw"], "rotate": 0}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "HI", "bits": 9, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 9, "attr": ["rw"], "rotate": 0}, {"bits": 14}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                           |
 |:------:|:------:|:-------:|:-------|:--------------------------------------|
-|  31:8  |        |         |        | Reserved                              |
-|  7:4   |   rw   |   0x0   | LO     | Min threshold for io_div4 measurement |
-|  3:0   |   rw   |   0xe   | HI     | Max threshold for io_div4 measurement |
+| 31:18  |        |         |        | Reserved                              |
+|  17:9  |   rw   |  0x76   | LO     | Min threshold for io_div4 measurement |
+|  8:0   |   rw   |  0x8a   | HI     | Max threshold for io_div4 measurement |
 
 ## MAIN_MEAS_CTRL_EN
 Enable for measurement control
@@ -317,21 +317,21 @@ Configuration controls for main measurement.
 The threshold fields are made wider than required (by 1 bit) to ensure
 there is room to adjust for measurement inaccuracies.
 - Offset: `0x34`
-- Reset default: `0x19a`
-- Reset mask: `0xfff`
+- Reset default: `0xec8a`
+- Reset mask: `0x3ffff`
 - Register enable: [`MEASURE_CTRL_REGWEN`](#measure_ctrl_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "HI", "bits": 6, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 6, "attr": ["rw"], "rotate": 0}, {"bits": 20}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "HI", "bits": 9, "attr": ["rw"], "rotate": 0}, {"name": "LO", "bits": 9, "attr": ["rw"], "rotate": 0}, {"bits": 14}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                        |
 |:------:|:------:|:-------:|:-------|:-----------------------------------|
-| 31:12  |        |         |        | Reserved                           |
-|  11:6  |   rw   |   0x6   | LO     | Min threshold for main measurement |
-|  5:0   |   rw   |  0x1a   | HI     | Max threshold for main measurement |
+| 31:18  |        |         |        | Reserved                           |
+|  17:9  |   rw   |  0x76   | LO     | Min threshold for main measurement |
+|  8:0   |   rw   |  0x8a   | HI     | Max threshold for main measurement |
 
 ## RECOV_ERR_CODE
 Recoverable Error code

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -115,9 +115,10 @@ package clkmgr_env_pkg;
     MainClkHz
   };
 
+  // Take into account if multiple aon clock cycles are needed for a measurement.
   parameter int ExpectedCounts[ClkMesrSize] = {
-    ClkInHz[ClkMesrIoDiv4] / AonClkHz - 1,
-    ClkInHz[ClkMesrMain] / AonClkHz - 1
+    (ClkInHz[ClkMesrIoDiv4] / AonClkHz) * 32 - 1,
+    (ClkInHz[ClkMesrMain] / AonClkHz) * 8 - 1
   };
 
   // functions

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -214,8 +214,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     csr_wr(.ptr(meas_ctrl_regs[which].en), .value(MuBi4False));
   endtask
 
-  local function int get_meas_ctrl_value(int min_threshold, int max_threshold, uvm_reg_field lo,
-                                         uvm_reg_field hi);
+  protected function int get_meas_ctrl_value(int min_threshold, int max_threshold,
+                                             uvm_reg_field lo, uvm_reg_field hi);
     int lo_mask = (1 << lo.get_n_bits()) - 1;
     int hi_mask = (1 << hi.get_n_bits()) - 1;
 
@@ -287,11 +287,15 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   task disturb_measured_clock(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIoDiv4: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "io"),
+                  UVM_MEDIUM)
         if (enable) cfg.io_clk_rst_vif.start_clk();
         else cfg.io_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrIoDiv4), .enable(enable));
       end
       ClkMesrMain: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "main"),
+                  UVM_MEDIUM)
         if (enable) cfg.main_clk_rst_vif.start_clk();
         else cfg.main_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrMain), .enable(enable));

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -10,10 +10,12 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   `uvm_object_new
 
   // This is measured in aon clocks. This is cannot be too precise because of a synchronizer.
-  localparam int CyclesToGetMeasurements = 6;
+  // It takes into account cases where some clocks need multiple aon clock cycles to get
+  // a measurement.
+  localparam int CyclesToGetMeasurements = 37;
 
   // The aon cycles between measurements, to make sure the previous measurement settles.
-  localparam int CyclesBetweenMeasurements = 6;
+  localparam int CyclesBetweenMeasurements = 37;
 
   // This is measured in clkmgr clk_i clocks. It is set to cover worst case delays.
   // The clk_i frequency is randomized for IPs, but the clkmgr is hooked to io_div4, which would

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -51,7 +51,10 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       uvm_reg_data_t prev_en;
       mubi4_t new_en = get_rand_mubi4_val(1, 1, 2);
       int prev_ctrl;
-      int new_ctrl = $urandom();
+      int max_threshold = ExpectedCounts[clk] + 2;
+      int min_threshold = ExpectedCounts[clk] - 2;
+      int new_ctrl = get_meas_ctrl_value(min_threshold, max_threshold,
+          meas_ctrl_regs[clk_mesr].ctrl_lo, meas_ctrl_regs[clk_mesr].ctrl_hi);
       int actual_ctrl;
       int lo_mask = ((1 << meas_ctrl_regs[clk_mesr].ctrl_lo.get_n_bits()) - 1) <<
                      meas_ctrl_regs[clk_mesr].ctrl_lo.get_lsb_pos();
@@ -66,11 +69,11 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(new_en));
       csr_rd_check(.ptr(meas_ctrl_regs[clk_mesr].en),
                    .compare_value(mubi4_t'(regwen_enable ? new_en : prev_en)));
+      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
       csr_rd_check(.ptr(ctrl_shadowed), .compare_value(regwen_enable ? new_ctrl : prev_ctrl),
                    .compare_mask(lo_mask | hi_mask));
       `uvm_info(`gfn, $sformatf("Check %0s regwen done", meas_ctrl_regs[clk_mesr].name),
                 UVM_MEDIUM)
-      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
     end
   endtask : check_meas_ctrl_regwen
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr.sv
@@ -499,8 +499,8 @@
   end
 
   clkmgr_meas_chk #(
-    .Cnt(16),
-    .RefCnt(1)
+    .Cnt(512),
+    .RefCnt(32)
   ) u_io_div4_meas (
     .clk_i,
     .rst_ni,
@@ -526,8 +526,8 @@
 
 
   clkmgr_meas_chk #(
-    .Cnt(64),
-    .RefCnt(1)
+    .Cnt(512),
+    .RefCnt(8)
   ) u_main_meas (
     .clk_i,
     .rst_ni,

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -80,10 +80,10 @@ package clkmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [3:0]  q;
+      logic [8:0]  q;
     } lo;
     struct packed {
-      logic [3:0]  q;
+      logic [8:0]  q;
     } hi;
   } clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t;
 
@@ -93,10 +93,10 @@ package clkmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [5:0]  q;
+      logic [8:0]  q;
     } lo;
     struct packed {
-      logic [5:0]  q;
+      logic [8:0]  q;
     } hi;
   } clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t;
 
@@ -190,16 +190,16 @@ package clkmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_alert_test_reg_t alert_test; // [53:50]
-    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [49:42]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [41:38]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [37:36]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [35:32]
-    clkmgr_reg2hw_measure_ctrl_regwen_reg_t measure_ctrl_regwen; // [31:31]
-    clkmgr_reg2hw_io_div4_meas_ctrl_en_reg_t io_div4_meas_ctrl_en; // [30:27]
-    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [26:19]
-    clkmgr_reg2hw_main_meas_ctrl_en_reg_t main_meas_ctrl_en; // [18:15]
-    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [14:3]
+    clkmgr_reg2hw_alert_test_reg_t alert_test; // [69:66]
+    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [65:58]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [57:54]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [53:52]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [51:48]
+    clkmgr_reg2hw_measure_ctrl_regwen_reg_t measure_ctrl_regwen; // [47:47]
+    clkmgr_reg2hw_io_div4_meas_ctrl_en_reg_t io_div4_meas_ctrl_en; // [46:43]
+    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [42:25]
+    clkmgr_reg2hw_main_meas_ctrl_en_reg_t main_meas_ctrl_en; // [24:21]
+    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [20:3]
     clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [2:0]
   } clkmgr_reg2hw_t;
 
@@ -272,9 +272,9 @@ package clkmgr_reg_pkg;
     4'b 0001, // index[ 8] CLKMGR_CLK_HINTS_STATUS
     4'b 0001, // index[ 9] CLKMGR_MEASURE_CTRL_REGWEN
     4'b 0001, // index[10] CLKMGR_IO_DIV4_MEAS_CTRL_EN
-    4'b 0001, // index[11] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[11] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
     4'b 0001, // index[12] CLKMGR_MAIN_MEAS_CTRL_EN
-    4'b 0011, // index[13] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[13] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
     4'b 0001, // index[14] CLKMGR_RECOV_ERR_CODE
     4'b 0001  // index[15] CLKMGR_FATAL_ERR_CODE
   };

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_top.sv
@@ -174,7 +174,7 @@ module clkmgr_reg_top (
   logic io_div4_meas_ctrl_en_busy;
   logic io_div4_meas_ctrl_shadowed_re;
   logic io_div4_meas_ctrl_shadowed_we;
-  logic [7:0] io_div4_meas_ctrl_shadowed_qs;
+  logic [17:0] io_div4_meas_ctrl_shadowed_qs;
   logic io_div4_meas_ctrl_shadowed_busy;
   logic io_div4_meas_ctrl_shadowed_hi_storage_err;
   logic io_div4_meas_ctrl_shadowed_hi_update_err;
@@ -185,7 +185,7 @@ module clkmgr_reg_top (
   logic main_meas_ctrl_en_busy;
   logic main_meas_ctrl_shadowed_re;
   logic main_meas_ctrl_shadowed_we;
-  logic [11:0] main_meas_ctrl_shadowed_qs;
+  logic [17:0] main_meas_ctrl_shadowed_qs;
   logic main_meas_ctrl_shadowed_busy;
   logic main_meas_ctrl_shadowed_hi_storage_err;
   logic main_meas_ctrl_shadowed_hi_update_err;
@@ -252,25 +252,25 @@ module clkmgr_reg_top (
   assign unused_io_div4_io_div4_meas_ctrl_en_wdata =
       ^io_div4_io_div4_meas_ctrl_en_wdata;
 
-  logic [3:0]  io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
-  logic [3:0]  io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
-  logic [7:0] io_div4_io_div4_meas_ctrl_shadowed_qs;
-  logic [7:0] io_div4_io_div4_meas_ctrl_shadowed_wdata;
+  logic [8:0]  io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
+  logic [8:0]  io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
+  logic [17:0] io_div4_io_div4_meas_ctrl_shadowed_qs;
+  logic [17:0] io_div4_io_div4_meas_ctrl_shadowed_wdata;
   logic io_div4_io_div4_meas_ctrl_shadowed_we;
   logic unused_io_div4_io_div4_meas_ctrl_shadowed_wdata;
   logic io_div4_io_div4_meas_ctrl_shadowed_re;
   logic io_div4_io_div4_meas_ctrl_shadowed_regwen;
 
   always_comb begin
-    io_div4_io_div4_meas_ctrl_shadowed_qs = 8'he;
-    io_div4_io_div4_meas_ctrl_shadowed_qs[3:0] = io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
-    io_div4_io_div4_meas_ctrl_shadowed_qs[7:4] = io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
+    io_div4_io_div4_meas_ctrl_shadowed_qs = 18'hec8a;
+    io_div4_io_div4_meas_ctrl_shadowed_qs[8:0] = io_div4_io_div4_meas_ctrl_shadowed_hi_qs_int;
+    io_div4_io_div4_meas_ctrl_shadowed_qs[17:9] = io_div4_io_div4_meas_ctrl_shadowed_lo_qs_int;
   end
 
   prim_reg_cdc #(
-    .DataWidth(8),
-    .ResetVal(8'he),
-    .BitMask(8'hff),
+    .DataWidth(18),
+    .ResetVal(18'hec8a),
+    .BitMask(18'h3ffff),
     .DstWrReq(0)
   ) u_io_div4_meas_ctrl_shadowed_cdc (
     .clk_src_i    (clk_i),
@@ -280,7 +280,7 @@ module clkmgr_reg_top (
     .src_regwen_i (measure_ctrl_regwen_qs),
     .src_we_i     (io_div4_meas_ctrl_shadowed_we),
     .src_re_i     (io_div4_meas_ctrl_shadowed_re),
-    .src_wd_i     (reg_wdata[7:0]),
+    .src_wd_i     (reg_wdata[17:0]),
     .src_busy_o   (io_div4_meas_ctrl_shadowed_busy),
     .src_qs_o     (io_div4_meas_ctrl_shadowed_qs), // for software read back
     .dst_update_i ('0),
@@ -338,25 +338,25 @@ module clkmgr_reg_top (
   assign unused_main_main_meas_ctrl_en_wdata =
       ^main_main_meas_ctrl_en_wdata;
 
-  logic [5:0]  main_main_meas_ctrl_shadowed_hi_qs_int;
-  logic [5:0]  main_main_meas_ctrl_shadowed_lo_qs_int;
-  logic [11:0] main_main_meas_ctrl_shadowed_qs;
-  logic [11:0] main_main_meas_ctrl_shadowed_wdata;
+  logic [8:0]  main_main_meas_ctrl_shadowed_hi_qs_int;
+  logic [8:0]  main_main_meas_ctrl_shadowed_lo_qs_int;
+  logic [17:0] main_main_meas_ctrl_shadowed_qs;
+  logic [17:0] main_main_meas_ctrl_shadowed_wdata;
   logic main_main_meas_ctrl_shadowed_we;
   logic unused_main_main_meas_ctrl_shadowed_wdata;
   logic main_main_meas_ctrl_shadowed_re;
   logic main_main_meas_ctrl_shadowed_regwen;
 
   always_comb begin
-    main_main_meas_ctrl_shadowed_qs = 12'h19a;
-    main_main_meas_ctrl_shadowed_qs[5:0] = main_main_meas_ctrl_shadowed_hi_qs_int;
-    main_main_meas_ctrl_shadowed_qs[11:6] = main_main_meas_ctrl_shadowed_lo_qs_int;
+    main_main_meas_ctrl_shadowed_qs = 18'hec8a;
+    main_main_meas_ctrl_shadowed_qs[8:0] = main_main_meas_ctrl_shadowed_hi_qs_int;
+    main_main_meas_ctrl_shadowed_qs[17:9] = main_main_meas_ctrl_shadowed_lo_qs_int;
   end
 
   prim_reg_cdc #(
-    .DataWidth(12),
-    .ResetVal(12'h19a),
-    .BitMask(12'hfff),
+    .DataWidth(18),
+    .ResetVal(18'hec8a),
+    .BitMask(18'h3ffff),
     .DstWrReq(0)
   ) u_main_meas_ctrl_shadowed_cdc (
     .clk_src_i    (clk_i),
@@ -366,7 +366,7 @@ module clkmgr_reg_top (
     .src_regwen_i (measure_ctrl_regwen_qs),
     .src_we_i     (main_meas_ctrl_shadowed_we),
     .src_re_i     (main_meas_ctrl_shadowed_re),
-    .src_wd_i     (reg_wdata[11:0]),
+    .src_wd_i     (reg_wdata[17:0]),
     .src_busy_o   (main_meas_ctrl_shadowed_busy),
     .src_qs_o     (main_meas_ctrl_shadowed_qs), // for software read back
     .dst_update_i ('0),
@@ -923,7 +923,7 @@ module clkmgr_reg_top (
   logic io_div4_io_div4_meas_ctrl_shadowed_gated_we;
   assign io_div4_io_div4_meas_ctrl_shadowed_gated_we =
     io_div4_io_div4_meas_ctrl_shadowed_we & io_div4_io_div4_meas_ctrl_shadowed_regwen;
-  //   F[hi]: 3:0
+  //   F[hi]: 8:0
   logic async_io_div4_meas_ctrl_shadowed_hi_err_update;
   logic async_io_div4_meas_ctrl_shadowed_hi_err_storage;
 
@@ -948,9 +948,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(io_div4_meas_ctrl_shadowed_hi_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (4),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'he),
+    .RESVAL  (9'h8a),
     .Mubi    (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_hi (
     .clk_i   (clk_io_div4_i),
@@ -960,7 +960,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (io_div4_io_div4_meas_ctrl_shadowed_re),
     .we     (io_div4_io_div4_meas_ctrl_shadowed_gated_we),
-    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[3:0]),
+    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[8:0]),
 
     // from internal hardware
     .de     (1'b0),
@@ -982,7 +982,7 @@ module clkmgr_reg_top (
     .err_storage (async_io_div4_meas_ctrl_shadowed_hi_err_storage)
   );
 
-  //   F[lo]: 7:4
+  //   F[lo]: 17:9
   logic async_io_div4_meas_ctrl_shadowed_lo_err_update;
   logic async_io_div4_meas_ctrl_shadowed_lo_err_storage;
 
@@ -1007,9 +1007,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(io_div4_meas_ctrl_shadowed_lo_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (4),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (4'h0),
+    .RESVAL  (9'h76),
     .Mubi    (1'b0)
   ) u_io_div4_meas_ctrl_shadowed_lo (
     .clk_i   (clk_io_div4_i),
@@ -1019,7 +1019,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (io_div4_io_div4_meas_ctrl_shadowed_re),
     .we     (io_div4_io_div4_meas_ctrl_shadowed_gated_we),
-    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[7:4]),
+    .wd     (io_div4_io_div4_meas_ctrl_shadowed_wdata[17:9]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1081,7 +1081,7 @@ module clkmgr_reg_top (
   logic main_main_meas_ctrl_shadowed_gated_we;
   assign main_main_meas_ctrl_shadowed_gated_we =
     main_main_meas_ctrl_shadowed_we & main_main_meas_ctrl_shadowed_regwen;
-  //   F[hi]: 5:0
+  //   F[hi]: 8:0
   logic async_main_meas_ctrl_shadowed_hi_err_update;
   logic async_main_meas_ctrl_shadowed_hi_err_storage;
 
@@ -1106,9 +1106,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(main_meas_ctrl_shadowed_hi_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (6),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h1a),
+    .RESVAL  (9'h8a),
     .Mubi    (1'b0)
   ) u_main_meas_ctrl_shadowed_hi (
     .clk_i   (clk_main_i),
@@ -1118,7 +1118,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (main_main_meas_ctrl_shadowed_re),
     .we     (main_main_meas_ctrl_shadowed_gated_we),
-    .wd     (main_main_meas_ctrl_shadowed_wdata[5:0]),
+    .wd     (main_main_meas_ctrl_shadowed_wdata[8:0]),
 
     // from internal hardware
     .de     (1'b0),
@@ -1140,7 +1140,7 @@ module clkmgr_reg_top (
     .err_storage (async_main_meas_ctrl_shadowed_hi_err_storage)
   );
 
-  //   F[lo]: 11:6
+  //   F[lo]: 17:9
   logic async_main_meas_ctrl_shadowed_lo_err_update;
   logic async_main_meas_ctrl_shadowed_lo_err_storage;
 
@@ -1165,9 +1165,9 @@ module clkmgr_reg_top (
     .dst_pulse_o(main_meas_ctrl_shadowed_lo_update_err)
   );
   prim_subreg_shadow #(
-    .DW      (6),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (6'h6),
+    .RESVAL  (9'h76),
     .Mubi    (1'b0)
   ) u_main_meas_ctrl_shadowed_lo (
     .clk_i   (clk_main_i),
@@ -1177,7 +1177,7 @@ module clkmgr_reg_top (
     // from register interface
     .re     (main_main_meas_ctrl_shadowed_re),
     .we     (main_main_meas_ctrl_shadowed_gated_we),
-    .wd     (main_main_meas_ctrl_shadowed_wdata[11:6]),
+    .wd     (main_main_meas_ctrl_shadowed_wdata[17:9]),
 
     // from internal hardware
     .de     (1'b0),

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
@@ -38,7 +38,7 @@ extern "C" {
 typedef enum dif_otp_ctrl_partition {
 % for part in parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
+  part_name_camel = Name.to_camel_case(part["name"])
   short_desc = part["desc"].split(".")[0].strip().replace("\n", " ")
   long_desc_lines = part["desc"].split(".", 1)[1].strip().splitlines()
   long_desc = "\n".join(["   *" + (" " if line else "") + line for
@@ -51,7 +51,7 @@ typedef enum dif_otp_ctrl_partition {
 ${long_desc}
   %endif
    */
-  kDifOtpCtrlPartition${part_name.as_camel_case()},
+  kDifOtpCtrlPartition${part_name_camel},
 % endfor
 } dif_otp_ctrl_partition_t;
 
@@ -104,8 +104,7 @@ typedef enum dif_otp_ctrl_status_code {
   // their values should not be randomized.
 % for part in parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   /**
    * Indicates an error occurred in the `${part_name_camel}` partition.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
@@ -232,8 +232,7 @@ TEST_F(ReadLockTest, NotLockablePartitions) {
   bool flag;
 % for part in [p for p in parts if p not in read_locked_csr_parts]:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   EXPECT_DIF_BADARG(
       dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartition${part_name_camel}));
@@ -250,8 +249,7 @@ TEST_F(ReadLockTest, NullArgs) {
   bool flag;
 % for part in read_locked_csr_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
   lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartition{part_name_camel}));"
 %>\
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -126,6 +126,7 @@ package clkmgr_env_pkg;
     UsbClkHz
   };
 
+  // Take into account if multiple aon clock cycles are needed for a measurement.
   parameter int ExpectedCounts[ClkMesrSize] = {
     ClkInHz[ClkMesrIo] / AonClkHz - 1,
     ClkInHz[ClkMesrIoDiv2] / AonClkHz - 1,

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -262,8 +262,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     csr_wr(.ptr(meas_ctrl_regs[which].en), .value(MuBi4False));
   endtask
 
-  local function int get_meas_ctrl_value(int min_threshold, int max_threshold, uvm_reg_field lo,
-                                         uvm_reg_field hi);
+  protected function int get_meas_ctrl_value(int min_threshold, int max_threshold,
+                                             uvm_reg_field lo, uvm_reg_field hi);
     int lo_mask = (1 << lo.get_n_bits()) - 1;
     int hi_mask = (1 << hi.get_n_bits()) - 1;
 
@@ -359,26 +359,36 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   task disturb_measured_clock(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIo: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "io"),
+                  UVM_MEDIUM)
         if (enable) cfg.io_clk_rst_vif.start_clk();
         else cfg.io_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrIo), .enable(enable));
       end
       ClkMesrIoDiv2: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "io"),
+                  UVM_MEDIUM)
         if (enable) cfg.io_clk_rst_vif.start_clk();
         else cfg.io_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrIoDiv2), .enable(enable));
       end
       ClkMesrIoDiv4: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "io"),
+                  UVM_MEDIUM)
         if (enable) cfg.io_clk_rst_vif.start_clk();
         else cfg.io_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrIoDiv4), .enable(enable));
       end
       ClkMesrMain: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "main"),
+                  UVM_MEDIUM)
         if (enable) cfg.main_clk_rst_vif.start_clk();
         else cfg.main_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrMain), .enable(enable));
       end
       ClkMesrUsb: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "usb"),
+                  UVM_MEDIUM)
         if (enable) cfg.usb_clk_rst_vif.start_clk();
         else cfg.usb_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrUsb), .enable(enable));

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -10,6 +10,8 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   `uvm_object_new
 
   // This is measured in aon clocks. This is cannot be too precise because of a synchronizer.
+  // It takes into account cases where some clocks need multiple aon clock cycles to get
+  // a measurement.
   localparam int CyclesToGetMeasurements = 6;
 
   // The aon cycles between measurements, to make sure the previous measurement settles.

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -51,7 +51,10 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       uvm_reg_data_t prev_en;
       mubi4_t new_en = get_rand_mubi4_val(1, 1, 2);
       int prev_ctrl;
-      int new_ctrl = $urandom();
+      int max_threshold = ExpectedCounts[clk] + 2;
+      int min_threshold = ExpectedCounts[clk] - 2;
+      int new_ctrl = get_meas_ctrl_value(min_threshold, max_threshold,
+          meas_ctrl_regs[clk_mesr].ctrl_lo, meas_ctrl_regs[clk_mesr].ctrl_hi);
       int actual_ctrl;
       int lo_mask = ((1 << meas_ctrl_regs[clk_mesr].ctrl_lo.get_n_bits()) - 1) <<
                      meas_ctrl_regs[clk_mesr].ctrl_lo.get_lsb_pos();
@@ -66,11 +69,11 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(new_en));
       csr_rd_check(.ptr(meas_ctrl_regs[clk_mesr].en),
                    .compare_value(mubi4_t'(regwen_enable ? new_en : prev_en)));
+      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
       csr_rd_check(.ptr(ctrl_shadowed), .compare_value(regwen_enable ? new_ctrl : prev_ctrl),
                    .compare_mask(lo_mask | hi_mask));
       `uvm_info(`gfn, $sformatf("Check %0s regwen done", meas_ctrl_regs[clk_mesr].name),
                 UVM_MEDIUM)
-      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
     end
   endtask : check_meas_ctrl_regwen
 

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/dif_otp_ctrl.h.tpl.not_yet
@@ -38,7 +38,7 @@ extern "C" {
 typedef enum dif_otp_ctrl_partition {
 % for part in parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
+  part_name_camel = Name.to_camel_case(part["name"])
   short_desc = part["desc"].split(".")[0].strip().replace("\n", " ")
   long_desc_lines = part["desc"].split(".", 1)[1].strip().splitlines()
   long_desc = "\n".join(["   *" + (" " if line else "") + line for
@@ -51,7 +51,7 @@ typedef enum dif_otp_ctrl_partition {
 ${long_desc}
   %endif
    */
-  kDifOtpCtrlPartition${part_name.as_camel_case()},
+  kDifOtpCtrlPartition${part_name_camel},
 % endfor
 } dif_otp_ctrl_partition_t;
 
@@ -104,8 +104,7 @@ typedef enum dif_otp_ctrl_status_code {
   // their values should not be randomized.
 % for part in parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   /**
    * Indicates an error occurred in the `${part_name_camel}` partition.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/dif_otp_ctrl_unittest.cc.tpl.not_yet
@@ -232,8 +232,7 @@ TEST_F(ReadLockTest, NotLockablePartitions) {
   bool flag;
 % for part in [p for p in parts if p not in read_locked_csr_parts]:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
 %>\
   EXPECT_DIF_BADARG(
       dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartition${part_name_camel}));
@@ -250,8 +249,7 @@ TEST_F(ReadLockTest, NullArgs) {
   bool flag;
 % for part in read_locked_csr_parts:
 <%
-  part_name = Name.from_snake_case(part["name"])
-  part_name_camel = part_name.as_camel_case()
+  part_name_camel = Name.to_camel_case(part["name"])
   lock_reading_line = f"dif_otp_ctrl_lock_reading(nullptr, kDifOtpCtrlPartition{part_name_camel}));"
 %>\
   EXPECT_DIF_BADARG(dif_otp_ctrl_reading_is_locked(

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -118,6 +118,7 @@ package clkmgr_env_pkg;
     UsbClkHz
   };
 
+  // Take into account if multiple aon clock cycles are needed for a measurement.
   parameter int ExpectedCounts[ClkMesrSize] = {
     ClkInHz[ClkMesrIo] / AonClkHz - 1,
     ClkInHz[ClkMesrIoDiv4] / AonClkHz - 1,

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -259,8 +259,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     csr_wr(.ptr(meas_ctrl_regs[which].en), .value(MuBi4False));
   endtask
 
-  local function int get_meas_ctrl_value(int min_threshold, int max_threshold, uvm_reg_field lo,
-                                         uvm_reg_field hi);
+  protected function int get_meas_ctrl_value(int min_threshold, int max_threshold,
+                                             uvm_reg_field lo, uvm_reg_field hi);
     int lo_mask = (1 << lo.get_n_bits()) - 1;
     int hi_mask = (1 << hi.get_n_bits()) - 1;
 
@@ -348,21 +348,29 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   task disturb_measured_clock(clk_mesr_e clk, bit enable);
     case (clk)
       ClkMesrIo: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "io"),
+                  UVM_MEDIUM)
         if (enable) cfg.io_clk_rst_vif.start_clk();
         else cfg.io_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrIo), .enable(enable));
       end
       ClkMesrIoDiv4: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "io"),
+                  UVM_MEDIUM)
         if (enable) cfg.io_clk_rst_vif.start_clk();
         else cfg.io_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrIoDiv4), .enable(enable));
       end
       ClkMesrMain: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "main"),
+                  UVM_MEDIUM)
         if (enable) cfg.main_clk_rst_vif.start_clk();
         else cfg.main_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrMain), .enable(enable));
       end
       ClkMesrUsb: begin
+        `uvm_info(`gfn, $sformatf("%sabling %s clk", enable ? "En" : "Dis", "usb"),
+                  UVM_MEDIUM)
         if (enable) cfg.usb_clk_rst_vif.start_clk();
         else cfg.usb_clk_rst_vif.stop_clk();
         control_sync_pulse_assert(.clk(ClkMesrUsb), .enable(enable));

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -10,6 +10,8 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
   `uvm_object_new
 
   // This is measured in aon clocks. This is cannot be too precise because of a synchronizer.
+  // It takes into account cases where some clocks need multiple aon clock cycles to get
+  // a measurement.
   localparam int CyclesToGetMeasurements = 6;
 
   // The aon cycles between measurements, to make sure the previous measurement settles.

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/env/seq_lib/clkmgr_regwen_vseq.sv
@@ -51,7 +51,10 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       uvm_reg_data_t prev_en;
       mubi4_t new_en = get_rand_mubi4_val(1, 1, 2);
       int prev_ctrl;
-      int new_ctrl = $urandom();
+      int max_threshold = ExpectedCounts[clk] + 2;
+      int min_threshold = ExpectedCounts[clk] - 2;
+      int new_ctrl = get_meas_ctrl_value(min_threshold, max_threshold,
+          meas_ctrl_regs[clk_mesr].ctrl_lo, meas_ctrl_regs[clk_mesr].ctrl_hi);
       int actual_ctrl;
       int lo_mask = ((1 << meas_ctrl_regs[clk_mesr].ctrl_lo.get_n_bits()) - 1) <<
                      meas_ctrl_regs[clk_mesr].ctrl_lo.get_lsb_pos();
@@ -66,11 +69,11 @@ class clkmgr_regwen_vseq extends clkmgr_base_vseq;
       csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(new_en));
       csr_rd_check(.ptr(meas_ctrl_regs[clk_mesr].en),
                    .compare_value(mubi4_t'(regwen_enable ? new_en : prev_en)));
+      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
       csr_rd_check(.ptr(ctrl_shadowed), .compare_value(regwen_enable ? new_ctrl : prev_ctrl),
                    .compare_mask(lo_mask | hi_mask));
       `uvm_info(`gfn, $sformatf("Check %0s regwen done", meas_ctrl_regs[clk_mesr].name),
                 UVM_MEDIUM)
-      csr_wr(.ptr(meas_ctrl_regs[clk_mesr].en), .value(MuBi4False));
     end
   endtask : check_meas_ctrl_regwen
 

--- a/util/ipgen/clkmgr_gen.py
+++ b/util/ipgen/clkmgr_gen.py
@@ -1,0 +1,79 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Provides support functions for clkmgr ipgen."""
+
+import math
+from collections import OrderedDict
+from typing import List
+
+from basegen.typing import ConfigT, ParamsT
+from topgen.clocks import Clocks, ClockSignal
+from topgen.lib import find_module
+
+def get_clkmgr_params(top: ConfigT) -> ParamsT:
+    """Gets parameters for clkmgr ipgen from top config."""
+    clocks = top["clocks"]
+    assert isinstance(clocks, Clocks)
+
+    typed_clocks = clocks.typed_clocks()
+    hint_names = typed_clocks.hint_names()
+
+    typed_clks = OrderedDict({
+        ty: {
+            nm: {
+                "src_name": sig.src.name,
+                "endpoint_ip": sig.endpoints[0][0]
+            }
+            for nm, sig in mp.items() if isinstance(sig, ClockSignal)
+        }
+        for ty, mp in typed_clocks._asdict().items() if isinstance(mp, dict)
+    })
+
+    # Will connect to alert_handler
+    with_alert_handler = find_module(top['module'],
+                                         'alert_handler') is not None
+
+    return {
+        "src_clks":
+        OrderedDict({name: vars(obj)
+                     for name, obj in clocks.srcs.items()}),
+        "derived_clks":
+        OrderedDict(
+            {name: vars(obj)
+             for name, obj in clocks.derived_srcs.items()}),
+        "typed_clocks":
+        OrderedDict({ty: d
+                     for ty, d in typed_clks.items() if d}),
+        "hint_names":
+        hint_names,
+        "parent_child_clks":
+        typed_clocks.parent_child_clks,
+        "exported_clks":
+        top["exported_clks"],
+        "number_of_clock_groups":
+        len(clocks.groups),
+        "with_alert_handler":
+        with_alert_handler,
+    }
+
+
+def get_all_srcs(src_clks: ConfigT, derived_clks: ConfigT) -> ConfigT:
+    """Returns a dict of all source and derived clocks.
+
+    The items in the dictionary are a dictionary containing the
+    SourceClock or DerivedSourceClock attributes for the  corresponding
+    clock.
+    """
+    all_srcs = src_clks.copy()
+    all_srcs.update(derived_clks)
+    return all_srcs
+
+
+def get_rg_srcs(typed_clocks: ConfigT) -> List[str]:
+    return list(sorted({sig['src_name'] for sig
+                       in typed_clocks['rg_clks'].values()}))
+
+
+def get_hint_targets(typed_clocks: ConfigT) -> List[str]:
+    return [sig['endpoint_ip'] for sig in typed_clocks['hint_clks'].values()]

--- a/util/ipgen/clkmgr_gen.py
+++ b/util/ipgen/clkmgr_gen.py
@@ -5,11 +5,24 @@
 
 import math
 from collections import OrderedDict
-from typing import List
+from typing import List, NamedTuple
 
 from basegen.typing import ConfigT, ParamsT
 from topgen.clocks import Clocks, ClockSignal
 from topgen.lib import find_module
+
+
+class ClockMeasureConfig(NamedTuple):
+    """Configuration parameters for clock measurements
+
+    - Register_width is the bit-width of the counter
+    - Reference_cycles is number of reference clock cycles per measurement
+    - Expected_count is the expected measurement
+    """
+    register_width: int
+    reference_cycles: int
+    expected_count: int
+
 
 def get_clkmgr_params(top: ConfigT) -> ParamsT:
     """Gets parameters for clkmgr ipgen from top config."""
@@ -32,7 +45,7 @@ def get_clkmgr_params(top: ConfigT) -> ParamsT:
 
     # Will connect to alert_handler
     with_alert_handler = find_module(top['module'],
-                                         'alert_handler') is not None
+                                     'alert_handler') is not None
 
     return {
         "src_clks":
@@ -71,9 +84,36 @@ def get_all_srcs(src_clks: ConfigT, derived_clks: ConfigT) -> ConfigT:
 
 
 def get_rg_srcs(typed_clocks: ConfigT) -> List[str]:
-    return list(sorted({sig['src_name'] for sig
-                       in typed_clocks['rg_clks'].values()}))
+    return list(
+        sorted({sig['src_name']
+                for sig in typed_clocks['rg_clks'].values()}))
 
 
 def get_hint_targets(typed_clocks: ConfigT) -> List[str]:
     return [sig['endpoint_ip'] for sig in typed_clocks['hint_clks'].values()]
+
+
+def config_clk_meas(clk: str,
+                    all_srcs: ConfigT,
+                    min_clk_ratio: float = 100.0) -> ClockMeasureConfig:
+    """Return configuration parameters for clock measurement.
+
+    Compute the number of reference clock cycles needed to get the
+    count resolution of at least min_clk_ratio. This determines the
+    number of reference clock cycles per measurement, and with that
+    compute and return the register width, the reference clock cycles,
+    and the expected clock count.
+    """
+    aon_freq: float = all_srcs['aon']['freq']
+    clk_freq: float = all_srcs[clk]['freq']
+    clk_ratio: float = clk_freq / aon_freq
+    if clk_ratio < min_clk_ratio:
+        # Use multipliers which are powers of two.
+        target_clk_ratio: int = 2**math.ceil(math.log2(min_clk_ratio))
+        multiplier: int = math.ceil(target_clk_ratio * 1.0 / clk_ratio)
+    else:
+        multiplier: int = math.ceil(min_clk_ratio / clk_ratio)
+    expected_count: int = round(clk_ratio * multiplier)
+    # One bit extra to stay safe.
+    bit_width: int = expected_count.bit_length() + 1
+    return ClockMeasureConfig(bit_width, multiplier, expected_count)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -21,6 +21,7 @@ from basegen.typing import ConfigT, ParamsT
 from design.lib.OtpMemMap import OtpMemMap
 from ipgen import (IpBlockRenderer, IpConfig, IpDescriptionOnlyRenderer,
                    IpTemplate, TemplateRenderError)
+from ipgen.clkmgr_gen import get_clkmgr_params
 from mako import exceptions
 from mako.lookup import TemplateLookup
 from mako.template import Template
@@ -33,7 +34,7 @@ from topgen import intermodule as im
 from topgen import lib as lib
 from topgen import merge_top, secure_prng, validate_top
 from topgen.c_test import TopGenCTest
-from topgen.clocks import Clocks, ClockSignal
+from topgen.clocks import Clocks
 from topgen.gen_dv import gen_dv
 from topgen.gen_top_docs import gen_top_docs
 from topgen.lib import find_module, find_modules, load_cfg
@@ -513,57 +514,10 @@ def generate_pinmux(top: ConfigT, module: ConfigT, out_path: Path) -> None:
     generate_ipgen(top, module, params, out_path)
 
 
-def _get_clkmgr_params(top: ConfigT) -> ParamsT:
-    """Gets parameters for clkmgr ipgen from top config."""
-    clocks = top["clocks"]
-    assert isinstance(clocks, Clocks)
-
-    typed_clocks = clocks.typed_clocks()
-    hint_names = typed_clocks.hint_names()
-
-    typed_clks = OrderedDict({
-        ty: {
-            nm: {
-                "src_name": sig.src.name,
-                "endpoint_ip": sig.endpoints[0][0]
-            }
-            for nm, sig in mp.items() if isinstance(sig, ClockSignal)
-        }
-        for ty, mp in typed_clocks._asdict().items() if isinstance(mp, dict)
-    })
-
-    # Will connect to alert_handler
-    with_alert_handler = lib.find_module(top['module'],
-                                         'alert_handler') is not None
-
-    return {
-        "src_clks":
-        OrderedDict({name: vars(obj)
-                     for name, obj in clocks.srcs.items()}),
-        "derived_clks":
-        OrderedDict(
-            {name: vars(obj)
-             for name, obj in clocks.derived_srcs.items()}),
-        "typed_clocks":
-        OrderedDict({ty: d
-                     for ty, d in typed_clks.items() if d}),
-        "hint_names":
-        hint_names,
-        "parent_child_clks":
-        typed_clocks.parent_child_clks,
-        "exported_clks":
-        top["exported_clks"],
-        "number_of_clock_groups":
-        len(clocks.groups),
-        "with_alert_handler":
-        with_alert_handler,
-    }
-
-
 # generate clkmgr with ipgen
 def generate_clkmgr(top: ConfigT, module: ConfigT, out_path: Path) -> None:
     log.info("Generating clkmgr with ipgen")
-    params = _get_clkmgr_params(top)
+    params = get_clkmgr_params(top)
     log.info("clkmgr params:")
     for k, v in params.items():
         log.info(f"{k}: {v}")
@@ -1184,7 +1138,7 @@ def create_ipgen_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
         insert_ip_attrs(instance, _get_racl_params(topcfg))
     if "clkmgr" in ipgen_instances:
         instance = ipgen_instances["clkmgr"][0]
-        insert_ip_attrs(instance, _get_clkmgr_params(topcfg))
+        insert_ip_attrs(instance, get_clkmgr_params(topcfg))
     if "flash_ctrl" in ipgen_instances:
         instance = ipgen_instances["flash_ctrl"][0]
         insert_ip_attrs(instance, _get_flash_ctrl_params(topcfg))

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -309,6 +309,10 @@ class Name:
     def from_snake_case(input: str) -> 'Name':
         return Name(input.split("_"))
 
+    @staticmethod
+    def to_camel_case(input: str) -> str:
+        return Name.from_snake_case(input).as_camel_case()
+
     def __init__(self, parts: List[str]):
         self._parts = tuple(parts)
         for p in parts:


### PR DESCRIPTION
This has 3 commits:

1. Create clock manager ipgen support module
2. Add to_camel_case staticmethod in topgen.lib.Name
3. Configure the clock measurement hardware and DV collateral

The first two are simple and generally useful, the third commit addresses the issue in #26385.

Fixes #26385 