### PR TITLE
[pentest] Add remaining FI tests to the automatic testing

### DIFF
--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -57,6 +57,23 @@ pentest_fi(
     test_vectors = LCCTRL_FI_TESTVECTOR_TARGETS,
 )
 
+OTP_FI_TESTVECTOR_TARGETS = [
+    "//sw/host/penetrationtests/testvectors/data:fi_otp",
+]
+
+OTP_FI_TESTVECTOR_ARGS = " ".join([
+    "--fi-otp-json=\"$(rootpath {})\"".format(target)
+    for target in OTP_FI_TESTVECTOR_TARGETS
+])
+
+pentest_fi(
+    name = "fi_otp",
+    slow_test = True,
+    test_args = OTP_FI_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/penetrationtests/fi_otp:harness",
+    test_vectors = OTP_FI_TESTVECTOR_TARGETS,
+)
+
 OTBN_FI_TESTVECTOR_TARGETS = [
     "//sw/host/penetrationtests/testvectors/data:fi_otbn",
 ]

--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -74,6 +74,23 @@ pentest_fi(
     test_vectors = OTP_FI_TESTVECTOR_TARGETS,
 )
 
+RNG_FI_TESTVECTOR_TARGETS = [
+    "//sw/host/penetrationtests/testvectors/data:fi_rng",
+]
+
+RNG_FI_TESTVECTOR_ARGS = " ".join([
+    "--fi-rng-json=\"$(rootpath {})\"".format(target)
+    for target in RNG_FI_TESTVECTOR_TARGETS
+])
+
+pentest_fi(
+    name = "fi_rng",
+    slow_test = True,
+    test_args = RNG_FI_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/penetrationtests/fi_rng:harness",
+    test_vectors = RNG_FI_TESTVECTOR_TARGETS,
+)
+
 OTBN_FI_TESTVECTOR_TARGETS = [
     "//sw/host/penetrationtests/testvectors/data:fi_otbn",
 ]

--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -40,6 +40,23 @@ pentest_fi(
     test_vectors = CRYPTO_FI_TESTVECTOR_TARGETS,
 )
 
+LCCTRL_FI_TESTVECTOR_TARGETS = [
+    "//sw/host/penetrationtests/testvectors/data:fi_lc_ctrl",
+]
+
+LCCTRL_FI_TESTVECTOR_ARGS = " ".join([
+    "--fi-lc-ctrl-json=\"$(rootpath {})\"".format(target)
+    for target in LCCTRL_FI_TESTVECTOR_TARGETS
+])
+
+pentest_fi(
+    name = "fi_lc_ctrl",
+    slow_test = True,
+    test_args = LCCTRL_FI_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/penetrationtests/fi_lc_ctrl:harness",
+    test_vectors = LCCTRL_FI_TESTVECTOR_TARGETS,
+)
+
 OTBN_FI_TESTVECTOR_TARGETS = [
     "//sw/host/penetrationtests/testvectors/data:fi_otbn",
 ]

--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -22,3 +22,20 @@ pentest_fi(
     test_harness = "//sw/host/tests/penetrationtests/fi_ibex:harness",
     test_vectors = IBEX_FI_TESTVECTOR_TARGETS,
 )
+
+CRYPTO_FI_TESTVECTOR_TARGETS = [
+    "//sw/host/penetrationtests/testvectors/data:fi_crypto",
+]
+
+CRYPTO_FI_TESTVECTOR_ARGS = " ".join([
+    "--fi-crypto-json=\"$(rootpath {})\"".format(target)
+    for target in CRYPTO_FI_TESTVECTOR_TARGETS
+])
+
+pentest_fi(
+    name = "fi_crypto",
+    slow_test = True,
+    test_args = CRYPTO_FI_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/penetrationtests/fi_crypto:harness",
+    test_vectors = CRYPTO_FI_TESTVECTOR_TARGETS,
+)

--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -91,6 +91,23 @@ pentest_fi(
     test_vectors = RNG_FI_TESTVECTOR_TARGETS,
 )
 
+ROM_FI_TESTVECTOR_TARGETS = [
+    "//sw/host/penetrationtests/testvectors/data:fi_rom",
+]
+
+ROM_FI_TESTVECTOR_ARGS = " ".join([
+    "--fi-rom-json=\"$(rootpath {})\"".format(target)
+    for target in ROM_FI_TESTVECTOR_TARGETS
+])
+
+pentest_fi(
+    name = "fi_rom",
+    slow_test = True,
+    test_args = ROM_FI_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/penetrationtests/fi_rom:harness",
+    test_vectors = ROM_FI_TESTVECTOR_TARGETS,
+)
+
 OTBN_FI_TESTVECTOR_TARGETS = [
     "//sw/host/penetrationtests/testvectors/data:fi_otbn",
 ]

--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load(":pentest.bzl", "pentest_fi")
+load(":pentest.bzl", "pentest_fi", "pentest_fi_otbn")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,4 +38,21 @@ pentest_fi(
     test_args = CRYPTO_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_crypto:harness",
     test_vectors = CRYPTO_FI_TESTVECTOR_TARGETS,
+)
+
+OTBN_FI_TESTVECTOR_TARGETS = [
+    "//sw/host/penetrationtests/testvectors/data:fi_otbn",
+]
+
+OTBN_FI_TESTVECTOR_ARGS = " ".join([
+    "--fi-otbn-json=\"$(rootpath {})\"".format(target)
+    for target in OTBN_FI_TESTVECTOR_TARGETS
+])
+
+pentest_fi_otbn(
+    name = "fi_otbn",
+    slow_test = True,
+    test_args = OTBN_FI_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/penetrationtests/fi_otbn:harness",
+    test_vectors = OTBN_FI_TESTVECTOR_TARGETS,
 )

--- a/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
@@ -23,7 +23,8 @@ extern "C" {
     value(_, Sha256) \
     value(_, ShadowRegAccess) \
     value(_, ShadowRegRead)
-UJSON_SERDE_ENUM(CryptoFiSubcommand, crypto_fi_subcommand_t, CRYPTOFI_SUBCOMMAND);
+C_ONLY(UJSON_SERDE_ENUM(CryptoFiSubcommand, crypto_fi_subcommand_t, CRYPTOFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(CryptoFiSubcommand, crypto_fi_subcommand_t, CRYPTOFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
 #define CRYPTOFI_AES_MODE(field, string) \
     field(key_trigger, bool) \

--- a/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
@@ -14,7 +14,8 @@ extern "C" {
 #define LCCTRLFI_SUBCOMMAND(_, value) \
     value(_, Init) \
     value(_, RuntimeCorruption)
-UJSON_SERDE_ENUM(LcCtrlFiSubcommand, lc_ctrl_fi_subcommand_t, LCCTRLFI_SUBCOMMAND);
+C_ONLY(UJSON_SERDE_ENUM(LcCtrlFiSubcommand, lc_ctrl_fi_subcommand_t, LCCTRLFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(LcCtrlFiSubcommand, lc_ctrl_fi_subcommand_t, LCCTRLFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
 #define LCCTRLFI_CORRUPTION(field, string) \
     field(res, uint32_t) \

--- a/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
@@ -32,7 +32,8 @@ extern "C" {
     value(_, KeySideload)  \
     value(_, LoadIntegrity) \
     value(_, PC)
-UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
+C_ONLY(UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
 #define OTBNFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \

--- a/sw/device/tests/penetrationtests/json/otp_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otp_fi_commands.h
@@ -17,7 +17,8 @@ extern "C" {
     value(_, LifeCycle) \
     value(_, OwnerSwCfg) \
     value(_, VendorTest)
-UJSON_SERDE_ENUM(OtpFiSubcommand, otp_fi_subcommand_t, OTPFI_SUBCOMMAND);
+C_ONLY(UJSON_SERDE_ENUM(OtpFiSubcommand, otp_fi_subcommand_t, OTPFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(OtpFiSubcommand, otp_fi_subcommand_t, OTPFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
 #define OTPFI_VENDORTEST_PARTITION(field, string) \
     field(vendor_test_comp, uint32_t, 16) \

--- a/sw/device/tests/penetrationtests/json/rng_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rng_fi_commands.h
@@ -62,12 +62,19 @@ UJSON_SERDE_STRUCT(RngFiEntrBiasOutput, rng_fi_entropy_src_bias_t, RNGFI_ENTRBIA
 UJSON_SERDE_STRUCT(RngFiFwOverwriteOutput, rng_fi_fw_overwrite_t, RNGFI_FWOVERWRITE_OUTPUT);
 
 #define RNGFI_EDN(field, string) \
-    field(collisions, uint32_t) \
     field(rand, uint32_t, 16) \
     field(alerts, uint32_t, 3) \
     field(err_status, uint32_t) \
     field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(RngFiEdn, rng_fi_edn_t, RNGFI_EDN);
+
+#define RNGFI_EDN_COLLISION(field, string) \
+    field(collisions, uint32_t) \
+    field(rand, uint32_t, 16) \
+    field(alerts, uint32_t, 3) \
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
+UJSON_SERDE_STRUCT(RngFiEdnCollision, rng_fi_edn_collisions_t, RNGFI_EDN_COLLISION);
 
 #define RNGFI_FWOVERWRITE_HEALTH(field, string) \
     field(disable_health_check, bool)

--- a/sw/device/tests/penetrationtests/json/rng_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rng_fi_commands.h
@@ -21,7 +21,8 @@ extern "C" {
     value(_, EdnBias) \
     value(_, FWOverride) \
     value(_, EntropySrcBias)
-UJSON_SERDE_ENUM(RngFiSubcommand, rng_fi_subcommand_t, RNGFI_SUBCOMMAND);
+C_ONLY(UJSON_SERDE_ENUM(RngFiSubcommand, rng_fi_subcommand_t, RNGFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(RngFiSubcommand, rng_fi_subcommand_t, RNGFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
 #define CRYPTOFI_CSRNG_MODE(field, string) \
     field(start_trigger, bool) \

--- a/sw/device/tests/penetrationtests/json/rom_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rom_fi_commands.h
@@ -14,8 +14,8 @@ extern "C" {
 #define ROMFI_SUBCOMMAND(_, value) \
     value(_, Init) \
     value(_, Read)
-UJSON_SERDE_ENUM(RomFiSubcommand, rom_fi_subcommand_t, ROMFI_SUBCOMMAND);
-
+C_ONLY(UJSON_SERDE_ENUM(RomFiSubcommand, rom_fi_subcommand_t, ROMFI_SUBCOMMAND));
+RUST_ONLY(UJSON_SERDE_ENUM(RomFiSubcommand, rom_fi_subcommand_t, ROMFI_SUBCOMMAND, RUST_DEFAULT_DERIVE, strum::EnumString));
 
 #define ROMFI_DIGEST(field, string) \
     field(digest, uint32_t, 8) \

--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -46,6 +46,21 @@ FIRMWARE_DEPS_FI = [
     "//sw/device/tests/penetrationtests/json:commands",
 ]
 
+FIRMWARE_DEPS_FI_OTBN = [
+    "//sw/device/tests/penetrationtests/firmware/fi:otbn_fi",
+    "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+    "//sw/device/lib/base:csr",
+    "//sw/device/lib/base:status",
+    "//sw/device/lib/crypto/drivers:entropy",
+    "//sw/device/lib/testing/test_framework:check",
+    "//sw/device/lib/testing/test_framework:ottf_main",
+    "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/ujson",
+
+    # Include all JSON commands.
+    "//sw/device/tests/penetrationtests/json:commands",
+]
+
 def pentest_fi(name, test_vectors, test_args, test_harness, slow_test = False):
     """A macro for defining a CryptoTest test case.
 
@@ -89,4 +104,49 @@ def pentest_fi(name, test_vectors, test_args, test_harness, slow_test = False):
             test_harness = test_harness,
         ),
         deps = FIRMWARE_DEPS_FI,
+    )
+
+def pentest_fi_otbn(name, test_vectors, test_args, test_harness, slow_test = False):
+    """A macro for defining a CryptoTest test case.
+
+    Args:
+        name: the name of the test.
+        test_vectors: the test vectors to use.
+        test_args: additional arguments to pass to the test.
+        test_harness: the test harness to use.
+        slow_test: indicate if the test should be run in the nightly CI.
+    """
+    tags = ["slow_test"] if slow_test else []
+    opentitan_test(
+        name = name,
+        srcs = ["//sw/device/tests/penetrationtests/firmware:firmware_fi_otbn.c"],
+        fpga = fpga_params(
+            timeout = "long",
+            data = test_vectors,
+            tags = tags,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        fpga_cw340 = fpga_params(
+            timeout = "long",
+            tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        exec_env = PENTEST_EXEC_ENVS,
+        silicon = silicon_params(
+            timeout = "eternal",
+            tags = tags,
+            data = test_vectors,
+            test_cmd = """
+                --bootstrap={firmware}
+            """ + test_args,
+            test_harness = test_harness,
+        ),
+        deps = FIRMWARE_DEPS_FI_OTBN,
     )

--- a/sw/host/penetrationtests/testvectors/data/BUILD
+++ b/sw/host/penetrationtests/testvectors/data/BUILD
@@ -28,3 +28,8 @@ filegroup(
     name = "fi_otp",
     srcs = ["fi_otp.json"],
 )
+
+filegroup(
+    name = "fi_rng",
+    srcs = ["fi_rng.json"],
+)

--- a/sw/host/penetrationtests/testvectors/data/BUILD
+++ b/sw/host/penetrationtests/testvectors/data/BUILD
@@ -15,6 +15,11 @@ filegroup(
 )
 
 filegroup(
+    name = "fi_lc_ctrl",
+    srcs = ["fi_lc_ctrl.json"],
+)
+
+filegroup(
     name = "fi_otbn",
     srcs = ["fi_otbn.json"],
 )

--- a/sw/host/penetrationtests/testvectors/data/BUILD
+++ b/sw/host/penetrationtests/testvectors/data/BUILD
@@ -33,3 +33,8 @@ filegroup(
     name = "fi_rng",
     srcs = ["fi_rng.json"],
 )
+
+filegroup(
+    name = "fi_rom",
+    srcs = ["fi_rom.json"],
+)

--- a/sw/host/penetrationtests/testvectors/data/BUILD
+++ b/sw/host/penetrationtests/testvectors/data/BUILD
@@ -5,11 +5,16 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
+    name = "fi_crypto",
+    srcs = ["fi_crypto.json"],
+)
+
+filegroup(
     name = "fi_ibex",
     srcs = ["fi_ibex.json"],
 )
 
 filegroup(
-    name = "fi_crypto",
-    srcs = ["fi_crypto.json"],
+    name = "fi_otbn",
+    srcs = ["fi_otbn.json"],
 )

--- a/sw/host/penetrationtests/testvectors/data/BUILD
+++ b/sw/host/penetrationtests/testvectors/data/BUILD
@@ -23,3 +23,8 @@ filegroup(
     name = "fi_otbn",
     srcs = ["fi_otbn.json"],
 )
+
+filegroup(
+    name = "fi_otp",
+    srcs = ["fi_otp.json"],
+)

--- a/sw/host/penetrationtests/testvectors/data/BUILD
+++ b/sw/host/penetrationtests/testvectors/data/BUILD
@@ -8,3 +8,8 @@ filegroup(
     name = "fi_ibex",
     srcs = ["fi_ibex.json"],
 )
+
+filegroup(
+    name = "fi_crypto",
+    srcs = ["fi_crypto.json"],
+)

--- a/sw/host/penetrationtests/testvectors/data/fi_crypto.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_crypto.json
@@ -1,0 +1,99 @@
+[
+  {
+    "test_case_id": 1,
+    "command": "Init",
+    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "expected_output": "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}"
+  },
+  {
+    "test_case_id": 2,
+    "command": "Aes",
+    "mode": "{\"key_trigger\": true,\"plaintext_trigger\": false,\"encrypt_trigger\": false,\"ciphertext_trigger\": false}",
+    "expected_output": "{\"ciphertext\":[141,145,88,155,234,129,16,92,221,12,69,21,69,208,99,12],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 3,
+    "command": "Aes",
+    "mode": "{\"key_trigger\": false,\"plaintext_trigger\": true,\"encrypt_trigger\": false,\"ciphertext_trigger\": false}",
+    "expected_output": "{\"ciphertext\":[141,145,88,155,234,129,16,92,221,12,69,21,69,208,99,12],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 4,
+    "command": "Aes",
+    "mode": "{\"key_trigger\": false,\"plaintext_trigger\": false,\"encrypt_trigger\": true,\"ciphertext_trigger\": false}",
+    "expected_output": "{\"ciphertext\":[141,145,88,155,234,129,16,92,221,12,69,21,69,208,99,12],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 5,
+    "command": "Aes",
+    "mode": "{\"key_trigger\": false,\"plaintext_trigger\": false,\"encrypt_trigger\": false,\"ciphertext_trigger\": true}",
+    "expected_output": "{\"ciphertext\":[141,145,88,155,234,129,16,92,221,12,69,21,69,208,99,12],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 6,
+    "command": "Kmac",
+    "mode": "{\"key_trigger\": true,\"absorb_trigger\": false,\"static_trigger\": false,\"squeeze_trigger\": false}",
+    "expected_output": "{\"digest\":[184,34,91,108,231,47,251,27],\"digest_2nd\":[142,188,186,201,216,47,203,192],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 7,
+    "command": "Kmac",
+    "mode": "{\"key_trigger\": false,\"absorb_trigger\": true,\"static_trigger\": false,\"squeeze_trigger\": false}",
+    "expected_output": "{\"digest\":[184,34,91,108,231,47,251,27],\"digest_2nd\":[142,188,186,201,216,47,203,192],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 8,
+    "command": "Kmac",
+    "mode": "{\"key_trigger\": false,\"absorb_trigger\": false,\"static_trigger\": true,\"squeeze_trigger\": false}",
+    "expected_output": "{\"digest\":[184,34,91,108,231,47,251,27],\"digest_2nd\":[142,188,186,201,216,47,203,192],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 9,
+    "command": "Kmac",
+    "mode": "{\"key_trigger\": false,\"absorb_trigger\": false,\"static_trigger\": false,\"squeeze_trigger\": true}",
+    "expected_output": "{\"digest\":[184,34,91,108,231,47,251,27],\"digest_2nd\":[142,188,186,201,216,47,203,192],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 10,
+    "command": "KmacState",
+    "expected_output": "{\"digest\":[184,34,91,108,231,47,251,27],\"share0\":[168,31,28,190,140,6,235,119,202,55,129,61,31,221,97,54,201,182,175,200,60,240,99,162,34,70,184,1,169,199,155,137,199,21,166,226,106,179,98,249,101,65,178,235,2,211,113,56,88,225,175,108,61,95,19,198,197,231,202,185,4,101,56,244,114,31,234,125,225,126,28,173,181,108,127,148,160,220,131,34,182,88,177,17,94,56,199,224,126,187,122,92,152,238,216,100,88,61,108,213,29,251,235,148,145,99,77,149,221,13,128,228,13,26,230,143,116,223,228,207,233,90,156,121,223,120,91,21,84,191,96,64,206,80,162,187,114,83,219,121,163,162,109,86,188,116,65,158,80,212,144,98,209,56,113,134,43,85,112,128,14,25,139,126,49,104,231,41,230,90,143,245,177,42,209,230,176,204,61,38,235,51,106,56,204,18,44,115,30,106,30,159,60,152,217,147,245,173,18,99], \"share1\": [16,61,71,210,107,41,16,108,170,255,75,141,112,27,129,192,106,34,217,60,0,9,134,114,167,165,248,253,101,35,171,138,185,143,55,87,2,191,132,184,145,19,156,5,186,11,190,103,7,53,249,90,176,27,236,206,170,101,38,115,109,136,230,237,252,163,80,180,57,81,215,109,102,224,97,53,168,152,2,43,118,77,150,109,153,47,176,198,185,117,94,130,159,28,85,216,85,93,101,95,242,84,50,129,216,139,224,215,217,68,215,28,238,249,156,219,224,30,116,181,94,13,244,179,232,1,217,35,109,31,50,174,157,31,126,158,254,106,227,249,54,150,163,32,114,31,117,24,160,167,100,139,108,127,12,236,92,245,254,144,188,30,44,151,48,78,221,38,113,206,94,4,187,19,17,217,159,162,248,255,171,51,124,205,226,207,231,86,132,74,185,169,126,221,67,204,253,13,21,24], \"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 11,
+    "command": "Sha256",
+    "input": "{\"message\": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}",
+    "mode": "{\"start_trigger\": true,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": false}",
+    "expected_output": "{\"tag\":[686569403,627255979,3962665531,1869430007,3580678696,2543765621,4151418325,927402239],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 12,
+    "command": "Sha256",
+    "input": "{\"message\": [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": true,\"process_trigger\": false,\"finish_trigger\": false}",
+    "expected_output": "{\"tag\":[1080378907,3894047529,4265098468,2275438372,2555095219,287412521,1595297801,1522967956],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 13,
+    "command": "Sha256",
+    "input": "{\"message\": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": true,\"finish_trigger\": false}",
+    "expected_output": "{\"tag\":[3996813713,3685128488,2749163006,1137088592,438890749,3186001028,96417470,3192245030],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 14,
+    "command": "Sha256",
+    "input": "{\"message\": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]}",
+    "mode": "{\"start_trigger\": false,\"msg_trigger\": false,\"process_trigger\": false,\"finish_trigger\": true}",
+    "expected_output": "{\"tag\":[956051232,3683224361,4139697432,3225996988,496274419,3147268997,3136358402,529633942],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 15,
+    "command": "ShadowRegAccess",
+    "expected_output": "{\"result\":[68162304,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 16,
+    "command": "ShadowRegRead",
+    "expected_output": "{\"result\":[0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  }
+]

--- a/sw/host/penetrationtests/testvectors/data/fi_lc_ctrl.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_lc_ctrl.json
@@ -1,0 +1,13 @@
+[
+  {
+    "test_case_id": 1,
+    "command": "Init",
+    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "expected_output": "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}"
+  },
+  {
+    "test_case_id": 2,
+    "command": "RuntimeCorruption",
+    "expected_output": "{\"res\":0,\"state\":17,\"counter\":5,\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  }
+]

--- a/sw/host/penetrationtests/testvectors/data/fi_otbn.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_otbn.json
@@ -1,0 +1,97 @@
+[
+  {
+    "test_case_id": 1,
+    "command": "Init",
+    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "expected_output": "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}"
+  },
+  {
+    "test_case_id": 2,
+    "command": "CharBeq",
+    "expected_output": "{\"result\":0,\"insn_cnt\":509,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 3,
+    "command": "CharBnRshi",
+    "input": "{\"big_num\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}",
+    "expected_output": "{\"big_num\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"insn_cnt\":109,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 4,
+    "command": "CharBnSel",
+     "input": "{\"big_num\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}",
+    "expected_output": "{\"big_num\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"insn_cnt\":1014,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 5,
+    "command": "CharBnWsrr",
+    "expected_output": "{\"res\":0,\"insn_cnt\":1089,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 6,
+    "command": "CharBne",
+    "expected_output": "{\"result\":0,\"insn_cnt\":509,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 7,
+    "command": "CharDmemAccess",
+    "expected_output": "{\"res\":0,\"insn_cnt\":271,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 8,
+    "command": "CharDmemWrite",
+    "expected_output": "{\"result\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"insn_cnt\":1,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 9,
+    "command": "CharHardwareDmemOpLoop",
+    "expected_output": "{\"loop_counter\":10000,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 10,
+    "command": "CharHardwareRegOpLoop",
+    "expected_output": "{\"loop_counter\":10000,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 11,
+    "command": "CharJal",
+    "expected_output": "{\"result\":0,\"insn_cnt\":505,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 12,
+    "command": "CharLw",
+    "expected_output": "{\"result\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"insn_cnt\":1084,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 13,
+    "command": "CharMem",
+    "input": "{\"byte_offset\":0,\"num_words\":4,\"imem\":false,\"dmem\":true}",
+    "expected_output": "{\"res\":0,\"imem_data\":[0,0,0,0,0,0,0,0],\"imem_addr\":[0,0,0,0,0,0,0,0],\"dmem_data\":[0,0,0,0,0,0,0,0],\"dmem_addr\":[0,0,0,0,0,0,0,0],\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 14,
+    "command": "CharRF",
+    "expected_output": "{\"res\":0,\"faulty_gpr\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"faulty_wdr\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 15,
+    "command": "CharUnrolledDmemOpLoop",
+    "expected_output": "{\"loop_counter\":100,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 16,
+    "command": "CharUnrolledRegOpLoop",
+    "expected_output": "{\"loop_counter\":100,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 17,
+    "command": "LoadIntegrity",
+    "expected_output": "{\"result\":0,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 18,
+    "command": "PC",
+    "input": "{\"pc\":2224}",
+    "expected_output": "{\"pc_dmem\":2224,\"pc_otbn\":2224,\"insn_cnt\":472,\"err_otbn\":0,\"err_ibx\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  }
+]

--- a/sw/host/penetrationtests/testvectors/data/fi_otp.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_otp.json
@@ -1,0 +1,28 @@
+[
+  {
+    "test_case_id": 1,
+    "command": "Init",
+    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "expected_output": "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}"
+  },
+  {
+    "test_case_id": 2,
+    "command": "HwCfg",
+    "expected_output": "{\"hw_cfg_comp\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"hw_cfg_fi\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"otp_error_causes\":[0,0,0,0,0,0,0,0,0,0],\"otp_status_codes\":0,\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 3,
+    "command": "LifeCycle",
+    "expected_output": "{\"life_cycle_comp\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"life_cycle_fi\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"otp_error_causes\":[0,0,0,0,0,0,0,0,0,0],\"otp_status_codes\":0,\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 4,
+    "command": "OwnerSwCfg",
+    "expected_output": "{\"owner_sw_cfg_comp\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"owner_sw_cfg_fi\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"otp_error_causes\":[0,0,0,0,0,0,0,0,0,0],\"otp_status_codes\":0,\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 5,
+    "command": "VendorTest",
+    "expected_output": "{\"vendor_test_comp\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"vendor_test_fi\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"otp_error_causes\":[0,0,0,0,0,0,0,0,0,0],\"otp_status_codes\":0,\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  }
+]

--- a/sw/host/penetrationtests/testvectors/data/fi_rng.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_rng.json
@@ -19,7 +19,7 @@
   {
     "test_case_id": 4,
     "command": "EdnBias",
-    "expected_output": "{\"collisions\":0,\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+    "expected_output": "{\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
   },
   {
     "test_case_id": 5,

--- a/sw/host/penetrationtests/testvectors/data/fi_rng.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_rng.json
@@ -1,0 +1,36 @@
+[
+  {
+    "test_case_id": 1,
+    "command": "CsrngInit",
+    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "expected_output": "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}"
+  },
+  {
+    "test_case_id": 2,
+    "command": "CsrngBias",
+    "input": "{\"start_trigger\": true,\"valid_trigger\": true,\"read_trigger\": true,\"all_trigger\": true}",
+    "expected_output": "{\"res\":0,\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 3,
+    "command": "EdnRespAck",
+    "expected_output": "{\"collisions\":0,\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 4,
+    "command": "EdnBias",
+    "expected_output": "{\"collisions\":0,\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 5,
+    "command": "FWOverride",
+    "input": "{\"disable_health_check\": true}",
+    "expected_output": "{\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  },
+  {
+    "test_case_id": 6,
+    "command": "FWOverride",
+    "input": "{\"disable_health_check\": false}",
+    "expected_output": "{\"rand\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  }
+]

--- a/sw/host/penetrationtests/testvectors/data/fi_rom.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_rom.json
@@ -1,0 +1,14 @@
+[
+  {
+    "test_case_id": 1,
+    "command": "Init",
+    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "expected_output": "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}"
+  },
+  {
+    "test_case_id": 2,
+    "command": "Read",
+    "input": "{\"start_trigger\": true,\"valid_trigger\": true,\"read_trigger\": true,\"all_trigger\": true}",
+    "expected_output": "{\"digest\":[0,0,0,0,0,0,0,0],\"err_status\":0,\"alerts\":[0,0,0],\"ast_alerts\":[0,0]}"
+  }
+]

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -13,6 +13,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "fi_crypto_commands_rust",
+    srcs = ["//sw/device/tests/penetrationtests/json:crypto_fi_commands"],
+)
+
+ujson_rust(
     name = "fi_ibex_commands_rust",
     srcs = ["//sw/device/tests/penetrationtests/json:ibex_fi_commands"],
 )
@@ -26,17 +31,20 @@ rust_library(
     name = "pentest_commands",
     srcs = [
         "src/commands.rs",
+        "src/fi_crypto_commands.rs",
         "src/fi_ibex_commands.rs",
         "src/lib.rs",
         "src/pentest_lib_commands.rs",
     ],
     compile_data = [
         ":commands_rust",
+        ":fi_crypto_commands_rust",
         ":fi_ibex_commands_rust",
         ":pentest_lib_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
+        "fi_crypto_commands_loc": "$(execpath :fi_crypto_commands_rust)",
         "fi_ibex_commands_loc": "$(execpath :fi_ibex_commands_rust)",
         "pentest_lib_commands_loc": "$(execpath :pentest_lib_commands_rust)",
     },

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -33,6 +33,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "fi_otp_commands_rust",
+    srcs = ["//sw/device/tests/penetrationtests/json:otp_fi_commands"],
+)
+
+ujson_rust(
     name = "pentest_lib_commands_rust",
     srcs = ["//sw/device/tests/penetrationtests/json:pentest_lib_commands"],
 )
@@ -45,6 +50,7 @@ rust_library(
         "src/fi_ibex_commands.rs",
         "src/fi_lc_ctrl_commands.rs",
         "src/fi_otbn_commands.rs",
+        "src/fi_otp_commands.rs",
         "src/lib.rs",
         "src/pentest_lib_commands.rs",
     ],
@@ -54,6 +60,7 @@ rust_library(
         ":fi_ibex_commands_rust",
         ":fi_lc_ctrl_commands_rust",
         ":fi_otbn_commands_rust",
+        ":fi_otp_commands_rust",
         ":pentest_lib_commands_rust",
     ],
     rustc_env = {
@@ -62,6 +69,7 @@ rust_library(
         "fi_ibex_commands_loc": "$(execpath :fi_ibex_commands_rust)",
         "fi_lc_ctrl_commands_loc": "$(execpath :fi_lc_ctrl_commands_rust)",
         "fi_otbn_commands_loc": "$(execpath :fi_otbn_commands_rust)",
+        "fi_otp_commands_loc": "$(execpath :fi_otp_commands_rust)",
         "pentest_lib_commands_loc": "$(execpath :pentest_lib_commands_rust)",
     },
     deps = [

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -43,6 +43,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "fi_rom_commands_rust",
+    srcs = ["//sw/device/tests/penetrationtests/json:rom_fi_commands"],
+)
+
+ujson_rust(
     name = "pentest_lib_commands_rust",
     srcs = ["//sw/device/tests/penetrationtests/json:pentest_lib_commands"],
 )
@@ -57,6 +62,7 @@ rust_library(
         "src/fi_otbn_commands.rs",
         "src/fi_otp_commands.rs",
         "src/fi_rng_commands.rs",
+        "src/fi_rom_commands.rs",
         "src/lib.rs",
         "src/pentest_lib_commands.rs",
     ],
@@ -68,6 +74,7 @@ rust_library(
         ":fi_otbn_commands_rust",
         ":fi_otp_commands_rust",
         ":fi_rng_commands_rust",
+        ":fi_rom_commands_rust",
         ":pentest_lib_commands_rust",
     ],
     rustc_env = {
@@ -78,6 +85,7 @@ rust_library(
         "fi_otbn_commands_loc": "$(execpath :fi_otbn_commands_rust)",
         "fi_otp_commands_loc": "$(execpath :fi_otp_commands_rust)",
         "fi_rng_commands_loc": "$(execpath :fi_rng_commands_rust)",
+        "fi_rom_commands_loc": "$(execpath :fi_rom_commands_rust)",
         "pentest_lib_commands_loc": "$(execpath :pentest_lib_commands_rust)",
     },
     deps = [

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -23,6 +23,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "fi_lc_ctrl_commands_rust",
+    srcs = ["//sw/device/tests/penetrationtests/json:lc_ctrl_fi_commands"],
+)
+
+ujson_rust(
     name = "fi_otbn_commands_rust",
     srcs = ["//sw/device/tests/penetrationtests/json:otbn_fi_commands"],
 )
@@ -38,6 +43,7 @@ rust_library(
         "src/commands.rs",
         "src/fi_crypto_commands.rs",
         "src/fi_ibex_commands.rs",
+        "src/fi_lc_ctrl_commands.rs",
         "src/fi_otbn_commands.rs",
         "src/lib.rs",
         "src/pentest_lib_commands.rs",
@@ -46,6 +52,7 @@ rust_library(
         ":commands_rust",
         ":fi_crypto_commands_rust",
         ":fi_ibex_commands_rust",
+        ":fi_lc_ctrl_commands_rust",
         ":fi_otbn_commands_rust",
         ":pentest_lib_commands_rust",
     ],
@@ -53,6 +60,7 @@ rust_library(
         "commands_loc": "$(execpath :commands_rust)",
         "fi_crypto_commands_loc": "$(execpath :fi_crypto_commands_rust)",
         "fi_ibex_commands_loc": "$(execpath :fi_ibex_commands_rust)",
+        "fi_lc_ctrl_commands_loc": "$(execpath :fi_lc_ctrl_commands_rust)",
         "fi_otbn_commands_loc": "$(execpath :fi_otbn_commands_rust)",
         "pentest_lib_commands_loc": "$(execpath :pentest_lib_commands_rust)",
     },

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -23,6 +23,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "fi_otbn_commands_rust",
+    srcs = ["//sw/device/tests/penetrationtests/json:otbn_fi_commands"],
+)
+
+ujson_rust(
     name = "pentest_lib_commands_rust",
     srcs = ["//sw/device/tests/penetrationtests/json:pentest_lib_commands"],
 )
@@ -33,6 +38,7 @@ rust_library(
         "src/commands.rs",
         "src/fi_crypto_commands.rs",
         "src/fi_ibex_commands.rs",
+        "src/fi_otbn_commands.rs",
         "src/lib.rs",
         "src/pentest_lib_commands.rs",
     ],
@@ -40,12 +46,14 @@ rust_library(
         ":commands_rust",
         ":fi_crypto_commands_rust",
         ":fi_ibex_commands_rust",
+        ":fi_otbn_commands_rust",
         ":pentest_lib_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
         "fi_crypto_commands_loc": "$(execpath :fi_crypto_commands_rust)",
         "fi_ibex_commands_loc": "$(execpath :fi_ibex_commands_rust)",
+        "fi_otbn_commands_loc": "$(execpath :fi_otbn_commands_rust)",
         "pentest_lib_commands_loc": "$(execpath :pentest_lib_commands_rust)",
     },
     deps = [

--- a/sw/host/penetrationtests/ujson_lib/BUILD
+++ b/sw/host/penetrationtests/ujson_lib/BUILD
@@ -38,6 +38,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "fi_rng_commands_rust",
+    srcs = ["//sw/device/tests/penetrationtests/json:rng_fi_commands"],
+)
+
+ujson_rust(
     name = "pentest_lib_commands_rust",
     srcs = ["//sw/device/tests/penetrationtests/json:pentest_lib_commands"],
 )
@@ -51,6 +56,7 @@ rust_library(
         "src/fi_lc_ctrl_commands.rs",
         "src/fi_otbn_commands.rs",
         "src/fi_otp_commands.rs",
+        "src/fi_rng_commands.rs",
         "src/lib.rs",
         "src/pentest_lib_commands.rs",
     ],
@@ -61,6 +67,7 @@ rust_library(
         ":fi_lc_ctrl_commands_rust",
         ":fi_otbn_commands_rust",
         ":fi_otp_commands_rust",
+        ":fi_rng_commands_rust",
         ":pentest_lib_commands_rust",
     ],
     rustc_env = {
@@ -70,6 +77,7 @@ rust_library(
         "fi_lc_ctrl_commands_loc": "$(execpath :fi_lc_ctrl_commands_rust)",
         "fi_otbn_commands_loc": "$(execpath :fi_otbn_commands_rust)",
         "fi_otp_commands_loc": "$(execpath :fi_otp_commands_rust)",
+        "fi_rng_commands_loc": "$(execpath :fi_rng_commands_rust)",
         "pentest_lib_commands_loc": "$(execpath :pentest_lib_commands_rust)",
     },
     deps = [

--- a/sw/host/penetrationtests/ujson_lib/src/fi_crypto_commands.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/fi_crypto_commands.rs
@@ -1,7 +1,4 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-pub mod commands;
-pub mod fi_crypto_commands;
-pub mod fi_ibex_commands;
-pub mod pentest_lib_commands;
+include!(env!("fi_crypto_commands_loc"));

--- a/sw/host/penetrationtests/ujson_lib/src/fi_lc_ctrl_commands.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/fi_lc_ctrl_commands.rs
@@ -1,9 +1,4 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-pub mod commands;
-pub mod fi_crypto_commands;
-pub mod fi_ibex_commands;
-pub mod fi_lc_ctrl_commands;
-pub mod fi_otbn_commands;
-pub mod pentest_lib_commands;
+include!(env!("fi_lc_ctrl_commands_loc"));

--- a/sw/host/penetrationtests/ujson_lib/src/fi_otbn_commands.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/fi_otbn_commands.rs
@@ -1,8 +1,4 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-pub mod commands;
-pub mod fi_crypto_commands;
-pub mod fi_ibex_commands;
-pub mod fi_otbn_commands;
-pub mod pentest_lib_commands;
+include!(env!("fi_otbn_commands_loc"));

--- a/sw/host/penetrationtests/ujson_lib/src/fi_otp_commands.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/fi_otp_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("fi_otp_commands_loc"));

--- a/sw/host/penetrationtests/ujson_lib/src/fi_rng_commands.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/fi_rng_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("fi_rng_commands_loc"));

--- a/sw/host/penetrationtests/ujson_lib/src/fi_rom_commands.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/fi_rom_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("fi_rom_commands_loc"));

--- a/sw/host/penetrationtests/ujson_lib/src/lib.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/lib.rs
@@ -7,4 +7,5 @@ pub mod fi_ibex_commands;
 pub mod fi_lc_ctrl_commands;
 pub mod fi_otbn_commands;
 pub mod fi_otp_commands;
+pub mod fi_rng_commands;
 pub mod pentest_lib_commands;

--- a/sw/host/penetrationtests/ujson_lib/src/lib.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/lib.rs
@@ -8,4 +8,5 @@ pub mod fi_lc_ctrl_commands;
 pub mod fi_otbn_commands;
 pub mod fi_otp_commands;
 pub mod fi_rng_commands;
+pub mod fi_rom_commands;
 pub mod pentest_lib_commands;

--- a/sw/host/penetrationtests/ujson_lib/src/lib.rs
+++ b/sw/host/penetrationtests/ujson_lib/src/lib.rs
@@ -6,4 +6,5 @@ pub mod fi_crypto_commands;
 pub mod fi_ibex_commands;
 pub mod fi_lc_ctrl_commands;
 pub mod fi_otbn_commands;
+pub mod fi_otp_commands;
 pub mod pentest_lib_commands;

--- a/sw/host/tests/penetrationtests/fi_crypto/BUILD
+++ b/sw/host/tests/penetrationtests/fi_crypto/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/penetrationtests/ujson_lib:pentest_commands",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/penetrationtests/fi_lc_ctrl/BUILD
+++ b/sw/host/tests/penetrationtests/fi_lc_ctrl/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/penetrationtests/ujson_lib:pentest_commands",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/penetrationtests/fi_lc_ctrl/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_lc_ctrl/src/main.rs
@@ -1,0 +1,138 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+
+use pentest_commands::commands::PenetrationtestCommand;
+use pentest_commands::fi_lc_ctrl_commands::LcCtrlFiSubcommand;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    fi_lc_ctrl_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FiLcCtrlTestCase {
+    test_case_id: usize,
+    command: String,
+    // Input only needed for the "Init" subcommand.
+    #[serde(default)]
+    input: String,
+    expected_output: String,
+}
+
+fn filter_response(response: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let mut map: serde_json::Map<String, serde_json::Value> = response.as_object().unwrap().clone();
+    // Depending on the device configuration, alerts can sometimes fire.
+    map.remove("alerts");
+    map.remove("ast_alerts");
+    map.remove("err_status");
+    // Device ID is different for each device.
+    map.remove("device_id");
+
+    map
+}
+
+fn run_fi_lc_ctrl_testcase(
+    test_case: &FiLcCtrlTestCase,
+    opts: &Opts,
+    uart: &dyn Uart,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "test case: {}, test: {}",
+        test_case.test_case_id,
+        test_case.command
+    );
+    PenetrationtestCommand::LCCtrlFi.send(uart)?;
+
+    // Send test subcommand.
+    LcCtrlFiSubcommand::from_str(test_case.command.as_str())
+        .context("unsupported LcCtrl FI subcommand")?
+        .send(uart)?;
+
+    // Check if we need to send an input.
+    if !test_case.input.is_empty() {
+        let input: serde_json::Value = serde_json::from_str(test_case.input.as_str()).unwrap();
+        input.send(uart)?;
+    }
+
+    // Get test output & filter.
+    let output = serde_json::Value::recv(uart, opts.timeout, false)?;
+    let output_received = filter_response(output.clone());
+
+    // Filter expected output.
+    let exp_output: serde_json::Value =
+        serde_json::from_str(test_case.expected_output.as_str()).unwrap();
+    let output_expected = filter_response(exp_output.clone());
+
+    // Check received with expected output.
+    if output_expected != output_received {
+        log::info!(
+            "FAILED {} test #{}: expected = '{}', actual = '{}'",
+            test_case.command,
+            test_case.test_case_id,
+            exp_output,
+            output
+        );
+        *fail_counter += 1;
+    }
+
+    Ok(())
+}
+
+fn test_fi_lc_ctrl(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.fi_lc_ctrl_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let fi_lc_ctrl_tests: Vec<FiLcCtrlTestCase> = serde_json::from_str(&raw_json)?;
+        for fi_lc_ctrl_test in &fi_lc_ctrl_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_fi_lc_ctrl_testcase(fi_lc_ctrl_test, opts, &*uart, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_fi_lc_ctrl, &opts, &transport);
+    Ok(())
+}

--- a/sw/host/tests/penetrationtests/fi_otbn/BUILD
+++ b/sw/host/tests/penetrationtests/fi_otbn/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/penetrationtests/ujson_lib:pentest_commands",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/penetrationtests/fi_otbn/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_otbn/src/main.rs
@@ -1,0 +1,141 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+
+use pentest_commands::commands::PenetrationtestCommand;
+use pentest_commands::fi_otbn_commands::OtbnFiSubcommand;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    fi_otbn_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FiOtbnTestCase {
+    test_case_id: usize,
+    command: String,
+    #[serde(default)]
+    input: String,
+    expected_output: String,
+}
+
+fn filter_response(response: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let mut map: serde_json::Map<String, serde_json::Value> = response.as_object().unwrap().clone();
+    // Depending on the device configuration, alerts can sometimes fire.
+    map.remove("alerts");
+    map.remove("ast_alerts");
+    map.remove("err_status");
+    // Device ID is different for each device.
+    map.remove("device_id");
+    // OTBN instruction counter should be const.
+    map.remove("insn_cnt");
+    // Filter as the CharBnWsrr returns random data from OTBN.
+    map.remove("data");
+
+    map
+}
+
+fn run_fi_otbn_testcase(
+    test_case: &FiOtbnTestCase,
+    opts: &Opts,
+    uart: &dyn Uart,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "test case: {}, test: {}",
+        test_case.test_case_id,
+        test_case.command
+    );
+    PenetrationtestCommand::OtbnFi.send(uart)?;
+
+    // Send test subcommand.
+    OtbnFiSubcommand::from_str(test_case.command.as_str())
+        .context("unsupported OTBN FI subcommand")?
+        .send(uart)?;
+
+    // Check if we need to send an input.
+    if !test_case.input.is_empty() {
+        let input: serde_json::Value = serde_json::from_str(test_case.input.as_str()).unwrap();
+        input.send(uart)?;
+    }
+
+    // Get test output & filter.
+    let output = serde_json::Value::recv(uart, opts.timeout, false)?;
+    let output_received = filter_response(output.clone());
+
+    // Filter expected output.
+    let exp_output: serde_json::Value =
+        serde_json::from_str(test_case.expected_output.as_str()).unwrap();
+    let output_expected = filter_response(exp_output.clone());
+
+    // Check received with expected output.
+    if output_expected != output_received {
+        log::info!(
+            "FAILED {} test #{}: expected = '{}', actual = '{}'",
+            test_case.command,
+            test_case.test_case_id,
+            exp_output,
+            output
+        );
+        *fail_counter += 1;
+    }
+
+    Ok(())
+}
+
+fn test_fi_otbn(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.fi_otbn_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let fi_otbn_tests: Vec<FiOtbnTestCase> = serde_json::from_str(&raw_json)?;
+        for fi_otbn_test in &fi_otbn_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_fi_otbn_testcase(fi_otbn_test, opts, &*uart, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_fi_otbn, &opts, &transport);
+    Ok(())
+}

--- a/sw/host/tests/penetrationtests/fi_otp/BUILD
+++ b/sw/host/tests/penetrationtests/fi_otp/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/penetrationtests/ujson_lib:pentest_commands",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/penetrationtests/fi_otp/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_otp/src/main.rs
@@ -1,0 +1,147 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+
+use pentest_commands::commands::PenetrationtestCommand;
+use pentest_commands::fi_otp_commands::OtpFiSubcommand;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    fi_otp_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FiOtpTestCase {
+    test_case_id: usize,
+    command: String,
+    // Input only needed for the "Init" subcommand.
+    #[serde(default)]
+    input: String,
+    expected_output: String,
+}
+
+fn filter_response(response: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let mut map: serde_json::Map<String, serde_json::Value> = response.as_object().unwrap().clone();
+    // Depending on the device configuration, alerts can sometimes fire.
+    map.remove("alerts");
+    map.remove("ast_alerts");
+    map.remove("err_status");
+    map.remove("otp_status_codes");
+    // Device ID is different for each device.
+    map.remove("device_id");
+    // Remove these entries as the test just returns the OTP content, which could
+    // be different for different configurations.
+    map.remove("hw_cfg_comp");
+    map.remove("hw_cfg_fi");
+    map.remove("owner_sw_cfg_comp");
+    map.remove("owner_sw_cfg_fi");
+    map.remove("vendor_test_comp");
+    map.remove("vendor_test_fi");
+
+    map
+}
+
+fn run_fi_otp_testcase(
+    test_case: &FiOtpTestCase,
+    opts: &Opts,
+    uart: &dyn Uart,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "test case: {}, test: {}",
+        test_case.test_case_id,
+        test_case.command
+    );
+    PenetrationtestCommand::OtpFi.send(uart)?;
+
+    // Send test subcommand.
+    OtpFiSubcommand::from_str(test_case.command.as_str())
+        .context("unsupported Otp FI subcommand")?
+        .send(uart)?;
+
+    // Check if we need to send an input.
+    if !test_case.input.is_empty() {
+        let input: serde_json::Value = serde_json::from_str(test_case.input.as_str()).unwrap();
+        input.send(uart)?;
+    }
+
+    // Get test output & filter.
+    let output = serde_json::Value::recv(uart, opts.timeout, false)?;
+    let output_received = filter_response(output.clone());
+
+    // Filter expected output.
+    let exp_output: serde_json::Value =
+        serde_json::from_str(test_case.expected_output.as_str()).unwrap();
+    let output_expected = filter_response(exp_output.clone());
+
+    // Check received with expected output.
+    if output_expected != output_received {
+        log::info!(
+            "FAILED {} test #{}: expected = '{}', actual = '{}'",
+            test_case.command,
+            test_case.test_case_id,
+            exp_output,
+            output
+        );
+        *fail_counter += 1;
+    }
+
+    Ok(())
+}
+
+fn test_fi_otp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.fi_otp_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let fi_otp_tests: Vec<FiOtpTestCase> = serde_json::from_str(&raw_json)?;
+        for fi_otp_test in &fi_otp_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_fi_otp_testcase(fi_otp_test, opts, &*uart, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_fi_otp, &opts, &transport);
+    Ok(())
+}

--- a/sw/host/tests/penetrationtests/fi_rng/BUILD
+++ b/sw/host/tests/penetrationtests/fi_rng/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/penetrationtests/ujson_lib:pentest_commands",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/penetrationtests/fi_rng/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_rng/src/main.rs
@@ -1,0 +1,140 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+
+use pentest_commands::commands::PenetrationtestCommand;
+use pentest_commands::fi_rng_commands::RngFiSubcommand;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    fi_rng_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FiRngTestCase {
+    test_case_id: usize,
+    command: String,
+    // Input only needed for the "Init" subcommand.
+    #[serde(default)]
+    input: String,
+    expected_output: String,
+}
+
+fn filter_response(response: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let mut map: serde_json::Map<String, serde_json::Value> = response.as_object().unwrap().clone();
+    // Depending on the device configuration, alerts can sometimes fire.
+    map.remove("alerts");
+    map.remove("ast_alerts");
+    map.remove("err_status");
+    // Device ID is different for each device.
+    map.remove("device_id");
+    // RAND is random data.
+    map.remove("rand");
+
+    map
+}
+
+fn run_fi_rng_testcase(
+    test_case: &FiRngTestCase,
+    opts: &Opts,
+    uart: &dyn Uart,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "test case: {}, test: {}",
+        test_case.test_case_id,
+        test_case.command
+    );
+    PenetrationtestCommand::RngFi.send(uart)?;
+
+    // Send test subcommand.
+    RngFiSubcommand::from_str(test_case.command.as_str())
+        .context("unsupported RNG FI subcommand")?
+        .send(uart)?;
+
+    // Check if we need to send an input.
+    if !test_case.input.is_empty() {
+        let input: serde_json::Value = serde_json::from_str(test_case.input.as_str()).unwrap();
+        input.send(uart)?;
+    }
+
+    // Get test output & filter.
+    let output = serde_json::Value::recv(uart, opts.timeout, false)?;
+    let output_received = filter_response(output.clone());
+
+    // Filter expected output.
+    let exp_output: serde_json::Value =
+        serde_json::from_str(test_case.expected_output.as_str()).unwrap();
+    let output_expected = filter_response(exp_output.clone());
+
+    // Check received with expected output.
+    if output_expected != output_received {
+        log::info!(
+            "FAILED {} test #{}: expected = '{}', actual = '{}'",
+            test_case.command,
+            test_case.test_case_id,
+            exp_output,
+            output
+        );
+        *fail_counter += 1;
+    }
+
+    Ok(())
+}
+
+fn test_fi_rng(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.fi_rng_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let fi_rng_tests: Vec<FiRngTestCase> = serde_json::from_str(&raw_json)?;
+        for fi_rng_test in &fi_rng_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_fi_rng_testcase(fi_rng_test, opts, &*uart, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_fi_rng, &opts, &transport);
+    Ok(())
+}

--- a/sw/host/tests/penetrationtests/fi_rom/BUILD
+++ b/sw/host/tests/penetrationtests/fi_rom/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/penetrationtests/ujson_lib:pentest_commands",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/penetrationtests/fi_rom/src/main.rs
+++ b/sw/host/tests/penetrationtests/fi_rom/src/main.rs
@@ -1,0 +1,138 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
+
+use pentest_commands::commands::PenetrationtestCommand;
+use pentest_commands::fi_rom_commands::RomFiSubcommand;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    fi_rom_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FiRomTestCase {
+    test_case_id: usize,
+    command: String,
+    // Input only needed for the "Init" subcommand.
+    #[serde(default)]
+    input: String,
+    expected_output: String,
+}
+
+fn filter_response(response: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    let mut map: serde_json::Map<String, serde_json::Value> = response.as_object().unwrap().clone();
+    // Depending on the device configuration, alerts can sometimes fire.
+    map.remove("alerts");
+    map.remove("ast_alerts");
+    map.remove("err_status");
+    // Device ID is different for each device.
+    map.remove("device_id");
+
+    map
+}
+
+fn run_fi_rom_testcase(
+    test_case: &FiRomTestCase,
+    opts: &Opts,
+    uart: &dyn Uart,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "test case: {}, test: {}",
+        test_case.test_case_id,
+        test_case.command
+    );
+    PenetrationtestCommand::RomFi.send(uart)?;
+
+    // Send test subcommand.
+    RomFiSubcommand::from_str(test_case.command.as_str())
+        .context("unsupported Rom FI subcommand")?
+        .send(uart)?;
+
+    // Check if we need to send an input.
+    if !test_case.input.is_empty() {
+        let input: serde_json::Value = serde_json::from_str(test_case.input.as_str()).unwrap();
+        input.send(uart)?;
+    }
+
+    // Get test output & filter.
+    let output = serde_json::Value::recv(uart, opts.timeout, false)?;
+    let output_received = filter_response(output.clone());
+
+    // Filter expected output.
+    let exp_output: serde_json::Value =
+        serde_json::from_str(test_case.expected_output.as_str()).unwrap();
+    let output_expected = filter_response(exp_output.clone());
+
+    // Check received with expected output.
+    if output_expected != output_received {
+        log::info!(
+            "FAILED {} test #{}: expected = '{}', actual = '{}'",
+            test_case.command,
+            test_case.test_case_id,
+            exp_output,
+            output
+        );
+        *fail_counter += 1;
+    }
+
+    Ok(())
+}
+
+fn test_fi_rom(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.fi_rom_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let fi_rom_tests: Vec<FiRomTestCase> = serde_json::from_str(&raw_json)?;
+        for fi_rom_test in &fi_rom_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_fi_rom_testcase(fi_rom_test, opts, &*uart, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_fi_rom, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR adds all other available FI pentests to the automatic testing framework. In particular, testing is added for:
- CryptoFi
- OtbnFi
- LCCtrlFi
- OtpFi
- RngFi
- RomFi

Moreover, this PR contains a small bug fix that was identified by the testing framework.


Based on and follows the same logic as #27088.