### PR TITLE
[clkmgr,doc] Fix doc copyright seen as title

### DIFF
--- a/hw/ip_templates/clkmgr/dv/README.md.tpl
+++ b/hw/ip_templates/clkmgr/dv/README.md.tpl
@@ -1,6 +1,6 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
+## Copyright lowRISC contributors (OpenTitan project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
 <% from topgen.lib import Name %>\
 # CLKMGR DV document
 

--- a/hw/top_darjeeling/ip_autogen/clkmgr/dv/README.md
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/dv/README.md
@@ -1,6 +1,3 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # CLKMGR DV document
 
 ## Goals

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/README.md
@@ -1,6 +1,3 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # CLKMGR DV document
 
 ## Goals

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/README.md
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/dv/README.md
@@ -1,6 +1,3 @@
-# Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # CLKMGR DV document
 
 ## Goals


### PR DESCRIPTION
- Remove the copyright header from the Markdown files as it is interpreted as a title by the doc generator when published online.