### PR TITLE
[hw,otp_ctrl,rtl] Use math.ceil to determine the required address bits

### DIFF
--- a/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_macro_pkg.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/rtl/otp_ctrl_macro_pkg.sv.tpl
@@ -21,10 +21,10 @@ package otp_ctrl_macro_pkg;
   parameter int OtpSizeWidth     = 2;
   parameter int OtpPwrSeqWidth   = 2;
 
-  parameter int OtpAddrWidth     = ${round(math.log2(otp_mmap["otp"]["depth"]))};
+  parameter int OtpAddrWidth     = ${math.ceil(math.log2(otp_mmap["otp"]["depth"]))};
   parameter int OtpIfWidth       = 2**OtpSizeWidth*OtpWidth;
   // Number of Byte address bits to cut off in order to get the native OTP word address.
-  parameter int OtpAddrShift     = ${round(math.log2(otp_mmap["otp"]["width"]))};
+  parameter int OtpAddrShift     = ${math.ceil(math.log2(otp_mmap["otp"]["width"]))};
 
   typedef logic [OtpSizeWidth-1:0] otp_macro_size_t;
   typedef logic [OtpAddrWidth-1:0] otp_macro_addr_t;


### PR DESCRIPTION
If the OTP depth is not a power of 2, we need to always round up to get the number of address bits. The previously used `round` function can round down or up, depending on the value, which is wrong. We need to always round up to get the last bit.

Because the upstream OTP maps have all a depth value that is a power of two, this change does not trigger any RTL change but only a template change.