### PR TITLE
[individualize,orchestrator] add AST config version to flash info field

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -157,9 +157,9 @@ static status_t provision(ujson_t *uj) {
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
   TRY(ujson_deserialize_manuf_ft_individualize_data_t(uj, &in_data));
   TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
-  TRY(manuf_individualize_device_hw_cfg(
-      &flash_ctrl_state, &otp_ctrl, kFlashInfoPage0Permissions,
-      (const uint32_t *)in_data.ft_device_id));
+  TRY(manuf_individualize_device_hw_cfg(&flash_ctrl_state, &otp_ctrl,
+                                        kFlashInfoPage0Permissions,
+                                        in_data.ft_device_id));
 #else
   TRY(manuf_individualize_device_hw_cfg(
       &flash_ctrl_state, &otp_ctrl, kFlashInfoPage0Permissions, kFtDeviceId));

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -59,6 +59,13 @@ const flash_info_field_t kFlashInfoFieldAstCalibrationData = {
     .byte_offset = kFlashInfoFieldAstCalibrationDataStartOffset,
 };
 
+const flash_info_field_t kFlashInfoFieldAstCfgVersion = {
+    .partition = 0,
+    .bank = 0,
+    .page = 0,
+    .byte_offset = kFlashInfoFieldAstCfgVersionStartOffset,
+};
+
 const flash_info_field_t kFlashInfoFieldCpDeviceId = {
     .partition = 0,
     .bank = 0,

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -62,6 +62,14 @@ enum {
       kFlashInfoAstCalibrationDataSizeInBytes / sizeof(uint32_t),
 
   /**
+   * AST Calibration Version Start / Size - Bank 0, Page 0
+   *
+   * The version of the AST calibration words that are stored in flash / OTP.
+   */
+  kFlashInfoFieldAstCfgVersionStartOffset = 304,
+  kFlashInfoFieldAstCfgVersionSizeIn32BitWords = 1,
+
+  /**
    * CP Device ID Start / Size - Bank 0, Page 0
    */
   kFlashInfoFieldCpDeviceIdStartOffset = 384,
@@ -101,6 +109,7 @@ extern const flash_info_field_t kFlashInfoFieldWaferXCoord;
 extern const flash_info_field_t kFlashInfoFieldWaferYCoord;
 extern const flash_info_field_t kFlashInfoFieldProcessData;
 extern const flash_info_field_t kFlashInfoFieldAstCalibrationData;
+extern const flash_info_field_t kFlashInfoFieldAstCfgVersion;
 extern const flash_info_field_t kFlashInfoFieldCpDeviceId;
 extern const flash_info_field_t kFlashInfoFieldAstIndividPatchAddr;
 extern const flash_info_field_t kFlashInfoFieldAstIndividPatchVal;

--- a/sw/device/silicon_creator/manuf/lib/individualize.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize.h
@@ -22,9 +22,7 @@
  *
  * Preconditions:
  * - ManufState is pre-populated in the appropriate flash info page.
- * - If DeviceId is already written to flash, the device ID provided must match.
- *   If the DeviceId slot in flash is all 0s, then the provided DeviceId will be
- *   what is written to OTP.
+ * - CP portion of the Device ID must be written to flash.
  *
  * Note: The test will skip all programming steps and succeed if the HW_CFG0/1
  * paritions are already locked. This is to facilitate test re-runs.
@@ -38,14 +36,14 @@
  * @param flash_info_page_0_permissions Access permissions to set on flash info
  *                                      page 0 (which temporarily holds
  *                                      device_id and manuf_state).
- * @param device_id DeviceId to check exists in flash, or inject in into OTP if
- *                  running in a test environment.
+ * @param ft_device_id FT portion of the Device ID to combine with the CP
+ *                     portion before writing it into OTP.
  * @return OK_STATUS on success.
  */
 status_t manuf_individualize_device_hw_cfg(
     dif_flash_ctrl_state_t *flash_state, const dif_otp_ctrl_t *otp_ctrl,
     dif_flash_ctrl_region_properties_t flash_info_page_0_permissions,
-    const uint32_t *device_id);
+    const uint32_t *ft_device_id);
 
 /**
  * Checks the HW_CFG0/1 OTP partition end state.

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
@@ -6,7 +6,6 @@
   name: "emulation",
   product: "earlgrey_a2",
   si_creator: "nuvoton",
-  ast_cfg_version: 0,
   package: "npcr10",
   target_lc_state: "prod",
   otp: "em00",

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation_dice_cwt.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation_dice_cwt.hjson
@@ -6,7 +6,6 @@
   name: "emulation_dice_cwt",
   product: "earlgrey_a2",
   si_creator: "nuvoton",
-  ast_cfg_version: 0,
   package: "npcr10",
   target_lc_state: "prod",
   otp: "em00",

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation_tpm.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation_tpm.hjson
@@ -6,7 +6,6 @@
   name: "emulation_tpm",
   product: "earlgrey_a2",
   si_creator: "nuvoton",
-  ast_cfg_version: 0,
   package: "npcr10",
   target_lc_state: "prod",
   otp: "em00",

--- a/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
@@ -6,7 +6,6 @@
   name: "sival",
   product: "earlgrey_a2",
   si_creator: "nuvoton",
-  ast_cfg_version: 0,
   package: "npcr10",
   target_lc_state: "prod",
   otp: "sv00",

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -177,6 +177,33 @@ class DeviceId():
         # Build full device ID.
         self.device_id = (self.sku_specific << 128) | self.base_uid
 
+    def update_ast_cfg_version(self, other: int) -> None:
+        """Updates the AST Config Version component of the device ID.
+
+        Args:
+            other: The other AST configuration version to update with.
+        """
+        if other < 0 or other > 255:
+            raise ValueError("AST config version should be in range [0, 256).")
+        self.ast_cfg_version = other
+
+        # Rebuild SKU-specific portion of the device ID.
+        self.sku_specific = util.bytes_to_int(
+            struct.pack(
+                "<BBHBBHIHBB",
+                self.package_id,
+                self.ast_cfg_version,
+                self.otp_id,
+                self.otp_version,
+                _RESERVED_VALUE,
+                _RESERVED_VALUE,
+                self.sku_id,
+                _RESERVED_VALUE,
+                _RESERVED_VALUE,
+                self.sku_specific_version,
+            ))
+        self.device_id = (self.sku_specific << 128) | self.base_uid
+
     def update_din(self, other: "DeviceIdentificationNumber") -> None:
         """Updates the DIN component of the device ID with another DIN object.
 

--- a/sw/host/provisioning/orchestrator/src/devid_header_gen.py
+++ b/sw/host/provisioning/orchestrator/src/devid_header_gen.py
@@ -28,7 +28,7 @@ def main(args_in):
         "--mode",
         type=str,
         choices=["cp", "ft"],
-        help="AST configuration version to be written to OTP.",
+        help="The device ID header to generate: CP or FT.",
     )
     parser.add_argument(
         "--sku-config",
@@ -47,12 +47,6 @@ def main(args_in):
         required=True,
         type=str,
         help="The template source file to be overwritten.",
-    )
-    parser.add_argument(
-        "--ast-cfg-version",
-        type=int,
-        help=
-        "AST configuration version to be written to OTP (overrides HJSON).",
     )
     args = parser.parse_args(args_in)
 

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -84,12 +84,6 @@ def main(args_in):
         help="SKU HJSON configuration file.",
     )
     parser.add_argument(
-        "--ast-cfg-version",
-        type=int,
-        help=
-        "AST configuration version to be written to OTP (overrides HJSON).",
-    )
-    parser.add_argument(
         "--package",
         type=str,
         help="Override of package string that is in the SKU config.",
@@ -154,11 +148,8 @@ def main(args_in):
 
     if not args.cp_only and args.db_path is None:
         parser.error("--db-path is required when --cp-only is not provided")
-    if args.use_ate_individ_bin and (args.ast_cfg_version is not None or
-                                     args.package is not None):
-        parser.error(
-            "--use-ate-individ-bin may not be used with --ast-cfg-version or --package"
-        )
+    if args.use_ate_individ_bin and args.package is not None:
+        parser.error("--use-ate-individ-bin may not be used with --package")
 
     # Load and validate a SKU configuration file.
     sku_config_path = resolve_runfile(args.sku_config)
@@ -166,11 +157,6 @@ def main(args_in):
     with open(sku_config_path, "r") as fp:
         sku_config_args = hjson.load(fp)
     sku_config = SkuConfig(**sku_config_args)
-
-    # Override AST configuration version if requested.
-    if args.ast_cfg_version:
-        sku_config.ast_cfg_version = args.ast_cfg_version
-        sku_config.validate()
 
     # Override package ID if requested.
     if args.package:

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -303,11 +303,18 @@ class OtDut():
 
             # Check device ID from OTP matches one constructed on host.
             #
-            # The CP portion may not match, but the FT portion should. The CP
-            # portion of the device ID is set in flash before the
-            # orchestrator.py is ever run, so the device's CP portion of the
-            # device ID should be take as the ground truth.
+            # The CP portion may not match, but the FT portion should, with the
+            # exception of the AST configuration version field as this is also
+            # set during CP. The CP portion of the device ID, and the AST
+            # configuration field of the FT device ID, are set in flash before
+            # the orchestrator.py is ever run, so the device's CP portion of the
+            # device ID should be taken as the ground truth.
             device_id_in_otp = DeviceId.from_hexstr(self.ft_data["device_id"])
+            # Replace the AST configuration version field of the host device ID
+            # to its counterpart from of the device as this field originates
+            # from flash info page 0, not from any host configuration.
+            self.device_id.update_ast_cfg_version(
+                device_id_in_otp.ast_cfg_version)
             if device_id_in_otp.sku_specific != self.device_id.sku_specific:
                 logging.error(
                     "FT Device ID from OTP does not match expected on host.")

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -25,10 +25,10 @@ class SkuConfig:
     package: str  # valid: any package that exists in package database
     target_lc_state: str  # valid: must be in ["dev", "prod", "prod_end"]
     otp: str  # valid: any 4 char string whose first char is alphabetic and last two are numeric
-    ast_cfg_version: int  # valid: any positive integer < 256 (to fit in one byte)
     perso_bin: str  # valid: any string
     token_encrypt_key: str  # valid: any file path that exists
     dice_ca: Optional[OrderedDict]  # valid: see CaConfig
+    ast_cfg_version: int = 255  # valid: any positive integer < 256 (to fit in one byte)
     ext_ca: Optional[OrderedDict] = None  # valid: see CaConfig
     owner_fw_boot_str: str = None  # valid: any string
 

--- a/sw/host/provisioning/orchestrator/tests/e2e.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e.sh
@@ -27,7 +27,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=${FPGA} \
-  --ast-cfg-version=0 \
   --non-interactive \
   "$@" \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/e2e_multistage.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_multistage.sh
@@ -31,7 +31,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=hyper310 \
-  --ast-cfg-version=0 \
   --non-interactive \
   --cp-only \
   --db-path=$TEST_TMPDIR/registry.sqlite
@@ -44,7 +43,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-unlock-token="0x11111111_11111111_11111111_11111111" \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --fpga=hyper310 \
-  --ast-cfg-version=0 \
   --fpga-dont-clear-bitstream \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e_option_flags.sh
@@ -29,7 +29,6 @@ $PYTHON ${ORCHESTRATOR_PATH} \
   --test-exit-token="0x22222222_22222222_22222222_22222222" \
   --package=${PACKAGE} \
   --fpga=hyper310 \
-  --ast-cfg-version=10 \
   --log-ujson-payloads \
   --non-interactive \
   --db-path=$TEST_TMPDIR/registry.sqlite


### PR DESCRIPTION
Previously, the AST config version field was provided by the host during the FT individualization step. However, since the AST values are programmed to flash info page 0 during the CP stage, the AST configuration version is also known then. Therefore we add a field to flash info page 0 to store this field and overwrite this portion of the FT device ID during individualization before the device ID is written to OTP.

Additionally, since this field will be programmed during the CP calibration step, not provided during FT, there is no longer a need for this CLI switch within the orchestrator. Hence it is removed.