### PR TITLE
[dv] enable copying filegroup targest to run dir

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -141,7 +141,7 @@ ifneq (${sw_images},)
 								$${run_dir}/$$(basename -s .bin $${artifact}).elf; \
 						fi; \
 				done; \
-			elif [[ $${kind} == "alias" || $${kind} == "opentitan_binary" ]]; then \
+			elif [[ $${kind} == "alias" || $${kind} == "opentitan_binary" || $${kind} == "filegroup" ]]; then \
 				for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
 					$${bazel_label} \
 					--ui_event_filters=-info \
@@ -149,7 +149,11 @@ ifneq (${sw_images},)
 					--output=starlark \
 					`# An opentitan_binary rule has all of its needed files in its runfiles.` \
 					--starlark:expr='"\n".join([f.path for f in target.files.to_list()])'); do \
-						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
+						if [[ $${kind} == "filegroup" ]]; then \
+							cp -f $$($${bazel_cmd} info output_base)/$${artifact} $${run_dir}/$$(basename $${artifact}); \
+						else \
+							cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
+						fi; \
 						if [[ $$artifact == *.bin && \
 							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
 							cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \


### PR DESCRIPTION
When a filegroup is used to point to a SW image in a dvsim config file, and the filegroup lives in an external bazel repo, i.e., @manufacturer_test_hooks//..., excuting a `bazel cquery ...` operation on it to obtain the file paths will yield a partial path relative to the `bazel info output_base` path. We need to account for this in the sim.mk file when copying over Bazel build SW images to the dvsim run dir.