### PR TITLE
[soc_dbg_ctrl] Correct wiring fault in jtag_status register

### DIFF
--- a/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
+++ b/hw/ip/soc_dbg_ctrl/dv/env/soc_dbg_ctrl_scoreboard.sv
@@ -125,6 +125,9 @@ task soc_dbg_ctrl_scoreboard::process_tl_core_access(
     "intr_test": begin
       // FIXME TODO MVy
     end
+    "debug_policy_relocked": begin
+      // FIXME TODO
+    end
     default: begin
       `uvm_fatal(`gfn, $sformatf("invalid CSR: %0s", csr.get_full_name()))
     end

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl.sv
@@ -249,7 +249,12 @@ module soc_dbg_ctrl
 
   // The status register is written by IBEX firmware and is reflected into the JTAG status register.
   // The JTAG user shall query this status register.
-  assign jtag_hw2reg.jtag_status = soc_dbg_ctrl_hw2reg_jtag_status_reg_t'(core_reg2hw.status);
+  assign jtag_hw2reg.jtag_status.auth_unlock_failed.d    = core_reg2hw.status.auth_unlock_failed.q;
+  assign jtag_hw2reg.jtag_status.auth_unlock_success.d   = core_reg2hw.status.auth_unlock_success.q;
+  assign jtag_hw2reg.jtag_status.auth_window_closed.d    = core_reg2hw.status.auth_window_closed.q;
+  assign jtag_hw2reg.jtag_status.auth_window_open.d      = core_reg2hw.status.auth_window_open.q;
+  assign jtag_hw2reg.jtag_status.auth_debug_intent_set.d =
+              core_reg2hw.status.auth_debug_intent_set.q;
 
   halt_state_e halt_state_d, halt_state_q;
 


### PR DESCRIPTION
This PR fixes the assignment from the 'status' register on the core interface to the 'jtag_status' register on the JTAG interface, since the two packed structures involved have their sub-fields declared in opposing orders.
The structure assignment was fragile and it is considered preferable to assign the fields individually to defend against further changes.

A minor tweak is also made to the scoreboard in the DV environment to help keep the 'smoke' regression more usable for catching build issues/regressions until such time as it is further developed.