### PR TITLE
[test] Port `example_test_from_rom` to DT

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1735,7 +1735,7 @@ opentitan_test(
     kind = "rom",
     linker_script = "//sw/device/lib/testing/test_rom:linker_script",
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//hw/top:dt",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:uart",

--- a/sw/device/tests/example_test_from_rom.c
+++ b/sw/device/tests/example_test_from_rom.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "dt/dt_api.h"
+#include "dt/dt_uart.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_pinmux.h"
@@ -13,8 +15,6 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/status.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
-
 static dif_pinmux_t pinmux;
 static dif_uart_t uart0;
 
@@ -22,22 +22,21 @@ bool rom_test_main(void) {
   // We need to set the test status as "in test" to indicate to the test code
   // has been reached, even though this test is also in the "boot ROM".
   test_status_set(kTestStatusInTest);
-  CHECK_DIF_OK(dif_pinmux_init(
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_pinmux_init_from_dt(kDtPinmuxAon, &pinmux));
   pinmux_testutils_init(&pinmux);
 
   // We need to initialize the UART regardless if we LOG any messages, since
   // Verilator and FPGA platforms use the UART to communicate the test results.
   if (kDeviceType != kDeviceSimDV) {
-    CHECK_DIF_OK(dif_uart_init(
-        mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
+    CHECK_DIF_OK(dif_uart_init_from_dt(kDtUartFirst, &uart0));
     CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
     CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
           "kClockFreqPeripheralHz must fit in uint32_t");
     CHECK_DIF_OK(dif_uart_configure(
         &uart0, (dif_uart_config_t){
                     .baudrate = (uint32_t)kUartBaudrate,
-                    .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                    .clk_freq_hz = dt_clock_frequency(
+                        dt_uart_clock(kDtUartFirst, kDtUartClockClk)),
                     .parity_enable = kDifToggleDisabled,
                     .parity = kDifUartParityEven,
                     .tx_enable = kDifToggleEnabled,


### PR DESCRIPTION
This test had the Darjeeling execution environment added but was still using Earlgrey constants.