### PR TITLE
[rv_plic, fpv] Unused code block because of NoRegwen type

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl.tpl
@@ -41,3 +41,18 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subre
 check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subreg.sv} -start_line\
  58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else\
  part}
+
+# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
+# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
+# any regwen types therefore all the mubi(4-16)_and functions are unused.
+check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused\
+ code block}
+
+check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused\
+ code block}
+
+check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused\
+ code block}
+
+check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
+ code block}

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -33,3 +33,14 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subre
 # For all the ip registers, de is true and hence wr_en is true. The branch misses the else part and
 # appeared dead.
 check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subreg.sv} -start_line 58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else part}
+
+# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
+# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
+# any regwen types therefore all the mubi(4-16)_and functions are unused.
+check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused code block}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -33,3 +33,14 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subre
 # For all the ip registers, de is true and hence wr_en is true. The branch misses the else part and
 # appeared dead.
 check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subreg.sv} -start_line 58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else part}
+
+# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
+# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
+# any regwen types therefore all the mubi(4-16)_and functions are unused.
+check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused code block}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -33,3 +33,14 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subre
 # For all the ip registers, de is true and hence wr_en is true. The branch misses the else part and
 # appeared dead.
 check_cov -waiver -add -source_file {../src/lowrisc_prim_subreg_0/rtl/prim_subreg.sv} -start_line 58 -end_line 58 -type {branch} -comment {wr_en is true and the branch doesn't contain the else part}
+
+# The waivers below are waiving the branch and statement (inside those branches) in mubi(4-16)_and
+# function in prim_mubi_pkg used in rv_plic_csr_assert_fpv. Since, rv_plic registers doesn't have
+# any regwen types therefore all the mubi(4-16)_and functions are unused.
+check_cov -waiver -add -start_line 119 -end_line 139 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused code block}


### PR DESCRIPTION
Since rv_plic registers has no regwen type, the mubi(4-16)_and_hi calls inside the unique case block are unused and appeared as dead branches and statements inside prim_mubi_pkg for mubi(4-16)_and.