### PR TITLE
[dv] Tweak how we pass the "id" argument to some uvm_info/uvm_error calls

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -143,9 +143,9 @@ interface alert_esc_if(input clk, input rst_n);
 
   function automatic bit get_alert();
     if (alert_tx_final.alert_p === 1'b1 && ping_pending) begin
-      `uvm_info("alert_esc_if::get_alert", $sformatf(
-                "This alert is a ping response: alert_p:%b, alert_n:%b, ping_pending:%p",
-                alert_tx_final.alert_p, alert_tx_final.alert_n, ping_pending),
+      `uvm_info($sformatf("%m"),
+                $sformatf("This alert is a ping response: alert_p:%b, alert_n:%b, ping_pending:%p",
+                          alert_tx_final.alert_p, alert_tx_final.alert_n, ping_pending),
                 UVM_MEDIUM)
     end
     get_alert = (alert_tx_final.alert_p === 1'b1 && alert_tx_final.alert_n === 1'b0 &&

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -153,7 +153,7 @@ task alert_monitor::wait_alert_init_done();
         wait (cfg.vif.monitor_cb.alert_tx_final.alert_p !=
               cfg.vif.monitor_cb.alert_tx_final.alert_n);
         @(posedge cfg.vif.clk);
-        `uvm_info("alert_monitor", "Alert init done!", UVM_HIGH)
+        `uvm_info($sformatf("%m"), "Alert init done!", UVM_HIGH)
         cfg.alert_init_done = 1;
         under_reset = 0;
       end

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -118,9 +118,10 @@ task esc_monitor::esc_thread();
         end
       end
 
-      `uvm_info("esc_monitor", $sformatf("[%s]: handshake status is %s, timeout=%0b",
-                                         req.alert_esc_type.name(), req.esc_handshake_sta.name(),
-                                         req.ping_timeout), UVM_HIGH)
+      `uvm_info($sformatf("%m"),
+                $sformatf("[%s]: handshake status is %s, timeout=%0b",
+                          req.alert_esc_type.name(), req.esc_handshake_sta.name(),
+                          req.ping_timeout), UVM_HIGH)
       if (cfg.en_cov) begin
         cov.m_esc_handshake_complete_cg.sample(req.alert_esc_type, req.esc_handshake_sta);
         if (cfg.en_ping_cov) cov.m_esc_trans_cg.sample(req.alert_esc_type);
@@ -163,8 +164,9 @@ task esc_monitor::check_esc_resp(alert_esc_seq_item req, bit is_ping, bit ping_t
         `downcast(req_clone, req.clone());
         req_clone.esc_handshake_sta = EscIntFail;
         alert_esc_port.write(req_clone);
-        `uvm_info("esc_monitor", $sformatf("[%s]: EscReceived has integrity error",
-                                           req.alert_esc_type.name()), UVM_HIGH)
+        `uvm_info($sformatf("%m"),
+                  $sformatf("[%s]: EscReceived has integrity error", req.alert_esc_type.name()),
+                  UVM_HIGH)
       end
       // If there is signal integrity error or it is not the first ping request or escalation
       // request, stay in this case for one more clock cycle.
@@ -181,8 +183,9 @@ task esc_monitor::check_esc_resp(alert_esc_seq_item req, bit is_ping, bit ping_t
       end else if (cfg.vif.monitor_cb.esc_rx.resp_p !== 1) begin
         req.esc_handshake_sta = EscIntFail;
         alert_esc_port.write(req);
-        `uvm_info("esc_monitor", $sformatf("[%s]: EscRespHi has integrity error",
-                                           req.alert_esc_type.name()), UVM_HIGH)
+        `uvm_info($sformatf("%m"),
+                  $sformatf("[%s]: EscRespHi has integrity error", req.alert_esc_type.name()),
+                  UVM_HIGH)
       end else begin
         req.esc_handshake_sta = EscRespLo;
       end
@@ -193,8 +196,9 @@ task esc_monitor::check_esc_resp(alert_esc_seq_item req, bit is_ping, bit ping_t
       end else if (cfg.vif.monitor_cb.esc_rx.resp_p !== 0) begin
         req.esc_handshake_sta = EscIntFail;
         alert_esc_port.write(req);
-        `uvm_info("esc_monitor", $sformatf("[%s]: EscRespLow has integrity error",
-                                           req.alert_esc_type.name()), UVM_HIGH)
+        `uvm_info($sformatf("%m"),
+                  $sformatf("[%s]: EscRespLow has integrity error", req.alert_esc_type.name()),
+                  UVM_HIGH)
       end else begin
         if (is_ping) req.esc_handshake_sta = EscRespPing0;
         else req.esc_handshake_sta = EscRespHi;
@@ -206,8 +210,9 @@ task esc_monitor::check_esc_resp(alert_esc_seq_item req, bit is_ping, bit ping_t
       end else if (cfg.vif.monitor_cb.esc_rx.resp_p !== 1) begin
         req.esc_handshake_sta = EscIntFail;
         alert_esc_port.write(req);
-        `uvm_info("esc_monitor", $sformatf("[%s]: EscRespPing0 has integrity error",
-                                           req.alert_esc_type.name()), UVM_HIGH)
+        `uvm_info($sformatf("%m"),
+                  $sformatf("[%s]: EscRespPing0 has integrity error", req.alert_esc_type.name()),
+                  UVM_HIGH)
       end else begin
         req.esc_handshake_sta = EscRespPing1;
       end
@@ -218,8 +223,9 @@ task esc_monitor::check_esc_resp(alert_esc_seq_item req, bit is_ping, bit ping_t
       end else if (cfg.vif.monitor_cb.esc_rx.resp_p !== 0) begin
         req.esc_handshake_sta = EscIntFail;
         alert_esc_port.write(req);
-        `uvm_info("esc_monitor", $sformatf("[%s]: EscRespPing1 has integrity error",
-                                           req.alert_esc_type.name()), UVM_HIGH)
+        `uvm_info($sformatf("%m"),
+                  $sformatf("[%s]: EscRespPing1 has integrity error", req.alert_esc_type.name()),
+                  UVM_HIGH)
       end else begin
         req.esc_handshake_sta = EscRespComplete;
       end

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -17,7 +17,6 @@ package csr_utils_pkg;
   uint              outstanding_accesses        = 0;
   uint              default_timeout_ns          = 2_000_000; // 2ms
   uint              default_spinwait_timeout_ns = 10_000_000; // 10ms
-  string            msg_id                      = "csr_utils";
   bit               default_csr_blocking        = 1;
   uvm_check_e       default_csr_check           = UVM_CHECK;
   bit               under_reset                 = 0;
@@ -26,14 +25,12 @@ package csr_utils_pkg;
 
   function automatic void increment_outstanding_access();
     outstanding_accesses++;
-    `uvm_info("csr_utils_pkg", $sformatf("increment_outstanding_access %0d", outstanding_accesses),
-              UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("%0d", outstanding_accesses), UVM_HIGH)
   endfunction
 
   function automatic void decrement_outstanding_access();
     outstanding_accesses--;
-    `uvm_info("csr_utils_pkg", $sformatf("decrement_outstanding_access %0d", outstanding_accesses),
-              UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("%0d", outstanding_accesses), UVM_HIGH)
   endfunction
 
   task automatic wait_no_outstanding_access();
@@ -67,7 +64,8 @@ package csr_utils_pkg;
     uvm_mem mem;
     addr[1:0] = 0;
     mem = ral.default_map.get_mem_by_offset(addr);
-    `DV_CHECK_NE_FATAL(mem, null, $sformatf("Can't find any mem with addr 0x%0h", addr), msg_id)
+    `DV_CHECK_NE_FATAL(mem, null,
+                       $sformatf("Can't find any mem with addr 0x%0h", addr), $sformatf("%m"))
     return mem;
   endfunction
 
@@ -84,13 +82,12 @@ package csr_utils_pkg;
     uvm_reg         csr;
     uvm_reg_field   fld;
     uvm_reg_data_t  result;
-    string          msg_id = {csr_utils_pkg::msg_id, "::get_reg_fld_mirror_value"};
     csr = ral.get_reg_by_name(reg_name);
-    `DV_CHECK_NE_FATAL(csr, null, "", msg_id)
+    `DV_CHECK_NE_FATAL(csr, null, "", $sformatf("%m"))
     // return field mirror value if field_name is passed, else return reg mirror value
     if (field_name != "") begin
       fld = csr.get_field_by_name(field_name);
-      `DV_CHECK_NE_FATAL(fld, null, "", msg_id)
+      `DV_CHECK_NE_FATAL(fld, null, "", $sformatf("%m"))
       result = fld.get_mirrored_value();
     end
     else begin
@@ -111,11 +108,11 @@ package csr_utils_pkg;
 
   // wait until current csr op is complete
   task automatic csr_wait(input uvm_reg csr);
-    `uvm_info(msg_id, $sformatf("%0s: wait_busy: %0b",
-                                csr.get_full_name(), csr.m_is_busy), UVM_HIGH)
+    `uvm_info($sformatf("%m"),
+              $sformatf("%0s: wait_busy: %0b", csr.get_full_name(), csr.m_is_busy), UVM_HIGH)
     wait(csr.m_is_busy == 1'b0);
-    `uvm_info(msg_id, $sformatf("%0s: done wait_busy: %0b",
-                                csr.get_full_name(), csr.m_is_busy), UVM_HIGH)
+    `uvm_info($sformatf("%m"),
+              $sformatf("%0s: done wait_busy: %0b", csr.get_full_name(), csr.m_is_busy), UVM_HIGH)
   endtask
 
   // Use `csr_wr` to construct `csr_update` to avoid replicated codes to handle nonblocking,
@@ -196,12 +193,10 @@ package csr_utils_pkg;
                             input bit                 en_shadow_wr = 1);
     fork
       begin : isolation_fork
-        string msg_id = {csr_utils_pkg::msg_id, "::csr_wr"};
-
         fork
           begin
             dv_base_reg dv_reg;
-            `downcast(dv_reg, csr, "", fatal, msg_id)
+            `downcast(dv_reg, csr, "", fatal, $sformatf("%m"))
 
             increment_outstanding_access();
             csr_pre_write_sub(csr, en_shadow_wr);
@@ -217,7 +212,7 @@ package csr_utils_pkg;
             decrement_outstanding_access();
           end
           begin
-            `DV_WAIT_TIMEOUT(timeout_ns, msg_id,
+            `DV_WAIT_TIMEOUT(timeout_ns, $sformatf("%m"),
                              $sformatf("Timeout waiting to csr_wr %0s (addr=0x%0h)",
                                        csr.get_full_name(), csr.get_address()))
           end
@@ -246,7 +241,7 @@ package csr_utils_pkg;
     if (check == UVM_CHECK) begin
       `DV_CHECK_EQ(status, UVM_IS_OK,
                    $sformatf("trying to write csr %0s", csr.get_full_name()),
-                   error, msg_id)
+                   error, $sformatf("%m"))
     end
     // Only update the predicted value if status is ok (otherwise the write isn't completed
     // successfully and the design shouldn't have accepted the written value)
@@ -257,7 +252,7 @@ package csr_utils_pkg;
 
   task automatic csr_pre_write_sub(uvm_reg csr, bit en_shadow_wr);
     dv_base_reg dv_reg;
-    `downcast(dv_reg, csr, "", fatal, msg_id)
+    `downcast(dv_reg, csr, "", fatal, $sformatf("%m"))
     if (dv_reg.get_is_shadowed() && en_shadow_wr) begin
       dv_reg.atomic_en_shadow_wr.get(1);
     end
@@ -265,7 +260,7 @@ package csr_utils_pkg;
 
   task automatic csr_post_write_sub(uvm_reg csr, bit en_shadow_wr);
     dv_base_reg dv_reg;
-    `downcast(dv_reg, csr, "", fatal, msg_id)
+    `downcast(dv_reg, csr, "", fatal, $sformatf("%m"))
     if (dv_reg.get_is_shadowed() && en_shadow_wr) begin
       dv_reg.atomic_en_shadow_wr.put(1);
     end
@@ -279,7 +274,6 @@ package csr_utils_pkg;
                           input bkdr_reg_path_e kind = BkdrRegPathRtl);
     csr_field_t   csr_or_fld = decode_csr_or_field(ptr);
     uvm_status_e  status;
-    string        msg_id = {csr_utils_pkg::msg_id, "::csr_poke"};
     uvm_reg_data_t old_mirrored_val;
 
     if (csr_or_fld.field != null) begin
@@ -294,8 +288,8 @@ package csr_utils_pkg;
       uvm_hdl_path_concat paths[$];
       csr_or_fld.csr.get_full_hdl_path(paths, kind.name);
       foreach (paths[0].slices[i]) str = $sformatf("%0s\n%0s", str, paths[0].slices[i].path);
-      `uvm_fatal(msg_id, $sformatf("poke failed for %0s, check below paths %0s",
-                                   ptr.get_full_name(), str))
+      `uvm_fatal($sformatf("%m"), $sformatf("poke failed for %0s, check below paths %0s",
+                                            ptr.get_full_name(), str))
     end
     // poke always updates predict value, if predict == 0, revert back to old mirrored value
     if (!predict || kind == BkdrRegPathRtlShadow) begin
@@ -323,7 +317,7 @@ package csr_utils_pkg;
       csr_rd_sub(.ptr(ptr), .value(value), .status(status), .check(check), .path(path),
                  .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr));
     end else begin
-      `DV_CHECK_EQ(backdoor, 0, "Don't enable backdoor with blocking = 0", error, msg_id)
+      `DV_CHECK_EQ(backdoor, 0, "Don't enable backdoor with blocking = 0", error, $sformatf("%m"))
       fork
         csr_rd_sub(.ptr(ptr), .value(value), .status(status), .check(check), .path(path),
                    .backdoor(backdoor), .timeout_ns(timeout_ns), .map(map), .user_ftdr(user_ftdr));
@@ -351,8 +345,6 @@ package csr_utils_pkg;
     fork
       begin : isolation_fork
         csr_field_t   csr_or_fld;
-        string        msg_id = {csr_utils_pkg::msg_id, "::csr_rd"};
-
         fork
           begin
             increment_outstanding_access();
@@ -370,12 +362,12 @@ package csr_utils_pkg;
             if (check == UVM_CHECK && !under_reset) begin
               `DV_CHECK_EQ(status, UVM_IS_OK,
                            $sformatf("trying to read csr/field %0s", ptr.get_full_name()),
-                           error, msg_id)
+                           error, $sformatf("%m"))
             end
             decrement_outstanding_access();
           end
           begin
-            `DV_WAIT_TIMEOUT(timeout_ns, msg_id,
+            `DV_WAIT_TIMEOUT(timeout_ns, $sformatf("%m"),
                              $sformatf("Timeout waiting to csr_rd %0s (addr=0x%0h)",
                                        ptr.get_full_name(), csr_or_fld.csr.get_address()))
           end
@@ -390,7 +382,6 @@ package csr_utils_pkg;
   function automatic uvm_reg_data_t csr_peek(uvm_object      ptr,
                                              uvm_check_e     check = default_csr_check,
                                              bkdr_reg_path_e kind = BkdrRegPathRtl);
-    string         msg_id = {csr_utils_pkg::msg_id, "::csr_peek"};
     csr_field_t    csr_or_fld = decode_csr_or_field(ptr);
     uvm_reg        csr = csr_or_fld.csr;
     uvm_reg_data_t value = 0;
@@ -401,15 +392,15 @@ package csr_utils_pkg;
     `DV_CHECK_FATAL(paths.size() > 0,
                     $sformatf("No backdoor defined for %0s path's %0s",
                               csr.get_full_name(), kind.name),
-                    msg_id)
+                    $sformatf("%m"))
 
     foreach (paths[0].slices[i]) begin
       uvm_reg_data_t field_val;
       `DV_CHECK_FATAL(uvm_hdl_read(paths[0].slices[i].path, field_val),
                       $sformatf("Failed to read %s, slice %d, at path %s",
                                 csr.get_full_name(), i, paths[0].slices[i].path),
-                      msg_id)
-      if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, msg_id)
+                      $sformatf("%m"))
+      if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, $sformatf("%m"))
 
       value |= field_val << paths[0].slices[i].offset;
     end
@@ -444,7 +435,6 @@ package csr_utils_pkg;
             uvm_reg_data_t  obs;
             uvm_reg_data_t  exp;
             uvm_reg_data_t  reset_val;
-            string          msg_id = {csr_utils_pkg::msg_id, "::csr_rd_check"};
 
             csr_or_fld = decode_csr_or_field(ptr);
 
@@ -465,7 +455,7 @@ package csr_utils_pkg;
               exp = (compare_vs_ral ? exp : compare_value) & compare_mask;
               `DV_CHECK_EQ(obs, exp, $sformatf("Regname: %0s reset value: 0x%0h %0s",
                                                ptr.get_full_name(), reset_val, err_msg),
-                           error, msg_id)
+                           error, $sformatf("%m"))
             end
           end
         join_none
@@ -500,8 +490,9 @@ package csr_utils_pkg;
 
     // Check if parent block or register is excluded from read-check
     if (csr_excl_item != null && csr_excl_item.is_excl(csr, csr_excl_type, csr_test_type)) begin
-      `uvm_info(msg_id, $sformatf("Skipping register %0s due to CsrExclWriteCheck exclusion",
-                                  csr.get_full_name()), UVM_MEDIUM)
+      `uvm_info($sformatf("%m"),
+                $sformatf("Skipping register %0s due to CsrExclWriteCheck exclusion",
+                          csr.get_full_name()), UVM_MEDIUM)
       return;
     end
 
@@ -572,7 +563,6 @@ package csr_utils_pkg;
       begin : isolation_fork
         csr_field_t     csr_or_fld;
         uvm_reg_data_t  read_data;
-        string          msg_id = {csr_utils_pkg::msg_id, "::csr_spinwait"};
 
         csr_or_fld = decode_csr_or_field(ptr);
         if (backdoor && spinwait_delay_ns == 0) spinwait_delay_ns = 1;
@@ -603,8 +593,8 @@ package csr_utils_pkg;
 
             csr_rd(.ptr(ptr), .value(read_data), .check(check), .path(path),
                    .blocking(1), .map(map), .user_ftdr(user_ftdr), .backdoor(backdoor));
-            `uvm_info(msg_id, $sformatf("ptr %0s == 0x%0h",
-                                        ptr.get_full_name(), read_data), verbosity)
+            `uvm_info($sformatf("%m"),
+                      $sformatf("ptr %0s == 0x%0h", ptr.get_full_name(), read_data), verbosity)
             case (compare_op)
               CompareOpEq:     if (read_data ==  exp_data) break;
               CompareOpCaseEq: if (read_data === exp_data) break;
@@ -621,10 +611,11 @@ package csr_utils_pkg;
           end
           // Wait for timeout_ns nanoseconds and then fail with an error (because this process
           // should have been killed before then)
-          `DV_WAIT_TIMEOUT(timeout_ns, msg_id,{"timeout ", $sformatf(
-                           "%0s (addr=0x%0h, Comparison=%s, exp_data=0x%0h, call_count=%0d)",
-                           ptr.get_full_name(), csr_or_fld.csr.get_address(), compare_op.name,
-                           exp_data, lcount)})
+          `DV_WAIT_TIMEOUT(timeout_ns, $sformatf("%m"),
+                           $sformatf({"timeout %0s (addr=0x%0h, Comparison=%s, ",
+                                      "exp_data=0x%0h, call_count=%0d)"},
+                                     ptr.get_full_name(), csr_or_fld.csr.get_address(),
+                                     compare_op.name, exp_data, lcount))
         join_any
         disable fork;
       end : isolation_fork
@@ -660,7 +651,6 @@ package csr_utils_pkg;
     fork
       begin : isolating_fork
         uvm_status_e status;
-        string       msg_id = {csr_utils_pkg::msg_id, "::mem_rd"};
 
         fork
           begin
@@ -671,12 +661,13 @@ package csr_utils_pkg;
             // but this doesn't work: if (user_ftdr != null) ptr.set_frontdoor(null);
             if (check == UVM_CHECK && !under_reset) begin
               `DV_CHECK_EQ(status, UVM_IS_OK,
-                           $sformatf("trying to read mem %0s", ptr.get_full_name()), error, msg_id)
+                           $sformatf("trying to read mem %0s", ptr.get_full_name()),
+                           error, $sformatf("%m"))
             end
             decrement_outstanding_access();
           end
           begin : mem_rd_timeout
-            `DV_WAIT_TIMEOUT(timeout_ns, msg_id,
+            `DV_WAIT_TIMEOUT(timeout_ns, $sformatf("%m"),
                              $sformatf("Timeout waiting to mem_rd %0s (addr=0x%0h)",
                                        ptr.get_full_name(), offset))
           end
@@ -715,7 +706,6 @@ package csr_utils_pkg;
      fork
       begin : isolation_fork
         uvm_status_e status;
-        string       msg_id = {csr_utils_pkg::msg_id, "::mem_wr"};
 
         fork
           begin
@@ -727,12 +717,12 @@ package csr_utils_pkg;
             if (check == UVM_CHECK && !under_reset) begin
               `DV_CHECK_EQ(status, UVM_IS_OK,
                            $sformatf("trying to write mem %0s", ptr.get_full_name()),
-                           error, msg_id)
+                           error, $sformatf("%m"))
             end
             decrement_outstanding_access();
           end
           begin
-            `DV_WAIT_TIMEOUT(timeout_ns, msg_id,
+            `DV_WAIT_TIMEOUT(timeout_ns, $sformatf("%m"),
                              $sformatf("Timeout waiting to mem_wr %0s (addr=0x%0h)",
                                        ptr.get_full_name(), offset))
           end
@@ -756,8 +746,9 @@ package csr_utils_pkg;
       foreach (flds[i]) begin
         if (m_csr_excl_item.is_excl(flds[i], csr_excl_type, csr_test_type)) begin
           csr_field_t fld_params = decode_csr_or_field(flds[i]);
-          `uvm_info(msg_id, $sformatf("Skipping field %0s due to %0s exclusion",
-                                    flds[i].get_full_name(), csr_excl_type.name()), UVM_HIGH)
+          `uvm_info($sformatf("%m"),
+                    $sformatf("Skipping field %0s due to %0s exclusion",
+                              flds[i].get_full_name(), csr_excl_type.name()), UVM_HIGH)
           get_mask_excl_fields &= ~(fld_params.mask << fld_params.shift);
         end
       end
@@ -779,9 +770,9 @@ package csr_utils_pkg;
 
     foreach (flds[i]) begin
       if (m_csr_excl_item.is_excl(flds[i], CsrExclWrite, csr_test_type)) begin
-        `uvm_info(msg_id, $sformatf(
-                  "Retain mirrored value 0x%0h for field %0s due to CsrExclWrite exclusion",
-                  `gmv(flds[i]), flds[i].get_full_name()), UVM_MEDIUM)
+        `uvm_info($sformatf("%m"),
+                  $sformatf("Retain mirrored 0x%0h for field %0s due to CsrExclWrite exclusion",
+                            `gmv(flds[i]), flds[i].get_full_name()), UVM_MEDIUM)
         wdata = get_csr_val_with_updated_field(flds[i], wdata, `gmv(flds[i]));
       end
     end
@@ -799,14 +790,14 @@ package csr_utils_pkg;
     // Attempt cast to blk. If it fails, then attempt to cast to CSR or field.
     if (!$cast(blk, ptr)) begin
       csr_field_t csr_or_fld = decode_csr_or_field(ptr);
-      `downcast(blk, csr_or_fld.csr.get_parent(), , , msg_id)
+      `downcast(blk, csr_or_fld.csr.get_parent(), , , $sformatf("%m"))
     end
 
     // Recurse through block's ancestors.
     do begin
       csr_excl_item csr_excl = blk.get_excl_item();
       if (csr_excl != null) return csr_excl;
-      `downcast(blk, blk.get_parent(), , , msg_id)
+      `downcast(blk, blk.get_parent(), , , $sformatf("%m"))
     end while (blk != null);
     return null;
   endfunction

--- a/hw/dv/sv/dv_base_reg/csr_excl_item.sv
+++ b/hw/dv/sv/dv_base_reg/csr_excl_item.sv
@@ -83,7 +83,7 @@ class csr_excl_item extends uvm_object;
       end else begin
         if (has_excl(csr_or_fld.csr.`gfn, csr_excl_type, csr_test_type, is_excl)) return is_excl;
       end
-      `downcast(blk, csr_or_fld.csr.get_parent(), , , msg_id)
+      `downcast(blk, csr_or_fld.csr.get_parent(), , , `gfn)
     end
 
     // Recurse through block's ancestors.

--- a/hw/dv/sv/dv_base_reg/dv_base_mem.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_mem.sv
@@ -53,7 +53,7 @@ function dv_base_mem::new(string           name,
                           int              has_coverage = UVM_NO_COVERAGE);
   super.new(name, size, n_bits, access, has_coverage);
   if (!(access inside {"RW", "RO", "WO"}))
-    `uvm_error("RegModel", $sformatf("Memory '%0s' can only be RW, RO or WO", get_full_name()))
+    `uvm_error(`gfn, $sformatf("Memory can only be RW, RO or WO (saw %s)", access))
 endfunction
 
 function void dv_base_mem::set_mem_partial_write_support(bit enable);
@@ -92,7 +92,7 @@ endfunction
 // (loosened slightly and now moved to the constructor)
 function void dv_base_mem::configure(uvm_reg_block parent, string hdl_path="");
    if (parent == null)
-     `uvm_fatal("REG/NULL_PARENT","configure: parent argument is null")
+     `uvm_fatal(`gfn, "configure: parent argument is null")
 
    set_parent(parent);
 

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -13,7 +13,6 @@ package dv_base_reg_pkg;
 
    // global paramters for number of csr tests (including memory test)
   parameter uint NUM_CSR_TESTS = 4;
-  string msg_id = "dv_base_reg_pkg";
 
   // csr field struct - hold field specific params
   typedef struct {
@@ -65,7 +64,6 @@ package dv_base_reg_pkg;
     uvm_reg       csr;
     uvm_reg_field fld;
     csr_field_t   result;
-    string        msg_id = {dv_base_reg_pkg::msg_id, "::decode_csr_or_field"};
 
     if ($cast(csr, ptr)) begin
       // return csr object with null field; set the mask to the width's all 1s and shift to 0
@@ -81,8 +79,8 @@ package dv_base_reg_pkg;
       result.shift = fld.get_lsb_pos();
     end
     else begin
-      `uvm_fatal(msg_id, $sformatf("ptr %0s is not of type uvm_reg or uvm_reg_field",
-                                   ptr.get_full_name()))
+      `uvm_fatal($sformatf("%m"),
+                 $sformatf("ptr %0s is not of type uvm_reg or uvm_reg_field", ptr.get_full_name()))
     end
     return result;
   endfunction : decode_csr_or_field
@@ -122,9 +120,10 @@ package dv_base_reg_pkg;
       uint           fshift;
       if (csr == null) csr = fields[i].get_parent();
       else if (csr != fields[i].get_parent()) begin
-        `uvm_fatal(msg_id, $sformatf({"The provided fields belong to at least two different CSRs: ",
-                                      "%s, %s. All fields must belong to the same CSR"},
-                                     fields[i-1].`gfn, fields[i].`gfn))
+        `uvm_fatal($sformatf("%m"),
+                   $sformatf({"The provided fields belong to at least two different CSRs: ",
+                              "%s, %s. All fields must belong to the same CSR"},
+                             fields[i-1].`gfn, fields[i].`gfn))
       end
       fmask = (1 << fields[i].get_n_bits()) - 1;
       fshift = fields[i].get_lsb_pos();

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -180,11 +180,13 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
     if (obj == null) begin
       // print factory overrides to help debug
       factory.print();
-      `uvm_fatal(msg_id, $sformatf("could not create %0s as a RAL model, see above for a list of \
-                                    type/instance overrides", name))
+      `uvm_fatal(`gfn,
+                 $sformatf({"Could not create %0s as a RAL model. ",
+                            "See above for a list of type/instance overrides"},
+                           name))
     end
     if (!$cast(ral, obj)) begin
-      `uvm_fatal(msg_id, $sformatf("cast failed - %0s is not a dv_base_reg_block", name))
+      `uvm_fatal(`gfn, $sformatf("Cast failed - %0s is not a dv_base_reg_block", name))
     end
     return ral;
   endfunction

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -90,8 +90,6 @@ package dv_utils_pkg;
     ClkFreqDiffAny
   } clk_freq_diff_e;
 
-  string msg_id = "dv_utils_pkg";
-
   // return the smaller value of 2 inputs
   function automatic int min2(int a, int b);
       return (a < b) ? a : b;
@@ -105,7 +103,7 @@ package dv_utils_pkg;
   // return the biggest value within the given queue of integers.
   function automatic int max(const ref int int_q[$]);
     `DV_CHECK_GT_FATAL(int_q.size(), 0, "max function cannot accept an empty queue of integers!",
-                       msg_id)
+                       $sformatf("%m"))
     // Assign the first value from the queue in case of negative integers.
     max = int_q[0];
     foreach (int_q[i]) max = max2(max, int_q[i]);
@@ -169,10 +167,10 @@ package dv_utils_pkg;
     if (obj == null) begin
       // print factory overrides to help debug
       factory.print(1);
-      `uvm_fatal(msg_id, $sformatf("could not create %0s seq", seq_name))
+      `uvm_fatal($sformatf("%m"), $sformatf("could not create %0s seq", seq_name))
     end
     if (!$cast(seq, obj)) begin
-      `uvm_fatal(msg_id, $sformatf("cast failed - %0s is not a uvm_sequence", seq_name))
+      `uvm_fatal($sformatf("%m"), $sformatf("cast failed - %0s is not a uvm_sequence", seq_name))
     end
     return seq;
   endfunction
@@ -224,12 +222,11 @@ package dv_utils_pkg;
                                                  output longint unsigned addr,
                                                  output longint unsigned size);
 
-    string msg_id = "sw_symbol_get_addr_size";
     string escaped_symbol = "";
     string symbol_for_filename = "";
 
-    `DV_CHECK_STRNE_FATAL(elf_file, "", "Input arg \"elf_file\" cannot be an empty string", msg_id)
-    `DV_CHECK_STRNE_FATAL(symbol,   "", "Input arg \"symbol\" cannot be an empty string", msg_id)
+    if (elf_file == "") `uvm_fatal($sformatf("%m"), "'elf_file' argument cannot be an empty string")
+    if (symbol == "") `uvm_fatal($sformatf("%m"), "'symbol' argument cannot be an empty string")
 
     // If the symbol has special characters, such as '$', escape it for the cmd below, but when
     // creating the file, omit the special characters entirely.
@@ -256,31 +253,32 @@ package dv_utils_pkg;
       // TODO #3838: shell pipes are bad 'mkay?
       ret = $system(cmd);
       `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Command \"%0s\" failed with exit code %0d", cmd, ret),
-                         msg_id)
+                         $sformatf("%m"))
 
       out_file_d = $fopen(out_file, "r");
-      `DV_CHECK_FATAL(out_file_d, $sformatf("Failed to open \"%0s\"", out_file), msg_id)
+      `DV_CHECK_FATAL(out_file_d, $sformatf("Failed to open \"%0s\"", out_file), $sformatf("%m"))
 
       ret = $fgets(line, out_file_d);
 
       // If the symbol did not exist in the elf (empty file), and we are ok with that, then return.
       if (!ret && does_not_exist_ok) return 0;
 
-      `DV_CHECK_FATAL(ret, $sformatf("Failed to read line from \"%0s\"", out_file), msg_id)
+      `DV_CHECK_FATAL(ret, $sformatf("Failed to read line from \"%0s\"", out_file), $sformatf("%m"))
 
       // The first line should have the addr in hex followed by its size as integer.
       ret = $sscanf(line, "%h %d", addr, size);
       `DV_CHECK_EQ_FATAL(ret, 2, $sformatf("Failed to extract {addr size} from line \"%0s\"", line),
-                         msg_id)
+                         $sformatf("%m"))
 
       // Attempt to read the next line should be met with EOF.
       void'($fgets(line, out_file_d));
       ret = $feof(out_file_d);
-      `DV_CHECK_FATAL(ret, $sformatf("EOF expected to be reached for \"%0s\"", out_file), msg_id)
+      `DV_CHECK_FATAL(ret, $sformatf("EOF expected to be reached for \"%0s\"", out_file),
+                      $sformatf("%m"))
       $fclose(out_file_d);
 
       ret = $system($sformatf("rm -rf %0s", out_file));
-      `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Failed to delete \"%0s\"", out_file), msg_id)
+      `DV_CHECK_EQ_FATAL(ret, 0, $sformatf("Failed to delete \"%0s\"", out_file), $sformatf("%m"))
       return 1;
     end
   endfunction
@@ -299,7 +297,7 @@ package dv_utils_pkg;
     string text, msg = "\n", lines[$];
 
     fd = $fopen(vmem_file, "r");
-    `DV_CHECK_FATAL(fd, $sformatf("Failed to open \"%0s\"", vmem_file), msg_id)
+    `DV_CHECK_FATAL(fd, $sformatf("Failed to open \"%0s\"", vmem_file), $sformatf("%m"))
     while (!$feof(fd)) begin
       string line;
       void'($fgets(line, fd));
@@ -308,7 +306,7 @@ package dv_utils_pkg;
       text = {text, line, "\n"};
     end
     $fclose(fd);
-    `DV_CHECK_STRNE_FATAL(text, "", , msg_id)
+    `DV_CHECK_STRNE_FATAL(text, "", , $sformatf("%m"))
 
     // Remove all block and single comments.
     text = str_utils_pkg::str_remove_sections(.s(text), .start_delim("/*"), .end_delim("*/"));
@@ -325,35 +323,36 @@ package dv_utils_pkg;
       str_utils_pkg::str_split(lines[i], tokens, " ");
       `DV_CHECK_FATAL(tokens.size() >= 2,
                       $sformatf("Line \"%s\" in VMEM file %s appears to be malformed",
-                                lines[i], vmem_file), msg_id)
+                                lines[i], vmem_file), $sformatf("%m"))
       if (!str_utils_pkg::str_starts_with(tokens[0], "@")) begin
-        `uvm_fatal(msg_id, $sformatf({"The first word \"%s\" on line \"%s\" in the VMEM file %s ",
-                                      " does not appear to be a valid address"},
-                                    tokens[0], lines[i], vmem_file))
+        `uvm_fatal($sformatf("%m"),
+                   $sformatf({"The first word \"%s\" on line \"%s\" in the VMEM file %s ",
+                              " does not appear to be a valid address"},
+                             tokens[0], lines[i], vmem_file))
       end
       tokens[0] = tokens[0].substr(1, tokens[0].len() - 1);
       `DV_CHECK_FATAL(tokens[0].len() <= bus_params_pkg::BUS_AW / 8 * 2,
                       $sformatf("Address width > %0d bytes is not supported: 0x%0s",
-                                bus_params_pkg::BUS_AW / 8, tokens[0]), msg_id)
+                                bus_params_pkg::BUS_AW / 8, tokens[0]), $sformatf("%m"))
       addr = tokens[0].atohex();
       tokens = tokens[1:$];
       if (i > 0) begin
         `DV_CHECK_FATAL(addr == last_addr,
                         $sformatf("Non-contiguous data unsupported - last_addr: 0x%0h, addr: 0x%0h",
-                                  last_addr, addr), msg_id)
+                                  last_addr, addr), $sformatf("%m"))
       end
       foreach (tokens[i]) begin
         logic [bus_params_pkg::BUS_DW-1:0] data;
         `DV_CHECK_FATAL(tokens[i].len() <= bus_params_pkg::BUS_DW / 8 * 2,
                         $sformatf("Data width > %0d bytes is not supported: 0x%0s",
-                                  bus_params_pkg::BUS_DW / 8, tokens[i]), msg_id)
+                                  bus_params_pkg::BUS_DW / 8, tokens[i]), $sformatf("%m"))
         data = tokens[i].atohex();
         msg = {msg, $sformatf("[0x%0h] = 0x%0h\n", addr + i, data)};
         vmem_data.push_back(data);
       end
       last_addr = addr + tokens.size();
     end
-    `uvm_info(msg_id, $sformatf("Contents of VMEM file %s:%s", vmem_file, msg), UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("Contents of VMEM file %s:%s", vmem_file, msg), UVM_HIGH)
   endfunction
 
   // sources

--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -17,8 +17,6 @@ interface prim_count_if #(
   `include "uvm_macros.svh"
   import uvm_pkg::*;
 
-  string msg_id = $sformatf("%m");
-
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
   string signal_forced;
 
@@ -34,8 +32,9 @@ interface prim_count_if #(
       `DV_CHECK(uvm_hdl_read(signal_forced, orig_value))
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value, force_value != orig_value;)
       `DV_CHECK(uvm_hdl_force(signal_forced, force_value))
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s from %0d to %0d", signal_forced, orig_value, force_value), UVM_LOW)
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s from %0d to %0d", signal_forced, orig_value, force_value),
+                UVM_LOW)
 
       @(negedge clk_i);
       `DV_CHECK(uvm_hdl_release(signal_forced))
@@ -43,7 +42,8 @@ interface prim_count_if #(
 
     virtual task automatic restore_fault();
       `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
-      `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
                 UVM_LOW)
     endtask
   endclass
@@ -51,7 +51,7 @@ interface prim_count_if #(
   prim_count_if_proxy if_proxy;
   initial begin
     signal_forced = $sformatf("%s.cnt_q[%0d]", path, $urandom_range(0, 1));
-    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, msg_id)
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, $sformatf("%m"))
 
     // Store the proxy object for TB to use
     if_proxy = new("if_proxy");
@@ -59,7 +59,7 @@ interface prim_count_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 
 endinterface

--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -17,8 +17,6 @@ interface prim_double_lfsr_if #(
   `include "uvm_macros.svh"
   import uvm_pkg::*;
 
-  string msg_id = $sformatf("%m");
-
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
   string signal_forced = $sformatf("%s.lfsr_state[0]", path);
   string signal_for_restore = $sformatf("%s.lfsr_state[1]", path);
@@ -36,8 +34,9 @@ interface prim_double_lfsr_if #(
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value, force_value != orig_value;)
 
       `DV_CHECK(uvm_hdl_force(signal_forced, force_value))
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s from %0d to %0d", signal_forced, orig_value, force_value), UVM_LOW)
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s from %0d to %0d", signal_forced, orig_value, force_value),
+                UVM_LOW)
 
       @(negedge clk_i);
       `DV_CHECK(uvm_hdl_release(signal_forced))
@@ -47,7 +46,8 @@ interface prim_double_lfsr_if #(
       logic [Width-1:0] restore_value;
       `DV_CHECK(uvm_hdl_read(signal_for_restore, restore_value))
       `DV_CHECK(uvm_hdl_deposit(signal_forced, restore_value))
-      `uvm_info(msg_id, $sformatf("Forcing %s to matching value %0d", signal_forced, restore_value),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s to matching value %0d", signal_forced, restore_value),
                 UVM_LOW)
     endtask
   endclass
@@ -55,8 +55,8 @@ interface prim_double_lfsr_if #(
   prim_double_lfsr_if_proxy if_proxy;
 
   initial begin
-    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, msg_id)
-    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_for_restore),, msg_id)
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, $sformatf("%m"))
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_for_restore),, $sformatf("%m"))
 
     // Store the proxy object for TB to use
     if_proxy = new("if_proxy");
@@ -64,6 +64,6 @@ interface prim_double_lfsr_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
+++ b/hw/dv/sv/sec_cm/prim_onehot_check_if.sv
@@ -37,8 +37,6 @@ interface prim_onehot_check_if #(
     OnehotAddrFault
   } onehot_fault_type_e;
 
-  string msg_id = $sformatf("%m");
-
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
   string oh_signal_forced = $sformatf("%s.oh_i", path);
   string en_signal_forced = $sformatf("%s.en_i", path);
@@ -54,7 +52,7 @@ interface prim_onehot_check_if #(
     endfunction : new
 
     virtual function void sample_cov(onehot_fault_type_e onehot_fault_type);
-      `uvm_fatal(msg_id, "sample_cov in base class")
+      `uvm_fatal($sformatf("%m"), "sample_cov in base class")
     endfunction
 
     virtual task inject_fault();
@@ -99,20 +97,19 @@ interface prim_onehot_check_if #(
             };
         end
         default:
-        `uvm_fatal(msg_id, $sformatf("Unexpected onehot_fault_type: %s", onehot_fault_type.name))
+          `uvm_fatal($sformatf("%m"),
+                     $sformatf("Unexpected onehot_fault_type: %s", onehot_fault_type.name))
       endcase
-      `uvm_info(msg_id, $sformatf("onehot_fault_type: %0s", onehot_fault_type.name), UVM_LOW)
+      `uvm_info($sformatf("%m"),
+                $sformatf("onehot_fault_type: %0s", onehot_fault_type.name), UVM_LOW)
       `DV_CHECK_FATAL(success)
 
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s from %0d to %0d", en_signal_forced, en_orig_value, en_force_value),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s from %0d to %0d, %s from %0d to %0d and %s from %0d to %0d",
+                          en_signal_forced, en_orig_value, en_force_value,
+                          oh_signal_forced, oh_orig_value, oh_force_value,
+                          addr_signal_forced, addr_orig_value, addr_force_value),
                 UVM_LOW)
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s from %0d to %0d", oh_signal_forced, oh_orig_value, oh_force_value),
-                UVM_LOW)
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s from %0d to %0d", addr_signal_forced, addr_orig_value, addr_force_value
-                ), UVM_LOW)
 
       `DV_CHECK(uvm_hdl_force(en_signal_forced, en_force_value))
       `DV_CHECK(uvm_hdl_force(oh_signal_forced, oh_force_value))
@@ -124,12 +121,12 @@ interface prim_onehot_check_if #(
     endtask
 
     virtual task restore_fault();
-      `uvm_info(msg_id, $sformatf("Forcing %s original value %0d", en_signal_forced, en_orig_value),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Restoring original value of %s (%0d), %s (%0d) and %s (%0d)",
+                          en_signal_forced, en_orig_value,
+                          oh_signal_forced, oh_orig_value,
+                          addr_signal_forced, addr_orig_value),
                 UVM_LOW)
-      `uvm_info(msg_id, $sformatf("Forcing %s original value %0d", oh_signal_forced, oh_orig_value),
-                UVM_LOW)
-      `uvm_info(msg_id, $sformatf("Forcing %s original value %0d",
-                                  addr_signal_forced, addr_orig_value), UVM_LOW)
       `DV_CHECK(uvm_hdl_deposit(en_signal_forced, en_orig_value))
       `DV_CHECK(uvm_hdl_deposit(oh_signal_forced, oh_orig_value))
       `DV_CHECK(uvm_hdl_deposit(addr_signal_forced, addr_orig_value))
@@ -164,7 +161,7 @@ interface prim_onehot_check_if #(
     function new(string name = "");
       super.new(name);
       if (sec_cm_pkg::en_sec_cm_cov) begin
-        onehot_with_addr_fault_cg = new(msg_id);
+        onehot_with_addr_fault_cg = new($sformatf("%m"));
       end
     endfunction
   endclass : prim_onehot_check_with_addr_fault_if_proxy
@@ -194,7 +191,7 @@ interface prim_onehot_check_if #(
     function new(string name = "");
       super.new(name);
       if (sec_cm_pkg::en_sec_cm_cov) begin
-        onehot_without_addr_fault_cg = new(msg_id);
+        onehot_without_addr_fault_cg = new($sformatf("%m"));
       end
     endfunction
   endclass : prim_onehot_check_without_addr_fault_if_proxy
@@ -202,8 +199,8 @@ interface prim_onehot_check_if #(
   prim_onehot_check_if_proxy if_proxy;
 
   initial begin
-    `DV_CHECK_FATAL(uvm_hdl_check_path(en_signal_forced),, msg_id)
-    `DV_CHECK_FATAL(uvm_hdl_check_path(oh_signal_forced),, msg_id)
+    `DV_CHECK_FATAL(uvm_hdl_check_path(en_signal_forced),, $sformatf("%m"))
+    `DV_CHECK_FATAL(uvm_hdl_check_path(oh_signal_forced),, $sformatf("%m"))
 
     // Store the proxy object for TB to use
     if (AddrCheck) begin
@@ -219,6 +216,6 @@ interface prim_onehot_check_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/prim_singleton_fifo_if.sv
+++ b/hw/dv/sv/sec_cm/prim_singleton_fifo_if.sv
@@ -20,8 +20,6 @@ interface prim_singleton_fifo_if #(
   `include "uvm_macros.svh"
   import uvm_pkg::*;
 
-  string msg_id = $sformatf("%m");
-
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
   string signal_forced;
 
@@ -38,7 +36,7 @@ interface prim_singleton_fifo_if #(
       @(negedge clk_i);
       `DV_CHECK(uvm_hdl_read(signal_forced, orig_value))
       `DV_CHECK(uvm_hdl_force(signal_forced, ~orig_value))
-      `uvm_info(msg_id,
+      `uvm_info($sformatf("%m"),
                 $sformatf("Forcing %s from %0d to %0d", signal_forced, orig_value, ~orig_value),
                 UVM_LOW)
 
@@ -48,7 +46,8 @@ interface prim_singleton_fifo_if #(
 
     virtual task automatic restore_fault();
       `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
-      `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
                 UVM_LOW)
     endtask
   endclass
@@ -59,7 +58,7 @@ interface prim_singleton_fifo_if #(
       string local_signal;
       local_signal = $urandom_range(0, 1) ? "inv_full" : "full_q";
       signal_forced = $sformatf("%s.%s", path, local_signal);
-      `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, msg_id)
+      `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, $sformatf("%m"))
 
       // Store the proxy object for TB to use
       if_proxy = new("if_proxy");
@@ -67,7 +66,7 @@ interface prim_singleton_fifo_if #(
       if_proxy.path = path;
       sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-      `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
+      `uvm_info($sformatf("%m"), $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
     end
   end
 

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -25,8 +25,10 @@ interface prim_sparse_fsm_flop_if #(
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
   string signal_forced = $sformatf("%s.u_state_flop.q_o", path);
 
-  // This signal only has to be forced if the associated parameter
-  // CustomForceName in prim_sparse_fsm_flop is set to a non-empty string.
+  // The prim_sparse_fsm_flop module is usually created with the PRIM_FLOP_SPARSE_FSM macro, which
+  // (when in simulation) passes an extra CustomForceName parameter to control how it should be
+  // forced.
+
   string parent_path = dv_utils_pkg::get_parent_hier($sformatf("%m"), 2);
   string custom_signal_forced = $sformatf("%s.%s", parent_path, CustomForceName);
 
@@ -72,10 +74,8 @@ interface prim_sparse_fsm_flop_if #(
 
       `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
                 UVM_LOW)
+
       `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s to original value %0d", custom_signal_forced, orig_value), UVM_LOW)
-      `DV_CHECK(uvm_hdl_deposit(custom_signal_forced, orig_value))
     endtask
   endclass
 

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -47,12 +47,15 @@ interface prim_sparse_fsm_flop_if #(
                                              force_value ^ orig_value
                                          ) inside {[1 : MaxFlipBits]};)
 
-      `uvm_info(msg_id, $sformatf(
-                "Forcing %s from %0d to %0d", signal_forced, orig_value, force_value), UVM_LOW)
+      `uvm_info($sformatf("%m"),
+                $sformatf("Forcing %s from %0d to %0d",
+                          signal_forced, orig_value, force_value),
+                UVM_LOW)
       `DV_CHECK(uvm_hdl_force(signal_forced, force_value))
       if (CustomForceName != "") begin
-        `uvm_info(msg_id, $sformatf(
-                  "Forcing %s from %0d to %0d", custom_signal_forced, orig_value, force_value),
+        `uvm_info($sformatf("%m"),
+                  $sformatf("Forcing %s from %0d to %0d",
+                            custom_signal_forced, orig_value, force_value),
                   UVM_LOW)
         `DV_CHECK(uvm_hdl_deposit(custom_signal_forced, force_value))
       end
@@ -72,9 +75,9 @@ interface prim_sparse_fsm_flop_if #(
       // implementation in the prim and the path is different in the close source
       if (CustomForceName != "") return;
 
-      `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Depositing original value (%0d) at %s", orig_value, signal_forced),
                 UVM_LOW)
-
       `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
     endtask
   endclass
@@ -82,7 +85,7 @@ interface prim_sparse_fsm_flop_if #(
   prim_sparse_fsm_flop_if_proxy if_proxy;
 
   initial begin
-    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, msg_id)
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced),, $sformatf("%m"))
 
     // Store the proxy object for TB to use
     if_proxy = new("if_proxy");
@@ -90,6 +93,6 @@ interface prim_sparse_fsm_flop_if #(
     if_proxy.path = path;
     sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
 
-    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
+    `uvm_info($sformatf("%m"), $sformatf("Interface proxy class is added for %s", path), UVM_HIGH)
   end
 endinterface

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -11,9 +11,6 @@ package sec_cm_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // package variables
-  string msg_id = "sec_cm_pkg";
-
   typedef enum int {
     SecCmPrimCount,
     SecCmPrimSparseFsmFlop,
@@ -43,22 +40,21 @@ package sec_cm_pkg;
       proxies = sec_cm_pkg::sec_cm_if_proxy_q.find_first() with (item.path == path);
     end
     if (proxies.size()) begin
-      `uvm_info(msg_id, $sformatf(
-                "find_sec_cm_if_proxy: found proxy for path %s: type = %0d, full path = %0s",
-                path,
-                proxies[0].sec_cm_type,
-                proxies[0].path
-                ), UVM_MEDIUM)
+      `uvm_info($sformatf("%m"),
+                $sformatf("found proxy for path %s: type = %0d, full path = %0s",
+                          path, proxies[0].sec_cm_type, proxies[0].path),
+                UVM_MEDIUM)
       return proxies[0];
-    end else `uvm_fatal(msg_id, $sformatf("find_sec_cm_if_proxy: no proxy with path %s", path))
+    end else `uvm_fatal($sformatf("%m"), $sformatf("no proxy with path %s", path))
     return null;
   endfunction
 
   function automatic void list_if_proxies(uvm_verbosity verbosity = UVM_MEDIUM);
-    `uvm_info(msg_id, "The sec_cm proxies:", verbosity)
+    `uvm_info($sformatf("%m"), "The sec_cm proxies:", verbosity)
     foreach (sec_cm_if_proxy_q[i]) begin
-      `uvm_info(msg_id, $sformatf(
-                "Path %0s, type %d", sec_cm_if_proxy_q[i].path, sec_cm_if_proxy_q[i].sec_cm_type),
+      `uvm_info($sformatf("%m"),
+                $sformatf("Path %0s, type %d",
+                          sec_cm_if_proxy_q[i].path, sec_cm_if_proxy_q[i].sec_cm_type),
                 verbosity)
     end
   endfunction

--- a/hw/dv/sv/tl_agent/tl_agent_pkg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_pkg.sv
@@ -46,8 +46,9 @@ package tl_agent_pkg;
 
   function automatic void enable_logging(string file_name="tl_agent.log");
     int log_fd = $fopen(file_name,"w");
-    `uvm_info("tl_agent_pkg", $sformatf("The TL agent transaction log will be saved to %0s",
-                              file_name), UVM_LOW)
+    `uvm_info($sformatf("%m"),
+              $sformatf("The TL agent transaction log will be saved to %0s", file_name),
+              UVM_LOW)
     uvm_top.set_report_id_verbosity_hier("tl_logging", UVM_HIGH);
     uvm_top.set_report_id_file_hier("tl_logging", log_fd);
     uvm_top.set_report_id_verbosity_hier("tl_logging", UVM_HIGH);

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -176,9 +176,7 @@ class tl_monitor extends dv_base_monitor#(
       req.a_mask   = h2d.a_mask;
       req.a_source = h2d.a_source;
       req.a_user   = h2d.a_user;
-      `uvm_info("tl_logging",
-                $sformatf("[%0s][a_chan] : %0s", agent_name, req.convert2string()),
-                UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("[%0s][a_chan] : %0s", agent_name, req.convert2string()), UVM_HIGH)
 
       if (cfg.en_cov) sample_outstanding_cov(req);
 
@@ -234,8 +232,7 @@ class tl_monitor extends dv_base_monitor#(
       rsp.d_size   = cfg.vif.mon_cb.d2h.d_size;
       rsp.d_user   = cfg.vif.mon_cb.d2h.d_user;
 
-      `uvm_info("tl_logging",
-                $sformatf("[%0s][d_chan] : %0s", agent_name, rsp.convert2string()), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("[%0s][d_chan] : %0s", agent_name, rsp.convert2string()), UVM_HIGH)
 
       d_chan_port.write(rsp);
       if (cfg.synchronise_ports) channel_dir_port.write(DataChannel);

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -75,9 +75,9 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     end
     if (cfg.csr_access_abort_pct_in_adapter > $urandom_range(0, 100)) begin
       bus_req.req_abort_after_a_valid_len = 1;
-      `uvm_info(this.get_name(), $sformatf("tl reg req item is allowed to be aborted"), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("tl reg req item is allowed to be aborted"), UVM_MEDIUM)
     end
-    `uvm_info(this.get_name(), {"tl_reg_adapter::reg2bus: ", bus_req.convert2string()}, UVM_HIGH)
+    `uvm_info(`gfn, bus_req.convert2string(), UVM_HIGH)
     return bus_req;
   endfunction : reg2bus
 
@@ -91,7 +91,7 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     `DV_CHECK_EQ(bus_rsp.d_source, bus_rsp.a_source)
     // indicate if the item is completed successfully for upper level to update predict value
     rw.status  = !bus_rsp.req_completed ? UVM_NOT_OK : UVM_IS_OK;
-    `uvm_info(this.get_name(), {"tl_reg_adapter::bus2reg: ", bus_rsp.convert2string()}, UVM_HIGH)
+    `uvm_info(`gfn, bus_rsp.convert2string(), UVM_HIGH)
   endfunction: bus2reg
 
 endclass : tl_reg_adapter


### PR DESCRIPTION
This was originally inspired by looking at some messages from the Verissimo linter but (working through a bunch of them) I found quite a few places things could be simpler and more informative. This PR is the result!