### PR TITLE
[soc_dbg_ctrl,dv] Exclude regs from CSR tests

### DIFF
--- a/hw/ip/soc_dbg_ctrl/data/soc_dbg_ctrl.hjson
+++ b/hw/ip/soc_dbg_ctrl/data/soc_dbg_ctrl.hjson
@@ -143,6 +143,11 @@
         shadowed: "true"
         update_err_alert: "recov_ctrl_update_err",
         storage_err_alert: "fatal_fault",
+        tags: [
+          // Writting to this register will gate by the debug_policy_category_shadowed register.
+          // So excluded from CSR automation test.
+          "excl:CsrNonInitTests:CsrExclWrite"
+        ]
         fields: [
           { bits: "3:0"
             mubi: true
@@ -329,6 +334,11 @@
         swaccess: "ro"
         hwaccess: "hwo"
         hwext:    "true"
+        tags: [
+          // The status register is written by IBEX firmware and is reflected into the JTAG status register.
+          // So excluded from CSR automation test.
+          "excl:CsrNonInitTests:CsrExclWriteCheck"
+        ]
         fields: [
           { bits: "0"
             name: "auth_debug_intent_set"


### PR DESCRIPTION
- Add excl:CsrNonInitTests tag property to some of the registers for which the internal HW logic is special and cannot be automatically checked with our test suite.