### PR TITLE
[dv] Avoid implementing the pre_body task

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_rng_seq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_rng_seq.sv
@@ -110,9 +110,9 @@ class entropy_src_base_rng_seq extends push_pull_indefinite_host_seq#(
     return is_hard_failed;
   endfunction
 
-  virtual task pre_body();
-    super.pre_body();
+  virtual task body();
     reset_rng();
+    super.body();
   endtask
 
   virtual function rng_val_t random_data_typical();

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_error_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_error_vseq.sv
@@ -10,9 +10,8 @@ class hmac_error_vseq extends hmac_long_msg_vseq;
   // Standard SV/UVM methods
   extern function new(string name="");
   extern function void pre_randomize();
-  extern task pre_body();
+  extern task body();
 endclass : hmac_error_vseq
-
 
 function hmac_error_vseq::new(string name="");
   super.new(name);
@@ -22,8 +21,8 @@ function void hmac_error_vseq::pre_randomize();
   this.legal_seq_c.constraint_mode(0);
 endfunction : pre_randomize
 
-task hmac_error_vseq::pre_body();
+task hmac_error_vseq::body();
   // No need to trigger Save and Restore for this test
   cfg.save_and_restore_pct = 0;
-  super.pre_body();
-endtask : pre_body
+  super.body();
+endtask : body

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
@@ -9,7 +9,6 @@ class hmac_stress_reset_vseq extends hmac_base_vseq;
 
   // Standard SV/UVM methods
   extern function new(string name="");
-  extern task pre_body();
   extern task body();
 endclass : hmac_stress_reset_vseq
 
@@ -18,14 +17,11 @@ function hmac_stress_reset_vseq::new(string name="");
   super.new(name);
 endfunction : new
 
-task hmac_stress_reset_vseq::pre_body();
+task hmac_stress_reset_vseq::body();
   // TODO (#25809) - The S&R is causing troubles with this test, this flag will be removed later
   // when reset is handled properly.
   cfg.save_and_restore_pct = 0;
-  super.pre_body();
-endtask : pre_body
 
-task hmac_stress_reset_vseq::body();
   for (int i = 1; i <= num_trans; i++) begin
     run_seq_with_rand_reset_vseq(create_seq_by_name("hmac_long_msg_vseq"), 1, 1_000);
   end

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_wipe_secret_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_wipe_secret_vseq.sv
@@ -14,7 +14,7 @@ class hmac_wipe_secret_vseq extends hmac_smoke_vseq;
   // Standard SV/UVM methods
   extern function new(string name="");
   extern function void pre_randomize();
-  extern task pre_body();
+  extern task body();
 endclass : hmac_wipe_secret_vseq
 
 
@@ -35,8 +35,9 @@ function void hmac_wipe_secret_vseq::pre_randomize();
   this.wipe_secret_c.constraint_mode(0);
 endfunction : pre_randomize
 
-task hmac_wipe_secret_vseq::pre_body();
+task hmac_wipe_secret_vseq::body();
   // No need to trigger Save and Restore for this test
   cfg.save_and_restore_pct = 0;
-  super.pre_body();
-endtask : pre_body
+
+  super.body();
+endtask : body


### PR DESCRIPTION
This is discouraged by some style guides (because it isn't guaranteed to run before body!). Avoid it, and implement this by overriding body() instead.