### PR TITLE
[rtl] Avoid some untyped parameters

### DIFF
--- a/hw/ip/prim/rtl/prim_intr_hw.sv
+++ b/hw/ip/prim/rtl/prim_intr_hw.sv
@@ -36,7 +36,7 @@ module prim_intr_hw # (
   //   - INTR_STATE for *status* interrupts is RO (it simply presents the raw HW input signal).
   //   - If the root_cause is cleared, INTR_STATE/intr_o also clears automatically.
   // More details about the interrupt type distinctions can be found in the comportability docs.
-  parameter              IntrT = "Event" // Event or Status
+  parameter string       IntrT = "Event" // Event or Status
 ) (
   // event
   input  clk_i,

--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -8,7 +8,7 @@
 `include "prim_assert.sv"
 
 module tlul_assert #(
-  parameter EndpointType = "Device" // can be either "Host" or "Device"
+  parameter string EndpointType = "Device" // can be either "Host" or "Device"
 ) (
   input clk_i,
   input rst_ni,


### PR DESCRIPTION
Trivial typing tidy-ups in the RTL. This won't have any effect on the behaviour, but avoids some lint warnings from Verissimo.