### PR TITLE
[hmac] Bump HMAC verification stage version into V3

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -40,7 +40,7 @@
       version:            "2.0.1",
       life_stage:         "L1",
       design_stage:       "D3",
-      verification_stage: "V2S",
+      verification_stage: "V3",
       dif_stage:          "S0",
       notes:              "",
     }


### PR DESCRIPTION
As this issue is closed https://github.com/lowRISC/opentitan/issues/22671, the verification stage should be moved to V3.