### PR TITLE
[base] Make Ibex driver return values directly, and wait for valid.

### DIFF
--- a/sw/device/lib/base/ibex.c
+++ b/sw/device/lib/base/ibex.c
@@ -21,24 +21,22 @@ static inline uint32_t rv_core_ibex_base(void) {
   return dt_rv_core_ibex_primary_reg_block(kRvCoreIbexDt);
 }
 
-status_t ibex_wait_rnd_valid(void) {
+void ibex_wait_rnd_valid(void) {
   while (true) {
-    uint32_t reg = abs_mmio_read32(rv_core_ibex_base() +
-                                   RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
+    uint32_t reg = ibex_rnd_status_read();
     if (bitfield_bit32_read(reg, RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT)) {
-      return OK_STATUS();
+      return;
     }
   }
 }
 
-status_t ibex_rnd_status_read(uint32_t *rnd_status) {
-  *rnd_status =
-      abs_mmio_read32(rv_core_ibex_base() + RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
-  return OK_STATUS();
+uint32_t ibex_rnd_status_read(void) {
+  return abs_mmio_read32(rv_core_ibex_base() +
+                         RV_CORE_IBEX_RND_STATUS_REG_OFFSET);
 }
 
-status_t ibex_rnd_data_read(uint32_t *rnd_data) {
-  *rnd_data =
-      abs_mmio_read32(rv_core_ibex_base() + RV_CORE_IBEX_RND_DATA_REG_OFFSET);
-  return OK_STATUS();
+uint32_t ibex_rnd_data_read(void) {
+  ibex_wait_rnd_valid();
+  return abs_mmio_read32(rv_core_ibex_base() +
+                         RV_CORE_IBEX_RND_DATA_REG_OFFSET);
 }

--- a/sw/device/lib/base/ibex.h
+++ b/sw/device/lib/base/ibex.h
@@ -13,30 +13,28 @@
 /**
  * Wait for random data in the RND_DATA CSR to be valid.
  *
- * Returns OTCRYPTO_OK when the random data is valid.
+ * Important: this function will hang if the entropy complex is not
+ * initialized. Callers are responsible for checking first.
  *
- * @return OTCRYPTO_OK.
+ * Returns once the random data is valid.
  */
-status_t ibex_wait_rnd_valid(void);
+void ibex_wait_rnd_valid(void);
 
 /**
  * Get random data from the EDN0 interface.
  *
- * Returns 32 bits of randomness from EDN0.
+ * Important: this function will hang if the entropy complex is not
+ * initialized. Callers are responsible for checking first.
  *
- * @param rnd_data The random data pointer.
- * @return OTCRYPTO_OK.
+ * @return 32 bits of randomness from EDN0.
  */
-status_t ibex_rnd_data_read(uint32_t *rnd_data);
+uint32_t ibex_rnd_data_read(void);
 
 /**
  * Get information on the state of the RND_DATA CSR.
  *
- * Returns the status of the randomness interface.
- *
- * @param rnd_status The status pointer.
- * @return OTCRYPTO_OK.
+ * @return the status of the randomness interface.
  */
-status_t ibex_rnd_status_read(uint32_t *rnd_status);
+uint32_t ibex_rnd_status_read(void);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_IBEX_H_

--- a/sw/device/lib/base/ibex_test.c
+++ b/sw/device/lib/base/ibex_test.c
@@ -16,19 +16,16 @@
 OTTF_DEFINE_TEST_CONFIG();
 
 static status_t ibex_entropy_test(void) {
-  uint32_t rnd_status;
-  uint32_t rnd_data[2];
-
   // Read the initial value of the RND_DATA CSR.
-  TRY(ibex_rnd_data_read(rnd_data));
+  uint32_t rnd_data0 = ibex_rnd_data_read();
   // Wait for RND_DATA to be valid again and check if RND_STATUS is as expected.
-  TRY(ibex_wait_rnd_valid());
-  TRY(ibex_rnd_status_read(&rnd_status));
+  ibex_wait_rnd_valid();
+  uint32_t rnd_status = ibex_rnd_status_read();
   TRY_CHECK(bitfield_bit32_read(rnd_status,
                                 RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_BIT));
   // Read RND_DATA again and check if it changed.
-  TRY(ibex_rnd_data_read(&rnd_data[1]));
-  TRY_CHECK(rnd_data[0] != rnd_data[1]);
+  uint32_t rnd_data1 = ibex_rnd_data_read();
+  TRY_CHECK(rnd_data0 != rnd_data1);
 
   return OK_STATUS();
 }


### PR DESCRIPTION
Fixing a few things I noticed about the new Ibex driver when I attempted to use it.

1. **Always wait for entropy to become valid before reading the register.** Skipping this could lead to repeated "random" values!
2. Add warnings to function documentation about initializing the entropy complex before calling functions that could hang.
3. The Ibex driver has no need to return status values, since it can't return errors. We can save some code-size-heavy `TRY` macros and some complexity by skipping the indirection.

On further inspection, it looks like this code was likely copied from `sw/device/lib/dif/div_rv_code_ibex.{c,h}` and then only lightly modified. As a more general caution, DIFs serve a very different purpose than security-critical base or cryptography libraries; they expose all the functionality of the hardware and are always called from a controlled context. Security-critical code needs the exact opposite: reduced attack surface and few, carefully tracked assumptions about the context.