### PR TITLE
[dv,ate] add ATE test to perform bootstrap erase

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  # This auxiliary chip sim cfg specification focuses on chip level manufacturing tests.
+  # Please see chip_sim_cfg.hjson for full setup details.
+
+  # Note: Please maintain alphabetical order.
+  tests: [
+    {
+      name: rom_e2e_bootstrap_ate_smoke
+      uvm_test_seq: chip_sw_rom_e2e_ate_smoke_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e/ate/binaries:ate_gpio_toggle_test:1:silicon_creator:signed",
+        "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_personalized:4"
+      ]
+      en_run_modes: ["sw_test_mode_mask_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=1000000000",
+        "+use_otp_image=OtpTypeCustom",
+        "+skip_flash_bkdr_load=1",
+      ]
+      run_timeout_mins: 800
+    }
+    {
+      name: rom_e2e_ft_personalize_sival
+      uvm_test_seq: chip_sw_rom_e2e_ft_perso_vseq
+      sw_images: [
+        "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival:1:silicon_creator:signed",
+        "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_individualized:4"
+      ]
+      en_run_modes: ["sw_test_mode_mask_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=1000000000",
+        "+use_otp_image=OtpTypeCustom",
+        "+skip_flash_bkdr_load=1",
+      ]
+      run_timeout_mins: 800
+    }
+  ]
+
+  regressions: [
+    {
+      name: ate_tests
+      tests: [
+        "rom_e2e_bootstrap_ate_smoke",
+        "rom_e2e_ft_personalize_sival",
+      ]
+    }
+  ]
+}
+

--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -8,6 +8,19 @@
   # Note: Please maintain alphabetical order.
   tests: [
     {
+      name: ate_bootstrap_flash_erase
+      uvm_test_seq: chip_sw_ate_bootstrap_flash_erase_vseq
+      # We do not need to load any flash images as this test is entirely host driven.
+      sw_images: []
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=160_000_000"
+        "+skip_flash_bkdr_load=1",
+        "+use_spi_load_bootstrap=1",
+      ]
+      run_timeout_mins: 180
+    }
+    {
       name: rom_e2e_bootstrap_ate_smoke
       uvm_test_seq: chip_sw_rom_e2e_ate_smoke_vseq
       sw_images: [
@@ -49,4 +62,3 @@
     }
   ]
 }
-

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -821,36 +821,6 @@
     //   ]
     //   run_timeout_mins: 480
     // }
-    {
-      name: rom_e2e_bootstrap_ate_smoke
-      uvm_test_seq: chip_sw_rom_e2e_ate_smoke_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/ate/binaries:ate_gpio_toggle_test:1:silicon_creator:signed",
-        "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_personalized:4"
-      ]
-      en_run_modes: ["sw_test_mode_mask_rom"]
-      run_opts: [
-        "+sw_test_timeout_ns=1000000000",
-        "+use_otp_image=OtpTypeCustom",
-        "+skip_flash_bkdr_load=1",
-      ]
-      run_timeout_mins: 800
-    }
-    {
-      name: rom_e2e_ft_personalize_sival
-      uvm_test_seq: chip_sw_rom_e2e_ft_perso_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival:1:silicon_creator:signed",
-        "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_individualized:4"
-      ]
-      en_run_modes: ["sw_test_mode_mask_rom"]
-      run_opts: [
-        "+sw_test_timeout_ns=1000000000",
-        "+use_otp_image=OtpTypeCustom",
-        "+skip_flash_bkdr_load=1",
-      ]
-      run_timeout_mins: 800
-    }
 
     // ROM func tests to be run with test ROM.
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -55,6 +55,7 @@
                 "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
                 "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
                 "{top_dv_path}/chip_smoketests.hjson",
+                "{top_dv_path}/chip_manuf_ate_tests.hjson",
                 "{top_dv_path}/chip_rom_tests.hjson",
                 // Enable C compilation of chip level dpi
                 "{proj_root}/hw/dv/dpi/dpi_sim_cfg.hjson",

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -139,6 +139,7 @@ filesets:
       - seq_lib/chip_sw_aes_masking_off_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_ate_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test performs a the first step of a ROM bootstrap operation, i.e.,
+// flash erase. It them confirms flash has been erased by reading back a few
+// SPI flash frames to check they are all 1s (which matches the erased state).
+
+class chip_sw_ate_bootstrap_flash_erase_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_ate_bootstrap_flash_erase_vseq)
+  `uvm_object_new
+
+  local function automatic void _check_flash_data_page(input integer address,
+                                                       input integer expected);
+    logic [TL_DW-1:0] actual;
+    actual = cfg.mem_bkdr_util_h[FlashBank0Data].read32(address);
+    `DV_CHECK_EQ(actual, expected)
+  endfunction
+
+  virtual task body();
+    spi_host_flash_seq m_spi_host_seq;
+
+    super.body();
+
+    // Drive SW straps for bootstrap.
+    `uvm_info(`gfn, "Driving SW straps high for bootstrap.", UVM_LOW)
+    cfg.chip_vif.sw_straps_if.drive(3'h7);
+
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
+
+    // Configure the spi_agent for flash mode and add command info.
+    `uvm_info(`gfn, "Configuring SPI flash commands.", UVM_LOW)
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
+
+    // Wait for the SPI flash commands to be configured by the (test) ROM.
+    `uvm_info(`gfn, "Waiting for SPI flash cmds on device to load ...", UVM_LOW)
+    csr_spinwait(
+      .ptr(ral.spi_device.cmd_info[spi_device_pkg::CmdInfoReadSfdp].opcode),
+      .exp_data(SpiFlashReadSfdp),
+      .backdoor(1),
+      .spinwait_delay_ns(5000));
+    csr_spinwait(
+      .ptr(ral.spi_device.cmd_info[spi_device_pkg::CmdInfoReadStatus1].opcode),
+      .exp_data(SpiFlashReadSts1),
+      .backdoor(1),
+      .spinwait_delay_ns(5000));
+    csr_spinwait(
+      .ptr(ral.spi_device.cmd_info_wren.opcode),
+      .exp_data(SpiFlashWriteEnable),
+      .backdoor(1),
+      .spinwait_delay_ns(5000));
+
+    // Send the SPI flash erase command.
+    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h)
+    m_spi_host_seq.opcode = SpiFlashChipErase;
+    `uvm_info(`gfn, "Sending SPI flash erase command ...", UVM_LOW)
+    spi_host_flash_issue_write_cmd(
+      .write_command(m_spi_host_seq),
+      .busy_timeout_ns(50_000_000),
+      .busy_poll_interval_ns(2_000_000));
+    `uvm_info(`gfn, "Done.", UVM_LOW)
+
+    // Read first flash data word to confirm they are erased.
+    _check_flash_data_page('h0, 32'hFFFF_FFFF);
+    `uvm_info(`gfn, "SPI flash erase done.", UVM_LOW)
+
+    // Set test passed.
+    cfg.chip_vif.sw_straps_if.drive(3'h0);
+    assert_por_reset();
+    override_test_status_and_finish(.passed(1'b1));
+  endtask
+
+endclass : chip_sw_ate_bootstrap_flash_erase_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -106,6 +106,7 @@
 `include "chip_sw_rom_e2e_jtag_debug_vseq.sv"
 `include "chip_sw_rom_e2e_jtag_inject_vseq.sv"
 `include "chip_sw_rom_e2e_self_hash_gls_vseq.sv"
+`include "chip_sw_ate_bootstrap_flash_erase_vseq.sv"
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"
 `include "chip_sw_ast_clk_rst_inputs_vseq.sv"


### PR DESCRIPTION
This contains two commits that:
1. consolidates all manufacturing ATE bringup tests to a separate dvsim configuration file, and
2. adds a simple ATE DV test that puts the DUT in bootstrap mode and then drives the correct SPI sequence to erase all of flash, which is the first part of performing a bootstrap operation.