### PR TITLE
[ip/chip_entropy_src] Update chip_entropy_src_testplan.hjson

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -138,7 +138,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:entropy_src_bypass_mode_health_test"]
     },
     {
       name: chip_sw_entropy_src_fips_mode_health_tests
@@ -175,7 +175,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:entropy_src_fips_mode_health_test"]
     },
     {
       name: chip_sw_entropy_src_validation


### PR DESCRIPTION
Adjusted the testplan to include the new FIPS-mode health tests for the entropy source. Adjusted the testplan to include the new BYPASS-mode health tests for the entropy source.
As per advice from vogelpi in #27064