### PR TITLE
[soc_dbg_ctrl,dv] Add VIF to drive misc IOs

### DIFF
--- a/hw/ip/soc_dbg_ctrl/dv/env/seq_lib/soc_dbg_ctrl_base_vseq.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/seq_lib/soc_dbg_ctrl_base_vseq.sv
@@ -35,7 +35,16 @@ function void soc_dbg_ctrl_base_vseq::set_handles();
 endfunction : set_handles
 
 task soc_dbg_ctrl_base_vseq::dut_init(string reset_kind = "HARD");
+  // Initialize some of DUT inputs
+  cfg.misc_vif.set_soc_dbg_state_blank();
+  cfg.misc_vif.set_lc_dft_en_off();
+  cfg.misc_vif.set_lc_hw_debug_en_off();
+  cfg.misc_vif.set_lc_raw_test_rma_off();
+  cfg.misc_vif.init_boot_status();
+  cfg.misc_vif.enable_halt_cpu_boot();
+
   super.dut_init();
+
   if (do_soc_dbg_ctrl_init) begin
     soc_dbg_ctrl_init();
   end

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env.sv
@@ -25,6 +25,11 @@ endfunction : new
 
 function void soc_dbg_ctrl_env::build_phase(uvm_phase phase);
   super.build_phase(phase);
+
+  // Retrieve the soc_dbg_ctrl_misc_io_if virtual interface
+  if (!uvm_config_db#(misc_vif_t)::get(this, "", "misc_vif", cfg.misc_vif)) begin
+    `uvm_fatal(`gfn, "Failed to get misc_vif from uvm_config_db")
+  end
 endfunction : build_phase
 
 function void soc_dbg_ctrl_env::connect_phase(uvm_phase phase);

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cfg.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_cfg.sv
@@ -5,6 +5,9 @@
 class soc_dbg_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(soc_dbg_ctrl_core_reg_block));
   `uvm_object_utils(soc_dbg_ctrl_env_cfg)
 
+  // External interfaces
+  misc_vif_t misc_vif;
+
   string jtag_ral_name = "soc_dbg_ctrl_jtag_reg_block";
 
   // Standard SV/UVM methods

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_env_pkg.sv
@@ -25,6 +25,8 @@ package soc_dbg_ctrl_env_pkg;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault", "recov_ctrl_update_err"};
 
   // Types
+  typedef virtual soc_dbg_ctrl_misc_io_if misc_vif_t;
+
   typedef enum bit [1:0] {
     AddrRead  = 0,
     AddrWrite = 1,

--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_misc_io_if.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_misc_io_if.sv
@@ -1,0 +1,173 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Interface to handle signal level code for the miscellaneous signals without an attached
+// UVM agent
+interface soc_dbg_ctrl_misc_io_if();
+  // Dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import soc_dbg_ctrl_env_pkg::*;
+  import soc_dbg_ctrl_test_pkg::*;
+
+  // Macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // Imports from packages
+  import soc_dbg_ctrl_pkg::soc_dbg_policy_t;
+  import soc_dbg_ctrl_pkg::dbg_category_e;
+  import lc_ctrl_state_pkg::soc_dbg_state_t;
+  import lc_ctrl_state_pkg::SocDbgStBlank;
+  import lc_ctrl_state_pkg::SocDbgStPreProd;
+  import lc_ctrl_state_pkg::SocDbgStProd;
+  import lc_ctrl_pkg::lc_tx_t;
+  import lc_ctrl_pkg::On;
+  import lc_ctrl_pkg::Off;
+  import pwrmgr_pkg::pwr_boot_status_t;
+  import rom_ctrl_pkg::pwrmgr_data_t;
+  import prim_mubi_pkg::mubi4_test_true_strict;
+  import prim_mubi_pkg::mubi4_bool_to_mubi;
+
+  // Variables corresponding to some of the DUT signals
+  soc_dbg_policy_t  soc_dbg_policy_bus;
+  soc_dbg_state_t   soc_dbg_state;
+  lc_tx_t           lc_dft_en;
+  lc_tx_t           lc_hw_debug_en;
+  lc_tx_t           lc_raw_test_rma;
+  pwr_boot_status_t boot_status;
+  logic             halt_cpu_boot;
+  pwrmgr_data_t     continue_cpu_boot;
+
+  // Methods to manage soc_dbg_policy_bus
+  function automatic soc_dbg_policy_t get_soc_dbg_policy_bus();
+    return soc_dbg_policy_bus;
+  endfunction : get_soc_dbg_policy_bus
+
+  function automatic logic is_soc_dbg_policy_valid();
+    return mubi4_test_true_strict(soc_dbg_policy_bus.valid);
+  endfunction : is_soc_dbg_policy_valid
+
+  function automatic logic is_soc_dbg_policy_relocked();
+    return mubi4_test_true_strict(soc_dbg_policy_bus.relocked);
+  endfunction : is_soc_dbg_policy_relocked
+
+  function automatic dbg_category_e get_soc_dbg_policy_category();
+    return soc_dbg_policy_bus.category;
+  endfunction : get_soc_dbg_policy_category
+
+  // Methods to manage soc_dbg_state
+  function automatic void set_soc_dbg_state_blank();
+    soc_dbg_state = SocDbgStBlank;
+  endfunction : set_soc_dbg_state_blank
+
+  function automatic void set_soc_dbg_state_preprod();
+    soc_dbg_state = SocDbgStPreProd;
+  endfunction : set_soc_dbg_state_preprod
+
+  function automatic void set_soc_dbg_state_prod();
+    soc_dbg_state = SocDbgStProd;
+  endfunction : set_soc_dbg_state_prod
+
+  // Methods to manage lc_dft_en
+  function automatic void set_lc_dft_en_on();
+    lc_dft_en = On;
+  endfunction : set_lc_dft_en_on
+
+  function automatic void set_lc_dft_en_off();
+    lc_dft_en = Off;
+  endfunction : set_lc_dft_en_off
+
+  // Methods to manage lc_hw_debug_en
+  function automatic void set_lc_hw_debug_en_on();
+    lc_hw_debug_en = On;
+  endfunction : set_lc_hw_debug_en_on
+
+  function automatic void set_lc_hw_debug_en_off();
+    lc_hw_debug_en = Off;
+  endfunction : set_lc_hw_debug_en_off
+
+  // Methods to manage lc_raw_test_rma
+  function automatic void set_lc_raw_test_rma_on();
+    lc_raw_test_rma = On;
+  endfunction : set_lc_raw_test_rma_on
+
+  function automatic void set_lc_raw_test_rma_off();
+    lc_raw_test_rma = Off;
+  endfunction : set_lc_raw_test_rma_off
+
+  // Methods to manage boot_status
+  function automatic void init_boot_status();
+    boot_status = '0;
+  endfunction : init_boot_status
+
+  function automatic void set_bs_cpu_fetch_en_on();
+    boot_status.cpu_fetch_en = On;
+  endfunction : set_bs_cpu_fetch_en_on
+
+  function automatic void set_bs_cpu_fetch_en_off();
+    boot_status.cpu_fetch_en = Off;
+  endfunction : set_bs_cpu_fetch_en_off
+
+  function automatic void set_bs_rom_ctrl_status_done(int index, logic done);
+    if (index < 0 || index >= pwrmgr_reg_pkg::NumRomInputs) begin
+      `uvm_fatal("SOC_DBG_CTRL_MISC_IO_IF", "Index out of range for boot_status.rom_ctrl_status");
+    end
+    boot_status.rom_ctrl_status[index].done = mubi4_bool_to_mubi(done);
+  endfunction : set_bs_rom_ctrl_status_done
+
+  function automatic void set_bs_rom_ctrl_status_good(int index, logic good);
+    if (index < 0 || index >= pwrmgr_reg_pkg::NumRomInputs) begin
+      `uvm_fatal("SOC_DBG_CTRL_MISC_IO_IF", "Index out of range for boot_status.rom_ctrl_status");
+    end
+    boot_status.rom_ctrl_status[index].good = mubi4_bool_to_mubi(good);
+  endfunction : set_bs_rom_ctrl_status_good
+
+  function automatic void set_bs_lc_done(logic done);
+    boot_status.lc_done = done;
+  endfunction : set_bs_lc_done
+
+  function automatic void set_bs_otp_done(logic done);
+    boot_status.otp_done = done;
+  endfunction : set_bs_otp_done
+
+  function automatic void set_bs_strap_sampled(logic sampled);
+    boot_status.strap_sampled = sampled;
+  endfunction : set_bs_strap_sampled
+
+  function automatic void set_bs_light_reset_req(logic reset_req);
+    boot_status.light_reset_req = reset_req;
+  endfunction : set_bs_light_reset_req
+
+  function automatic void set_bs_clk_main_status(logic main_status);
+    boot_status.clk_status.main_status = main_status;
+  endfunction : set_bs_clk_main_status
+
+  function automatic void set_bs_clk_io_status(logic io_status);
+    boot_status.clk_status.io_status = io_status;
+  endfunction : set_bs_clk_io_status
+
+  // Methods to manage halt_cpu_boot
+  function automatic void enable_halt_cpu_boot();
+    halt_cpu_boot = 1'b1;
+  endfunction : enable_halt_cpu_boot
+
+  function automatic void disable_halt_cpu_boot();
+    halt_cpu_boot = 1'b0;
+  endfunction : disable_halt_cpu_boot
+
+  // Methods to manage continue_cpu_boot
+  function automatic pwrmgr_data_t get_continue_cpu_boot();
+    return continue_cpu_boot;
+  endfunction : get_continue_cpu_boot
+
+  function automatic logic is_continue_cpu_boot_done();
+    return mubi4_test_true_strict(continue_cpu_boot.done);
+  endfunction : is_continue_cpu_boot_done
+
+  function automatic logic is_continue_cpu_boot_good();
+    return mubi4_test_true_strict(continue_cpu_boot.good);
+  endfunction : is_continue_cpu_boot_good
+
+endinterface : soc_dbg_ctrl_misc_io_if

--- a/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim.core
+++ b/hw/ip/soc_dbg_ctrl/dv/soc_dbg_ctrl_sim.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:dv:soc_dbg_ctrl_test
       - lowrisc:dv:soc_dbg_ctrl_sva
     files:
+      - env/soc_dbg_ctrl_misc_io_if.sv
       - tb.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/soc_dbg_ctrl/dv/tb.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/tb.sv
@@ -16,64 +16,44 @@ module tb;
   wire                                    clk;
   wire                                    rst_n;
   wire                                    rst_shadowed_n;
-  wire soc_dbg_ctrl_pkg::soc_dbg_policy_t soc_dbg_policy_bus;
-  wire lc_ctrl_state_pkg::soc_dbg_state_t soc_dbg_state;
-  wire lc_ctrl_pkg::lc_tx_t               lc_dft_en;
-  wire lc_ctrl_pkg::lc_tx_t               lc_hw_debug_en;
-  wire lc_ctrl_pkg::lc_tx_t               lc_raw_test_rma;
-  wire pwrmgr_pkg::pwr_boot_status_t      boot_status;
-  wire                                    halt_cpu_boot;
-  wire rom_ctrl_pkg::pwrmgr_data_t        continue_cpu_boot;
 
   // Interfaces
-  clk_rst_if      clk_rst_if    (.clk(clk), .rst_n(rst_n));
-  rst_shadowed_if rst_shad_if   (.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
-  tl_if           tl_csr_if     (.clk(clk), .rst_n(rst_n));
-  tl_if           tl_jtag_if    (.clk(clk), .rst_n(rst_n));
+  clk_rst_if              clk_rst_if    (.clk(clk), .rst_n(rst_n));
+  rst_shadowed_if         rst_shad_if   (.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
+  tl_if                   tl_csr_if     (.clk(clk), .rst_n(rst_n));
+  tl_if                   tl_jtag_if    (.clk(clk), .rst_n(rst_n));
+  soc_dbg_ctrl_misc_io_if misc_if       ();
 
   `DV_ALERT_IF_CONNECT()
 
   // DUT
   soc_dbg_ctrl dut (
-    .clk_i                    (clk                    ),
-    .rst_ni                   (rst_n                  ),
-    .rst_shadowed_ni          (rst_shadowed_n         ),
+    .clk_i                    (clk                        ),
+    .rst_ni                   (rst_n                      ),
+    .rst_shadowed_ni          (rst_shadowed_n             ),
     // Alerts
-    .alert_rx_i               (alert_rx               ),
-    .alert_tx_o               (alert_tx               ),
+    .alert_rx_i               (alert_rx                   ),
+    .alert_tx_o               (alert_tx                   ),
     // TLUL Core interface
-    .core_tl_i                (tl_csr_if.h2d          ),
-    .core_tl_o                (tl_csr_if.d2h          ),
+    .core_tl_i                (tl_csr_if.h2d              ),
+    .core_tl_o                (tl_csr_if.d2h              ),
     // TLUL JTAG interface
-    .jtag_tl_i                (tl_jtag_if.h2d         ),
-    .jtag_tl_o                (tl_jtag_if.d2h         ),
+    .jtag_tl_i                (tl_jtag_if.h2d             ),
+    .jtag_tl_o                (tl_jtag_if.d2h             ),
     // Debug policy distributed to the SoC
-    .soc_dbg_policy_bus_o     (soc_dbg_policy_bus     ),
+    .soc_dbg_policy_bus_o     (misc_if.soc_dbg_policy_bus ),
     // LC CTRL broadcast signals
-    .soc_dbg_state_i          (soc_dbg_state          ),
-    .lc_dft_en_i              (lc_dft_en              ),
-    .lc_hw_debug_en_i         (lc_hw_debug_en         ),
-    .lc_raw_test_rma_i        (lc_raw_test_rma        ),
-    .boot_status_i            (boot_status            ),
+    .soc_dbg_state_i          (misc_if.soc_dbg_state      ),
+    .lc_dft_en_i              (misc_if.lc_dft_en          ),
+    .lc_hw_debug_en_i         (misc_if.lc_hw_debug_en     ),
+    .lc_raw_test_rma_i        (misc_if.lc_raw_test_rma    ),
+    .boot_status_i            (misc_if.boot_status        ),
     // Boot information from the pwrmgr
     // Halts CPU boot in early lifecycle stages after reset based on an external signal
     // Halt functionality disappears in the production lifecycle
-    .halt_cpu_boot_i          (halt_cpu_boot          ),
-    .continue_cpu_boot_o      (continue_cpu_boot      )
+    .halt_cpu_boot_i          (misc_if.halt_cpu_boot      ),
+    .continue_cpu_boot_o      (misc_if.continue_cpu_boot  )
   );
-
-  // TODO (#27112) Should be dynamically driven/monitored
-  // Manage inputs
-  assign soc_dbg_state    = lc_ctrl_state_pkg::SocDbgStBlank;
-  assign lc_dft_en        = lc_ctrl_pkg::Off;
-  assign lc_hw_debug_en   = lc_ctrl_pkg::Off;
-  assign lc_raw_test_rma  = lc_ctrl_pkg::Off;
-  assign boot_status      = '0;
-  assign halt_cpu_boot    = 1'b1;
-
-  // Manage outputs
-  // assign io_if.soc_dbg_policy_bus  = soc_dbg_policy_bus;
-  // assign io_if.continue_cpu_boot   = continue_cpu_boot;
 
   initial begin
     clk_rst_if.set_active();
@@ -83,6 +63,7 @@ module tb;
     uvm_config_db#(virtual rst_shadowed_if)::set(null, "*.env", "rst_shadowed_vif", rst_shad_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_*_core*", "vif", tl_csr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_*_jtag*", "vif", tl_jtag_if);
+    uvm_config_db#(misc_vif_t)::set(null, "*.env", "misc_vif", misc_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Create an interface to handle miscellaneous signals without any attached UVM agent.

This PR resolves #27112.