### PR TITLE
[soc_dbg_ctrl] Fix register reset value

### DIFF
--- a/hw/ip/soc_dbg_ctrl/data/soc_dbg_ctrl.hjson
+++ b/hw/ip/soc_dbg_ctrl/data/soc_dbg_ctrl.hjson
@@ -166,7 +166,7 @@
         storage_err_alert: "fatal_fault",
         fields: [
           { bits: "6:0"
-            resval: "0x0"
+            resval: "0x50"
             name: "debug_policy_category"
             desc: '''
                   Debug Policy Control Setting.
@@ -197,7 +197,7 @@
         hwaccess: "hwo"
         fields: [
           { bits: "6:0"
-            resval: "0x0"
+            resval: "0x50"
             name: "category"
             desc: '''
                   The debug policy determined by hardware or software.
@@ -277,7 +277,7 @@
         hwaccess: "hwo"
         fields: [
           { bits: "6:0"
-            resval: "0x0"
+            resval: "0x50"
             name: "category"
             desc: '''
                   The debug policy determined by hardware or software.

--- a/hw/ip/soc_dbg_ctrl/doc/registers.md
+++ b/hw/ip/soc_dbg_ctrl/doc/registers.md
@@ -56,7 +56,7 @@ Once valid is set to Mubi4::True, the debug policy cannot be written anymore.
 ## DEBUG_POLICY_CATEGORY_SHADOWED
 Debug Policy category
 - Offset: `0x8`
-- Reset default: `0x0`
+- Reset default: `0x50`
 - Reset mask: `0x7f`
 
 ### Fields
@@ -68,7 +68,7 @@ Debug Policy category
 |  Bits  |  Type  |  Reset  | Name                  | Description                                                                                                                                                     |
 |:------:|:------:|:-------:|:----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  31:7  |        |         |                       | Reserved                                                                                                                                                        |
-|  6:0   |   rw   |   0x0   | debug_policy_category | Debug Policy Control Setting. Indicates the current debug authorization policy that is distributed to the rest of the SoC to govern debug / DFT feature unlock. |
+|  6:0   |   rw   |  0x50   | debug_policy_category | Debug Policy Control Setting. Indicates the current debug authorization policy that is distributed to the rest of the SoC to govern debug / DFT feature unlock. |
 
 ## DEBUG_POLICY_RELOCKED
 Debug Policy relocked
@@ -90,7 +90,7 @@ Debug Policy relocked
 ## TRACE_DEBUG_POLICY_CATEGORY
 Trace register to observe the debug category that is either determined by hardware or software.
 - Offset: `0x10`
-- Reset default: `0x0`
+- Reset default: `0x50`
 - Reset mask: `0x7f`
 
 ### Fields
@@ -102,7 +102,7 @@ Trace register to observe the debug category that is either determined by hardwa
 |  Bits  |  Type  |  Reset  | Name     | Description                                          |
 |:------:|:------:|:-------:|:---------|:-----------------------------------------------------|
 |  31:7  |        |         |          | Reserved                                             |
-|  6:0   |   ro   |   0x0   | category | The debug policy determined by hardware or software. |
+|  6:0   |   ro   |  0x50   | category | The debug policy determined by hardware or software. |
 
 ## TRACE_DEBUG_POLICY_VALID_RELOCKED
 Trace register to observe the valid or relocked state that is either determined by hardware or software.
@@ -158,7 +158,7 @@ Debug Status Register
 ## JTAG_TRACE_DEBUG_POLICY_CATEGORY
 Trace register to observe the debug category that is either determined by hardware or software.
 - Offset: `0x0`
-- Reset default: `0x0`
+- Reset default: `0x50`
 - Reset mask: `0x7f`
 
 ### Fields
@@ -170,7 +170,7 @@ Trace register to observe the debug category that is either determined by hardwa
 |  Bits  |  Type  |  Reset  | Name     | Description                                          |
 |:------:|:------:|:-------:|:---------|:-----------------------------------------------------|
 |  31:7  |        |         |          | Reserved                                             |
-|  6:0   |   ro   |   0x0   | category | The debug policy determined by hardware or software. |
+|  6:0   |   ro   |  0x50   | category | The debug policy determined by hardware or software. |
 
 ## JTAG_TRACE_DEBUG_POLICY_VALID_RELOCKED
 Trace register to observe the valid or relocked state that is either determined by hardware or software.

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_core_reg_top.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_core_reg_top.sv
@@ -283,7 +283,7 @@ module soc_dbg_ctrl_core_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (7'h0),
+    .RESVAL  (7'h50),
     .Mubi    (1'b0)
   ) u_trace_debug_policy_category (
     .clk_i   (clk_i),

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_jtag_reg_top.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_jtag_reg_top.sv
@@ -150,7 +150,7 @@ module soc_dbg_ctrl_jtag_reg_top (
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (7'h0),
+    .RESVAL  (7'h50),
     .Mubi    (1'b0)
   ) u_jtag_trace_debug_policy_category (
     .clk_i   (clk_i),

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
@@ -116,10 +116,10 @@ package soc_dbg_ctrl_reg_pkg;
   parameter logic [1:0] SOC_DBG_CTRL_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] SOC_DBG_CTRL_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] SOC_DBG_CTRL_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_RESVAL = 1'h 0;
-  parameter logic [6:0] SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED_RESVAL = 7'h 0;
+  parameter logic [6:0] SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED_RESVAL = 7'h 50;
   parameter logic [6:0]
       SOC_DBG_CTRL_DEBUG_POLICY_CATEGORY_SHADOWED_DEBUG_POLICY_CATEGORY_RESVAL =
-      7'h 0;
+      7'h 50;
 
   // Register index for core interface
   typedef enum int {


### PR DESCRIPTION
- Reset of the DEBUG_POLICY_CATEGORY registers was initialized to 0x0 but it should be 0x50 (= `DbgCategoryLocked`).