### PR TITLE
[opentitantool] Add support for WAIT on rescue

### DIFF
--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -18,7 +18,7 @@ use crate::impl_serializable_error;
 use crate::io::console::ConsoleDevice;
 use crate::transport::TransportError;
 
-#[derive(Clone, Debug, Args, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Args, Serialize, Deserialize)]
 pub struct UartParams {
     /// UART instance.
     #[arg(long, default_value = "CONSOLE")]

--- a/sw/host/opentitanlib/src/rescue/mod.rs
+++ b/sw/host/opentitanlib/src/rescue/mod.rs
@@ -24,6 +24,8 @@ pub enum RescueError {
     BadMode(String),
     #[error("configuration error: {0}")]
     Configuration(String),
+    #[error("bad protocol: {0}")]
+    BadProtocol(String),
 }
 
 #[derive(ValueEnum, Default, Debug, Clone, Copy, PartialEq)]
@@ -104,15 +106,25 @@ pub enum RescueMode: u32 {
 }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+/// Determines how `Rescue::enter` should enter rescue mode.
+pub enum EntryMode {
+    /// Reset the chip using the external power-on reset signal.
+    Reset,
+    /// Assume the chip is in rescue mode and needs to soft-reboot back to rescue mode.
+    Reboot,
+    /// Do nothing; assume the chip is ready to go to rescue mode.
+    None,
+}
+
 pub trait Rescue {
-    fn enter(&self, transport: &TransportWrapper, reset_target: bool) -> Result<()>;
+    fn enter(&self, transport: &TransportWrapper, mode: EntryMode) -> Result<()>;
     fn set_mode(&self, mode: RescueMode) -> Result<()>;
     fn send(&self, data: &[u8]) -> Result<()>;
     fn recv(&self) -> Result<Vec<u8>>;
 
     // Not supported by all backends
     fn set_speed(&self, speed: u32) -> Result<u32>;
-    fn wait(&self) -> Result<()>;
     fn reboot(&self) -> Result<()>;
 
     fn get_raw(&self, mode: RescueMode) -> Result<Vec<u8>> {

--- a/sw/host/opentitanlib/src/rescue/mod.rs
+++ b/sw/host/opentitanlib/src/rescue/mod.rs
@@ -2,7 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use thiserror::Error;
+
+use crate::app::TransportWrapper;
+use crate::chip::boot_log::BootLog;
+use crate::chip::boot_svc::{BootSlot, BootSvc, OwnershipActivateRequest, OwnershipUnlockRequest};
+use crate::chip::device_id::DeviceId;
+use crate::with_unknown;
 
 pub mod serial;
 pub mod xmodem;
@@ -11,4 +18,88 @@ pub mod xmodem;
 pub enum RescueError {
     #[error("bad mode: {0}")]
     BadMode(String),
+}
+
+with_unknown! {
+pub enum RescueMode: u32 {
+    Rescue = u32::from_be_bytes(*b"RESQ"),
+    RescueB = u32::from_be_bytes(*b"RESB"),
+    BootLog = u32::from_be_bytes(*b"BLOG"),
+    BootSvcReq = u32::from_be_bytes(*b"BREQ"),
+    BootSvcRsp = u32::from_be_bytes(*b"BRSP"),
+    OwnerBlock = u32::from_be_bytes(*b"OWNR"),
+    GetOwnerPage0 = u32::from_be_bytes(*b"OPG0"),
+    GetOwnerPage1 = u32::from_be_bytes(*b"OPG1"),
+    DeviceId = u32::from_be_bytes(*b"OTID"),
+    EraseOwner = u32::from_be_bytes(*b"KLBR"),
+}
+}
+
+pub trait Rescue {
+    fn enter(&self, transport: &TransportWrapper, reset_target: bool) -> Result<()>;
+    fn set_mode(&self, mode: RescueMode) -> Result<()>;
+    fn send(&self, data: &[u8]) -> Result<()>;
+    fn recv(&self) -> Result<Vec<u8>>;
+
+    // Not supported by all backends
+    fn set_speed(&self, speed: u32) -> Result<()>;
+    fn wait(&self) -> Result<()>;
+    fn reboot(&self) -> Result<()>;
+
+    fn get_raw(&self, mode: RescueMode) -> Result<Vec<u8>> {
+        self.set_mode(mode)?;
+        self.recv()
+    }
+
+    fn set_raw(&self, mode: RescueMode, data: &[u8]) -> Result<()> {
+        self.set_mode(mode)?;
+        self.send(data)
+    }
+
+    fn update_firmware(&self, slot: BootSlot, image: &[u8]) -> Result<()> {
+        let mode = if slot == BootSlot::SlotB {
+            RescueMode::RescueB
+        } else {
+            RescueMode::Rescue
+        };
+        self.set_raw(mode, image)
+    }
+
+    fn get_boot_log(&self) -> Result<BootLog> {
+        let blog = self.get_raw(RescueMode::BootLog)?;
+        Ok(BootLog::try_from(blog.as_slice())?)
+    }
+
+    fn get_boot_svc(&self) -> Result<BootSvc> {
+        let bsvc = self.get_raw(RescueMode::BootSvcRsp)?;
+        Ok(BootSvc::try_from(bsvc.as_slice())?)
+    }
+
+    fn get_device_id(&self) -> Result<DeviceId> {
+        let id = self.get_raw(RescueMode::DeviceId)?;
+        DeviceId::read(&mut std::io::Cursor::new(&id))
+    }
+
+    fn set_next_bl0_slot(&self, primary: BootSlot, next: BootSlot) -> Result<()> {
+        let message = BootSvc::next_boot_bl0_slot(primary, next);
+        self.set_raw(RescueMode::BootSvcReq, &message.to_bytes()?)
+    }
+
+    fn ownership_unlock(&self, unlock: OwnershipUnlockRequest) -> Result<()> {
+        let message = BootSvc::ownership_unlock(unlock);
+        self.set_raw(RescueMode::BootSvcReq, &message.to_bytes()?)
+    }
+
+    fn ownership_activate(&self, activate: OwnershipActivateRequest) -> Result<()> {
+        let message = BootSvc::ownership_activate(activate);
+        self.set_raw(RescueMode::BootSvcReq, &message.to_bytes()?)
+    }
+
+    fn set_owner_config(&self, data: &[u8]) -> Result<()> {
+        self.set_raw(RescueMode::OwnerBlock, data)
+    }
+
+    fn erase_owner(&self) -> Result<()> {
+        self.set_raw(RescueMode::EraseOwner, &[])
+    }
 }

--- a/sw/host/opentitanlib/src/rescue/mod.rs
+++ b/sw/host/opentitanlib/src/rescue/mod.rs
@@ -2,22 +2,91 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
+use clap::{Args, ValueEnum};
 use thiserror::Error;
 
 use crate::app::TransportWrapper;
 use crate::chip::boot_log::BootLog;
 use crate::chip::boot_svc::{BootSlot, BootSvc, OwnershipActivateRequest, OwnershipUnlockRequest};
 use crate::chip::device_id::DeviceId;
+use crate::io::uart::UartParams;
 use crate::with_unknown;
 
 pub mod serial;
 pub mod xmodem;
 
+pub use serial::RescueSerial;
+
 #[derive(Debug, Error)]
 pub enum RescueError {
     #[error("bad mode: {0}")]
     BadMode(String),
+    #[error("configuration error: {0}")]
+    Configuration(String),
+}
+
+#[derive(ValueEnum, Default, Debug, Clone, Copy, PartialEq)]
+pub enum RescueProtocol {
+    #[default]
+    Xmodem,
+    UsbDfu,
+    SpiDfu,
+}
+
+#[derive(ValueEnum, Default, Debug, Clone, Copy, PartialEq)]
+pub enum RescueTrigger {
+    #[default]
+    SerialBreak,
+    Gpio,
+    Strap,
+}
+
+#[derive(Clone, Default, Debug, Args)]
+pub struct RescueParams {
+    /// Rescue Protocol
+    #[arg(short, long, value_enum, default_value_t = RescueProtocol::Xmodem)]
+    pub protocol: RescueProtocol,
+    #[arg(short, long, value_enum, default_value_t = RescueTrigger::SerialBreak)]
+    pub trigger: RescueTrigger,
+    #[arg(short, long, default_value = "")]
+    pub value: String,
+    #[command(flatten)]
+    uart: UartParams,
+}
+
+impl RescueParams {
+    pub fn create(&self, transport: &TransportWrapper) -> Result<Box<dyn Rescue>> {
+        match self.protocol {
+            RescueProtocol::Xmodem => self.create_serial(transport),
+            RescueProtocol::UsbDfu => self.create_usbdfu(transport),
+            RescueProtocol::SpiDfu => self.create_spidfu(transport),
+        }
+    }
+    fn create_serial(&self, transport: &TransportWrapper) -> Result<Box<dyn Rescue>> {
+        ensure!(
+            self.trigger == RescueTrigger::SerialBreak,
+            RescueError::Configuration(format!(
+                "Xmodem does not support trigger {:?}",
+                self.trigger
+            ))
+        );
+        ensure!(
+            self.value.is_empty(),
+            RescueError::Configuration(format!(
+                "Xmodem does not support trigger value {:?}",
+                self.value
+            ))
+        );
+
+        Ok(Box::new(RescueSerial::new(self.uart.create(transport)?)))
+    }
+    fn create_usbdfu(&self, _transport: &TransportWrapper) -> Result<Box<dyn Rescue>> {
+        unimplemented!()
+    }
+    fn create_spidfu(&self, _transport: &TransportWrapper) -> Result<Box<dyn Rescue>> {
+        unimplemented!()
+    }
 }
 
 with_unknown! {
@@ -42,7 +111,7 @@ pub trait Rescue {
     fn recv(&self) -> Result<Vec<u8>>;
 
     // Not supported by all backends
-    fn set_speed(&self, speed: u32) -> Result<()>;
+    fn set_speed(&self, speed: u32) -> Result<u32>;
     fn wait(&self) -> Result<()>;
     fn reboot(&self) -> Result<()>;
 

--- a/sw/host/opentitanlib/src/rescue/serial.rs
+++ b/sw/host/opentitanlib/src/rescue/serial.rs
@@ -56,7 +56,7 @@ impl Rescue for RescueSerial {
         Ok(())
     }
 
-    fn set_speed(&self, baud: u32) -> Result<()> {
+    fn set_speed(&self, baud: u32) -> Result<u32> {
         // Make sure the requested rate is a known rate.
         let symbol = match baud {
             115200 => Self::BAUD_115K,
@@ -84,8 +84,9 @@ impl Rescue for RescueSerial {
             return Err(RescueError::BadMode(result[0].clone()).into());
         }
         // Change our side of the connection to the new rate.
+        let old = self.uart.get_baudrate()?;
         self.uart.set_baudrate(baud)?;
-        Ok(())
+        Ok(old)
     }
 
     fn set_mode(&self, mode: RescueMode) -> Result<()> {

--- a/sw/host/opentitanlib/src/rescue/serial.rs
+++ b/sw/host/opentitanlib/src/rescue/serial.rs
@@ -7,12 +7,9 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use crate::app::TransportWrapper;
-use crate::chip::boot_log::BootLog;
-use crate::chip::boot_svc::{BootSlot, BootSvc, OwnershipActivateRequest, OwnershipUnlockRequest};
-use crate::chip::device_id::DeviceId;
 use crate::io::uart::Uart;
 use crate::rescue::xmodem::Xmodem;
-use crate::rescue::RescueError;
+use crate::rescue::{Rescue, RescueError, RescueMode};
 use crate::uart::console::UartConsole;
 
 pub struct RescueSerial {
@@ -23,19 +20,9 @@ pub struct RescueSerial {
 
 impl RescueSerial {
     const ONE_SECOND: Duration = Duration::from_secs(1);
-    pub const RESCUE: [u8; 4] = *b"RESQ";
-    pub const RESCUE_B: [u8; 4] = *b"RESB";
-    pub const REBOOT: [u8; 4] = *b"REBO";
-    pub const BAUD: [u8; 4] = *b"BAUD";
-    pub const BOOT_LOG: [u8; 4] = *b"BLOG";
-    pub const BOOT_SVC_REQ: [u8; 4] = *b"BREQ";
-    pub const BOOT_SVC_RSP: [u8; 4] = *b"BRSP";
-    pub const OWNER_BLOCK: [u8; 4] = *b"OWNR";
-    pub const GET_OWNER_PAGE0: [u8; 4] = *b"OPG0";
-    pub const GET_OWNER_PAGE1: [u8; 4] = *b"OPG1";
-    pub const OT_ID: [u8; 4] = *b"OTID";
-    pub const ERASE_OWNER: [u8; 4] = *b"KLBR";
-    pub const WAIT: [u8; 4] = *b"WAIT";
+    pub const REBOOT: RescueMode = RescueMode(u32::from_be_bytes(*b"REBO"));
+    pub const BAUD: RescueMode = RescueMode(u32::from_be_bytes(*b"BAUD"));
+    pub const WAIT: RescueMode = RescueMode(u32::from_be_bytes(*b"WAIT"));
 
     const BAUD_115K: [u8; 4] = *b"115K";
     const BAUD_230K: [u8; 4] = *b"230K";
@@ -51,8 +38,10 @@ impl RescueSerial {
             enter_delay: Duration::from_secs(5),
         }
     }
+}
 
-    pub fn enter(&self, transport: &TransportWrapper, reset_target: bool) -> Result<()> {
+impl Rescue for RescueSerial {
+    fn enter(&self, transport: &TransportWrapper, reset_target: bool) -> Result<()> {
         log::info!("Setting serial break to trigger rescue mode.");
         self.uart.set_break(true)?;
         if reset_target {
@@ -67,7 +56,7 @@ impl RescueSerial {
         Ok(())
     }
 
-    pub fn set_baud(&self, baud: u32) -> Result<()> {
+    fn set_speed(&self, baud: u32) -> Result<()> {
         // Make sure the requested rate is a known rate.
         let symbol = match baud {
             115200 => Self::BAUD_115K,
@@ -81,7 +70,7 @@ impl RescueSerial {
 
         // Request to change rates.  We don't use `set_mode` here because changing
         // rates isn't a "mode" request and doesn't respond the same way.
-        self.uart.write(&Self::BAUD)?;
+        self.uart.write(&Self::BAUD.0.to_be_bytes())?;
         self.uart.write(b"\r")?;
         let result = UartConsole::wait_for(&*self.uart, r"(ok|error):.*\r\n", Self::ONE_SECOND)?;
         if result[1] == "error" {
@@ -99,7 +88,8 @@ impl RescueSerial {
         Ok(())
     }
 
-    pub fn set_mode(&self, mode: [u8; 4]) -> Result<()> {
+    fn set_mode(&self, mode: RescueMode) -> Result<()> {
+        let mode = mode.0.to_be_bytes();
         self.uart.write(&mode)?;
         let enter = b'\r';
         self.uart.write(std::slice::from_ref(&enter))?;
@@ -116,84 +106,26 @@ impl RescueSerial {
         Ok(())
     }
 
-    pub fn wait(&self) -> Result<()> {
+    fn wait(&self) -> Result<()> {
         self.set_mode(Self::WAIT)?;
         Ok(())
     }
 
-    pub fn reboot(&self) -> Result<()> {
+    fn reboot(&self) -> Result<()> {
         self.set_mode(Self::REBOOT)?;
         Ok(())
     }
 
-    pub fn update_firmware(&self, slot: BootSlot, image: &[u8]) -> Result<()> {
-        self.set_mode(if slot == BootSlot::SlotB {
-            Self::RESCUE_B
-        } else {
-            Self::RESCUE
-        })?;
+    fn send(&self, data: &[u8]) -> Result<()> {
         let xm = Xmodem::new();
-        xm.send(&*self.uart, image)?;
+        xm.send(&*self.uart, data)?;
         Ok(())
     }
 
-    pub fn get_raw(&self, mode: [u8; 4]) -> Result<Vec<u8>> {
-        self.set_mode(mode)?;
+    fn recv(&self) -> Result<Vec<u8>> {
         let mut data = Vec::new();
         let xm = Xmodem::new();
         xm.receive(&*self.uart, &mut data)?;
         Ok(data)
-    }
-
-    pub fn get_boot_log(&self) -> Result<BootLog> {
-        let blog = self.get_raw(Self::BOOT_LOG)?;
-        Ok(BootLog::try_from(blog.as_slice())?)
-    }
-
-    pub fn get_boot_svc(&self) -> Result<BootSvc> {
-        let bsvc = self.get_raw(Self::BOOT_SVC_RSP)?;
-        Ok(BootSvc::try_from(bsvc.as_slice())?)
-    }
-
-    pub fn get_device_id(&self) -> Result<DeviceId> {
-        let id = self.get_raw(Self::OT_ID)?;
-        DeviceId::read(&mut std::io::Cursor::new(&id))
-    }
-
-    pub fn set_boot_svc_raw(&self, data: &[u8]) -> Result<()> {
-        self.set_mode(Self::BOOT_SVC_REQ)?;
-        let xm = Xmodem::new();
-        xm.send(&*self.uart, data)?;
-        Ok(())
-    }
-
-    pub fn set_next_bl0_slot(&self, primary: BootSlot, next: BootSlot) -> Result<()> {
-        let message = BootSvc::next_boot_bl0_slot(primary, next);
-        let data = message.to_bytes()?;
-        self.set_boot_svc_raw(&data)
-    }
-
-    pub fn ownership_unlock(&self, unlock: OwnershipUnlockRequest) -> Result<()> {
-        let message = BootSvc::ownership_unlock(unlock);
-        let data = message.to_bytes()?;
-        self.set_boot_svc_raw(&data)
-    }
-
-    pub fn ownership_activate(&self, activate: OwnershipActivateRequest) -> Result<()> {
-        let message = BootSvc::ownership_activate(activate);
-        let data = message.to_bytes()?;
-        self.set_boot_svc_raw(&data)
-    }
-
-    pub fn set_owner_config(&self, data: &[u8]) -> Result<()> {
-        self.set_mode(Self::OWNER_BLOCK)?;
-        let xm = Xmodem::new();
-        xm.send(&*self.uart, data)?;
-        Ok(())
-    }
-
-    pub fn erase_owner(&self) -> Result<()> {
-        self.set_mode(Self::ERASE_OWNER)?;
-        Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/rescue/xmodem.rs
+++ b/sw/host/opentitanlib/src/rescue/xmodem.rs
@@ -188,7 +188,8 @@ impl Xmodem {
                 }
                 _ => {
                     return Err(XmodemError::UnsupportedMode(format!(
-                        "bad start of packet: {byte:?}"
+                        "bad start of packet: {byte:02x} ({})",
+                        byte as char
                     ))
                     .into());
                 }

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -20,6 +20,7 @@ use opentitanlib::image::image::Image;
 use opentitanlib::image::manifest::ManifestKind;
 use opentitanlib::ownership::{OwnerBlock, TlvHeader};
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::{Rescue, RescueMode};
 use opentitanlib::util::file::FromReader;
 use opentitanlib::util::parse_int::ParseInt;
 
@@ -96,7 +97,7 @@ impl CommandDispatch for Firmware {
         rescue.enter(transport, self.reset_target)?;
         if let Some(rate) = self.rate {
             prev_baudrate = uart.get_baudrate()?;
-            rescue.set_baud(rate)?;
+            rescue.set_speed(rate)?;
         }
         rescue.wait()?;
         if self.erase_other_slot {
@@ -109,7 +110,7 @@ impl CommandDispatch for Firmware {
         }
         rescue.update_firmware(self.slot, payload)?;
         if self.rate.is_some() {
-            rescue.set_baud(prev_baudrate)?;
+            rescue.set_speed(prev_baudrate)?;
         }
         if !self.wait {
             transport.reset_target(Duration::from_millis(50), false)?;
@@ -143,7 +144,7 @@ impl CommandDispatch for GetBootLog {
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
         if self.raw {
-            let data = rescue.get_raw(RescueSerial::BOOT_LOG)?;
+            let data = rescue.get_raw(RescueMode::BootLog)?;
             Ok(Some(Box::new(RawBytes(data))))
         } else {
             let data = rescue.get_boot_log()?;
@@ -177,7 +178,7 @@ impl CommandDispatch for GetBootSvc {
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
         if self.raw {
-            let data = rescue.get_raw(RescueSerial::BOOT_SVC_RSP)?;
+            let data = rescue.get_raw(RescueMode::BootSvcRsp)?;
             Ok(Some(Box::new(RawBytes(data))))
         } else {
             let data = rescue.get_boot_svc()?;
@@ -211,7 +212,7 @@ impl CommandDispatch for GetDeviceId {
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport, self.reset_target)?;
         if self.raw {
-            let data = rescue.get_raw(RescueSerial::OT_ID)?;
+            let data = rescue.get_raw(RescueMode::DeviceId)?;
             Ok(Some(Box::new(RawBytes(data))))
         } else {
             let data = rescue.get_device_id()?;
@@ -434,8 +435,8 @@ impl CommandDispatch for GetOwnerConfig {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         let page = match self.page {
-            0 => RescueSerial::GET_OWNER_PAGE0,
-            1 => RescueSerial::GET_OWNER_PAGE1,
+            0 => RescueMode::GetOwnerPage0,
+            1 => RescueMode::GetOwnerPage1,
             _ => return Err(anyhow!("Unsupported page {}", self.page)),
         };
         let uart = self.params.create(transport)?;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -52,7 +52,6 @@ enum RootCommandHierarchy {
     Otp(command::otp::Otp),
     #[command(subcommand)]
     Ownership(command::ownership::OwnershipCommand),
-    #[command(subcommand)]
     Rescue(command::rescue::RescueCommand),
     #[command(subcommand)]
     Rsa(command::rsa::Rsa),

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -14,6 +14,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::Rescue;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -14,7 +14,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
-use opentitanlib::rescue::Rescue;
+use opentitanlib::rescue::{EntryMode, Rescue};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 
@@ -228,8 +228,7 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
 
     if let Some(fw) = &opts.rescue_after_activate {
         let data = std::fs::read(fw)?;
-        rescue.enter(transport, /*reset_target=*/ true)?;
-        rescue.wait()?;
+        rescue.enter(transport, EntryMode::Reset)?;
         rescue.update_firmware(opts.rescue_slot, &data)?;
         // Clear the opposite slot because we changed the scrambling/ecc settings
         // for the application area of flash.

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
-use opentitanlib::rescue::Rescue;
+use opentitanlib::rescue::{EntryMode, Rescue};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 
@@ -68,7 +68,7 @@ fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let rescue = RescueSerial::new(Rc::clone(&uart));
 
     log::info!("###### Get Device Info ######");
-    rescue.enter(transport, /*reset=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     let devid = rescue.get_device_id()?;
 
     log::info!("###### Upload Owner Block ######");

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::Rescue;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 

--- a/sw/host/tests/ownership/rescue_limit_test.rs
+++ b/sw/host/tests/ownership/rescue_limit_test.rs
@@ -14,7 +14,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
-use opentitanlib::rescue::Rescue;
+use opentitanlib::rescue::{EntryMode, Rescue};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 
@@ -118,7 +118,7 @@ fn flash_limit_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // 384K, block 385 and 386 will be buffered in RAM and the rescue module
     // will reject the write request and terminate the upload.
     let data = vec![0u8; 448 * 1024];
-    rescue.enter(transport, /*reset_target=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     let result = rescue.update_firmware(BootSlot::SlotA, &data);
     assert_eq!(result.unwrap_err().to_string(), "Cancelled");
     log::info!("Got expected 'Cancel' during upload of too-large payload.");

--- a/sw/host/tests/ownership/rescue_limit_test.rs
+++ b/sw/host/tests/ownership/rescue_limit_test.rs
@@ -14,6 +14,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::Rescue;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 

--- a/sw/host/tests/ownership/rescue_permission_test.rs
+++ b/sw/host/tests/ownership/rescue_permission_test.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::Rescue;
 use opentitanlib::test_utils::init::InitializeTest;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/ownership/rescue_permission_test.rs
+++ b/sw/host/tests/ownership/rescue_permission_test.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::rescue::serial::RescueSerial;
-use opentitanlib::rescue::Rescue;
+use opentitanlib::rescue::{EntryMode, Rescue};
 use opentitanlib::test_utils::init::InitializeTest;
 
 #[derive(Debug, Parser)]
@@ -103,7 +103,7 @@ fn rescue_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<(
     log::info!("###### Check Rescue Dis-Allowed Command ######");
     // We'll check a boot_svc command that has been removed from the
     // allowlist when we use the `WithRescueRestricted` configuration.
-    rescue.enter(transport, /*reset_target=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     let result = rescue.set_next_bl0_slot(
         /*primary=*/ BootSlot::Unspecified,
         /*next=*/ BootSlot::SlotA,

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -16,6 +16,7 @@ use opentitanlib::ownership::{
     OwnerConfigItem, OwnerFlashConfig, OwnerFlashRegion, OwnerRescueConfig, OwnershipKeyAlg,
 };
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::Rescue;
 
 use std::path::Path;
 

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -16,7 +16,7 @@ use opentitanlib::ownership::{
     OwnerConfigItem, OwnerFlashConfig, OwnerFlashRegion, OwnerRescueConfig, OwnershipKeyAlg,
 };
 use opentitanlib::rescue::serial::RescueSerial;
-use opentitanlib::rescue::Rescue;
+use opentitanlib::rescue::{EntryMode, Rescue};
 
 use std::path::Path;
 
@@ -27,7 +27,7 @@ pub fn get_device_info(
     transport: &TransportWrapper,
     rescue: &RescueSerial,
 ) -> Result<(BootLog, DeviceId)> {
-    rescue.enter(transport, /*reset=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     Ok((rescue.get_boot_log()?, rescue.get_device_id()?))
 }
 
@@ -51,9 +51,9 @@ pub fn ownership_unlock(
     }
     .apply_to(Option::<&mut std::fs::File>::None)?;
 
-    rescue.enter(transport, /*reset=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     rescue.ownership_unlock(unlock)?;
-    rescue.enter(transport, /*reset=*/ false)?;
+    rescue.enter(transport, EntryMode::Reboot)?;
     let result = rescue.get_boot_svc()?;
     match result.message {
         Message::OwnershipUnlockResponse(r) => r.status.into(),
@@ -96,9 +96,9 @@ pub fn ownership_activate(
     }
     .apply_to(Option::<&mut std::fs::File>::None)?;
 
-    rescue.enter(transport, /*reset=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     rescue.ownership_activate(activate)?;
-    rescue.enter(transport, /*reset=*/ false)?;
+    rescue.enter(transport, EntryMode::Reboot)?;
     let result = rescue.get_boot_svc()?;
     match &result.message {
         Message::OwnershipActivateResponse(r) => r.status.into(),
@@ -262,7 +262,7 @@ where
     }
     let mut owner_config = Vec::new();
     owner.write(&mut owner_config)?;
-    rescue.enter(transport, /*reset=*/ true)?;
+    rescue.enter(transport, EntryMode::Reset)?;
     rescue.set_owner_config(&owner_config)?;
     Ok(())
 }

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -14,7 +14,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
-use opentitanlib::rescue::Rescue;
+use opentitanlib::rescue::{EntryMode, Rescue};
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 
@@ -181,8 +181,9 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     if let Some(fw) = &opts.rescue_after_activate {
         let data = std::fs::read(fw)?;
-        rescue.enter(transport, /*reset_target=*/ true)?;
+        rescue.enter(transport, EntryMode::Reset)?;
         rescue.update_firmware(BootSlot::SlotA, &data)?;
+        rescue.reboot()?;
     }
 
     log::info!("###### Boot After Transfer Complete ######");

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -14,6 +14,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_svc::{BootSlot, UnlockMode};
 use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::rescue::Rescue;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 


### PR DESCRIPTION
Cherry pick the following changes from `earlgrey_1.0.0` to allow master version of opentitantool to be able to rescue with newer ROM_EXT version that advertise `Rescue 1.0`. This cherry picks the following sha from earlgrey_1.0.0 with modifycation to make them build on master

 * 8aa221be8ca01915666e292923f07b09a2a40dd8
 * 0ce26d6deccaf7d31c219beb01596e6ed6a35121
 * 9264a7fb24af8bf5ae6ae44f3096a4cc3f49de7d
    * Updated to keep the `--wait` in addition to the new `--reboot` parameter as to not break CLI for external users

I do not know what the procedure is for cherry picking, so please let me know.