### PR TITLE
[ujson] Add support for quoted integers.

### DIFF
--- a/sw/device/lib/ujson/ujson.c
+++ b/sw/device/lib/ujson/ujson.c
@@ -161,6 +161,15 @@ status_t ujson_parse_qs(ujson_t *uj, char *str, size_t len) {
 status_t ujson_parse_integer(ujson_t *uj, void *result, size_t rsz) {
   char ch = (char)TRY(consume_whitespace(uj));
   bool neg = false;
+  bool quoted = false;
+
+  if (ch == '"') {
+    // If we encounter a quote while parsing an integer, assume that
+    // the quoted string will contain an integer.  Get the next
+    // character and continue parsing as if we expect an integer.
+    quoted = true;
+    ch = (char)TRY(ujson_getc(uj));
+  }
 
   if (ch == '-') {
     neg = true;
@@ -186,8 +195,19 @@ status_t ujson_parse_integer(ujson_t *uj, void *result, size_t rsz) {
       break;
     ch = (char)s.value;
   }
-  if (status_ok(s))
-    TRY(ujson_ungetc(uj, ch));
+
+  if (status_ok(s)) {
+    if (quoted) {
+      if (ch != '"') {
+        return INVALID_ARGUMENT();
+      }
+      // Close quote on an integer in quoted string.
+      // Don't have to unget the quote because we
+      // want to consume it.
+    } else {
+      TRY(ujson_ungetc(uj, ch));
+    }
+  }
 
   if (neg) {
     if (value > (uint64_t)INT64_MAX + 1) {

--- a/sw/device/lib/ujson/ujson_test.cc
+++ b/sw/device/lib/ujson/ujson_test.cc
@@ -141,6 +141,8 @@ TEST(UJson, ParseInteger) {
   INT(uint8_t, "256", 0);
   // This value overflows int64 and becomes its own negative.
   INT(int64_t, "9223372036854775808", -9223372036854775808);
+  // Quoted number.
+  INT(uint32_t, "\"123\"", 123);
 }
 #undef INT
 #undef SIMPLE_INT


### PR DESCRIPTION
This change implements parsed for quoted integers. The implementation authored by cfrantz@google.com.

JSON messages generated by protobuf libraries will use quoted strings for `uint64` types. See for example:

```json
{
  "wafer_auth_secret": [
    2790285947,
    1491553456,
    2694274708,
    1137231153,
    1404344500,
    190480117,
    3248928340,
    4233979174
  ],
  "test_unlock_token_hash": [
    "18123448053906926503",
    "14479932172051545263"
  ],
  "test_exit_token_hash":[
    "895855566562726762",
    "1749132506438826860"
  ]
}
```

The change provided in this patch allows the device to parse the payload above. Before this change, the ujson module would return a parsing integer error.