### PR TITLE
[rv_plic, fpv] FI through stopat to generate stimuli coverage

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -226,7 +226,7 @@ report
 #-------------------------------------------------------------------------
 
 if {$env(COV) == 1} {
-  check_cov -measure -time_limit 2h
+  check_cov -measure -all -time_limit 2h
   check_cov -report -force -exclude { reset waived }
   check_cov -report -no_return -report_file cover.html \
       -html -force -exclude { reset waived }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# This line is a default case statement which could be executed if a parasitic state has been
-# injected to the state register of u_prim_alert_sender.
-check_cov -waiver -add -start_line 249 -end_line 249 -instance {dut.gen_alert_tx[0].u_prim_alert_sender} -comment {No parasitic state injection while doing FPV}
-
-# The intention to add this assertion is to make sure that while doing FPV there is not a
-# possibility to inject parasitic state to the state register of alert sender FSM.
-assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
-
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
 
@@ -44,3 +36,14 @@ check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused code block}
 
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+# Below task acts as an isolated container for the following assertion and stopat.
+task -create FSMParasiticState
+
+# Drives any possible value to state_q.
+stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
+
+# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
+# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
+# checker coverage for the default case.
+assert -name FSMParasiticState::AlertSenderFSMParasiticState_A {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# This line is a default case statement which could be executed if a parasitic state has been
-# injected to the state register of u_prim_alert_sender.
-check_cov -waiver -add -start_line 249 -end_line 249 -instance {dut.gen_alert_tx[0].u_prim_alert_sender} -comment {No parasitic state injection while doing FPV}
-
-# The intention to add this assertion is to make sure that while doing FPV there is not a
-# possibility to inject parasitic state to the state register of alert sender FSM.
-assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
-
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
 
@@ -44,3 +36,14 @@ check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused code block}
 
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+# Below task acts as an isolated container for the following assertion and stopat.
+task -create FSMParasiticState
+
+# Drives any possible value to state_q.
+stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
+
+# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
+# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
+# checker coverage for the default case.
+assert -name FSMParasiticState::AlertSenderFSMParasiticState_A {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -2,14 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# This line is a default case statement which could be executed if a parasitic state has been
-# injected to the state register of u_prim_alert_sender.
-check_cov -waiver -add -start_line 249 -end_line 249 -instance {dut.gen_alert_tx[0].u_prim_alert_sender} -comment {No parasitic state injection while doing FPV}
-
-# The intention to add this assertion is to make sure that while doing FPV there is not a
-# possibility to inject parasitic state to the state register of alert sender FSM.
-assert -name AlertSenderNoParasiticState_A {dut.gen_alert_tx[0].u_prim_alert_sender.state_q <= 6}
-
 # The port data_o in u_data_chk is untied and used nowhere.
 check_cov -waiver -add -start_line 25 -end_line 56 -type {statement} -instance {dut.u_reg.u_chk.u_tlul_data_integ_dec.u_data_chk} -comment {data_o is untied}
 
@@ -44,3 +36,14 @@ check_cov -waiver -add -start_line 258 -end_line 278 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -comment {Unused code block}
 
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused code block}
+
+# Below task acts as an isolated container for the following assertion and stopat.
+task -create FSMParasiticState
+
+# Drives any possible value to state_q.
+stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
+
+# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
+# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
+# checker coverage for the default case.
+assert -name FSMParasiticState::AlertSenderFSMParasiticState_A {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}


### PR DESCRIPTION
This PR uses a mechanism to inject fault in the state register
of alert FSM. This mechanism is to create a stopat at state_q
so that jasper drives any possible value. When it does, we cover
the stimuli coverage for a default case in prim_alert_sender.
To cover the checker coverage, an assertion is added. This
assertion and stopat is created in a separate isolated task so
that none of our proved assertions fails when we are doing FI
in FPV.