### PR TITLE
[dv, spi_device] Correct hdl_path for ram_cfg

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_ram_cfg_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_ram_cfg_vseq.sv
@@ -9,9 +9,10 @@ class spi_device_ram_cfg_vseq extends spi_device_base_vseq;
 
   virtual task body();
     prim_ram_2p_pkg::ram_2p_cfg_t src_ram_cfg, dst_ram_cfg, egress_ram_cfg, ingress_ram_cfg;
-    string src_path = "tb.dut.ram_cfg_i";
-    string dst_path = "tb.dut.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem.cfg_i";
-    string egress_path = "tb.dut.u_spid_dpram.gen_ram1r1w.u_sys2spi_mem.u_mem.cfg_i";
+    string src_path     = `SRAM_TYPE == spi_device_pkg::SramType2p ?  "tb.dut.ram_cfg_sys2spi_i" :
+                                                                      "tb.dut.ram_cfg_spi2sys_i";
+    string dst_path     = "tb.dut.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem.cfg_i";
+    string egress_path  = "tb.dut.u_spid_dpram.gen_ram1r1w.u_sys2spi_mem.u_mem.cfg_i";
     string ingress_path = "tb.dut.u_spid_dpram.gen_ram1r1w.u_spi2sys_mem.u_mem.cfg_i";
 
     repeat (100) begin


### PR DESCRIPTION
Sorts out UVM error due to incorrect hdl path