### PR TITLE
[gpio, Xcelium] Unconnected racl ports

### DIFF
--- a/hw/ip_templates/gpio/dv/tb/tb.sv.tpl
+++ b/hw/ip_templates/gpio/dv/tb/tb.sv.tpl
@@ -67,6 +67,10 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
+    // RACL interface
+    .racl_policies_i('0),
+    .racl_error_o   (  ),
+
     .cio_gpio_i          (gpio_i),
     .cio_gpio_o          (gpio_o),
     .cio_gpio_en_o       (gpio_oe)

--- a/hw/top_darjeeling/ip_autogen/gpio/dv/tb/tb.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/dv/tb/tb.sv
@@ -67,6 +67,10 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
+    // RACL interface
+    .racl_policies_i('0),
+    .racl_error_o   (  ),
+
     .cio_gpio_i          (gpio_i),
     .cio_gpio_o          (gpio_o),
     .cio_gpio_en_o       (gpio_oe)

--- a/hw/top_earlgrey/ip_autogen/gpio/dv/tb/tb.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/dv/tb/tb.sv
@@ -67,6 +67,10 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
+    // RACL interface
+    .racl_policies_i('0),
+    .racl_error_o   (  ),
+
     .cio_gpio_i          (gpio_i),
     .cio_gpio_o          (gpio_o),
     .cio_gpio_en_o       (gpio_oe)

--- a/hw/top_englishbreakfast/ip_autogen/gpio/dv/tb/tb.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/dv/tb/tb.sv
@@ -67,6 +67,10 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
+    // RACL interface
+    .racl_policies_i('0),
+    .racl_error_o   (  ),
+
     .cio_gpio_i          (gpio_i),
     .cio_gpio_o          (gpio_o),
     .cio_gpio_en_o       (gpio_oe)


### PR DESCRIPTION
Xcelium 23.09.s002 throws the warning about the racl ports being unconnected.