### PR TITLE
[dv,ate] add test to bootstrap a single flash data page

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -21,6 +21,18 @@
       run_timeout_mins: 180
     }
     {
+      name: ate_bootstrap_one_frame
+      uvm_test_seq: chip_sw_ate_bootstrap_one_frame_vseq
+      sw_images: ["//sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_prod:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=160_000_000"
+        "+skip_flash_bkdr_load=1",
+        "+use_spi_load_bootstrap=1",
+      ]
+      run_timeout_mins: 180
+    }
+    {
       name: rom_e2e_bootstrap_ate_smoke
       uvm_test_seq: chip_sw_rom_e2e_ate_smoke_vseq
       sw_images: [

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -140,6 +140,7 @@ filesets:
       - seq_lib/chip_sw_flash_host_gnt_err_inj_vseq.sv: {is_include_file: true}
       - seq_lib/chip_padctrl_attributes_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_ate_bootstrap_flash_erase_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_ate_bootstrap_one_frame_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_ate_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_ft_perso_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_one_frame_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ate_bootstrap_one_frame_vseq.sv
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test performs a the first two steps of a ROM bootstrap operation, i.e.,
+// flash erase followed by a single page program operation. It them confirms
+// flash has been programmed by backdoor reading back the first data page.
+
+class chip_sw_ate_bootstrap_one_frame_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_ate_bootstrap_one_frame_vseq)
+  `uvm_object_new
+
+  local function automatic void _check_flash_data_page(input integer address,
+                                                       input integer expected);
+    logic [TL_DW-1:0] actual;
+    actual = cfg.mem_bkdr_util_h[FlashBank0Data].read32(address);
+    `DV_CHECK_EQ(actual, expected)
+  endfunction
+
+  virtual task body();
+    spi_host_flash_seq m_spi_host_seq;
+    byte sw_byte_q[$];
+    uint start_addr = 0;
+    uint SPI_FLASH_PAGE_SIZE = 256;
+
+    super.body();
+
+    // Drive SW straps for bootstrap.
+    `uvm_info(`gfn, "Driving SW straps high for bootstrap.", UVM_LOW)
+    cfg.chip_vif.sw_straps_if.drive(3'h7);
+
+    // Set CSB inactive times to reasonable values. sys_clk is at 24 MHz, and
+    // it needs to capture CSB pulses.
+    cfg.m_spi_host_agent_cfg.min_idle_ns_after_csb_drop = 50;
+    cfg.m_spi_host_agent_cfg.max_idle_ns_after_csb_drop = 200;
+
+    // Configure the spi_agent for flash mode and add command info.
+    `uvm_info(`gfn, "Configuring SPI flash commands.", UVM_LOW)
+    spi_agent_configure_flash_cmds(cfg.m_spi_host_agent_cfg);
+
+    // Wait for the SPI flash commands to be configured by the (test) ROM.
+    `uvm_info(`gfn, "Waiting for SPI flash cmds on device to load ...", UVM_LOW)
+    csr_spinwait(
+      .ptr(ral.spi_device.cmd_info[spi_device_pkg::CmdInfoReadSfdp].opcode),
+      .exp_data(SpiFlashReadSfdp),
+      .backdoor(1),
+      .spinwait_delay_ns(5000));
+    csr_spinwait(
+      .ptr(ral.spi_device.cmd_info[spi_device_pkg::CmdInfoReadStatus1].opcode),
+      .exp_data(SpiFlashReadSts1),
+      .backdoor(1),
+      .spinwait_delay_ns(5000));
+    csr_spinwait(
+      .ptr(ral.spi_device.cmd_info_wren.opcode),
+      .exp_data(SpiFlashWriteEnable),
+      .backdoor(1),
+      .spinwait_delay_ns(5000));
+
+    `uvm_info(`gfn, "Reading SW image frames ...", UVM_LOW)
+    `uvm_info(`gfn, $sformatf("SW Image : %0s\n",
+      {cfg.sw_images[SwTypeTestSlotA], ".64.vmem"}), UVM_LOW);
+    read_sw_frames({cfg.sw_images[SwTypeTestSlotA], ".64.vmem"}, sw_byte_q);
+    `uvm_info(`gfn, "Done.", UVM_LOW)
+
+    // Send the SPI flash erase command.
+    `uvm_info(`gfn, "Sending SPI flash erase command ...", UVM_LOW)
+    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h)
+    m_spi_host_seq.opcode = SpiFlashChipErase;
+    spi_host_flash_issue_write_cmd(
+      .write_command(m_spi_host_seq),
+      .busy_timeout_ns(50_000_000),
+      .busy_poll_interval_ns(2_000_000));
+    `uvm_info(`gfn, "Done.", UVM_LOW)
+
+    // Send the SPI flash (single) page program command.
+    `uvm_info(`gfn, "Sending SPI flash page program command ...", UVM_LOW)
+    `uvm_create_on(m_spi_host_seq, p_sequencer.spi_host_sequencer_h)
+    // Program the first page of flash after the manifest.
+    start_addr = 32'h400;
+    m_spi_host_seq.opcode = SpiFlashPageProgram;
+    m_spi_host_seq.address_q = {start_addr[23:16], start_addr[15:8], start_addr[7:0]};
+    for (int i = 0; i < SPI_FLASH_PAGE_SIZE; i++) begin
+      m_spi_host_seq.payload_q.push_back(sw_byte_q[start_addr + i]);
+    end
+    spi_host_flash_issue_write_cmd(
+      .write_command(m_spi_host_seq),
+      .busy_timeout_ns(10_000_000),
+      .busy_poll_interval_ns(500_000));
+    `uvm_info(`gfn, "Done.", UVM_LOW)
+
+    // Read back the programmed flash data page to confirm it has been
+    // programmed correctly.
+    `uvm_info(`gfn, $sformatf("Checking page program succeeded ...\n"), UVM_LOW);
+    for (int a = start_addr; a < start_addr + SPI_FLASH_PAGE_SIZE; a += 4) begin
+      logic [TL_DW-1:0] expected_word = {sw_byte_q[a + 3], sw_byte_q[a + 2],
+                                         sw_byte_q[a + 1], sw_byte_q[a + 0]};
+      `uvm_info(`gfn, $sformatf("  Checking SW image word at address %08x: %08x ...\n",
+        a, expected_word), UVM_LOW);
+      _check_flash_data_page(a, expected_word);
+    end
+    `uvm_info(`gfn, "Done.", UVM_LOW)
+
+    // Set test passed.
+    cfg.chip_vif.sw_straps_if.drive(3'h0);
+    assert_por_reset();
+    override_test_status_and_finish(.passed(1'b1));
+  endtask
+
+endclass : chip_sw_ate_bootstrap_one_frame_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -107,6 +107,7 @@
 `include "chip_sw_rom_e2e_jtag_inject_vseq.sv"
 `include "chip_sw_rom_e2e_self_hash_gls_vseq.sv"
 `include "chip_sw_ate_bootstrap_flash_erase_vseq.sv"
+`include "chip_sw_ate_bootstrap_one_frame_vseq.sv"
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"
 `include "chip_sw_ast_clk_rst_inputs_vseq.sv"

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -76,6 +76,7 @@ _MANUF_TEST_LOCKED_KEY = None
         srcs = ["empty_functest.c"],
         ecdsa_key = _MANUF_TEST_LOCKED_KEY if (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS else ecdsa_key_for_lc_state(ECDSA_SPX_KEY_STRUCTS, lc_val),
         exec_env = {
+            "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },


### PR DESCRIPTION
This adds a DV test that performs two basic bootstrap operations:
1. SPI flash erase, and
2. a single page program.

This is to facilitate bootstrap operation bringup in ATE environments. This fixes #27150.