### PR TITLE
[individualize] Add abort to end simulation

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/sram_start.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.S
@@ -199,7 +199,9 @@ sram_start:
   lw   t3, 0(sp)
   addi sp, sp, OTTF_WORD_SIZE
   mv   sp, t3
-  ebreak
+  loop_forever:
+    wfi
+    j loop_forever
 
   // Set function size to allow disassembly.
   .size sram_start, .-sram_start


### PR DESCRIPTION
Usually test_status_set() calls abort (see [here](https://github.com/lowRISC/opentitan/blob/earlgrey_1.0.0/sw/device/lib/testing/test_framework/status.h#L82)). It is not used for ATE simulation so we need to explicitly add it.
Without it the simulation fails at the end due to SW reset.