### PR TITLE
[usbdev, Xcelium] Unconnected output port ram_cfg_rsp_o

### DIFF
--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -158,6 +158,7 @@ module tb;
 
     // memory configuration
     .ram_cfg_i              ('0),
+    .ram_cfg_rsp_o          (  ),
 
     // Interrupts
     .intr_pkt_received_o    (intr_pkt_received    ),


### PR DESCRIPTION
Xcelium 23.09.s002 throws the warning about the port not connected.