### PR TITLE
[rom_ctrl,rtl] Fix some false assertions

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -540,10 +540,9 @@ module rom_ctrl
   if (!SecDisableScrambling) begin : gen_fsm_scramble_enabled_asserts
 
     `ASSERT(InvalidStateTerminal_A,
-            gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid |=>
-            gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid)
+            ##1 !$fell(gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid))
     `ASSERT(BusLocalEscChk_A,
-            gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid |->
+            gen_fsm_scramble_enabled.u_checker_fsm.state_d == rom_ctrl_pkg::Invalid |=>
             !bus_rom_rvalid)
   end
 


### PR DESCRIPTION
Fix a couple of assertions in the RTL (so that they become true!). There are detailed notes in the commit messages.

No change to the design.