### PR TITLE
[opentitanlib] Support UART break via proxy

### DIFF
--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -265,6 +265,10 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_baudrate(*rate)?;
                         Ok(Response::Uart(UartResponse::SetBaudrate))
                     }
+                    UartRequest::SetBreak(enable) => {
+                        instance.set_break(*enable)?;
+                        Ok(Response::Uart(UartResponse::SetBreak))
+                    }
                     UartRequest::SetParity(parity) => {
                         instance.set_parity(*parity)?;
                         Ok(Response::Uart(UartResponse::SetParity))

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -182,6 +182,7 @@ pub enum UartRequest {
     SetBaudrate {
         rate: u32,
     },
+    SetBreak(bool),
     SetParity(Parity),
     GetDevicePath,
     Read {
@@ -199,6 +200,7 @@ pub enum UartRequest {
 pub enum UartResponse {
     GetBaudrate { rate: u32 },
     SetBaudrate,
+    SetBreak,
     SetParity,
     GetDevicePath { path: String },
     Read { data: Vec<u8> },

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -80,6 +80,13 @@ impl Uart for ProxyUart {
         }
     }
 
+    fn set_break(&self, enable: bool) -> Result<()> {
+        match self.execute_command(UartRequest::SetBreak(enable))? {
+            UartResponse::SetBreak => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn set_parity(&self, parity: Parity) -> Result<()> {
         match self.execute_command(UartRequest::SetParity(parity))? {
             UartResponse::SetParity => Ok(()),


### PR DESCRIPTION
It apperars that when adding a new method to the Uart trait for controlling break condition.  I forgot to add a corresponding new message to the proxy protocol.  With this patch, it becomes possible to use UART break (e.g. rescue protocol) via opentitansession.
