### PR TITLE
[rom_ctrl,dv] Fix forcing in rom_ctrl_compare_if

### DIFF
--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
@@ -39,7 +39,8 @@ interface rom_ctrl_compare_if ();
     // that the valid states are separated by a hamming distance of at least 3, so we can just
     // invert one of the bits of the signal for a cycle and will know that we're setting an invalid
     // value.
-    force u_compare.state_d[0] = ~u_compare.state_d[0];
+    int good_val = u_compare.state_d;
+    force u_compare.state_d[0] = ~good_val[0];
     @(negedge u_compare.clk_i);
     release u_compare.state_d[0];
   endtask


### PR DESCRIPTION
I hadn't realised that "force" behaves like a continuous assignment, so my previous code was essentially doing:

  assign foo = ~foo;

This gives you an infinite loop in the simulator. D'oh...