### PR TITLE
[hsmtool] Add support for prehashing in CloudKMS

### DIFF
--- a/sw/host/hsmtool/acorn/acorn.rs
+++ b/sw/host/hsmtool/acorn/acorn.rs
@@ -297,6 +297,7 @@ impl SpxInterface for Acorn {
                 Ok(KeyInfo {
                     hash: rust_string(rsp.hash),
                     algorithm: rust_string(rsp.algorithm),
+                    domain: None,
                     public_key: pkey.to_vec(),
                     private_blob: blob.to_vec(),
                 })
@@ -315,6 +316,7 @@ impl SpxInterface for Acorn {
         &self,
         alias: &str,
         algorithm: &str,
+        _domain: SpxDomain,
         token: &str,
         flags: GenerateFlags,
     ) -> Result<KeyEntry> {
@@ -352,6 +354,7 @@ impl SpxInterface for Acorn {
                     alias: rust_string(rsp.alias),
                     hash: Some(rust_string(rsp.hash)),
                     algorithm: algorithm.to_string(),
+                    domain: None,
                     private_blob,
                     private_key,
                 })
@@ -370,6 +373,7 @@ impl SpxInterface for Acorn {
         &self,
         alias: &str,
         algorithm: &str,
+        _domain: SpxDomain,
         token: &str,
         overwrite: bool,
         public_key: &[u8],
@@ -415,6 +419,7 @@ impl SpxInterface for Acorn {
                     alias: rust_string(rsp.alias),
                     hash: Some(rust_string(rsp.hash)),
                     algorithm: algorithm.to_string(),
+                    domain: None,
                     ..Default::default()
                 })
             } else {

--- a/sw/host/hsmtool/acorn/spx.rs
+++ b/sw/host/hsmtool/acorn/spx.rs
@@ -14,6 +14,8 @@ pub struct KeyEntry {
     pub hash: Option<String>,
     /// Algorithm to be used with the key.
     pub algorithm: String,
+    /// Domain to be used with the key (only when keys are restricted to a specific domain).
+    pub domain: Option<SpxDomain>,
     /// Opaque representation of the private key material.
     pub private_blob: Vec<u8>,
     /// Exported private key material (only when GenerateFlags::EXPORT_PRIVATE is set).
@@ -26,6 +28,8 @@ pub struct KeyInfo {
     pub hash: String,
     /// Algorithm to be used with the key.
     pub algorithm: String,
+    /// Domain to be used with the key (only when keys are restricted to a specific domain).
+    pub domain: Option<SpxDomain>,
     /// Public key material.
     pub public_key: Vec<u8>,
     /// Opaque representation of the private key material.
@@ -56,15 +60,18 @@ pub trait SpxInterface {
         &self,
         alias: &str,
         algorithm: &str,
+        domain: SpxDomain,
         token: &str,
         flags: GenerateFlags,
     ) -> Result<KeyEntry>;
 
     /// Import a key pair.
+    #[allow(clippy::too_many_arguments)]
     fn import_keypair(
         &self,
         alias: &str,
         algorithm: &str,
+        domain: SpxDomain,
         token: &str,
         overwrite: bool,
         public_key: &[u8],

--- a/sw/host/hsmtool/src/commands/spx/generate.rs
+++ b/sw/host/hsmtool/src/commands/spx/generate.rs
@@ -13,7 +13,7 @@ use crate::error::HsmError;
 use crate::module::Module;
 use crate::util::attribute::AttrData;
 use acorn::GenerateFlags;
-use sphincsplus::{EncodeKey, SphincsPlus, SpxSecretKey};
+use sphincsplus::{EncodeKey, SphincsPlus, SpxDomain, SpxSecretKey};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Generate {
@@ -21,6 +21,13 @@ pub struct Generate {
     label: String,
     #[arg(short, long, default_value = "SHA2-128s-simple")]
     algorithm: SphincsPlus,
+    #[arg(
+        short,
+        long,
+        default_value = "None",
+        help = "SLH-DSA domain (if the backend requires the domain to be associated with the key)"
+    )]
+    domain: SpxDomain,
     #[arg(short, long, help = "Overwrite an existing key with the same label")]
     overwrite: bool,
     #[arg(short, long, help = "Export the private key material to a file")]
@@ -43,7 +50,13 @@ impl Dispatch for Generate {
             if self.overwrite { GenerateFlags::OVERWRITE } else { GenerateFlags::NONE }
             | if self.export.is_some() { GenerateFlags::EXPORT_PRIVATE } else { GenerateFlags::NONE };
 
-        let key = spx.generate_key(&self.label, &self.algorithm.to_string(), token, flags)?;
+        let key = spx.generate_key(
+            &self.label,
+            &self.algorithm.to_string(),
+            self.domain,
+            token,
+            flags,
+        )?;
 
         if let Some(path) = &self.export {
             let sk = SpxSecretKey::from_bytes(self.algorithm, &key.private_key)?;

--- a/sw/host/hsmtool/src/commands/spx/import.rs
+++ b/sw/host/hsmtool/src/commands/spx/import.rs
@@ -12,12 +12,19 @@ use crate::commands::{BasicResult, Dispatch};
 use crate::error::HsmError;
 use crate::module::Module;
 use crate::util::attribute::AttrData;
-use sphincsplus::{DecodeKey, SpxPublicKey, SpxSecretKey};
+use sphincsplus::{DecodeKey, SpxDomain, SpxPublicKey, SpxSecretKey};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct Import {
     #[arg(short, long)]
     label: String,
+    #[arg(
+        short,
+        long,
+        default_value = "None",
+        help = "SLH-DSA domain (if the backend requires the domain to be associated with the key)"
+    )]
+    domain: SpxDomain,
     #[arg(short, long, help = "Overwrite an existing key with the same label")]
     overwrite: bool,
     filename: PathBuf,
@@ -40,6 +47,7 @@ impl Dispatch for Import {
         let key = spx.import_keypair(
             &self.label,
             &sk.algorithm().to_string(),
+            self.domain,
             token,
             self.overwrite,
             pk.as_bytes(),

--- a/sw/host/hsmtool/src/commands/spx/list.rs
+++ b/sw/host/hsmtool/src/commands/spx/list.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use cryptoki::session::Session;
 use serde::{Deserialize, Serialize};
+use sphincsplus::SpxDomain;
 use std::any::Any;
 
 use crate::commands::Dispatch;
@@ -19,6 +20,7 @@ pub struct Key {
     pub id: String,
     pub label: String,
     pub algorithm: String,
+    pub domain: Option<SpxDomain>,
 }
 
 #[derive(Default, Debug, Serialize)]
@@ -49,6 +51,7 @@ impl Dispatch for List {
                 id: info.hash,
                 label: key.alias,
                 algorithm: info.algorithm,
+                domain: info.domain,
             });
         }
         Ok(result)

--- a/sw/host/hsmtool/src/extra/spxef.rs
+++ b/sw/host/hsmtool/src/extra/spxef.rs
@@ -93,6 +93,7 @@ impl SpxInterface for SpxEf {
         Ok(KeyInfo {
             hash: "".into(),
             algorithm: pk.algorithm().to_string(),
+            domain: None,
             public_key: pk.as_bytes().to_vec(),
             private_blob: Vec::new(),
         })
@@ -103,6 +104,7 @@ impl SpxInterface for SpxEf {
         &self,
         alias: &str,
         algorithm: &str,
+        _domain: SpxDomain,
         _token: &str,
         flags: GenerateFlags,
     ) -> Result<KeyEntry> {
@@ -137,6 +139,7 @@ impl SpxInterface for SpxEf {
             alias: alias.into(),
             hash: Some("".into()),
             algorithm: sk.algorithm().to_string(),
+            domain: None,
             private_blob: Vec::new(),
             private_key,
         })
@@ -147,6 +150,7 @@ impl SpxInterface for SpxEf {
         &self,
         alias: &str,
         algorithm: &str,
+        _domain: SpxDomain,
         _token: &str,
         overwrite: bool,
         public_key: &[u8],
@@ -181,6 +185,7 @@ impl SpxInterface for SpxEf {
             alias: alias.into(),
             hash: None,
             algorithm: sk.algorithm().to_string(),
+            domain: None,
             private_blob: Vec::new(),
             private_key: Vec::new(),
         })

--- a/sw/host/hsmtool/src/extra/spxkms.rs
+++ b/sw/host/hsmtool/src/extra/spxkms.rs
@@ -279,6 +279,7 @@ impl SpxInterface for SpxKms {
         Ok(KeyInfo {
             hash: "".into(),
             algorithm,
+            domain: Some(SpxDomain::Pure),
             public_key: Base64::decode_vec(data)?,
             private_blob: Vec::new(),
         })
@@ -289,6 +290,7 @@ impl SpxInterface for SpxKms {
         &self,
         alias: &str,
         _algorithm: &str,
+        _domain: SpxDomain,
         _token: &str,
         flags: GenerateFlags,
     ) -> Result<KeyEntry> {
@@ -322,6 +324,7 @@ impl SpxInterface for SpxKms {
         &self,
         _alias: &str,
         _algorithm: &str,
+        _domain: SpxDomain,
         _token: &str,
         _overwrite: bool,
         _public_key: &[u8],

--- a/sw/host/hsmtool/src/extra/spxkms.rs
+++ b/sw/host/hsmtool/src/extra/spxkms.rs
@@ -122,7 +122,7 @@ struct KmsDigest {
     sha256: String,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Default)]
 struct KmsSignRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     digest: Option<KmsDigest>,
@@ -131,7 +131,8 @@ struct KmsSignRequest {
 }
 
 impl SpxKms {
-    const ALGORITHM: &'static str = "PQ_SIGN_SLH_DSA_SHA2_128S";
+    const PURE_ALGORITHM: &'static str = "PQ_SIGN_SLH_DSA_SHA2_128S";
+    const PREHASH_ALGORITHM: &'static str = "PQ_SIGN_HASH_SLH_DSA_SHA2_128S_SHA256";
 
     pub fn new(parameters: &str) -> Result<Box<Self>> {
         let output = Command::new("gcloud")
@@ -168,6 +169,21 @@ impl SpxKms {
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr);
             Err(anyhow!("gcloud error {:?}: {}", output.status, stderr))
+        }
+    }
+
+    fn kms_to_algorithm(kms_algo: &str) -> Result<String> {
+        match kms_algo {
+            Self::PURE_ALGORITHM | Self::PREHASH_ALGORITHM => Ok("SLH-DSA-SHA2-128S".into()),
+            _ => Err(HsmError::Unsupported(format!("algorithm {kms_algo}")).into()),
+        }
+    }
+
+    fn kms_to_domain(kms_algo: &str) -> Result<SpxDomain> {
+        match kms_algo {
+            Self::PURE_ALGORITHM => Ok(SpxDomain::Pure),
+            Self::PREHASH_ALGORITHM => Ok(SpxDomain::PreHashedSha256),
+            _ => Err(HsmError::Unsupported(format!("algorithm {kms_algo}")).into()),
         }
     }
 
@@ -214,7 +230,7 @@ impl SpxKms {
         match versions
             .crypto_key_versions
             .iter()
-            .filter(|v| v.state == "ENABLED" && v.algorithm == Self::ALGORITHM)
+            .filter(|v| v.state == "ENABLED" && Self::kms_to_algorithm(&v.algorithm).is_ok())
             .last()
         {
             Some(key) => Ok(key.clone()),
@@ -248,14 +264,15 @@ impl SpxInterface for SpxKms {
                 .rsplit_once('/')
                 .ok_or_else(|| HsmError::ParseError("could not parse key name".into()))
                 .with_context(|| format!("key name {:?}", k.name))?;
-            if k.version_template.algorithm != Self::ALGORITHM {
+            if Self::kms_to_algorithm(&k.version_template.algorithm).is_err() {
                 continue;
             }
             let key = self.get_key_version(name)?;
             result.push(KeyEntry {
                 alias: name.into(),
                 hash: None,
-                algorithm: key.algorithm.clone(),
+                algorithm: Self::kms_to_algorithm(&key.algorithm)?,
+                domain: Some(Self::kms_to_domain(&key.algorithm)?),
                 ..Default::default()
             });
         }
@@ -265,10 +282,6 @@ impl SpxInterface for SpxKms {
     /// Get the public key info.
     fn get_key_info(&self, alias: &str) -> Result<KeyInfo> {
         let key = self.get_public_key(alias)?;
-        let algorithm = key
-            .algorithm
-            .trim_start_matches("PQ_SIGN_")
-            .replace('_', "-");
         let data = if let Some(pem) = &key.pem {
             pem.as_str()
         } else if let Some(public_key) = &key.public_key {
@@ -278,8 +291,8 @@ impl SpxInterface for SpxKms {
         };
         Ok(KeyInfo {
             hash: "".into(),
-            algorithm,
-            domain: Some(SpxDomain::Pure),
+            algorithm: Self::kms_to_algorithm(&key.algorithm)?,
+            domain: Some(Self::kms_to_domain(&key.algorithm)?),
             public_key: Base64::decode_vec(data)?,
             private_blob: Vec::new(),
         })
@@ -290,31 +303,33 @@ impl SpxInterface for SpxKms {
         &self,
         alias: &str,
         _algorithm: &str,
-        _domain: SpxDomain,
+        domain: SpxDomain,
         _token: &str,
         flags: GenerateFlags,
     ) -> Result<KeyEntry> {
         if flags.contains(GenerateFlags::EXPORT_PRIVATE) {
             return Err(HsmError::Unsupported("export of private key material".into()).into());
         }
+        let algorithm = match domain {
+            SpxDomain::Pure => Self::PURE_ALGORITHM,
+            SpxDomain::PreHashedSha256 => Self::PREHASH_ALGORITHM,
+            _ => return Err(HsmError::Unsupported(format!("domain {domain}")).into()),
+        };
         let url = self
             .keyring
             .join(&format!("cryptoKeys?crypto_key_id={alias}"))?;
         let template = KmsCreateKey {
             purpose: "ASYMMETRIC_SIGN".into(),
             version_template: VersionTemplate {
-                algorithm: Self::ALGORITHM.into(),
+                algorithm: algorithm.into(),
                 protection_level: "SOFTWARE".into(),
             },
         };
         let resp = self.post::<KmsKeyRef>(url, &template)?;
         Ok(KeyEntry {
             alias: alias.into(),
-            algorithm: resp
-                .version_template
-                .algorithm
-                .trim_start_matches("PQ_SIGN_")
-                .replace('_', "-"),
+            algorithm: Self::kms_to_algorithm(&resp.version_template.algorithm)?,
+            domain: Some(Self::kms_to_domain(&resp.version_template.algorithm)?),
             ..Default::default()
         })
     }
@@ -345,28 +360,40 @@ impl SpxInterface for SpxKms {
         domain: SpxDomain,
         message: &[u8],
     ) -> Result<Vec<u8>> {
-        match domain {
-            SpxDomain::Pure => {}
-            _ => {
-                return Err(HsmError::Unsupported(format!(
-                    "domain {domain} not supported by {}",
-                    self.get_version()?
-                ))
-                .into())
-            }
-        };
         let alias = alias.ok_or(HsmError::NoSearchCriteria)?;
         if key_hash.is_some() {
             log::warn!("ignored key_hash {key_hash:?}");
         }
         let key = self.get_key_version(alias)?;
+        let keydomain = Self::kms_to_domain(&key.algorithm)?;
+        if domain != keydomain {
+            return Err(HsmError::Unsupported(format!(
+                "domain {domain} not supported by key {alias}",
+            ))
+            .into());
+        }
+
         let url = self
             .keyring
             .join(&format!("/v1/{}:asymmetricSign", key.name))?;
-        let req = KmsSignRequest {
-            digest: None,
-            data: Some(Base64::encode_string(message)),
+
+        // Format the signing request:
+        // - For the "pure" domain, we place the message in the `data` field.
+        // - For the "prehashed" domain, we place the digest into the `digest` field.
+        let req = match keydomain {
+            SpxDomain::Pure => KmsSignRequest {
+                data: Some(Base64::encode_string(message)),
+                ..Default::default()
+            },
+            SpxDomain::PreHashedSha256 => KmsSignRequest {
+                digest: Some(KmsDigest {
+                    sha256: Base64::encode_string(message),
+                }),
+                ..Default::default()
+            },
+            _ => unreachable!(),
         };
+
         let resp = self.post::<IndexMap<String, String>>(url, &req)?;
         let signature = Base64::decode_vec(&resp["signature"])?;
         Ok(signature)
@@ -386,6 +413,13 @@ impl SpxInterface for SpxKms {
             log::warn!("ignored key_hash {key_hash:?}");
         }
         let info = self.get_key_info(alias)?;
+        let keydomain = info.domain.expect("kms key domain");
+        if domain != keydomain {
+            return Err(HsmError::Unsupported(format!(
+                "domain {domain} not supported by key {alias}",
+            ))
+            .into());
+        }
         let pk =
             SpxPublicKey::from_bytes(SphincsPlus::from_str(&info.algorithm)?, &info.public_key)?;
         match pk.verify(domain, signature, message) {

--- a/sw/host/hsmtool/src/extra/spxkms.rs
+++ b/sw/host/hsmtool/src/extra/spxkms.rs
@@ -224,7 +224,8 @@ impl SpxKms {
 
     fn get_public_key(&self, alias: &str) -> Result<KmsPublicKey> {
         let key = self.get_key_version(alias)?;
-        let url = self.keyring.join(&format!("/v1/{}/publicKey", key.name))?;
+        let mut url = self.keyring.join(&format!("/v1/{}/publicKey", key.name))?;
+        url.set_query(Some("public_key_format=NIST_PQC"));
         self.get(url)
     }
 }


### PR DESCRIPTION
CloudKMS is addedsupport for SLH-DSA signatures using the prehashed domain.  Add support for keygen, sign and verify with prehashing.

1. Check the domain during keygen.  CloudKMS encodes both the algorithm and domain into their notion of algorithm, so you must provide the domain at keygen time.
2. Check that the `domain` given for sign and verify matches the domain for which the key was generated.