### PR TITLE
Remove all hardcoded reset requests constants

### DIFF
--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -88,21 +88,6 @@ typedef enum dif_pwrmgr_domain_option {
 typedef uint8_t dif_pwrmgr_domain_config_t;
 
 /**
- * A reset request source.
- *
- * Constants below are bitmasks that can be used to define sets of reset
- * request sources.
- *
- * See also: `dif_pwrmgr_request_sources_t`.
- *
- * Note: This needs to be updated once the HW is finalized.
- */
-typedef enum dif_pwrmgr_reset_request_source {
-  kDifPwrmgrResetRequestSourceOne = (1u << 0),
-  kDifPwrmgrResetRequestSourceTwo = (1u << 1),
-} dif_pwrmgr_reset_request_source_t;
-
-/**
  * A set of request sources.
  *
  * This type is used for specifying which request sources are enabled for a

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -29,6 +29,11 @@ typedef enum dif_pwrmgr_wakeup_request_source {
   kDifPwrmgrWakeupRequestSourceSix = (1u << 5),
 } dif_pwrmgr_wakeup_request_source_t;
 
+typedef enum dif_pwrmgr_reset_request_source {
+  kDifPwrmgrResetRequestSourceOne = (1u << 0),
+  kDifPwrmgrResetRequestSourceTwo = (1u << 1),
+} dif_pwrmgr_reset_request_source_t;
+
 /**
  * Returns a `uint32_t` with a single zero bit.
  */

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -97,9 +97,12 @@ static void test_gateable_clocks_off(const dif_clkmgr_t *clkmgr,
   CHECK_DIF_OK(
       dif_clkmgr_gateable_clock_set_enabled(clkmgr, clock, kDifToggleEnabled));
   // Enable watchdog bite reset.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kDtAonTimerAon),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   LOG_INFO("Testing peripheral clock %d, with unit %s", clock,
            peri_context[clock].peripheral_name);
 

--- a/sw/device/tests/pwrmgr_sleep_resets_lib.c
+++ b/sw/device/tests/pwrmgr_sleep_resets_lib.c
@@ -184,9 +184,12 @@ void config_sysrst(dif_pinmux_index_t pad_pin) {
   LOG_INFO("sysrst enabled");
 
   // Set sysrst as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_sysrst_ctrl_instance_id(kSysrstCtrlDt),
+      kDtSysrstCtrlResetReqRstReq, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   LOG_INFO("Reset Request SourceOne is set");
 
   // Configure sysrst key combo
@@ -235,9 +238,12 @@ void config_wdog(uint64_t bark_micros, uint64_t bite_micros) {
   CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(aon_timer, bark_cycles,
                                                       bite_cycles, false));
   // Set wdog as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kDtAonTimerAon),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
 }
 
 void trigger_escalation(void) {

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -602,9 +602,12 @@ static void peripheral_init(void) {
   CHECK_DIF_OK(dif_uart_init_from_dt(kDtUart0, &uart));
 
   // Set pwrmgr reset_en
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kDtAonTimerAon),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
 }
 
 static void collect_alert_dump_and_compare(test_round_t round) {

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -239,9 +239,13 @@ bool test_main(void) {
           aon_timer_testutils_get_aon_cycles_32_from_us(100, &bite_cycles));
 
       // Set wdog as a reset source.
+      dif_pwrmgr_request_sources_t reset_sources;
+      CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+          &pwrmgr, kDifPwrmgrReqTypeReset,
+          dt_aon_timer_instance_id(kDtAonTimerAon), kDtAonTimerResetReqAonTimer,
+          &reset_sources));
       CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
-          &pwrmgr, kDifPwrmgrReqTypeReset, kDifPwrmgrResetRequestSourceTwo,
-          kDifToggleEnabled));
+          &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
       // Setup the watchdog bark and bite timeouts.
       CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(
           &aon_timer, bark_cycles, bite_cycles, false));

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -70,6 +70,7 @@ static_assert(kDtAlertHandlerCount == 1,
 dif_pwrmgr_request_sources_t aon_timer_wakeup_sources;
 dif_pwrmgr_request_sources_t adc_ctrl_wakeup_sources;
 dif_pwrmgr_request_sources_t all_wakeup_sources;
+dif_pwrmgr_request_sources_t wdog_reset_sources;
 
 /**
  * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
@@ -182,6 +183,9 @@ void init_peripherals(void) {
   CHECK_DIF_OK(dif_pwrmgr_find_request_source(
       &pwrmgr, kDifPwrmgrReqTypeWakeup, dt_adc_ctrl_instance_id(kAdcCtrlDt),
       kDtAdcCtrlWakeupWkupReq, &adc_ctrl_wakeup_sources));
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kDtAonTimerAon),
+      kDtAonTimerResetReqAonTimer, &wdog_reset_sources));
   CHECK_DIF_OK(dif_pwrmgr_get_all_request_sources(
       &pwrmgr, kDifPwrmgrReqTypeWakeup, &all_wakeup_sources));
 }
@@ -320,9 +324,8 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
   CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(aon_timer, bark_cycles,
                                                       bite_cycles, false));
   // Set wdog as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, wdog_reset_sources, kDifToggleEnabled));
 }
 
 /**
@@ -363,9 +366,8 @@ static void normal_sleep_wdog(const dif_pwrmgr_t *pwrmgr) {
 
 static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
   // Set por as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, wdog_reset_sources, kDifToggleEnabled));
 
   // Program the pwrmgr to go to deep sleep state (clocks off).
   CHECK_STATUS_OK(
@@ -378,9 +380,8 @@ static void low_power_por(const dif_pwrmgr_t *pwrmgr) {
 
 static void normal_sleep_por(const dif_pwrmgr_t *pwrmgr) {
   // Set por as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, wdog_reset_sources, kDifToggleEnabled));
 
   // Place device into low power and immediately wake.
   dif_pwrmgr_domain_config_t config;

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -43,9 +43,8 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
       pwrmgr, kDifPwrmgrReqTypeReset,
       dt_sysrst_ctrl_instance_id(kDtSysrstCtrlAon), kDtSysrstCtrlResetReqRstReq,
       &reset_sources));
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              reset_sources,
-                                              kDifToggleEnabled));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   LOG_INFO("Reset Request SourceOne is set");
 
   // Configure sysrst key combo

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -38,8 +38,13 @@ static void config_sysrst(const dif_pwrmgr_t *pwrmgr,
   LOG_INFO("sysrst enabled");
 
   // Set sysrst as a reset source.
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset,
+      dt_sysrst_ctrl_instance_id(kDtSysrstCtrlAon), kDtSysrstCtrlResetReqRstReq,
+      &reset_sources));
   CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
+                                              reset_sources,
                                               kDifToggleEnabled));
   LOG_INFO("Reset Request SourceOne is set");
 
@@ -95,9 +100,12 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);
 
   // Set wdog as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kDtAonTimerAon),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
 
   // Setup the wdog bark and bite timeouts.
   CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(aon_timer, bark_cycles,
@@ -137,8 +145,7 @@ static void wdog_bite_test(const dif_aon_timer_t *aon_timer,
 bool test_main(void) {
   // Initialize pwrmgr.
   dif_pwrmgr_t pwrmgr;
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kDtPwrmgrAon, &pwrmgr));
 
   // Initialize sysrst_ctrl.
   dif_sysrst_ctrl_t sysrst_ctrl_aon;

--- a/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
+++ b/sw/device/tests/sim_dv/sysrst_ctrl_ec_rst_l_test.c
@@ -127,11 +127,15 @@ static void configure_combo_reset(void) {
                                      .allow_zero = true,
                                      .enabled = kDifToggleEnabled,
                                      .override_value = true}));
-  // Prepare rstmgr for a reset with sysrst_ctrl (source one).
+  // Prepare rstmgr for a reset with sysrst_ctrl.
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceOne,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset,
+      dt_sysrst_ctrl_instance_id(kDtSysrstCtrlAon), kDtSysrstCtrlResetReqRstReq,
+      &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   // Issue WFI and wait for reset condition.
   test_status_set(kTestStatusInWfi);
   wait_for_interrupt();
@@ -177,8 +181,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_sysrst_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
       &sysrst_ctrl));
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kDtPwrmgrAon, &pwrmgr));
   CHECK_DIF_OK(dif_rstmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
 

--- a/sw/device/tests/soc_proxy_smoketest.c
+++ b/sw/device/tests/soc_proxy_smoketest.c
@@ -29,9 +29,12 @@ void after_por(dif_pwrmgr_t *pwrmgr) {
   LOG_INFO("Reset after POR.");
 
   // Enable external reset request in pwrmgr.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      pwrmgr, kDifPwrmgrReqTypeReset, dt_soc_proxy_instance_id(kDtSocProxy),
+      kDtSocProxyResetReqExternal, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
   LOG_INFO("External resets enabled.");
 
   // Give DV environment time for triggering external reset.
@@ -115,15 +118,10 @@ bool test_main(void) {
   dif_rv_plic_t rv_plic;
   dif_soc_proxy_t soc_proxy;
 
-  CHECK_DIF_OK(dif_pwrmgr_init(
-      mmio_region_from_addr(TOP_DARJEELING_PWRMGR_AON_BASE_ADDR), &pwrmgr));
-  CHECK_DIF_OK(dif_rstmgr_init(
-      mmio_region_from_addr(TOP_DARJEELING_RSTMGR_AON_BASE_ADDR), &rstmgr));
-  CHECK_DIF_OK(dif_rv_plic_init(
-      mmio_region_from_addr(TOP_DARJEELING_RV_PLIC_BASE_ADDR), &rv_plic));
-  CHECK_DIF_OK(dif_soc_proxy_init(
-      mmio_region_from_addr(TOP_DARJEELING_SOC_PROXY_CORE_BASE_ADDR),
-      &soc_proxy));
+  CHECK_DIF_OK(dif_pwrmgr_init_from_dt(kDtPwrmgrAon, &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init_from_dt(kDtRstmgrAon, &rstmgr));
+  CHECK_DIF_OK(dif_rv_plic_init_from_dt(kDtRvPlic, &rv_plic));
+  CHECK_DIF_OK(dif_soc_proxy_init_from_dt(kDtSocProxy, &soc_proxy));
 
   // Behave based on reset reason.
   if (UNWRAP(

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
@@ -148,9 +148,12 @@ void enter_deep_sleep(void) {
 void set_up_reset_request(void) {
   // Prepare rstmgr for a reset.
   CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
-                                              kDifPwrmgrResetRequestSourceTwo,
-                                              kDifToggleEnabled));
+  dif_pwrmgr_request_sources_t reset_sources;
+  CHECK_DIF_OK(dif_pwrmgr_find_request_source(
+      &pwrmgr, kDifPwrmgrReqTypeReset, dt_aon_timer_instance_id(kAonTimerDt),
+      kDtAonTimerResetReqAonTimer, &reset_sources));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeReset, reset_sources, kDifToggleEnabled));
 
   CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&aon_timer));
 


### PR DESCRIPTION
The goal of this PR is to remove this from the DIF headers:
```c
typedef enum dif_pwrmgr_reset_request_source {
  kDifPwrmgrResetRequestSourceOne = (1u << 0),
  kDifPwrmgrResetRequestSourceTwo = (1u << 1),
} dif_pwrmgr_reset_request_source_t;
```
Instead, the reset request sources can be queried via the DT.

Remaining issue:

- [ ] `chip_sw_sysrst_ctrl_ec_rst_l` fails in DV, apparently due to [this delay](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sysrst_ctrl_ec_rst_l_vseq.sv#L72). @matutem might know why this was introduced. The issue is independent of this change