### PR TITLE
[ottf_console] optimize TX-ready GPIO feature

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -67,10 +67,6 @@ static buffer_sink_t base_stdout = {
 // The GPIO TX indicator pin that can be used with the SPI console.
 static dif_gpio_t *spi_console_gpio = NULL;
 static dif_gpio_pin_t spi_console_tx_ready_gpio = UINT32_MAX;
-// The amount of time to pause between GPIO toggles to enable the host to detect
-// the GPIO indicator rising edges. This was empircally determined using the
-// CW310 FPGA and HyperDebug host.
-static const uint32_t kGpioToggleDelayMicros = 100000;
 
 void base_set_stdout(buffer_sink_t out) {
   if (out.sink == NULL) {
@@ -152,56 +148,58 @@ static size_t spi_device_send_frame(void *data, const char *buf, size_t len) {
     frame_header_bytes[i + 8] = (len >> (i * 8)) & 0xff;
   }
 
-  uint32_t available_buffer_size = 0;
-  do {
+  // Wait for enough space to free up in the SPI flash buffer if we are in
+  // operating in polling mode.
+  if (spi_console_gpio == NULL) {
+    uint32_t available_buffer_size = 0;
     uint32_t last_read_address = 0;
-    if (dif_spi_device_get_last_read_address(spi_device, &last_read_address) !=
-        kDifOk) {
-      return 0;
-    }
+    do {
+      if (dif_spi_device_get_last_read_address(spi_device,
+                                               &last_read_address) != kDifOk) {
+        return 0;
+      }
 
-    // If we are not using the GPIO TX-ready indicator pin (which is the
-    // default) the host SPI console is constantly polling the spi_device to see
-    // if data is available to be read out. In this case, we need to adjust the
-    // last read address.
-    //
-    // Specifically, the when the host is continuously reading from the read
-    // buffer, it is unaware of whether it is going to find a valid new frame
-    // (marked by a magic number in the frame header), an frame header all
-    // zeros, or garbage, since it is operating in polling mode. This could
-    // result in the reported last_read_address being one header size ahead of
-    // the actual address of the last valid frame if all the frames in the read
-    // buffer has been consumed by the host. While it's harmless to use the
-    // last read address even if the reported value is a frame header ahead,
-    // doing so might temporarily underestimate the available buffer size by the
-    // size of a frame header (or 12 bytes to be specific).
-    //
-    // However, if we are using the GPIO TX-ready indicator pin, the host will
-    // only ever attempt to read out data if it was signaled to do so by the
-    // device. In which case the last read address is always correct.
-    uint32_t adjusted_last_read_address =
-        kSpiDeviceReadBufferSizeBytes + last_read_address;
-    if (spi_console_gpio == NULL) {
-      adjusted_last_read_address =
-          (adjusted_last_read_address - kSpiDeviceFrameHeaderSizeBytes) %
+      // If we are not using the GPIO TX-ready indicator pin (which is the
+      // default) the host SPI console is constantly polling the spi_device to
+      // see if data is available to be read out. In this case, we need to
+      // adjust the last read address.
+      //
+      // Specifically, when the host is continuously reading from the read
+      // buffer, it is unaware of whether it is going to find a valid new frame
+      // (marked by a magic number in the frame header), an frame header all
+      // zeros, or garbage, since it is operating in polling mode. This could
+      // result in the reported last_read_address being one header size ahead of
+      // the actual address of the last valid frame if all the frames in the
+      // read buffer has been consumed by the host. While it's harmless to use
+      // the last read address even if the reported value is a frame header
+      // ahead, doing so might temporarily underestimate the available buffer
+      // size by the size of a frame header (or 12 bytes to be specific).
+      //
+      // However, if we are using the GPIO TX-ready indicator pin, the host will
+      // only ever attempt to read out data if it was signaled to do so by the
+      // device. In which case the next write address will always be 0, i.e.,
+      // the beginning of the buffer.
+      uint32_t adjusted_last_read_address =
+          (kSpiDeviceReadBufferSizeBytes + last_read_address -
+           kSpiDeviceFrameHeaderSizeBytes) %
           kSpiDeviceReadBufferSizeBytes;
-    } else {
-      adjusted_last_read_address %= kSpiDeviceReadBufferSizeBytes;
-    }
-    // Frames are always word aligned, so ensure the last read address is word
-    // aligned too.
-    uint32_t next_read_address = ((adjusted_last_read_address + 1) & ~3u) %
-                                 kSpiDeviceReadBufferSizeBytes;
 
-    if (next_read_address > next_write_address) {
-      available_buffer_size = next_read_address - next_write_address - 1;
-    } else {
-      available_buffer_size =
-          next_read_address +
-          (kSpiDeviceReadBufferSizeBytes - next_write_address) - 1;
-    }
-  } while ((frame_size_bytes + kSpiDeviceBufferPreservedSizeBytes) >
-           available_buffer_size);
+      // Frames are always word aligned, so ensure the last read address is word
+      // aligned too.
+      uint32_t next_read_address = ((adjusted_last_read_address + 1) & ~3u) %
+                                   kSpiDeviceReadBufferSizeBytes;
+
+      // Compute the remaining free space in the SPI flash buffer.
+      if (next_read_address > next_write_address) {
+        available_buffer_size = next_read_address - next_write_address - 1;
+      } else {
+        available_buffer_size =
+            next_read_address +
+            (kSpiDeviceReadBufferSizeBytes - next_write_address) - 1;
+      }
+    } while ((frame_size_bytes + kSpiDeviceBufferPreservedSizeBytes) >
+             available_buffer_size);
+  }
 
   // Send aligned data.
   size_t data_write_address =
@@ -235,9 +233,39 @@ static size_t spi_device_send_frame(void *data, const char *buf, size_t len) {
     return 0;
   }
 
+  // Update the next write address and frame number.
   next_write_address =
       (next_write_address + frame_size_bytes) % kSpiDeviceReadBufferSizeBytes;
   spi_device_frame_num++;
+
+  // Block until the host to reads out the frame by toggling the GPIO TX-ready
+  // indicator pin to signal to the host to clock out data from the spi_device
+  // egress buffer.
+  if (spi_console_gpio != NULL) {
+    OT_DISCARD(
+        dif_gpio_write(spi_console_gpio, spi_console_tx_ready_gpio, true));
+    bool cs_state = true;
+    bool target_cs_state = false;
+    // There will be two bulk transfers that can be synchronized by the
+    // chip-select action. First the host will read out the 12-byte frame
+    // header, followed by the N-byte payload. Each transfer can be observed by
+    // the chip-select toggling low then high. After the first toggle low, when
+    // the host begins reading out the frame header, we can deassert the
+    // TX-ready pin as the host has already initiated the two SPI transactions.
+    for (size_t i = 0; i < 4; ++i) {
+      do {
+        if (dif_spi_device_get_csb_status(spi_device, &cs_state) != kDifOk) {
+          return 0;
+        }
+      } while (cs_state != target_cs_state);
+      if (i == 0) {
+        OT_DISCARD(
+            dif_gpio_write(spi_console_gpio, spi_console_tx_ready_gpio, false));
+      }
+      target_cs_state = !target_cs_state;
+    }
+    next_write_address = 0;
+  }
 
   return len;
 }
@@ -250,21 +278,9 @@ static size_t base_dev_spi_device(void *data, const char *buf, size_t len) {
     if (payload_len > kSpiDeviceMaxFramePayloadSizeBytes) {
       payload_len = kSpiDeviceMaxFramePayloadSizeBytes;
     }
-
     if (spi_device_send_frame(data, buf + write_data_len, payload_len) ==
         payload_len) {
       write_data_len += payload_len;
-
-      // Toggle the GPIO TX-ready indicator pin to signal to the host to clock
-      // out data from the spi_device egress buffer.
-      if (spi_console_gpio != NULL) {
-        OT_DISCARD(
-            dif_gpio_write(spi_console_gpio, spi_console_tx_ready_gpio, true));
-        busy_spin_micros(kGpioToggleDelayMicros);
-        OT_DISCARD(
-            dif_gpio_write(spi_console_gpio, spi_console_tx_ready_gpio, false));
-        busy_spin_micros(kGpioToggleDelayMicros);
-      }
     }
   }
 

--- a/sw/host/opentitanlib/src/console/spi.rs
+++ b/sw/host/opentitanlib/src/console/spi.rs
@@ -20,7 +20,6 @@ pub struct SpiConsoleDevice<'a> {
     rx_buf: RefCell<VecDeque<u8>>,
     next_read_address: Cell<u32>,
     device_tx_ready_pin: Option<&'a Rc<dyn GpioPin>>,
-    device_tx_ready: Cell<bool>,
 }
 
 impl<'a> SpiConsoleDevice<'a> {
@@ -46,7 +45,6 @@ impl<'a> SpiConsoleDevice<'a> {
             console_next_frame_number: Cell::new(0),
             next_read_address: Cell::new(0),
             device_tx_ready_pin,
-            device_tx_ready: Cell::new(false),
         })
     }
 
@@ -97,11 +95,19 @@ impl<'a> SpiConsoleDevice<'a> {
             % SpiConsoleDevice::SPI_FLASH_READ_BUFFER_SIZE;
         self.read_data(data_address, &mut data)?;
 
-        let next_read_address: u32 = (read_address
-            + u32::try_from(SpiConsoleDevice::SPI_FRAME_HEADER_SIZE + data_len_bytes_w_pad)
-                .unwrap())
-            % SpiConsoleDevice::SPI_FLASH_READ_BUFFER_SIZE;
-        self.next_read_address.set(next_read_address);
+        if self.get_tx_ready_pin()?.is_some() {
+            // When using the TX-indicator pin feature, we always write each SPI frame at the
+            // beginning of the flash buffer, and wait for the host to ready it out before writing
+            // another frame.
+            self.next_read_address.set(0);
+        } else {
+            let next_read_address: u32 = (read_address
+                + u32::try_from(SpiConsoleDevice::SPI_FRAME_HEADER_SIZE + data_len_bytes_w_pad)
+                    .unwrap())
+                % SpiConsoleDevice::SPI_FLASH_READ_BUFFER_SIZE;
+            self.next_read_address.set(next_read_address);
+        }
+
         // Copy data to the internal data queue.
         self.rx_buf.borrow_mut().extend(&data[..data_len_bytes]);
         Ok(data_len_bytes)
@@ -131,15 +137,14 @@ impl<'a> ConsoleDevice for SpiConsoleDevice<'a> {
     fn console_read(&self, buf: &mut [u8], _timeout: Duration) -> Result<usize> {
         if self.rx_buf.borrow().is_empty() {
             if let Some(ready_pin) = self.get_tx_ready_pin()? {
-                if !self.device_tx_ready.get() && ready_pin.read()? {
-                    self.device_tx_ready.set(true);
+                if ready_pin.read()? {
                     if self.read_from_spi()? == 0 {
                         // If we are gated by the TX-ready pin, only perform the SPI console read if
                         // the ready pin is high.
                         return Ok(0);
                     }
-                } else if self.device_tx_ready.get() && !ready_pin.read()? {
-                    self.device_tx_ready.set(false);
+                } else {
+                    return Ok(0);
                 }
             } else if self.read_from_spi()? == 0 {
                 return Ok(0);

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
@@ -47,6 +47,8 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     // Load the ELF binary and get the expect data.
     let elf_binary = fs::read(&opts.firmware_elf)?;
     let object = object::File::parse(&*elf_binary)?;
+    let data = test_utils::object::symbol_data(&object, "kTest4KbDataStr")?;
+    let data_str = std::str::from_utf8(&data)?.trim_matches(char::from(0));
 
     // Wait for generic strings to be transmitted.
     for _ in 0..2 {
@@ -54,8 +56,6 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
         _ = UartConsole::wait_for(&spi_console_device, "ABC", opts.timeout)?;
 
         // Receive 4K of data from the device.
-        let data = test_utils::object::symbol_data(&object, "kTest4KbDataStr")?;
-        let data_str = std::str::from_utf8(&data)?.trim_matches(char::from(0));
         _ = UartConsole::wait_for(&spi_console_device, data_str, opts.timeout)?;
     }
 


### PR DESCRIPTION
This optimizes the TX-ready GPIO feature by only writing one frame at a time to the SPI flash buffer and monitoring the chip-select state for when the device is free to overwrite the data in the buffer (i.e., the host has read out the data). This eliminates the need to add delays between TX-ready GPIO toggling.