### PR TITLE
Rv timer new reg pkg

### DIFF
--- a/hw/ip/rv_timer/dv/env/rv_timer_env.core
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:ip:rv_timer_reg_pkg
     files:
       - rv_timer_env_pkg.sv
       - rv_timer_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/rv_timer/rv_timer.core
+++ b/hw/ip/rv_timer/rv_timer.core
@@ -9,8 +9,8 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
+      - lowrisc:ip:rv_timer_reg_pkg
     files:
-      - rtl/rv_timer_reg_pkg.sv
       - rtl/rv_timer_reg_top.sv
       - rtl/timer_core.sv
       - rtl/rv_timer.sv

--- a/hw/ip/rv_timer/rv_timer_reg_pkg.core
+++ b/hw/ip/rv_timer/rv_timer_reg_pkg.core
@@ -1,0 +1,16 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:rv_timer_reg_pkg"
+description: "RISC-V timer reg pkg"
+filesets:
+  files_rtl:
+    files:
+      - rtl/rv_timer_reg_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl


### PR DESCRIPTION
This will allow the TB to derive DV parameters from the templated rv_timer_reg_pkg.sv instead of having hardcoded values