### PR TITLE
[opentitanlib] Support ECDSA and SPX+ pem signature

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -301,6 +301,7 @@ rust_library(
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib/bindgen",
+        "//sw/host/opentitanlib/util",
         "//sw/host/sphincsplus",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -141,10 +141,9 @@ impl EcdsaRawSignature {
 
             // Let's try interpreting the file as ASN.1 DER.
             // If unsuccessful, attempt PEM decoding.
-            EcdsaRawSignature::from_der(&data).or_else(|_| {
-                EcdsaRawSignature::from_pem(&data)
-                    .with_context(|| format!("Failed parsing {path:?}"))
-            })
+            EcdsaRawSignature::from_der(&data)
+                .or_else(|_| EcdsaRawSignature::from_pem(&data))
+                .with_context(|| format!("Failed parsing {path:?}"))
         }
     }
 

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -9,6 +9,7 @@ use ecdsa::signature::hazmat::PrehashVerifier;
 use ecdsa::Signature;
 use p256::ecdsa::{SigningKey, VerifyingKey};
 use p256::NistP256;
+use pem_rfc7468::Decoder;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
@@ -20,6 +21,7 @@ use std::str::FromStr;
 
 use super::Error;
 use crate::crypto::sha256::Sha256Digest;
+use util::clean_pem_bytes_for_parsing;
 
 pub struct EcdsaPrivateKey {
     pub key: SigningKey,
@@ -132,13 +134,17 @@ impl EcdsaRawSignature {
             // This must be a raw signature, just read it as is.
             EcdsaRawSignature::read(&mut file)
         } else {
-            // Let's try interpreting the file as ASN.1 DER.
             let mut data = Vec::<u8>::new();
 
             file.read_to_end(&mut data)
                 .with_context(|| "Failed to read {path:?}")?;
 
-            EcdsaRawSignature::from_der(&data).with_context(|| format!("Failed parsing {path:?}"))
+            // Let's try interpreting the file as ASN.1 DER.
+            // If unsuccessful, attempt PEM decoding.
+            EcdsaRawSignature::from_der(&data).or_else(|_| {
+                EcdsaRawSignature::from_pem(&data)
+                    .with_context(|| format!("Failed parsing {path:?}"))
+            })
         }
     }
 
@@ -186,6 +192,22 @@ impl EcdsaRawSignature {
         s.resize(32, 0u8);
 
         Ok(EcdsaRawSignature { r, s })
+    }
+
+    fn from_pem(data: &[u8]) -> Result<EcdsaRawSignature> {
+        // Ensures valid PEM markers and a recognized label are present.
+        let _ = pem_rfc7468::decode_label(data)?;
+        let mut buf = Vec::new();
+        let result = Decoder::new(data);
+        match result {
+            Ok(mut decoder) => decoder.decode_to_end(&mut buf)?,
+            _ => {
+                let cleaned_data = clean_pem_bytes_for_parsing(data)?;
+                let mut decoder = Decoder::new(&cleaned_data)?;
+                decoder.decode_to_end(&mut buf)?
+            }
+        };
+        Self::from_der(buf.as_slice())
     }
 }
 

--- a/sw/host/opentitanlib/util/BUILD
+++ b/sw/host/opentitanlib/util/BUILD
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "util",
+    srcs = ["src/lib.rs"],
+    deps = [
+        "@crate_index//:anyhow",
+        "@crate_index//:pem-rfc7468",
+    ],
+)

--- a/sw/host/opentitanlib/util/src/lib.rs
+++ b/sw/host/opentitanlib/util/src/lib.rs
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+use pem_rfc7468::{LineEnding, BASE64_WRAP_WIDTH};
+
+/// Cleans PEM-like byte slices for parsing, attempting to handle non-standard formats.
+///
+/// This function is primarily designed as a recovery step when input PEM bytes have
+/// already failed to be parsed by a standard PEM library.
+///
+/// Some signing tools or commands may generate custom header fields after the
+/// '-----BEGIN ...-----' marker but before the actual Base64 encoded payload.
+/// For example:
+/// -----BEGIN AUTH SIGNATURE-----
+/// ALGORITHM: ES256
+///
+/// [BASE64 PAYLOAD LINE 1]
+/// [BASE64 PAYLOAD LINE 2]
+/// -----END AUTH SIGNATURE-----
+///
+/// Such custom fields (like "ALGORITHM: ES256" and the subsequent blank line)
+/// do not strictly adhere to PEM specifications like RFC 7468 for the text encoding
+/// of the payload itself (which expects the Base64 block to follow.)
+///
+/// This function attempts to strip these non-standard intermediate lines and retain
+/// only the BEGIN/END markers and the core Base64 payload.
+///
+/// Assumptions made by this function:
+/// 1. The very first line of the `pem_bytes` input MUST be the '-----BEGIN ...-----' marker.
+///    This line is always preserved.
+/// 2. A line that is part of the actual Base64 payload is expected to have a length
+///    equal to `pem_rfc7468::BASE64_WRAP_WIDTH`. This is used as a primary trigger
+///    to identify the start of the payload.
+/// 3. Any custom lines that appear between the '-----BEGIN ...-----' marker
+///    and the Base64 payload are assumed NOT to have a length equal to
+///    `pem_rfc7468::BASE64_WRAP_WIDTH`. Such lines will be discarded.
+///
+pub fn clean_pem_bytes_for_parsing(pem_bytes: &[u8]) -> Result<Vec<u8>, pem_rfc7468::Error> {
+    let pem_content_str = std::str::from_utf8(pem_bytes)?;
+    let mut lines_iter = pem_content_str.lines();
+    let mut output_bytes: Vec<u8> = Vec::new();
+    if let Some(begin_line_str) = lines_iter.next() {
+        output_bytes.extend_from_slice(begin_line_str.as_bytes());
+        output_bytes.extend_from_slice(LineEnding::default().as_bytes());
+    } else {
+        return Err(pem_rfc7468::Error::EncapsulatedText);
+    }
+
+    let mut processing_base64_payload = false;
+
+    for line_str in lines_iter {
+        if !processing_base64_payload && line_str.len() == BASE64_WRAP_WIDTH {
+            processing_base64_payload = true;
+        }
+        if processing_base64_payload {
+            output_bytes.extend_from_slice(line_str.as_bytes());
+            output_bytes.extend_from_slice(LineEnding::default().as_bytes());
+        }
+    }
+    Ok(output_bytes)
+}

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -26,7 +26,7 @@ use opentitanlib::image::manifest_def::ManifestSpec;
 use opentitanlib::image::manifest_ext::{ManifestExtEntry, ManifestExtId};
 use opentitanlib::util::file::{FromReader, ToWriter};
 use opentitanlib::util::parse_int::ParseInt;
-use sphincsplus::{DecodeKey, SpxDomain, SpxPublicKey, SpxSecretKey};
+use sphincsplus::{DecodeKey, SphincsPlus, SpxDomain, SpxPublicKey, SpxRawSignature, SpxSecretKey};
 
 /// Bootstrap the target device.
 #[derive(Debug, Args)]
@@ -144,6 +144,9 @@ pub struct ManifestUpdateCommand {
     /// The signature domain (None, Pure, PreHashedSha256)
     #[arg(long, default_value_t = SpxDomain::default())]
     domain: SpxDomain,
+    /// The signature algorithm (Shake128sSimple, Sha2128sSimple)
+    #[arg(long, default_value_t = SphincsPlus::Sha2128sSimple)]
+    spx_algorithm: SphincsPlus,
     /// Set to true if the firmware uses a byte-reversed representation of the hash.
     #[arg(long, action = clap::ArgAction::Set, default_value = "false")]
     spx_hash_reversal_bug: bool,
@@ -334,8 +337,10 @@ impl CommandDispatch for ManifestUpdateCommand {
         }
         // Attach SPX+ signature.
         if let Some(spx_signature) = &self.spx_signature {
-            let signature = std::fs::read(spx_signature)?;
-            image.add_manifest_extension(ManifestExtEntry::new_spx_signature_entry(&signature)?)?;
+            let signature = SpxRawSignature::read_from_file(spx_signature, self.spx_algorithm)?;
+            image.add_manifest_extension(ManifestExtEntry::new_spx_signature_entry(
+                signature.as_bytes(),
+            )?)?;
         }
 
         image.write_to_file(self.output.as_ref().unwrap_or(&self.image))?;

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -10,7 +10,9 @@ use std::path::PathBuf;
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
-use sphincsplus::{DecodeKey, EncodeKey, SphincsPlus, SpxDomain, SpxPublicKey, SpxSecretKey};
+use sphincsplus::{
+    DecodeKey, EncodeKey, SphincsPlus, SpxDomain, SpxPublicKey, SpxRawSignature, SpxSecretKey,
+};
 
 #[derive(Annotate, serde::Serialize)]
 pub struct SpxPublicKeyInfo {
@@ -155,6 +157,9 @@ pub struct SpxVerifyCommand {
     /// The signature domain (Raw, Pure, PreHashedSha256)
     #[arg(long, default_value_t = SpxDomain::default())]
     domain: SpxDomain,
+    /// The signature algorithm (Shake128sSimple, Sha2128sSimple)
+    #[arg(long, default_value_t = SphincsPlus::Sha2128sSimple)]
+    spx_algorithm: SphincsPlus,
     /// The file containing the SPHINCS+ raw public key in PEM format.
     #[arg(value_name = "KEY")]
     public_key: PathBuf,
@@ -175,8 +180,8 @@ impl CommandDispatch for SpxVerifyCommand {
             message.reverse();
         }
         let public_key = SpxPublicKey::read_pem_file(&self.public_key)?;
-        let signature = std::fs::read(&self.signature)?;
-        public_key.verify(self.domain, &signature, &message)?;
+        let signature = SpxRawSignature::read_from_file(&self.signature, self.spx_algorithm)?;
+        public_key.verify(self.domain, signature.as_bytes(), &message)?;
         Ok(None)
     }
 }

--- a/sw/host/sphincsplus/BUILD
+++ b/sw/host/sphincsplus/BUILD
@@ -52,6 +52,7 @@ rust_library(
         "error.rs",
         "key.rs",
         "lib.rs",
+        "signature.rs",
         "variants.rs",
     ],
     proc_macro_deps = [
@@ -60,6 +61,7 @@ rust_library(
     deps = [
         ":bindgen_sha2_128s_simple",
         ":bindgen_shake_128s_simple",
+        "//sw/host/opentitanlib/util",
         "@crate_index//:asn1",
         "@crate_index//:pem-rfc7468",
         "@crate_index//:serde",

--- a/sw/host/sphincsplus/lib.rs
+++ b/sw/host/sphincsplus/lib.rs
@@ -4,10 +4,12 @@
 
 mod error;
 mod key;
+mod signature;
 mod variants;
 
 pub use error::SpxError;
 pub use key::{SpxDomain, SpxPublicKey, SpxSecretKey};
+pub use signature::SpxRawSignature;
 pub use variants::SphincsPlus;
 
 use std::path::Path;

--- a/sw/host/sphincsplus/signature.rs
+++ b/sw/host/sphincsplus/signature.rs
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use pem_rfc7468::Decoder;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use crate::{SphincsPlus, SpxError};
+use util::clean_pem_bytes_for_parsing;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SpxRawSignature {
+    raw_data: Vec<u8>,
+}
+
+impl SpxRawSignature {
+    pub fn read(src: &mut impl Read, algorithm: SphincsPlus) -> Result<Self, SpxError> {
+        let mut raw_data = Vec::new();
+        raw_data.resize(algorithm.signature_len(), 0);
+        src.read_exact(&mut raw_data)?;
+        Ok(SpxRawSignature { raw_data })
+    }
+
+    pub fn read_from_file(path: &Path, algorithm: SphincsPlus) -> Result<Self, SpxError> {
+        let mut file = File::open(path)?;
+        let file_size = std::fs::metadata(path)?.len() as usize;
+
+        if file_size == algorithm.signature_len() {
+            // This must be a raw signature, just read it as is.
+            SpxRawSignature::read(&mut file, algorithm)
+        } else {
+            let mut data = Vec::<u8>::new();
+
+            file.read_to_end(&mut data)?;
+
+            // Try parsing as PEM decoding.
+            SpxRawSignature::from_pem(&data, algorithm)
+        }
+    }
+
+    fn from_pem(data: &[u8], algorithm: SphincsPlus) -> Result<Self, SpxError> {
+        // Ensures valid PEM markers and a recognized label are present.
+        let _ = pem_rfc7468::decode_label(data)?;
+        let mut raw_data = Vec::new();
+        let result = Decoder::new(data);
+        match result {
+            Ok(mut decoder) => decoder.decode_to_end(&mut raw_data)?,
+            _ => {
+                let cleaned_data = clean_pem_bytes_for_parsing(data)?;
+                let mut decoder = Decoder::new(&cleaned_data)?;
+                decoder.decode_to_end(&mut raw_data)?
+            }
+        };
+        if algorithm.signature_len() != raw_data.len() {
+            return Err(SpxError::BadSigLength(raw_data.len()));
+        }
+        Ok(SpxRawSignature { raw_data })
+    }
+
+    /// Returns the raw signature bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.raw_data.as_slice()
+    }
+}


### PR DESCRIPTION
This PR includes 2 commits:

1. Introduces the ability to parse ECDSA signatures from PEM-encoded files and a new utility function handles deviations from strict RFC 7468 PEM formatting,
2.  Introduces the ability to parse SPX+ signatures from PEM-encoded files and a new `SpxSignature` struct to 
encapsulate raw SPX+ signature.