### PR TITLE
[soc_dbg_ctrl,dv] Fix JTAG CSR assert

### DIFF
--- a/hw/ip/soc_dbg_ctrl/dv/sva/soc_dbg_ctrl_bind.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/sva/soc_dbg_ctrl_bind.sv
@@ -15,8 +15,8 @@ module soc_dbg_ctrl_bind;
   bind soc_dbg_ctrl soc_dbg_ctrl_core_csr_assert_fpv soc_dbg_ctrl_core_csr_assert (
     .clk_i,
     .rst_ni,
-    .h2d    (core_tl_i),
-    .d2h    (core_tl_o)
+    .h2d  (core_tl_i),
+    .d2h  (core_tl_o)
   );
 
   bind soc_dbg_ctrl tlul_assert #(
@@ -31,7 +31,7 @@ module soc_dbg_ctrl_bind;
   bind soc_dbg_ctrl soc_dbg_ctrl_jtag_csr_assert_fpv soc_dbg_ctrl_jtag_csr_assert (
     .clk_i,
     .rst_ni,
-    .h2d    (core_tl_i),
-    .d2h    (core_tl_o)
+    .h2d  (jtag_tl_i),
+    .d2h  (jtag_tl_o)
   );
 endmodule : soc_dbg_ctrl_bind


### PR DESCRIPTION
- Fix typo for soc_dbg_ctrl_jtag_csr_assert_fpv binding module