### PR TITLE
[rom_ext] Advance the security version if requested

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -186,6 +186,21 @@ def _manifest_impl(ctx):
             },
         )
 
+    secver_write = ctx.attr.secver_write
+    if secver_write == "none":
+        # nothing to do
+        pass
+    elif secver_write in ("false", "true"):
+        mf["extension_params"].append(
+            {
+                "secver_write": {
+                    "secver_write": json.decode(secver_write),
+                },
+            },
+        )
+    else:
+        fail("Unknown value for secver_write:", secver_write)
+
     if ctx.attr.isfb_erase_allowed_policy:
         mf["extension_params"].append(
             {
@@ -229,6 +244,7 @@ _manifest = rule(
         "extensions": attr.string_list(doc = "Names of the manifest extensions as an array of strings"),
         "integrator_specific_firmware_binding": attr.string(doc = "Create an Integrator Specific Firmware Block (ISFB) JSON object"),
         "isfb_erase_allowed_policy": attr.string(doc = "Create an ISFB Erase Allowed Policy JSON object"),
+        "secver_write": attr.string(default = "none", values = ["none", "false", "true"], doc = "Add the secver_write extension with the specified value"),
     },
 )
 

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -33,6 +33,9 @@ extern rom_error_t manifest_ext_get_spx_key(
 extern rom_error_t manifest_ext_get_spx_signature(
     const manifest_t *manifest,
     const manifest_ext_spx_signature_t **spx_signature);
+extern rom_error_t manifest_ext_get_secver_write(
+    const manifest_t *manifest,
+    const manifest_ext_secver_write_t **secver_write);
 extern rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
                                          const manifest_ext_isfb_t **isfb);
 extern rom_error_t manifest_ext_get_isfb_erase(

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -14,8 +14,23 @@ load(
     "SLOTS",
     "TEST_OWNER_CONFIGS",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
+
+string_flag(
+    name = "secver_write",
+    build_setting_default = "false",
+    values = [
+        "false",
+        "true",
+    ],
+)
+
+config_setting(
+    name = "secver_write_true",
+    flag_values = {":secver_write": "true"},
+)
 
 cc_library(
     name = "rom_ext_manifest",

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -2,6 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+def secver_write_selection():
+    """Return the secver_write value based on the configuration setting."""
+    return select({
+        "//sw/device/silicon_creator/rom_ext:secver_write_true": "true",
+        "//conditions:default": "false",
+    })
+
 # The ROM_EXT version number to encode into the manifest.
 # NOTE: the version numbers are integers, but have to be encoded as strings
 # because of how the bazel rule accepts attributes.

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -1,0 +1,168 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex", "hex_digits")
+load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load("//rules:linker.bzl", "ld_library")
+load("//rules:manifest.bzl", "manifest")
+load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_binary", "opentitan_test")
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
+    "ROM_EXT_VERSION",
+    "SLOTS",
+    "TEST_OWNER_CONFIGS",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+manifest(d = {
+    "name": "manifest0",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "0",
+    "security_version": "0",
+    "secver_write": "false",
+})
+
+manifest(d = {
+    "name": "manifest1",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "1",
+    "security_version": "1",
+    "secver_write": "true",
+})
+
+manifest(d = {
+    "name": "manifest2",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "2",
+    "security_version": "2",
+    "secver_write": "false",
+})
+
+manifest(d = {
+    "name": "manifest3",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": "0",
+    "version_minor": "3",
+    "security_version": "3",
+    "secver_write": "true",
+})
+
+_TEST_ROM_EXTS = {
+    "0": {
+        "manifest": ":manifest0",
+    },
+    "1": {
+        "manifest": ":manifest1",
+    },
+    "2": {
+        "manifest": ":manifest2",
+    },
+    "3": {
+        "manifest": ":manifest3",
+    },
+}
+
+[
+    opentitan_binary(
+        name = "rom_ext_{}".format(name),
+        testonly = True,
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:fpga_cw340",
+        ],
+        extra_bazel_features = [
+            "minsize",
+            "use_lld",
+        ],
+        linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_virtual",
+        manifest = param["manifest"],
+        spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+        deps = [
+            "//sw/device/lib/crt",
+            "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:test_owner",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake",
+            "//sw/device/silicon_creator/lib/rescue:rescue_xmodem",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509",
+            "//sw/device/silicon_creator/rom_ext/imm_section:main_section_dice_x509_slot_virtual",
+        ],
+    )
+    for name, param in _TEST_ROM_EXTS.items()
+]
+
+opentitan_test(
+    name = "secver_write_test",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{rom_ext}@0 {boot_test}@0x10000",
+        binaries = {
+            ":boot_test": "boot_test",
+            ":rom_ext_1": "rom_ext1",
+            ":rom_ext_2": "rom_ext2",
+            ":rom_ext_3": "rom_ext3",
+        },
+        changes_otp = True,
+        exit_success = "BFV:{}".format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
+        rom_ext = ":rom_ext_0",
+        test_cmd = """
+            # First, assemble the additional images we'll need for this test.
+            --exec="image assemble -s 131072 --mirror=false -o fw1.bin {rom_ext1}@0 {boot_test}@0x10000"
+            --exec="image assemble -s 131072 --mirror=false -o fw2.bin {rom_ext2}@0 {boot_test}@0x10000"
+            --exec="image assemble -s 131072 --mirror=false -o fw3.bin {rom_ext3}@0 {boot_test}@0x10000"
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+
+            # Bootstrap the initial version 0 into SlotA
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 0'"
+
+            # Rescue and update to SlotB.  We expect to update the secver.
+            --exec="rescue firmware --raw --slot=SlotB fw1.bin"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 1'"
+
+            # Rescue and update to SlotA.  We expect NOT to update the secver.
+            --exec="rescue firmware --raw --slot=SlotA fw2.bin"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 1'"
+
+            # Rescue and update to SlotB.  We expect to update the secver.
+            --exec="rescue firmware --raw --slot=SlotB fw3.bin"
+            --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 3'"
+
+            # Finally, bootstrap back to version 0, which we expect NOT to work.
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='{exit_success}' --timeout=10s"
+            no-op
+        """,
+    ),
+)
+
+opentitan_binary(
+    name = "boot_test",
+    testonly = True,
+    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -713,6 +713,23 @@ static void rom_ext_rescue_lockdown(boot_data_t *boot_data) {
   owner_block_info_lockdown(owner_config.info);
 }
 
+static rom_error_t rom_ext_advance_secver(boot_data_t *boot_data,
+                                          const manifest_t *manifest) {
+  const manifest_ext_secver_write_t *secver;
+  rom_error_t error;
+  error = manifest_ext_get_secver_write(manifest, &secver);
+  if (error == kErrorOk) {
+    if (secver->write == kHardenedBoolTrue &&
+        manifest->security_version > boot_data->min_security_version_rom_ext) {
+      // If our security version is greater than the minimum security version
+      // advance the minimum version to our version.
+      boot_data->min_security_version_rom_ext = manifest->security_version;
+      return boot_data_write(boot_data);
+    }
+  }
+  return kErrorOk;
+}
+
 static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
   const manifest_t *self = rom_ext_manifest();
@@ -734,6 +751,9 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     //   //sw/device/silicon_creator/rom_ext/imm_section/defs.bzl
     dbg_printf("info: imm_section hash unenforced\r\n");
   }
+
+  // Maybe advance the security version.
+  HARDENED_RETURN_IF_ERROR(rom_ext_advance_secver(boot_data, self));
 
   // Prepare dice chain builder for CDI_1.
   HARDENED_RETURN_IF_ERROR(dice_chain_init());

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -12,6 +12,7 @@ load(
     "ROM_EXT_VARIATIONS",
     "ROM_EXT_VERSION",
     "SLOTS",
+    "secver_write_selection",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -22,6 +23,7 @@ manifest(d = {
     "version_major": ROM_EXT_VERSION.MAJOR,
     "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
+    "secver_write": secver_write_selection(),
     "visibility": ["//visibility:private"],
 })
 


### PR DESCRIPTION
1. Make the ROM_EXT detect the `secver_write` extension in the manifest. If present and the manifest security version is greater than the current boot_data minimum security version, update the value and write boot_data.
2. Add a string flag to the build system that allows the `secver_write` value to be set at build time.
3. Add a test which sequences firmware through a series of ROM_EXTs which advance the security version.  Confirm each update and confirm that an older ROM_EXT will no longer execute.