### PR TITLE
[rom_ctrl,fpv] An initial FPV environment for rom_ctrl

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -66,6 +66,11 @@ if {$stopat ne ""} {
   stopat -env $stopat
 }
 
+# Before loading any TCL scripts in AFTER_LOAD, we initialize the pre_phases variable to zero. The
+# idea is that the AFTER_LOAD scripts can set it to something else if necessary (but there will be
+# no initial phases if the scripts do not).
+set pre_phases 0
+
 if {[info exists ::env(AFTER_LOAD)]} {
     set flist $env(AFTER_LOAD)
     foreach file $flist {
@@ -209,6 +214,17 @@ set_proofgrid_per_engine_max_local_jobs 2
 #-------------------------------------------------------------------------
 # prove all assertions & report
 #-------------------------------------------------------------------------
+
+# If there are any AFTER_LOAD scripts, they may have defined some "initial phases". These are
+# counted with a $pre_phases variable (which defaults to zero). If it is positive, we iterate
+# through that many phases from zero, proving them in turn.
+#
+# Properties that should go in phase N have names that start with "preN_", and these properties are
+# selected with a regexp.
+for {set phase 0} {$phase < $pre_phases} {incr phase} {
+    puts "Starting 'pre${phase}_ phase... (maximum phase ${pre_phases})"
+    prove -property "pre${phase}_.*" -regexp
+}
 
 get_reset_info -x_value -with_reset_pin
 

--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -39,6 +39,19 @@
   `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S,                                            \
               $stable(rst_ni) == 0 |-> HIER_.ERR_NAME_ == 0 [*10])
 
+// When an error signal rises, expect to see the associated ALERT_IN_ signal go high in at most
+// MAX_CYCLES_
+//
+// This is expected to cause an alert to be signalled, but avoids needing to reason about the
+// internals of the alert sender (which are checked with formal properties in the prim_alert_rxtx*
+// cores).
+//
+// The NAME_, HIER_, GATE_, MAX_CYCLES_ and ERR_NAME_ arguments are the same as for
+// `ASSERT_ERROR_TRIGGER_ERR.
+`define ASSERT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_IN_, GATE_, MAX_CYCLES_, ERR_NAME_) \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ALERT_IN_, GATE_, MAX_CYCLES_, ERR_NAME_,           \
+                            `ASSERT_DEFAULT_CLK, `ASSERT_DEFAULT_RST)
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Assertions for CMs that trigger alerts
@@ -63,6 +76,35 @@
 
 `define ASSERT_PRIM_FIFO_SYNC_SINGLETON_ERROR_TRIGGER_ALERT(NAME, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
   `ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// The input flavour of assertions for CMs that trigger alerts
+//
+// Note that the default value for MAX_CYCLES_ in these assertions is much smaller than
+// _SEC_CM_ALERT_MAX_CYC. Because we are asserting something about the *input* for the alert system,
+// the timing can be much tighter: we default to two cycles.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+
+`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+
+`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, unused_err_o)
+
+`define ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+
+`define ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT_IN(NAME_, REG_TOP_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT_IN(NAME_, \
+    REG_TOP_HIER_.u_prim_reg_we_check.u_prim_onehot_check, ALERT_, GATE_, MAX_CYCLES_)
+
+`define ASSERT_PRIM_FIFO_SYNC_SINGLETON_ERROR_TRIGGER_ALERT_IN(NAME, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = 2) \
+  `ASSERT_ERROR_TRIGGER_ALERT_IN(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/hw/ip/rom_ctrl/dv/formal/rom_ctrl_formal_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/formal/rom_ctrl_formal_cfg.hjson
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  name: rom_ctrl_fpv
+
+  flow: formal
+  sub_flow: fpv
+  import_cfgs: [
+    "{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"
+  ]
+
+  dut: tb
+  fusesoc_core: lowrisc:dv:rom_ctrl_fpv
+  after_load: ["{proj_root}/hw/ip/rom_ctrl/dv/formal/verify.tcl"]
+}

--- a/hw/ip/rom_ctrl/dv/formal/rom_ctrl_fpv.core
+++ b/hw/ip/rom_ctrl/dv/formal/rom_ctrl_fpv.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:rom_ctrl_fpv:0.1"
+description: "ROM_CTRL formal verification"
+filesets:
+  files_formal:
+    depend:
+      - lowrisc:ip:rom_ctrl
+    files:
+      - tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  formal:
+    default_tool: icarus
+    filesets:
+      - files_formal
+    toplevel: tb

--- a/hw/ip/rom_ctrl/dv/formal/tb.sv
+++ b/hw/ip/rom_ctrl/dv/formal/tb.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for rom_ctrl
+// Intended to be used with a formal tool.
+
+module tb
+  import rom_ctrl_reg_pkg::NumAlerts;
+  import prim_rom_pkg::rom_cfg_t;
+(
+  input  clk_i,
+  input  rst_ni,
+  input  rom_cfg_t rom_cfg_i,
+
+  input  tlul_pkg::tl_h2d_t rom_tl_i,
+  output tlul_pkg::tl_d2h_t rom_tl_o,
+
+  input  tlul_pkg::tl_h2d_t regs_tl_i,
+  output tlul_pkg::tl_d2h_t regs_tl_o,
+
+  // Alerts
+  input  prim_alert_pkg::alert_rx_t [NumAlerts-1:0] alert_rx_i,
+  output prim_alert_pkg::alert_tx_t [NumAlerts-1:0] alert_tx_o,
+
+  // Connections to other blocks
+  output rom_ctrl_pkg::pwrmgr_data_t pwrmgr_data_o,
+  output rom_ctrl_pkg::keymgr_data_t keymgr_data_o,
+  input  kmac_pkg::app_rsp_t         kmac_data_i,
+  output kmac_pkg::app_req_t         kmac_data_o
+ );
+
+  rom_ctrl dut (
+    .clk_i,
+    .rst_ni,
+    .rom_cfg_i,
+    .rom_tl_i,
+    .rom_tl_o,
+    .regs_tl_i,
+    .regs_tl_o,
+    .alert_rx_i,
+    .alert_tx_o,
+    .pwrmgr_data_o,
+    .keymgr_data_o,
+    .kmac_data_i,
+    .kmac_data_o
+  );
+
+endmodule

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is used as an "after_load" file for rom_ctrl verification.

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -35,3 +35,32 @@ assert \
        ->
      |dut.alerts"
 assert -disable "tb.dut.gen_asserts_with_scrambling.FpvSecCmCheckerFsmAlert_A"
+
+# The register top has a write-enable check (u_prim_reg_we_check) and this uses prim_onehot_check to
+# generate an error signal if the write-enable has more than one bit set. This can't happen in
+# normal operation, so the FPV test cannot see the precondition for the inner prim's Onehot0Check_A
+# assertion.
+#
+# Since there's actually only one register that is possible to write, this isn't really a security
+# feature and doesn't need testing with e.g. a stopat. Instead, assert that the value is always
+# onehot0 and disable the cover property.
+assert -name "AlwaysOneHot0_A" "\$onehot0(dut.u_reg_regs.reg_we_check)"
+set prim_onehot_check_path "tb.dut.u_reg_regs.u_prim_reg_we_check.u_prim_onehot_check"
+cover -disable "${prim_onehot_check_path}.Onehot0Check_A:precondition1"
+
+# There is also the FpvSecCmRegWeOnehotCheck_A assertion to check that a fatal alert gets generated
+# if the reg_we_check signal in rom_ctrl_regs_reg_top is not onehot0. Since we have just proved this
+# can't happen, disable the precondition cover.
+cover -disable "tb.dut.FpvSecCmRegWeOnehotCheck_A:precondition1"
+
+# The prim_one_hot_check module is instantiated with the EnableCheck parameter true. As such, it has
+# an EnableCheck_A assertion that asserts none of the write-enable bits are set if en_i is false.
+# The only way a write-enable signal can be set is through alert_test_we, which implies reg_we and
+# addr_hit[0]. That addr_hit[0] signal implies that addrmiss will be false, which implies en_i will
+# be high.
+#
+# But maybe it still makes sense to have this path to the error signal (catching some cases of fault
+# injection). Use a stopat on the input to u_prim_reg_we_check to allow this signal to vary freely.
+task -create FreeWe -copy "${prim_onehot_check_path}.gen_enable_check.gen_not_strict.EnableCheck_A*"
+stopat -task FreeWe "dut.u_reg_regs.u_prim_reg_we_check.oh_i"
+assert -disable "${prim_onehot_check_path}.gen_enable_check.gen_not_strict.EnableCheck_A"

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -169,3 +169,15 @@ cover -name GlitchyCounter::rjs \
 # in the GlitchyCounter task.
 task -edit GlitchyCounter -copy "tb.dut.StabilityChkkeymgr_A*"
 assert -disable "tb.dut.StabilityChkkeymgr_A"
+
+# Once the contents of ROM have been read and the hash has been compared with the expected digest,
+# the dut will set pwrmgr_data_o.done. This acts like a sort of validity signal for
+# pwrmgr_data_o.good, but that signal is flopped through a prim_mubi4_sender in rom_ctrl_compare, so
+# will only be stable if it was stable from the previous cycle.
+assert -name "pre0_CheckerGoodStable_A" \
+    "dut.pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True ->
+     \$stable(dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.matches_q)"
+
+# Configure the phased prove command in fpv.tcl so that it proves the two layers of "pre" properties
+# first.
+set pre_phases 1

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -154,3 +154,18 @@ assert -name "CannotSaturateDn_compare_count_A" \
 cover -disable "tb.${compare_count_path}.g_check_incr.UpCntIncrStable_A:precondition1"
 cover -disable "tb.${compare_count_path}.g_check_incr.DnCntIncrStable_A:precondition1"
 
+# There are quite a few properties about rom_ctrl that only make sense in the "running phase", when
+# the entire ROM has been read and we are allowing bus accesses. Precondition cover properties for
+# these are awkward because a trace would need to read the whole of the ROM! Cheat and make a task
+# where the checker counter can be given a different value, which allows us to skip that phase of
+# the startup.
+task -create GlitchyCounter
+stopat -task GlitchyCounter "dut.gen_fsm_scramble_enabled.u_checker_fsm.u_counter.addr_q"
+cover -name GlitchyCounter::rjs \
+    "dut.gen_fsm_scramble_enabled.u_checker_fsm.counter_done"
+
+# The StabilityChkkeymgr_A assertion checks that we don't change the value we present to pwrmgr once
+# we have sent a value to keymgr. Because this only happens after reading the whole ROM, we prove it
+# in the GlitchyCounter task.
+task -edit GlitchyCounter -copy "tb.dut.StabilityChkkeymgr_A*"
+assert -disable "tb.dut.StabilityChkkeymgr_A"

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -128,3 +128,29 @@ foreach fifo_pr { { u_reqfifo ReqFifo } { u_sramreqfifo SramReqFifo } { u_rspfif
         cover -disable "tb.${ptr_path}.g_check_incr.DnCntIncrStable_A:precondition1"
     }
 }
+
+# We used a stopat above to allow the cnt_q for the u_compare address prim_count to be forced. The
+# clr_i, set_i and decr_en_i signals to that module are all wired to zero, so we need to waive the
+# preconditions for some associated assertions.
+set compare_count_path "dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.u_prim_count_addr"
+assert -name "NoClear_compare_count_A" "!${compare_count_path}.clr_i"
+assert -name "NoSet_compare_count_A" "!${compare_count_path}.set_i"
+assert -name "NoDecr_compare_count_A" "!${compare_count_path}.decr_en_i"
+cover -disable "tb.${compare_count_path}.g_check_clr_fwd_a.*:precondition1" -regexp
+cover -disable "tb.${compare_count_path}.g_check_set_fwd_a.*:precondition1" -regexp
+cover -disable "tb.${compare_count_path}.g_check_inc_and_dec.*:precondition1" -regexp
+cover -disable "tb.${compare_count_path}.g_check_decr.*:precondition1" -regexp
+
+# The logic in rom_ctrl_compare also ensures that the count isn't asked to increment after it gets
+# to the end. Whether or not NumWords is a power of two, this means we'll never try to increment
+# past the maximum representable value.
+#
+# Add assertions to check that we don't try (which make sure the gating logic on addr_incr in
+# rom_ctrl_compare is correct) and disable the unreachable cover properties.
+assert -name "CannotSaturateUp_compare_count_A" \
+    "${compare_count_path}.incr_en_i -> !&${compare_count_path}.cnt_o"
+assert -name "CannotSaturateDn_compare_count_A" \
+    "${compare_count_path}.incr_en_i -> |${compare_count_path}.cnt_q\[1\]"
+cover -disable "tb.${compare_count_path}.g_check_incr.UpCntIncrStable_A:precondition1"
+cover -disable "tb.${compare_count_path}.g_check_incr.DnCntIncrStable_A:precondition1"
+

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -14,3 +14,24 @@
 task -create CompareFsm -copy "tb.dut.gen_asserts_with_scrambling.FpvSecCmCompareFsmAlert_A*"
 stopat -task CompareFsm "dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.state_q"
 assert -disable "tb.dut.gen_asserts_with_scrambling.FpvSecCmCompareFsmAlert_A"
+
+# There is also a security check in FpvSecCmCheckerFsmAlert_A. The FSM uses PRIM_FLOP_SPARSE_FSM to
+# check that if the FSM is corrupted then an assert will be generated. The assert doesn't quite work
+# though, because it ends up asserting that a broken state_d will cause the assertion. The state_d
+# variable is actually combinationally driven to ensure that it is always a valid state. (This is
+# better than allowing the state to stay arbitrary: it guarantees that a fault will cause a the FSM
+# state to move to one a large hamming distance from the valid states).
+#
+# The cleanest approach is probably to use a stopat on state_q and define a different assertion,
+# which says an unexpected state will instantly cause the prim_alert_sender to be asked to send an
+# alert.
+task -create CheckerFsm
+stopat -task CheckerFsm "dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q"
+assert \
+    -name "CheckerFsm::BadCheckerStateCausesAlert_A" \
+    "!(dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q inside
+       {rom_ctrl_pkg::ReadingLow, rom_ctrl_pkg::ReadingHigh, rom_ctrl_pkg::RomAhead,
+        rom_ctrl_pkg::KmacAhead, rom_ctrl_pkg::Checking, rom_ctrl_pkg::Done})
+       ->
+     |dut.alerts"
+assert -disable "tb.dut.gen_asserts_with_scrambling.FpvSecCmCheckerFsmAlert_A"

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -64,3 +64,67 @@ cover -disable "tb.dut.FpvSecCmRegWeOnehotCheck_A:precondition1"
 task -create FreeWe -copy "${prim_onehot_check_path}.gen_enable_check.gen_not_strict.EnableCheck_A*"
 stopat -task FreeWe "dut.u_reg_regs.u_prim_reg_we_check.oh_i"
 assert -disable "${prim_onehot_check_path}.gen_enable_check.gen_not_strict.EnableCheck_A"
+
+# There are several prim_count instances in the dut. All of these detect fault injection by
+# generating an error, which causes an alert, if the two counters don't sum to the right total. For
+# FPV testing, we have to use stopat to allow the fault injection, copy the property to the task and
+# disable the version that doesn't have the stopat.
+#
+# The prim_count instances that lie in u_tl_adapter_rom all have their clr_i and decr_en_i signals
+# wired to zero. For these instances, disable the cover property for the assertions that talk about
+# them handling the signals being nonzero.
+task -create PrimCount
+
+task -edit PrimCount -copy "tb.dut.gen_asserts_with_scrambling.FpvSecCmCompareAddrCtrCheck_A*"
+stopat -task PrimCount "dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.u_prim_count_addr.cnt_q"
+assert -disable "tb.dut.gen_asserts_with_scrambling.FpvSecCmCompareAddrCtrCheck_A"
+
+# Waive coverage for the ClrFwd_A assertion in every instantiation of prim_count. This assertion is
+# supposed to check that the clr_i signal works, but the instantiation in tlul_adapter_sram wires
+# clr_i to zero. Also add an assertion that checks this really is dead zero.
+#
+# The decr_en_i signal is also wired to zero. Again, we add an assertion to check this is true and
+# then waive precondition coverage for things that need a decrement request.
+#
+# Similarly, we have to waive coverage for the UpCntIncrStable_A assertion. This assertion is
+# supposed to be checking that the count saturates at its maximum value (instead of wrapping). But
+# it's actually impossible to get into a situation where we're trying to increment past one request
+# or response. This is because the ROM always responds in exactly one cycle so there's no way to
+# increment a second time. The same is true for the down count.
+#
+# Finally, we have to waive coverage for the UpCntIncrStable_A and DnCntIncrStable_A assertions for
+# these prim_count counters. In each case, these are impossible to hit because we have a 2 entry
+# FIFO and the ROM always replies in exactly one cycle.
+
+foreach fifo_pr { { u_reqfifo ReqFifo } { u_sramreqfifo SramReqFifo } { u_rspfifo RspFifo } } {
+    set fifo_inst_name [lindex $fifo_pr 0]
+    set fifo_prop_name [lindex $fifo_pr 1]
+
+    set fifo_path "dut.u_tl_adapter_rom.${fifo_inst_name}"
+
+    foreach ptr_pr { { u_wptr Wptr } { u_rptr Rptr } } {
+        set ptr_inst_name [lindex $ptr_pr 0]
+        set ptr_prop_name [lindex $ptr_pr 1]
+
+        set ptr_path "${fifo_path}.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.${ptr_inst_name}"
+
+        task -edit PrimCount -copy "tb.dut.FpvSecCm${fifo_prop_name}${ptr_prop_name}Check_A*"
+        stopat -task PrimCount "${ptr_path}.cnt_q"
+        assert -disable "tb.dut.FpvSecCm${fifo_prop_name}${ptr_prop_name}Check_A"
+
+        assert -name "NoClear_${fifo_prop_name}_${ptr_inst_name}_A" "!${ptr_path}.clr_i"
+        assert -name "NoDecr_${fifo_prop_name}_${ptr_inst_name}_A" "!${ptr_path}.decr_en_i"
+
+        cover -disable "tb.${ptr_path}.g_check_clr_fwd_a.*:precondition1" -regexp
+        cover -disable "tb.${ptr_path}.g_check_inc_and_dec.*:precondition1" -regexp
+        cover -disable "tb.${ptr_path}.g_check_decr.*:precondition1" -regexp
+
+        assert -name "CannotSaturateUp_${fifo_prop_name}_${ptr_inst_name}_A" \
+            "${ptr_path}.incr_en_i && !${ptr_path}.set_i -> !&${ptr_path}.cnt_o"
+        cover -disable "tb.${ptr_path}.g_check_incr.UpCntIncrStable_A:precondition1"
+
+        assert -name "CannotSaturateDn_${fifo_prop_name}_${ptr_inst_name}_A" \
+            "${ptr_path}.incr_en_i && !${ptr_path}.set_i -> |${ptr_path}.cnt_q\[1\]"
+        cover -disable "tb.${ptr_path}.g_check_incr.DnCntIncrStable_A:precondition1"
+    }
+}

--- a/hw/ip/rom_ctrl/dv/formal/verify.tcl
+++ b/hw/ip/rom_ctrl/dv/formal/verify.tcl
@@ -3,3 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This is used as an "after_load" file for rom_ctrl verification.
+
+# There is a security check in FpvSecCmCompareFsmAlert_A. This checks that an FSM error in
+# u_checker_fsm.u_compare.u_state_regs will get propagated to an alert. Such an FSM error cannot
+# happen without fault injection, so we move the property into a task and use a stopat to allow the
+# FSM's state_q variable to vary arbitrarily.
+#
+# Once the property has been copied, disable the original version (in <embedded>::) and the
+# associated cover property.
+task -create CompareFsm -copy "tb.dut.gen_asserts_with_scrambling.FpvSecCmCompareFsmAlert_A*"
+stopat -task CompareFsm "dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.state_q"
+assert -disable "tb.dut.gen_asserts_with_scrambling.FpvSecCmCompareFsmAlert_A"

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -477,18 +477,18 @@ module rom_ctrl
 
   // Assertions to check that we've wired up our alert bits correctly
   if (!SecDisableScrambling) begin : gen_asserts_with_scrambling
-    `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CompareFsmAlert_A,
-                                         gen_fsm_scramble_enabled.
-                                         u_checker_fsm.u_compare.u_state_regs,
-                                         alert_tx_o[AlertFatal])
+    `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT_IN(CompareFsmAlert_A,
+                                            gen_fsm_scramble_enabled.
+                                            u_checker_fsm.u_compare.u_state_regs,
+                                            gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CheckerFsmAlert_A,
                                          gen_fsm_scramble_enabled.
                                          u_checker_fsm.u_state_regs,
                                          alert_tx_o[AlertFatal])
-    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CompareAddrCtrCheck_A,
-                                           gen_fsm_scramble_enabled.
-                                           u_checker_fsm.u_compare.u_prim_count_addr,
-                                           alert_tx_o[AlertFatal])
+    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT_IN(CompareAddrCtrCheck_A,
+                                              gen_fsm_scramble_enabled.
+                                              u_checker_fsm.u_compare.u_prim_count_addr,
+                                              gen_alert_tx[AlertFatal].u_alert_sender.alert_req_i)
   end
 
   // The pwrmgr_data_o output (the "done" and "good" signals) should have a known value when out of

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -516,12 +516,11 @@ module rom_ctrl
 
   // Check that pwrmgr_data_o.done is never de-asserted once asserted
   `ASSERT(PwrmgrDataChk_A,
-          pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True |=>
-          pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True,
+          !$fell(pwrmgr_data_o.done == prim_mubi_pkg::MuBi4True),
           clk_i, !rst_ni || internal_alert)
 
   // Check that keymgr_data_o.valid is never de-asserted once asserted
-  `ASSERT(KeymgrValidChk_A, keymgr_data_o.valid |=> keymgr_data_o.valid,
+  `ASSERT(KeymgrValidChk_A, !$fell(keymgr_data_o.valid),
           clk_i, !rst_ni || internal_alert)
 
   // Check that rom_tl_o.d_valid is not asserted unless pwrmgr_data_o.done is asseterd.


### PR DESCRIPTION
For the structure of this PR:
- The first two commits come from #27142 and will disappear after that has been merged.
- The third commit comes from #27143 and will disappear after that has been merged.

The following 9 commits are incremental. The first one (commit 4) sets up a rather trivial testbench that just instantiates the block and exposes its ports. At this point, you can run
```
util/dvsim/dvsim.py hw/ip/rom_ctrl/dv/formal/rom_ctrl_formal_cfg.hjson --gui
```
and *something* happens!

Unfortunately, most of what you see is the failure of various cover properties. Lots of them are checking countermeasures against fault injection attacks. To cover these events, you need some `stopat` calls, which the later commits contain.

The second-last commit also increases the assertions that get proven by adding a helper assertion (found by SST).

The final commit is to `rom_ctrl.sv`! But it's just rephrasing a couple of assertions to avoid pointless cover properties.