### PR TITLE
[rom_ctrl,dv] Correctly force u_compare.state_d

### DIFF
--- a/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
+++ b/hw/ip/rom_ctrl/dv/tb/rom_ctrl_compare_if.sv
@@ -39,8 +39,13 @@ interface rom_ctrl_compare_if ();
     // that the valid states are separated by a hamming distance of at least 3, so we can just
     // invert one of the bits of the signal for a cycle and will know that we're setting an invalid
     // value.
-    int good_val = u_compare.state_d;
-    force u_compare.state_d[0] = ~good_val[0];
+    logic good_val;
+
+    // Note that we have to set this separately from the declaration because it needs to be a static
+    // variable in order to be used for the force statement below.
+    good_val = u_compare.state_d[0];
+
+    force u_compare.state_d[0] = ~good_val;
     @(negedge u_compare.clk_i);
     release u_compare.state_d[0];
   endtask


### PR DESCRIPTION
The previous logic was wrong because good_val has to be a static variable, which means that the initializer that was part of the variable definition only runs once.

(Well, that was silly! And it's kind of embarrassing how many times I had to run the code to figure out what was going on!)