### PR TITLE
[Uart, Xcelium] Xcelium 23.09.s002 warnings

### DIFF
--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -78,7 +78,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
           uart_nf_vif.cb.rx_sync_q2);
       end
     end
-  endtask;
+  endtask
 
   virtual task process_uart_tx_fifo();
     uart_item act_item, exp_item;

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -47,6 +47,12 @@ module tb;
     .alert_rx_i           (alert_rx   ),
     .alert_tx_o           (alert_tx   ),
 
+    // RACL interface
+    .racl_policies_i      ('0         ),
+    .racl_error_o         (           ),
+
+    .lsio_trigger_o       (           ),
+
     .cio_rx_i             (uart_rx    ),
     .cio_tx_o             (uart_tx    ),
     .cio_tx_en_o          (uart_tx_en ),


### PR DESCRIPTION
- Xcelium 23.09.s002 throws the warning about the ports being unconnected.
- Unexpected semicolon after endtask