### PR TITLE
[reggen] Re-order subfields of hw2reg packed structs

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -151,13 +151,9 @@ package adc_ctrl_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [1:0]  d;
-      logic        de;
-    } adc_chn_value_ext;
-    struct packed {
       logic [9:0] d;
       logic        de;
-    } adc_chn_value;
+    } adc_chn_value_intr;
     struct packed {
       logic [1:0]  d;
       logic        de;
@@ -165,33 +161,37 @@ package adc_ctrl_reg_pkg;
     struct packed {
       logic [9:0] d;
       logic        de;
-    } adc_chn_value_intr;
+    } adc_chn_value;
+    struct packed {
+      logic [1:0]  d;
+      logic        de;
+    } adc_chn_value_ext;
   } adc_ctrl_hw2reg_adc_chn_val_mreg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-      logic        de;
-    } match;
-    struct packed {
       logic        d;
       logic        de;
     } trans;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } match;
   } adc_ctrl_hw2reg_filter_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
+      logic        d;
       logic        de;
-    } match;
+    } oneshot;
     struct packed {
       logic        d;
       logic        de;
     } trans;
     struct packed {
-      logic        d;
+      logic [7:0]  d;
       logic        de;
-    } oneshot;
+    } match;
   } adc_ctrl_hw2reg_adc_intr_status_reg_t;
 
   typedef struct packed {

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -147,34 +147,30 @@ package aes_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [1:0]  d;
-    } operation;
-    struct packed {
-      logic [5:0]  d;
-    } mode;
-    struct packed {
-      logic [2:0]  d;
-    } key_len;
-    struct packed {
       logic        d;
-    } sideload;
+    } manual_operation;
     struct packed {
       logic [2:0]  d;
     } prng_reseed_rate;
     struct packed {
       logic        d;
-    } manual_operation;
+    } sideload;
+    struct packed {
+      logic [2:0]  d;
+    } key_len;
+    struct packed {
+      logic [5:0]  d;
+    } mode;
+    struct packed {
+      logic [1:0]  d;
+    } operation;
   } aes_hw2reg_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } start;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key_iv_data_in_clear;
+    } prng_reseed;
     struct packed {
       logic        d;
       logic        de;
@@ -182,30 +178,18 @@ package aes_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prng_reseed;
+    } key_iv_data_in_clear;
+    struct packed {
+      logic        d;
+      logic        de;
+    } start;
   } aes_hw2reg_trigger_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } idle;
-    struct packed {
-      logic        d;
-      logic        de;
-    } stall;
-    struct packed {
-      logic        d;
-      logic        de;
-    } output_lost;
-    struct packed {
-      logic        d;
-      logic        de;
-    } output_valid;
-    struct packed {
-      logic        d;
-      logic        de;
-    } input_ready;
+    } alert_fatal_fault;
     struct packed {
       logic        d;
       logic        de;
@@ -213,7 +197,23 @@ package aes_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } alert_fatal_fault;
+    } input_ready;
+    struct packed {
+      logic        d;
+      logic        de;
+    } output_valid;
+    struct packed {
+      logic        d;
+      logic        de;
+    } output_lost;
+    struct packed {
+      logic        d;
+      logic        de;
+    } stall;
+    struct packed {
+      logic        d;
+      logic        de;
+    } idle;
   } aes_hw2reg_status_reg_t;
 
   // Register -> HW type

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -114,11 +114,11 @@ package aon_timer_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } wkup_timer_expired;
+    } wdog_timer_bark;
     struct packed {
       logic        d;
       logic        de;
-    } wdog_timer_bark;
+    } wkup_timer_expired;
   } aon_timer_hw2reg_intr_state_reg_t;
 
   typedef struct packed {

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -137,11 +137,7 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cs_cmd_req_done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cs_entropy_req;
+    } cs_fatal_err;
     struct packed {
       logic        d;
       logic        de;
@@ -149,7 +145,11 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cs_fatal_err;
+    } cs_entropy_req;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cs_cmd_req_done;
   } csrng_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -158,26 +158,26 @@ package csrng_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [2:0]  d;
       logic        de;
-    } cmd_rdy;
+    } cmd_sts;
     struct packed {
       logic        d;
       logic        de;
     } cmd_ack;
     struct packed {
-      logic [2:0]  d;
+      logic        d;
       logic        de;
-    } cmd_sts;
+    } cmd_rdy;
   } csrng_hw2reg_sw_cmd_sts_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } genbits_vld;
+    } genbits_fips;
     struct packed {
       logic        d;
-    } genbits_fips;
+    } genbits_vld;
   } csrng_hw2reg_genbits_vld_reg_t;
 
   typedef struct packed {
@@ -197,31 +197,7 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sw_app_enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } read_int_state_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fips_force_enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } acmd_flag0_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cs_bus_cmp_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cmd_stage_invalid_acmd_alert;
+    } cmd_stage_reseed_cnt_alert;
     struct packed {
       logic        d;
       logic        de;
@@ -229,106 +205,38 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cmd_stage_reseed_cnt_alert;
+    } cmd_stage_invalid_acmd_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cs_bus_cmp_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } acmd_flag0_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fips_force_enable_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } read_int_state_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sw_app_enable_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } enable_field_alert;
   } csrng_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } sfifo_cmd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_genbits_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_cmdreq_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_rcstage_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_keyvrc_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_updreq_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_bencreq_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_bencack_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_pdata_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_final_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_gbencack_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_grcstage_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_ggenreq_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_gadstage_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_ggenbits_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_blkenc_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cmd_stage_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } main_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } drbg_gen_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } drbg_updbe_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } drbg_updob_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } aes_cipher_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cmd_gen_cnt_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fifo_write_err;
+    } fifo_state_err;
     struct packed {
       logic        d;
       logic        de;
@@ -336,7 +244,99 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fifo_state_err;
+    } fifo_write_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd_gen_cnt_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } aes_cipher_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } drbg_updob_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } drbg_updbe_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } drbg_gen_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd_stage_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_blkenc_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_ggenbits_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_gadstage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_ggenreq_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_grcstage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_gbencack_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_final_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_pdata_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_bencack_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_bencreq_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_updreq_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_keyvrc_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_rcstage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_cmdreq_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_genbits_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_cmd_err;
   } csrng_hw2reg_err_code_reg_t;
 
   typedef struct packed {

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -203,7 +203,7 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } dma_done;
+    } dma_error;
     struct packed {
       logic        d;
       logic        de;
@@ -211,7 +211,7 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } dma_error;
+    } dma_done;
   } dma_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -242,7 +242,7 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } initial_transfer;
+    } go;
     struct packed {
       logic        d;
       logic        de;
@@ -250,26 +250,14 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } go;
+    } initial_transfer;
   } dma_hw2reg_control_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } busy;
-    struct packed {
-      logic        d;
-      logic        de;
-    } done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } aborted;
-    struct packed {
-      logic        d;
-      logic        de;
-    } error;
+    } chunk_done;
     struct packed {
       logic        d;
       logic        de;
@@ -277,34 +265,26 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } chunk_done;
+    } error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } aborted;
+    struct packed {
+      logic        d;
+      logic        de;
+    } done;
+    struct packed {
+      logic        d;
+      logic        de;
+    } busy;
   } dma_hw2reg_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } src_addr_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } dst_addr_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } opcode_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } size_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } bus_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } base_limit_error;
+    } asid_error;
     struct packed {
       logic        d;
       logic        de;
@@ -312,7 +292,27 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } asid_error;
+    } base_limit_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } size_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } opcode_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } dst_addr_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } src_addr_error;
   } dma_hw2reg_error_code_reg_t;
 
   typedef struct packed {

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -115,18 +115,22 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } edn_cmd_req_done;
+    } edn_fatal_err;
     struct packed {
       logic        d;
       logic        de;
-    } edn_fatal_err;
+    } edn_cmd_req_done;
   } edn_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } cmd_sts;
+    struct packed {
       logic        d;
       logic        de;
-    } cmd_reg_rdy;
+    } cmd_ack;
     struct packed {
       logic        d;
       logic        de;
@@ -134,22 +138,18 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cmd_ack;
-    struct packed {
-      logic [2:0]  d;
-      logic        de;
-    } cmd_sts;
+    } cmd_reg_rdy;
   } edn_hw2reg_sw_cmd_sts_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [2:0]  d;
       logic        de;
-    } boot_mode;
+    } cmd_sts;
     struct packed {
       logic        d;
       logic        de;
-    } auto_mode;
+    } cmd_ack;
     struct packed {
       logic [3:0]  d;
       logic        de;
@@ -157,30 +157,18 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cmd_ack;
+    } auto_mode;
     struct packed {
-      logic [2:0]  d;
+      logic        d;
       logic        de;
-    } cmd_sts;
+    } boot_mode;
   } edn_hw2reg_hw_cmd_sts_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } edn_enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } boot_req_mode_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } auto_req_mode_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cmd_fifo_rst_field_alert;
+    } csrng_ack_err;
     struct packed {
       logic        d;
       logic        de;
@@ -188,34 +176,26 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } csrng_ack_err;
+    } cmd_fifo_rst_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } auto_req_mode_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } boot_req_mode_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } edn_enable_field_alert;
   } edn_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } sfifo_rescmd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_gencmd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } edn_ack_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } edn_main_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } edn_cntr_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fifo_write_err;
+    } fifo_state_err;
     struct packed {
       logic        d;
       logic        de;
@@ -223,7 +203,27 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fifo_state_err;
+    } fifo_write_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } edn_cntr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } edn_main_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } edn_ack_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_gencmd_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_rescmd_err;
   } edn_hw2reg_err_code_reg_t;
 
   typedef struct packed {

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -279,11 +279,7 @@ package entropy_src_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } es_entropy_valid;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_health_test_failed;
+    } es_fatal_err;
     struct packed {
       logic        d;
       logic        de;
@@ -291,7 +287,11 @@ package entropy_src_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } es_fatal_err;
+    } es_health_test_failed;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_entropy_valid;
   } entropy_src_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -306,163 +306,163 @@ package entropy_src_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_repcnt_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_repcnts_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_adaptp_hi_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_adaptp_lo_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_bucket_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_markov_hi_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_markov_lo_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_extht_hi_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_thresh;
+    } bypass_thresh;
     struct packed {
       logic [15:0] d;
-    } bypass_thresh;
+    } fips_thresh;
   } entropy_src_hw2reg_extht_lo_thresholds_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_repcnt_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_repcnts_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_adaptp_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_adaptp_lo_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_extht_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_extht_lo_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_bucket_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_markov_hi_watermarks_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } fips_watermark;
+    } bypass_watermark;
     struct packed {
       logic [15:0] d;
-    } bypass_watermark;
+    } fips_watermark;
   } entropy_src_hw2reg_markov_lo_watermarks_reg_t;
 
   typedef struct packed {
@@ -508,34 +508,34 @@ package entropy_src_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [3:0]  d;
-    } repcnt_fail_count;
-    struct packed {
-      logic [3:0]  d;
-    } adaptp_hi_fail_count;
-    struct packed {
-      logic [3:0]  d;
-    } adaptp_lo_fail_count;
-    struct packed {
-      logic [3:0]  d;
-    } bucket_fail_count;
-    struct packed {
-      logic [3:0]  d;
-    } markov_hi_fail_count;
+    } repcnts_fail_count;
     struct packed {
       logic [3:0]  d;
     } markov_lo_fail_count;
     struct packed {
       logic [3:0]  d;
-    } repcnts_fail_count;
+    } markov_hi_fail_count;
+    struct packed {
+      logic [3:0]  d;
+    } bucket_fail_count;
+    struct packed {
+      logic [3:0]  d;
+    } adaptp_lo_fail_count;
+    struct packed {
+      logic [3:0]  d;
+    } adaptp_hi_fail_count;
+    struct packed {
+      logic [3:0]  d;
+    } repcnt_fail_count;
   } entropy_src_hw2reg_alert_fail_counts_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [3:0]  d;
-    } extht_hi_fail_count;
+    } extht_lo_fail_count;
     struct packed {
       logic [3:0]  d;
-    } extht_lo_fail_count;
+    } extht_hi_fail_count;
   } entropy_src_hw2reg_extht_fail_counts_reg_t;
 
   typedef struct packed {
@@ -557,96 +557,36 @@ package entropy_src_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [1:0]  d;
-    } entropy_fifo_depth;
-    struct packed {
-      logic [2:0]  d;
-    } sha3_fsm;
-    struct packed {
       logic        d;
-    } sha3_block_pr;
-    struct packed {
-      logic        d;
-    } sha3_squeezing;
-    struct packed {
-      logic        d;
-    } sha3_absorbed;
-    struct packed {
-      logic        d;
-    } sha3_err;
+    } main_sm_boot_done;
     struct packed {
       logic        d;
     } main_sm_idle;
     struct packed {
       logic        d;
-    } main_sm_boot_done;
+    } sha3_err;
+    struct packed {
+      logic        d;
+    } sha3_absorbed;
+    struct packed {
+      logic        d;
+    } sha3_squeezing;
+    struct packed {
+      logic        d;
+    } sha3_block_pr;
+    struct packed {
+      logic [2:0]  d;
+    } sha3_fsm;
+    struct packed {
+      logic [1:0]  d;
+    } entropy_fifo_depth;
   } entropy_src_hw2reg_debug_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } fips_enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } entropy_data_reg_en_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } module_enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } threshold_scope_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rng_bit_enable_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fw_ov_sha3_start_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fw_ov_mode_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fw_ov_entropy_insert_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_route_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_type_field_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_main_sm_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_bus_cmp_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_thresh_cfg_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_fw_ov_wr_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_fw_ov_disable_alert;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fips_flag_field_alert;
+    } postht_entropy_drop_alert;
     struct packed {
       logic        d;
       logic        de;
@@ -654,50 +594,74 @@ package entropy_src_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } postht_entropy_drop_alert;
+    } fips_flag_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_fw_ov_disable_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_fw_ov_wr_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_thresh_cfg_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_bus_cmp_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_main_sm_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_type_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_route_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fw_ov_entropy_insert_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fw_ov_mode_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fw_ov_sha3_start_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rng_bit_enable_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } threshold_scope_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } module_enable_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } entropy_data_reg_en_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fips_enable_field_alert;
   } entropy_src_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } sfifo_esrng_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_distr_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_observe_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sfifo_esfinal_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_ack_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_main_sm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } es_cntr_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sha3_state_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sha3_rst_storage_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fifo_write_err;
+    } fifo_state_err;
     struct packed {
       logic        d;
       logic        de;
@@ -705,7 +669,43 @@ package entropy_src_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fifo_state_err;
+    } fifo_write_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sha3_rst_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sha3_state_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_cntr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_main_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } es_ack_sm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_esfinal_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_observe_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_distr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sfifo_esrng_err;
   } entropy_src_hw2reg_err_code_reg_t;
 
   typedef struct packed {

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -144,7 +144,7 @@ package hmac_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } hmac_done;
+    } hmac_err;
     struct packed {
       logic        d;
       logic        de;
@@ -152,46 +152,46 @@ package hmac_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } hmac_err;
+    } hmac_done;
   } hmac_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } hmac_en;
+      logic [5:0]  d;
+    } key_length;
+    struct packed {
+      logic [3:0]  d;
+    } digest_size;
     struct packed {
       logic        d;
-    } sha_en;
-    struct packed {
-      logic        d;
-    } endian_swap;
+    } key_swap;
     struct packed {
       logic        d;
     } digest_swap;
     struct packed {
       logic        d;
-    } key_swap;
+    } endian_swap;
     struct packed {
-      logic [3:0]  d;
-    } digest_size;
+      logic        d;
+    } sha_en;
     struct packed {
-      logic [5:0]  d;
-    } key_length;
+      logic        d;
+    } hmac_en;
   } hmac_hw2reg_cfg_reg_t;
 
   typedef struct packed {
     struct packed {
+      logic [5:0]  d;
+    } fifo_depth;
+    struct packed {
       logic        d;
-    } hmac_idle;
+    } fifo_full;
     struct packed {
       logic        d;
     } fifo_empty;
     struct packed {
       logic        d;
-    } fifo_full;
-    struct packed {
-      logic [5:0]  d;
-    } fifo_depth;
+    } hmac_idle;
   } hmac_hw2reg_status_reg_t;
 
   typedef struct packed {

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -450,55 +450,7 @@ package i2c_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fmt_threshold;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_threshold;
-    struct packed {
-      logic        d;
-      logic        de;
-    } acq_threshold;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_overflow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } controller_halt;
-    struct packed {
-      logic        d;
-      logic        de;
-    } scl_interference;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sda_interference;
-    struct packed {
-      logic        d;
-      logic        de;
-    } stretch_timeout;
-    struct packed {
-      logic        d;
-      logic        de;
-    } sda_unstable;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cmd_complete;
-    struct packed {
-      logic        d;
-      logic        de;
-    } tx_stretch;
-    struct packed {
-      logic        d;
-      logic        de;
-    } tx_threshold;
-    struct packed {
-      logic        d;
-      logic        de;
-    } acq_stretch;
+    } host_timeout;
     struct packed {
       logic        d;
       logic        de;
@@ -506,43 +458,91 @@ package i2c_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } host_timeout;
+    } acq_stretch;
+    struct packed {
+      logic        d;
+      logic        de;
+    } tx_threshold;
+    struct packed {
+      logic        d;
+      logic        de;
+    } tx_stretch;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd_complete;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sda_unstable;
+    struct packed {
+      logic        d;
+      logic        de;
+    } stretch_timeout;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sda_interference;
+    struct packed {
+      logic        d;
+      logic        de;
+    } scl_interference;
+    struct packed {
+      logic        d;
+      logic        de;
+    } controller_halt;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_overflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } acq_threshold;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_threshold;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fmt_threshold;
   } i2c_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } fmtfull;
-    struct packed {
-      logic        d;
-    } rxfull;
-    struct packed {
-      logic        d;
-    } fmtempty;
-    struct packed {
-      logic        d;
-    } hostidle;
-    struct packed {
-      logic        d;
-    } targetidle;
-    struct packed {
-      logic        d;
-    } rxempty;
-    struct packed {
-      logic        d;
-    } txfull;
-    struct packed {
-      logic        d;
-    } acqfull;
-    struct packed {
-      logic        d;
-    } txempty;
+    } ack_ctrl_stretch;
     struct packed {
       logic        d;
     } acqempty;
     struct packed {
       logic        d;
-    } ack_ctrl_stretch;
+    } txempty;
+    struct packed {
+      logic        d;
+    } acqfull;
+    struct packed {
+      logic        d;
+    } txfull;
+    struct packed {
+      logic        d;
+    } rxempty;
+    struct packed {
+      logic        d;
+    } targetidle;
+    struct packed {
+      logic        d;
+    } hostidle;
+    struct packed {
+      logic        d;
+    } fmtempty;
+    struct packed {
+      logic        d;
+    } rxfull;
+    struct packed {
+      logic        d;
+    } fmtfull;
   } i2c_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -552,37 +552,37 @@ package i2c_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [11:0] d;
-    } fmtlvl;
+    } rxlvl;
     struct packed {
       logic [11:0] d;
-    } rxlvl;
+    } fmtlvl;
   } i2c_hw2reg_host_fifo_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [11:0] d;
-    } txlvl;
+    } acqlvl;
     struct packed {
       logic [11:0] d;
-    } acqlvl;
+    } txlvl;
   } i2c_hw2reg_target_fifo_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } scl_rx;
+    } sda_rx;
     struct packed {
       logic [15:0] d;
-    } sda_rx;
+    } scl_rx;
   } i2c_hw2reg_val_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } abyte;
-    struct packed {
       logic [2:0]  d;
     } signal;
+    struct packed {
+      logic [7:0]  d;
+    } abyte;
   } i2c_hw2reg_acqdata_reg_t;
 
   typedef struct packed {
@@ -604,7 +604,11 @@ package i2c_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } nack;
+    } arbitration_lost;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_timeout;
     struct packed {
       logic        d;
       logic        de;
@@ -612,18 +616,14 @@ package i2c_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } bus_timeout;
-    struct packed {
-      logic        d;
-      logic        de;
-    } arbitration_lost;
+    } nack;
   } i2c_hw2reg_controller_events_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } tx_pending;
+    } arbitration_lost;
     struct packed {
       logic        d;
       logic        de;
@@ -631,7 +631,7 @@ package i2c_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } arbitration_lost;
+    } tx_pending;
   } i2c_hw2reg_target_events_reg_t;
 
   // Register -> HW type

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -191,7 +191,7 @@ package keymgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } invalid_op;
+    } invalid_shadow_update;
     struct packed {
       logic        d;
       logic        de;
@@ -199,58 +199,14 @@ package keymgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } invalid_shadow_update;
+    } invalid_op;
   } keymgr_hw2reg_err_code_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } cmd;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_fsm;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_op;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_out;
-    struct packed {
-      logic        d;
-      logic        de;
-    } regfile_intg;
-    struct packed {
-      logic        d;
-      logic        de;
-    } shadow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_fsm_intg;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_fsm_chk;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_fsm_cnt;
-    struct packed {
-      logic        d;
-      logic        de;
-    } reseed_cnt;
-    struct packed {
-      logic        d;
-      logic        de;
-    } side_ctrl_fsm;
+    } key_ecc;
     struct packed {
       logic        d;
       logic        de;
@@ -258,30 +214,58 @@ package keymgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } key_ecc;
+    } side_ctrl_fsm;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reseed_cnt;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_fsm_cnt;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_fsm_chk;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_fsm_intg;
+    struct packed {
+      logic        d;
+      logic        de;
+    } shadow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } regfile_intg;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_out;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_op;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_done;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_fsm;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd;
   } keymgr_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } invalid_creator_seed;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_owner_seed;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_dev_id;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_health_state;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_key_version;
+    } invalid_digest;
     struct packed {
       logic        d;
       logic        de;
@@ -289,7 +273,23 @@ package keymgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } invalid_digest;
+    } invalid_key_version;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_health_state;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_dev_id;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_owner_seed;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_creator_seed;
   } keymgr_hw2reg_debug_reg_t;
 
   // Register -> HW type

--- a/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
+++ b/hw/ip/keymgr_dpe/rtl/keymgr_dpe_reg_pkg.sv
@@ -213,7 +213,7 @@ package keymgr_dpe_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } invalid_op;
+    } invalid_shadow_update;
     struct packed {
       logic        d;
       logic        de;
@@ -221,58 +221,14 @@ package keymgr_dpe_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } invalid_shadow_update;
+    } invalid_op;
   } keymgr_dpe_hw2reg_err_code_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } cmd;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_fsm;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_op;
-    struct packed {
-      logic        d;
-      logic        de;
-    } kmac_out;
-    struct packed {
-      logic        d;
-      logic        de;
-    } regfile_intg;
-    struct packed {
-      logic        d;
-      logic        de;
-    } shadow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_fsm_intg;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_fsm_chk;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_fsm_cnt;
-    struct packed {
-      logic        d;
-      logic        de;
-    } reseed_cnt;
-    struct packed {
-      logic        d;
-      logic        de;
-    } side_ctrl_fsm;
+    } key_ecc;
     struct packed {
       logic        d;
       logic        de;
@@ -280,38 +236,58 @@ package keymgr_dpe_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } key_ecc;
+    } side_ctrl_fsm;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reseed_cnt;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_fsm_cnt;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_fsm_chk;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_fsm_intg;
+    struct packed {
+      logic        d;
+      logic        de;
+    } shadow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } regfile_intg;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_out;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_op;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_done;
+    struct packed {
+      logic        d;
+      logic        de;
+    } kmac_fsm;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd;
   } keymgr_dpe_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } invalid_creator_seed;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_owner_seed;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_dev_id;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_health_state;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_key_version;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_key;
-    struct packed {
-      logic        d;
-      logic        de;
-    } invalid_digest;
+    } inactive_lc_en;
     struct packed {
       logic        d;
       logic        de;
@@ -319,7 +295,31 @@ package keymgr_dpe_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } inactive_lc_en;
+    } invalid_digest;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_key;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_key_version;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_health_state;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_dev_id;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_owner_seed;
+    struct packed {
+      logic        d;
+      logic        de;
+    } invalid_creator_seed;
   } keymgr_dpe_hw2reg_debug_reg_t;
 
   // Register -> HW type

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -181,7 +181,7 @@ package kmac_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } kmac_done;
+    } kmac_err;
     struct packed {
       logic        d;
       logic        de;
@@ -189,7 +189,7 @@ package kmac_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } kmac_err;
+    } kmac_done;
   } kmac_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -199,28 +199,28 @@ package kmac_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } sha3_idle;
-    struct packed {
-      logic        d;
-    } sha3_absorb;
-    struct packed {
-      logic        d;
-    } sha3_squeeze;
-    struct packed {
-      logic [4:0]  d;
-    } fifo_depth;
-    struct packed {
-      logic        d;
-    } fifo_empty;
-    struct packed {
-      logic        d;
-    } fifo_full;
+    } alert_recov_ctrl_update_err;
     struct packed {
       logic        d;
     } alert_fatal_fault;
     struct packed {
       logic        d;
-    } alert_recov_ctrl_update_err;
+    } fifo_full;
+    struct packed {
+      logic        d;
+    } fifo_empty;
+    struct packed {
+      logic [4:0]  d;
+    } fifo_depth;
+    struct packed {
+      logic        d;
+    } sha3_squeeze;
+    struct packed {
+      logic        d;
+    } sha3_absorb;
+    struct packed {
+      logic        d;
+    } sha3_idle;
   } kmac_hw2reg_status_reg_t;
 
   typedef struct packed {

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -86,40 +86,40 @@ package lc_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } initialized;
-    struct packed {
-      logic        d;
-    } ready;
-    struct packed {
-      logic        d;
-    } ext_clock_switched;
-    struct packed {
-      logic        d;
-    } transition_successful;
-    struct packed {
-      logic        d;
-    } transition_count_error;
-    struct packed {
-      logic        d;
-    } transition_error;
-    struct packed {
-      logic        d;
-    } token_error;
-    struct packed {
-      logic        d;
-    } flash_rma_error;
-    struct packed {
-      logic        d;
-    } otp_error;
-    struct packed {
-      logic        d;
-    } state_error;
+    } otp_partition_error;
     struct packed {
       logic        d;
     } bus_integ_error;
     struct packed {
       logic        d;
-    } otp_partition_error;
+    } state_error;
+    struct packed {
+      logic        d;
+    } otp_error;
+    struct packed {
+      logic        d;
+    } flash_rma_error;
+    struct packed {
+      logic        d;
+    } token_error;
+    struct packed {
+      logic        d;
+    } transition_error;
+    struct packed {
+      logic        d;
+    } transition_count_error;
+    struct packed {
+      logic        d;
+    } transition_successful;
+    struct packed {
+      logic        d;
+    } ext_clock_switched;
+    struct packed {
+      logic        d;
+    } ready;
+    struct packed {
+      logic        d;
+    } initialized;
   } lc_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -133,10 +133,10 @@ package lc_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } ext_clock_en;
+    } volatile_raw_unlock;
     struct packed {
       logic        d;
-    } volatile_raw_unlock;
+    } ext_clock_en;
   } lc_ctrl_hw2reg_transition_ctrl_reg_t;
 
   typedef struct packed {
@@ -170,19 +170,19 @@ package lc_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } product_id;
+    } silicon_creator_id;
     struct packed {
       logic [15:0] d;
-    } silicon_creator_id;
+    } product_id;
   } lc_ctrl_hw2reg_hw_revision0_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } revision_id;
-    struct packed {
       logic [23:0] d;
     } reserved;
+    struct packed {
+      logic [7:0]  d;
+    } revision_id;
   } lc_ctrl_hw2reg_hw_revision1_reg_t;
 
   typedef struct packed {

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -116,7 +116,7 @@ package mbx_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } mbx_ready;
+    } mbx_error;
     struct packed {
       logic        d;
       logic        de;
@@ -124,31 +124,31 @@ package mbx_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } mbx_error;
+    } mbx_ready;
   } mbx_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } abort;
+    } error;
     struct packed {
       logic        d;
-    } error;
+    } abort;
   } mbx_hw2reg_control_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } busy;
-    struct packed {
-      logic        d;
-    } sys_intr_state;
+    } sys_async_enable;
     struct packed {
       logic        d;
     } sys_intr_enable;
     struct packed {
       logic        d;
-    } sys_async_enable;
+    } sys_intr_state;
+    struct packed {
+      logic        d;
+    } busy;
   } mbx_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -335,31 +335,23 @@ package mbx_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } abort;
-    struct packed {
-      logic        d;
-    } doe_intr_en;
+    } go;
     struct packed {
       logic        d;
     } doe_async_msg_en;
     struct packed {
       logic        d;
-    } go;
+    } doe_intr_en;
+    struct packed {
+      logic        d;
+    } abort;
   } mbx_hw2reg_soc_control_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } busy;
-    struct packed {
-      logic        d;
-      logic        de;
-    } doe_intr_status;
-    struct packed {
-      logic        d;
-      logic        de;
-    } error;
+    } ready;
     struct packed {
       logic        d;
       logic        de;
@@ -367,7 +359,15 @@ package mbx_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } ready;
+    } error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } doe_intr_status;
+    struct packed {
+      logic        d;
+      logic        de;
+    } busy;
   } mbx_hw2reg_soc_status_reg_t;
 
   // Register -> HW type for soc interface

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -147,79 +147,59 @@ package otbn_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } bad_data_addr;
-    struct packed {
-      logic        d;
-    } bad_insn_addr;
-    struct packed {
-      logic        d;
-    } call_stack;
-    struct packed {
-      logic        d;
-    } illegal_insn;
-    struct packed {
-      logic        d;
-    } loop;
-    struct packed {
-      logic        d;
-    } key_invalid;
-    struct packed {
-      logic        d;
-    } rnd_rep_chk_fail;
-    struct packed {
-      logic        d;
-    } rnd_fips_chk_fail;
-    struct packed {
-      logic        d;
-    } imem_intg_violation;
-    struct packed {
-      logic        d;
-    } dmem_intg_violation;
-    struct packed {
-      logic        d;
-    } reg_intg_violation;
-    struct packed {
-      logic        d;
-    } bus_intg_violation;
-    struct packed {
-      logic        d;
-    } bad_internal_state;
-    struct packed {
-      logic        d;
-    } illegal_bus_access;
+    } fatal_software;
     struct packed {
       logic        d;
     } lifecycle_escalation;
     struct packed {
       logic        d;
-    } fatal_software;
+    } illegal_bus_access;
+    struct packed {
+      logic        d;
+    } bad_internal_state;
+    struct packed {
+      logic        d;
+    } bus_intg_violation;
+    struct packed {
+      logic        d;
+    } reg_intg_violation;
+    struct packed {
+      logic        d;
+    } dmem_intg_violation;
+    struct packed {
+      logic        d;
+    } imem_intg_violation;
+    struct packed {
+      logic        d;
+    } rnd_fips_chk_fail;
+    struct packed {
+      logic        d;
+    } rnd_rep_chk_fail;
+    struct packed {
+      logic        d;
+    } key_invalid;
+    struct packed {
+      logic        d;
+    } loop;
+    struct packed {
+      logic        d;
+    } illegal_insn;
+    struct packed {
+      logic        d;
+    } call_stack;
+    struct packed {
+      logic        d;
+    } bad_insn_addr;
+    struct packed {
+      logic        d;
+    } bad_data_addr;
   } otbn_hw2reg_err_bits_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } imem_intg_violation;
-    struct packed {
-      logic        d;
-      logic        de;
-    } dmem_intg_violation;
-    struct packed {
-      logic        d;
-      logic        de;
-    } reg_intg_violation;
-    struct packed {
-      logic        d;
-      logic        de;
-    } bus_intg_violation;
-    struct packed {
-      logic        d;
-      logic        de;
-    } bad_internal_state;
-    struct packed {
-      logic        d;
-      logic        de;
-    } illegal_bus_access;
+    } fatal_software;
     struct packed {
       logic        d;
       logic        de;
@@ -227,7 +207,27 @@ package otbn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fatal_software;
+    } illegal_bus_access;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bad_internal_state;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_intg_violation;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_violation;
+    struct packed {
+      logic        d;
+      logic        de;
+    } dmem_intg_violation;
+    struct packed {
+      logic        d;
+      logic        de;
+    } imem_intg_violation;
   } otbn_hw2reg_fatal_alert_cause_reg_t;
 
   typedef struct packed {

--- a/hw/ip/otp_macro/rtl/otp_macro_reg_pkg.sv
+++ b/hw/ip/otp_macro/rtl/otp_macro_reg_pkg.sv
@@ -157,33 +157,9 @@ package otp_macro_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [2:0]  d;
-      logic        de;
-    } field0;
-    struct packed {
-      logic [9:0] d;
-      logic        de;
-    } field1;
-    struct packed {
       logic        d;
       logic        de;
-    } field2;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field3;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field4;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field5;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field6;
+    } field8;
     struct packed {
       logic        d;
       logic        de;
@@ -191,26 +167,11 @@ package otp_macro_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } field8;
-  } otp_macro_hw2reg_csr3_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic [5:0]  d;
-      logic        de;
-    } field0;
-    struct packed {
-      logic [1:0]  d;
-      logic        de;
-    } field1;
+    } field6;
     struct packed {
       logic        d;
       logic        de;
-    } field2;
-    struct packed {
-      logic [2:0]  d;
-      logic        de;
-    } field3;
+    } field5;
     struct packed {
       logic        d;
       logic        de;
@@ -218,30 +179,69 @@ package otp_macro_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } field5;
-    struct packed {
-      logic [15:0] d;
-      logic        de;
-    } field6;
-  } otp_macro_hw2reg_csr5_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic [5:0]  d;
-      logic        de;
-    } field0;
-    struct packed {
-      logic [2:0]  d;
-      logic        de;
-    } field1;
+    } field3;
     struct packed {
       logic        d;
       logic        de;
     } field2;
     struct packed {
+      logic [9:0] d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } field0;
+  } otp_macro_hw2reg_csr3_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+      logic        de;
+    } field6;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field5;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field4;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } field3;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
+    struct packed {
+      logic [1:0]  d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic [5:0]  d;
+      logic        de;
+    } field0;
+  } otp_macro_hw2reg_csr5_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } field3;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic [5:0]  d;
+      logic        de;
+    } field0;
   } otp_macro_hw2reg_csr7_reg_t;
 
   // Register -> HW type

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -116,11 +116,11 @@ package pattgen_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } done_ch0;
+    } done_ch1;
     struct packed {
       logic        d;
       logic        de;
-    } done_ch1;
+    } done_ch0;
   } pattgen_hw2reg_intr_state_reg_t;
 
   // Register -> HW type

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
@@ -38,11 +38,11 @@ package rom_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } checker_error;
+    } integrity_error;
     struct packed {
       logic        d;
       logic        de;
-    } integrity_error;
+    } checker_error;
   } rom_ctrl_hw2reg_fatal_alert_cause_reg_t;
 
   typedef struct packed {

--- a/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
+++ b/hw/ip/soc_dbg_ctrl/rtl/soc_dbg_ctrl_reg_pkg.sv
@@ -77,11 +77,11 @@ package soc_dbg_ctrl_reg_pkg;
     struct packed {
       logic [3:0]  d;
       logic        de;
-    } valid;
+    } relocked;
     struct packed {
       logic [3:0]  d;
       logic        de;
-    } relocked;
+    } valid;
   } soc_dbg_ctrl_hw2reg_trace_debug_policy_valid_relocked_reg_t;
 
   // Register -> HW type for core interface
@@ -160,56 +160,56 @@ package soc_dbg_ctrl_reg_pkg;
     struct packed {
       logic [3:0]  d;
       logic        de;
-    } valid;
+    } relocked;
     struct packed {
       logic [3:0]  d;
       logic        de;
-    } relocked;
+    } valid;
   } soc_dbg_ctrl_hw2reg_jtag_trace_debug_policy_valid_relocked_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } auth_debug_intent_set;
-    struct packed {
-      logic        d;
-    } auth_window_open;
-    struct packed {
-      logic        d;
-    } auth_window_closed;
+    } auth_unlock_failed;
     struct packed {
       logic        d;
     } auth_unlock_success;
     struct packed {
       logic        d;
-    } auth_unlock_failed;
+    } auth_window_closed;
+    struct packed {
+      logic        d;
+    } auth_window_open;
+    struct packed {
+      logic        d;
+    } auth_debug_intent_set;
   } soc_dbg_ctrl_hw2reg_jtag_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } main_clk_status;
+      logic [2:0]  d;
+    } boot_greenlight_good;
+    struct packed {
+      logic [2:0]  d;
+    } boot_greenlight_done;
+    struct packed {
+      logic [5:0]  d;
+    } halt_fsm_state;
     struct packed {
       logic        d;
-    } io_clk_status;
-    struct packed {
-      logic        d;
-    } otp_done;
+    } cpu_fetch_en;
     struct packed {
       logic        d;
     } lc_done;
     struct packed {
       logic        d;
-    } cpu_fetch_en;
+    } otp_done;
     struct packed {
-      logic [5:0]  d;
-    } halt_fsm_state;
+      logic        d;
+    } io_clk_status;
     struct packed {
-      logic [2:0]  d;
-    } boot_greenlight_done;
-    struct packed {
-      logic [2:0]  d;
-    } boot_greenlight_good;
+      logic        d;
+    } main_clk_status;
   } soc_dbg_ctrl_hw2reg_jtag_boot_status_reg_t;
 
   typedef struct packed {

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -429,27 +429,7 @@ package spi_device_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } upload_cmdfifo_not_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } upload_payload_not_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } upload_payload_overflow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } readbuf_watermark;
-    struct packed {
-      logic        d;
-      logic        de;
-    } readbuf_flip;
-    struct packed {
-      logic        d;
-      logic        de;
-    } tpm_header_not_empty;
+    } tpm_rdfifo_drop;
     struct packed {
       logic        d;
       logic        de;
@@ -457,36 +437,56 @@ package spi_device_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } tpm_rdfifo_drop;
+    } tpm_header_not_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } readbuf_flip;
+    struct packed {
+      logic        d;
+      logic        de;
+    } readbuf_watermark;
+    struct packed {
+      logic        d;
+      logic        de;
+    } upload_payload_overflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } upload_payload_not_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } upload_cmdfifo_not_empty;
   } spi_device_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } flash_status_fifo_clr;
+    } flash_read_buffer_clr;
     struct packed {
       logic        d;
       logic        de;
-    } flash_read_buffer_clr;
+    } flash_status_fifo_clr;
   } spi_device_hw2reg_control_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } csb;
+    } tpm_csb;
     struct packed {
       logic        d;
-    } tpm_csb;
+    } csb;
   } spi_device_hw2reg_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } addr_4b_en;
+    } pending;
     struct packed {
       logic        d;
-    } pending;
+    } addr_4b_en;
   } spi_device_hw2reg_addr_mode_reg_t;
 
   typedef struct packed {
@@ -495,25 +495,21 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } busy;
+      logic [21:0] d;
+    } status;
     struct packed {
       logic        d;
     } wel;
     struct packed {
-      logic [21:0] d;
-    } status;
+      logic        d;
+    } busy;
   } spi_device_hw2reg_flash_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [4:0]  d;
-      logic        de;
-    } cmdfifo_depth;
-    struct packed {
       logic        d;
       logic        de;
-    } cmdfifo_notempty;
+    } addrfifo_notempty;
     struct packed {
       logic [4:0]  d;
       logic        de;
@@ -521,33 +517,37 @@ package spi_device_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } addrfifo_notempty;
+    } cmdfifo_notempty;
+    struct packed {
+      logic [4:0]  d;
+      logic        de;
+    } cmdfifo_depth;
   } spi_device_hw2reg_upload_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [8:0]  d;
-      logic        de;
-    } payload_depth;
-    struct packed {
       logic [7:0]  d;
       logic        de;
     } payload_start_idx;
+    struct packed {
+      logic [8:0]  d;
+      logic        de;
+    } payload_depth;
   } spi_device_hw2reg_upload_status2_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } data;
-    struct packed {
       logic        d;
-    } busy;
+    } addr4b_mode;
     struct packed {
       logic        d;
     } wel;
     struct packed {
       logic        d;
-    } addr4b_mode;
+    } busy;
+    struct packed {
+      logic [7:0]  d;
+    } data;
   } spi_device_hw2reg_upload_cmdfifo_reg_t;
 
   typedef struct packed {
@@ -556,42 +556,42 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
+      logic [2:0]  d;
       logic        de;
-    } rev;
-    struct packed {
-      logic        d;
-      logic        de;
-    } locality;
+    } max_rd_size;
     struct packed {
       logic [2:0]  d;
       logic        de;
     } max_wr_size;
     struct packed {
-      logic [2:0]  d;
+      logic        d;
       logic        de;
-    } max_rd_size;
+    } locality;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } rev;
   } spi_device_hw2reg_tpm_cap_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } cmdaddr_notempty;
+    } rdfifo_aborted;
     struct packed {
       logic        d;
     } wrfifo_pending;
     struct packed {
       logic        d;
-    } rdfifo_aborted;
+    } cmdaddr_notempty;
   } spi_device_hw2reg_tpm_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [23:0] d;
-    } addr;
-    struct packed {
       logic [7:0]  d;
     } cmd;
+    struct packed {
+      logic [23:0] d;
+    } addr;
   } spi_device_hw2reg_tpm_cmd_addr_reg_t;
 
   // Register -> HW type

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -186,62 +186,18 @@ package spi_host_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } error;
+    } spi_event;
     struct packed {
       logic        d;
       logic        de;
-    } spi_event;
+    } error;
   } spi_host_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-      logic        de;
-    } txqd;
-    struct packed {
-      logic [7:0]  d;
-      logic        de;
-    } rxqd;
-    struct packed {
-      logic [3:0]  d;
-      logic        de;
-    } cmdqd;
-    struct packed {
       logic        d;
       logic        de;
-    } rxwm;
-    struct packed {
-      logic        d;
-      logic        de;
-    } byteorder;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rxstall;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rxempty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rxfull;
-    struct packed {
-      logic        d;
-      logic        de;
-    } txwm;
-    struct packed {
-      logic        d;
-      logic        de;
-    } txstall;
-    struct packed {
-      logic        d;
-      logic        de;
-    } txempty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } txfull;
+    } ready;
     struct packed {
       logic        d;
       logic        de;
@@ -249,26 +205,58 @@ package spi_host_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } ready;
+    } txfull;
+    struct packed {
+      logic        d;
+      logic        de;
+    } txempty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } txstall;
+    struct packed {
+      logic        d;
+      logic        de;
+    } txwm;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rxfull;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rxempty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rxstall;
+    struct packed {
+      logic        d;
+      logic        de;
+    } byteorder;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rxwm;
+    struct packed {
+      logic [3:0]  d;
+      logic        de;
+    } cmdqd;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } rxqd;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } txqd;
   } spi_host_hw2reg_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } cmdbusy;
-    struct packed {
-      logic        d;
-      logic        de;
-    } overflow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } underflow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cmdinval;
+    } accessinval;
     struct packed {
       logic        d;
       logic        de;
@@ -276,7 +264,19 @@ package spi_host_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } accessinval;
+    } cmdinval;
+    struct packed {
+      logic        d;
+      logic        de;
+    } underflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } overflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmdbusy;
   } spi_host_hw2reg_error_status_reg_t;
 
   // Register -> HW type

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -73,27 +73,7 @@ package sram_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } bus_integ_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } init_error;
-    struct packed {
-      logic        d;
-      logic        de;
-    } escalated;
-    struct packed {
-      logic        d;
-      logic        de;
-    } scr_key_valid;
-    struct packed {
-      logic        d;
-      logic        de;
-    } scr_key_seed_valid;
-    struct packed {
-      logic        d;
-      logic        de;
-    } init_done;
+    } sram_alert;
     struct packed {
       logic        d;
       logic        de;
@@ -101,7 +81,27 @@ package sram_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } sram_alert;
+    } init_done;
+    struct packed {
+      logic        d;
+      logic        de;
+    } scr_key_seed_valid;
+    struct packed {
+      logic        d;
+      logic        de;
+    } scr_key_valid;
+    struct packed {
+      logic        d;
+      logic        de;
+    } escalated;
+    struct packed {
+      logic        d;
+      logic        de;
+    } init_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_integ_error;
   } sram_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_pkg.sv
@@ -430,27 +430,7 @@ package sysrst_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } pwrb_in;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key0_in;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key1_in;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key2_in;
-    struct packed {
-      logic        d;
-      logic        de;
-    } lid_open;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ac_present;
+    } flash_wp_l;
     struct packed {
       logic        d;
       logic        de;
@@ -458,18 +438,34 @@ package sysrst_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } flash_wp_l;
+    } ac_present;
+    struct packed {
+      logic        d;
+      logic        de;
+    } lid_open;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key2_in;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key1_in;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key0_in;
+    struct packed {
+      logic        d;
+      logic        de;
+    } pwrb_in;
   } sysrst_ctrl_hw2reg_pin_in_value_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } combo0_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } combo1_h2l;
+    } combo3_h2l;
     struct packed {
       logic        d;
       logic        de;
@@ -477,58 +473,18 @@ package sysrst_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } combo3_h2l;
+    } combo1_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } combo0_h2l;
   } sysrst_ctrl_hw2reg_combo_intr_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } pwrb_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key0_in_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key1_in_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key2_in_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ac_present_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ec_rst_l_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } flash_wp_l_h2l;
-    struct packed {
-      logic        d;
-      logic        de;
-    } pwrb_l2h;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key0_in_l2h;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key1_in_l2h;
-    struct packed {
-      logic        d;
-      logic        de;
-    } key2_in_l2h;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ac_present_l2h;
+    } flash_wp_l_l2h;
     struct packed {
       logic        d;
       logic        de;
@@ -536,7 +492,51 @@ package sysrst_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } flash_wp_l_l2h;
+    } ac_present_l2h;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key2_in_l2h;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key1_in_l2h;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key0_in_l2h;
+    struct packed {
+      logic        d;
+      logic        de;
+    } pwrb_l2h;
+    struct packed {
+      logic        d;
+      logic        de;
+    } flash_wp_l_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ec_rst_l_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ac_present_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key2_in_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key1_in_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } key0_in_h2l;
+    struct packed {
+      logic        d;
+      logic        de;
+    } pwrb_h2l;
   } sysrst_ctrl_hw2reg_key_intr_status_reg_t;
 
   // Register -> HW type

--- a/hw/ip/trial1/rtl/trial1_reg_pkg.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_pkg.sv
@@ -148,11 +148,11 @@ package trial1_reg_pkg;
     struct packed {
       logic [15:0] d;
       logic        de;
-    } field0;
+    } field1;
     struct packed {
       logic [15:0] d;
       logic        de;
-    } field1;
+    } field0;
   } trial1_hw2reg_rwtype3_reg_t;
 
   typedef struct packed {
@@ -189,15 +189,7 @@ package trial1_reg_pkg;
     struct packed {
       logic [3:0]  d;
       logic        de;
-    } field1;
-    struct packed {
-      logic [3:0]  d;
-      logic        de;
-    } field3;
-    struct packed {
-      logic [3:0]  d;
-      logic        de;
-    } field4;
+    } field6;
     struct packed {
       logic [3:0]  d;
       logic        de;
@@ -205,7 +197,15 @@ package trial1_reg_pkg;
     struct packed {
       logic [3:0]  d;
       logic        de;
-    } field6;
+    } field4;
+    struct packed {
+      logic [3:0]  d;
+      logic        de;
+    } field3;
+    struct packed {
+      logic [3:0]  d;
+      logic        de;
+    } field1;
   } trial1_hw2reg_mixtype0_reg_t;
 
   typedef struct packed {

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -233,31 +233,7 @@ package uart_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } tx_watermark;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_watermark;
-    struct packed {
-      logic        d;
-      logic        de;
-    } tx_done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_overflow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_frame_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_break_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_timeout;
+    } tx_empty;
     struct packed {
       logic        d;
       logic        de;
@@ -265,28 +241,52 @@ package uart_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } tx_empty;
+    } rx_timeout;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_break_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_frame_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_overflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } tx_done;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_watermark;
+    struct packed {
+      logic        d;
+      logic        de;
+    } tx_watermark;
   } uart_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } txfull;
-    struct packed {
-      logic        d;
-    } rxfull;
-    struct packed {
-      logic        d;
-    } txempty;
-    struct packed {
-      logic        d;
-    } txidle;
+    } rxempty;
     struct packed {
       logic        d;
     } rxidle;
     struct packed {
       logic        d;
-    } rxempty;
+    } txidle;
+    struct packed {
+      logic        d;
+    } txempty;
+    struct packed {
+      logic        d;
+    } rxfull;
+    struct packed {
+      logic        d;
+    } txfull;
   } uart_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -297,20 +297,20 @@ package uart_reg_pkg;
     struct packed {
       logic [2:0]  d;
       logic        de;
-    } rxilvl;
+    } txilvl;
     struct packed {
       logic [2:0]  d;
       logic        de;
-    } txilvl;
+    } rxilvl;
   } uart_hw2reg_fifo_ctrl_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [7:0]  d;
-    } txlvl;
+    } rxlvl;
     struct packed {
       logic [7:0]  d;
-    } rxlvl;
+    } txlvl;
   } uart_hw2reg_fifo_status_reg_t;
 
   typedef struct packed {

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -498,67 +498,7 @@ package usbdev_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } pkt_received;
-    struct packed {
-      logic        d;
-      logic        de;
-    } pkt_sent;
-    struct packed {
-      logic        d;
-      logic        de;
-    } disconnected;
-    struct packed {
-      logic        d;
-      logic        de;
-    } host_lost;
-    struct packed {
-      logic        d;
-      logic        de;
-    } link_reset;
-    struct packed {
-      logic        d;
-      logic        de;
-    } link_suspend;
-    struct packed {
-      logic        d;
-      logic        de;
-    } link_resume;
-    struct packed {
-      logic        d;
-      logic        de;
-    } av_out_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } av_overflow;
-    struct packed {
-      logic        d;
-      logic        de;
-    } link_in_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_crc_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_pid_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rx_bitstuff_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } frame;
-    struct packed {
-      logic        d;
-      logic        de;
-    } powered;
+    } av_setup_empty;
     struct packed {
       logic        d;
       logic        de;
@@ -566,7 +506,67 @@ package usbdev_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } av_setup_empty;
+    } powered;
+    struct packed {
+      logic        d;
+      logic        de;
+    } frame;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_bitstuff_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_pid_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_crc_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_in_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } av_overflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rx_full;
+    struct packed {
+      logic        d;
+      logic        de;
+    } av_out_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_resume;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_suspend;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_reset;
+    struct packed {
+      logic        d;
+      logic        de;
+    } host_lost;
+    struct packed {
+      logic        d;
+      logic        de;
+    } disconnected;
+    struct packed {
+      logic        d;
+      logic        de;
+    } pkt_sent;
+    struct packed {
+      logic        d;
+      logic        de;
+    } pkt_received;
   } usbdev_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -578,50 +578,50 @@ package usbdev_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [10:0] d;
-    } frame;
+      logic        d;
+    } rx_empty;
     struct packed {
       logic        d;
-    } host_lost;
-    struct packed {
-      logic [2:0]  d;
-    } link_state;
-    struct packed {
-      logic        d;
-    } sense;
-    struct packed {
-      logic [3:0]  d;
-    } av_out_depth;
-    struct packed {
-      logic [2:0]  d;
-    } av_setup_depth;
-    struct packed {
-      logic        d;
-    } av_out_full;
+    } av_setup_full;
     struct packed {
       logic [3:0]  d;
     } rx_depth;
     struct packed {
       logic        d;
-    } av_setup_full;
+    } av_out_full;
+    struct packed {
+      logic [2:0]  d;
+    } av_setup_depth;
+    struct packed {
+      logic [3:0]  d;
+    } av_out_depth;
     struct packed {
       logic        d;
-    } rx_empty;
+    } sense;
+    struct packed {
+      logic [2:0]  d;
+    } link_state;
+    struct packed {
+      logic        d;
+    } host_lost;
+    struct packed {
+      logic [10:0] d;
+    } frame;
   } usbdev_hw2reg_usbstat_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [4:0]  d;
-    } buffer;
-    struct packed {
-      logic [6:0]  d;
-    } size;
+      logic [3:0]  d;
+    } ep;
     struct packed {
       logic        d;
     } setup;
     struct packed {
-      logic [3:0]  d;
-    } ep;
+      logic [6:0]  d;
+    } size;
+    struct packed {
+      logic [4:0]  d;
+    } buffer;
   } usbdev_hw2reg_rxfifo_reg_t;
 
   typedef struct packed {
@@ -648,7 +648,7 @@ package usbdev_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } sending;
+    } rdy;
     struct packed {
       logic        d;
       logic        de;
@@ -656,66 +656,62 @@ package usbdev_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } rdy;
+    } sending;
   } usbdev_hw2reg_configin_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic [11:0] d;
-    } status;
+    } mask;
     struct packed {
       logic [11:0] d;
-    } mask;
+    } status;
   } usbdev_hw2reg_out_data_toggle_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [11:0] d;
-    } status;
+    } mask;
     struct packed {
       logic [11:0] d;
-    } mask;
+    } status;
   } usbdev_hw2reg_in_data_toggle_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } rx_dp_i;
-    struct packed {
-      logic        d;
-    } rx_dn_i;
-    struct packed {
-      logic        d;
-    } rx_d_i;
-    struct packed {
-      logic        d;
-    } tx_dp_o;
-    struct packed {
-      logic        d;
-    } tx_dn_o;
-    struct packed {
-      logic        d;
-    } tx_d_o;
-    struct packed {
-      logic        d;
-    } tx_se0_o;
+    } pwr_sense;
     struct packed {
       logic        d;
     } tx_oe_o;
     struct packed {
       logic        d;
-    } pwr_sense;
+    } tx_se0_o;
+    struct packed {
+      logic        d;
+    } tx_d_o;
+    struct packed {
+      logic        d;
+    } tx_dn_o;
+    struct packed {
+      logic        d;
+    } tx_dp_o;
+    struct packed {
+      logic        d;
+    } rx_d_i;
+    struct packed {
+      logic        d;
+    } rx_dn_i;
+    struct packed {
+      logic        d;
+    } rx_dp_i;
   } usbdev_hw2reg_phy_pins_sense_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } module_active;
-    struct packed {
-      logic        d;
-      logic        de;
-    } disconnected;
+    } bus_not_idle;
     struct packed {
       logic        d;
       logic        de;
@@ -723,73 +719,77 @@ package usbdev_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } bus_not_idle;
+    } disconnected;
+    struct packed {
+      logic        d;
+      logic        de;
+    } module_active;
   } usbdev_hw2reg_wake_events_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } count;
+      logic [11:0] d;
+    } endpoints;
     struct packed {
       logic        d;
-    } datatog_out;
-    struct packed {
-      logic        d;
-    } drop_rx;
+    } ign_avsetup;
     struct packed {
       logic        d;
     } drop_avout;
     struct packed {
       logic        d;
-    } ign_avsetup;
+    } drop_rx;
     struct packed {
-      logic [11:0] d;
-    } endpoints;
+      logic        d;
+    } datatog_out;
+    struct packed {
+      logic [7:0]  d;
+    } count;
   } usbdev_hw2reg_count_out_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } count;
+      logic [11:0] d;
+    } endpoints;
     struct packed {
       logic        d;
-    } nodata;
+    } timeout;
     struct packed {
       logic        d;
     } nak;
     struct packed {
       logic        d;
-    } timeout;
+    } nodata;
     struct packed {
-      logic [11:0] d;
-    } endpoints;
+      logic [7:0]  d;
+    } count;
   } usbdev_hw2reg_count_in_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } count;
-    struct packed {
       logic [11:0] d;
     } endpoints;
+    struct packed {
+      logic [7:0]  d;
+    } count;
   } usbdev_hw2reg_count_nodata_in_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
-    } count;
-    struct packed {
       logic        d;
-    } pid_invalid;
-    struct packed {
-      logic        d;
-    } bitstuff;
+    } crc5;
     struct packed {
       logic        d;
     } crc16;
     struct packed {
       logic        d;
-    } crc5;
+    } bitstuff;
+    struct packed {
+      logic        d;
+    } pid_invalid;
+    struct packed {
+      logic [7:0]  d;
+    } count;
   } usbdev_hw2reg_count_errors_reg_t;
 
   // Register -> HW type

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_pkg.sv
@@ -102,11 +102,7 @@ package ac_range_check_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadowed_update_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } shadowed_storage_err;
+    } counter_err;
     struct packed {
       logic        d;
       logic        de;
@@ -114,30 +110,30 @@ package ac_range_check_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } counter_err;
+    } shadowed_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } shadowed_update_err;
   } ac_range_check_hw2reg_alert_status_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [7:0]  d;
+      logic [4:0]  d;
       logic        de;
-    } deny_cnt;
+    } deny_range_index;
+    struct packed {
+      logic [4:0]  d;
+      logic        de;
+    } denied_ctn_uid;
+    struct packed {
+      logic [3:0]  d;
+      logic        de;
+    } denied_source_role;
     struct packed {
       logic        d;
       logic        de;
-    } denied_read_access;
-    struct packed {
-      logic        d;
-      logic        de;
-    } denied_write_access;
-    struct packed {
-      logic        d;
-      logic        de;
-    } denied_execute_access;
-    struct packed {
-      logic        d;
-      logic        de;
-    } denied_no_match;
+    } denied_racl_write;
     struct packed {
       logic        d;
       logic        de;
@@ -145,19 +141,23 @@ package ac_range_check_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } denied_racl_write;
+    } denied_no_match;
     struct packed {
-      logic [3:0]  d;
+      logic        d;
       logic        de;
-    } denied_source_role;
+    } denied_execute_access;
     struct packed {
-      logic [4:0]  d;
+      logic        d;
       logic        de;
-    } denied_ctn_uid;
+    } denied_write_access;
     struct packed {
-      logic [4:0]  d;
+      logic        d;
       logic        de;
-    } deny_range_index;
+    } denied_read_access;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } deny_cnt;
   } ac_range_check_hw2reg_log_status_reg_t;
 
   typedef struct packed {

--- a/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -601,11 +601,7 @@ package alert_handler_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } classa;
-    struct packed {
-      logic        d;
-      logic        de;
-    } classb;
+    } classd;
     struct packed {
       logic        d;
       logic        de;
@@ -613,7 +609,11 @@ package alert_handler_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } classd;
+    } classb;
+    struct packed {
+      logic        d;
+      logic        de;
+    } classa;
   } alert_handler_hw2reg_intr_state_reg_t;
 
   typedef struct packed {

--- a/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -120,11 +120,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_aes_val;
-    struct packed {
-      logic        d;
-      logic        de;
-    } clk_main_hmac_val;
+    } clk_main_otbn_val;
     struct packed {
       logic        d;
       logic        de;
@@ -132,7 +128,11 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_otbn_val;
+    } clk_main_hmac_val;
+    struct packed {
+      logic        d;
+      logic        de;
+    } clk_main_aes_val;
   } clkmgr_hw2reg_clk_hints_status_reg_t;
 
   typedef struct packed {
@@ -154,15 +154,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadow_update_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div4_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } main_measure_err;
+    } main_timeout_err;
     struct packed {
       logic        d;
       logic        de;
@@ -170,14 +162,22 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } main_timeout_err;
+    } main_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div4_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } shadow_update_err;
   } clkmgr_hw2reg_recov_err_code_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg;
+    } shadow_storage_err;
     struct packed {
       logic        d;
       logic        de;
@@ -185,7 +185,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadow_storage_err;
+    } reg_intg;
   } clkmgr_hw2reg_fatal_err_code_reg_t;
 
   // Register -> HW type

--- a/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -156,19 +156,19 @@ package gpio_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_out_lower_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_out_upper_reg_t;
 
   typedef struct packed {
@@ -178,19 +178,19 @@ package gpio_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_oe_lower_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_oe_upper_reg_t;
 
   typedef struct packed {
@@ -205,9 +205,17 @@ package gpio_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } prescaler;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } input_select;
+    struct packed {
       logic        d;
       logic        de;
-    } enable;
+    } polarity;
     struct packed {
       logic        d;
       logic        de;
@@ -215,15 +223,7 @@ package gpio_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } polarity;
-    struct packed {
-      logic [7:0]  d;
-      logic        de;
-    } input_select;
-    struct packed {
-      logic [7:0]  d;
-      logic        de;
-    } prescaler;
+    } enable;
   } gpio_hw2reg_inp_prd_cnt_ctrl_mreg_t;
 
   typedef struct packed {

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -438,8 +438,7 @@ module otp_ctrl
     // Aggregate all the remaining errors / alerts from the partitions and the DAI/LCI
     for (int k = 0; k < NumPart+2; k++) begin
       // Set the error bit if the error status of the corresponding partition is nonzero.
-      // Need to reverse the order here since the field enumeration in hw2reg.status is reversed.
-      part_errors_reduced[NumPart+1-k] = |part_error[k];
+      part_errors_reduced[k] = |part_error[k];
       // Filter for integrity and consistency check failures.
       fatal_check_error_d |= part_error[k] inside {CheckFailError, FsmStateError};
 
@@ -505,15 +504,17 @@ module otp_ctrl
     hw2reg.direct_access_rdata = dai_rdata;
     // ANDing this state with dai_idle write-protects all DAI regs during pending operations.
     hw2reg.direct_access_regwen.d = direct_access_regwen_q & dai_idle;
-    // Assign these to the status register.
-    hw2reg.status = {part_errors_reduced,
-                     chk_timeout,
-                     lfsr_fsm_err,
-                     scrmbl_fsm_err,
-                     part_fsm_err[KdiIdx],
-                     fatal_bus_integ_error_q,
-                     dai_idle,
-                     chk_pending};
+    // Report partition errors in the status register; relies upon the field ordering and the
+    // presence of only the scalar signal 'd' in each partition-specific field.
+    hw2reg.status = otp_ctrl_hw2reg_status_reg_t'(part_errors_reduced);
+    // Overwrite the other fields of the status register with specific error conditions.
+    hw2reg.status.timeout_error.d = chk_timeout;
+    hw2reg.status.lfsr_fsm_error.d = lfsr_fsm_err;
+    hw2reg.status.scrambling_fsm_error.d = scrmbl_fsm_err;
+    hw2reg.status.key_deriv_fsm_error.d = part_fsm_err[KdiIdx];
+    hw2reg.status.bus_integ_error.d = fatal_bus_integ_error_q;
+    hw2reg.status.dai_idle.d = dai_idle;
+    hw2reg.status.check_pending.d = chk_pending;
     // Error code registers.
     hw2reg.err_code = part_error;
     // Interrupt signals

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -468,107 +468,107 @@ package otp_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } otp_operation_done;
+    } otp_error;
     struct packed {
       logic        d;
       logic        de;
-    } otp_error;
+    } otp_operation_done;
   } otp_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } vendor_test_error;
-    struct packed {
-      logic        d;
-    } creator_sw_cfg_error;
-    struct packed {
-      logic        d;
-    } owner_sw_cfg_error;
-    struct packed {
-      logic        d;
-    } ownership_slot_state_error;
-    struct packed {
-      logic        d;
-    } rot_creator_auth_error;
-    struct packed {
-      logic        d;
-    } rot_owner_auth_slot0_error;
-    struct packed {
-      logic        d;
-    } rot_owner_auth_slot1_error;
-    struct packed {
-      logic        d;
-    } plat_integ_auth_slot0_error;
-    struct packed {
-      logic        d;
-    } plat_integ_auth_slot1_error;
-    struct packed {
-      logic        d;
-    } plat_owner_auth_slot0_error;
-    struct packed {
-      logic        d;
-    } plat_owner_auth_slot1_error;
-    struct packed {
-      logic        d;
-    } plat_owner_auth_slot2_error;
-    struct packed {
-      logic        d;
-    } plat_owner_auth_slot3_error;
-    struct packed {
-      logic        d;
-    } ext_nvm_error;
-    struct packed {
-      logic        d;
-    } rom_patch_error;
-    struct packed {
-      logic        d;
-    } hw_cfg0_error;
-    struct packed {
-      logic        d;
-    } hw_cfg1_error;
-    struct packed {
-      logic        d;
-    } secret0_error;
-    struct packed {
-      logic        d;
-    } secret1_error;
-    struct packed {
-      logic        d;
-    } secret2_error;
-    struct packed {
-      logic        d;
-    } secret3_error;
-    struct packed {
-      logic        d;
-    } life_cycle_error;
-    struct packed {
-      logic        d;
-    } dai_error;
-    struct packed {
-      logic        d;
-    } lci_error;
-    struct packed {
-      logic        d;
-    } timeout_error;
-    struct packed {
-      logic        d;
-    } lfsr_fsm_error;
-    struct packed {
-      logic        d;
-    } scrambling_fsm_error;
-    struct packed {
-      logic        d;
-    } key_deriv_fsm_error;
-    struct packed {
-      logic        d;
-    } bus_integ_error;
+    } check_pending;
     struct packed {
       logic        d;
     } dai_idle;
     struct packed {
       logic        d;
-    } check_pending;
+    } bus_integ_error;
+    struct packed {
+      logic        d;
+    } key_deriv_fsm_error;
+    struct packed {
+      logic        d;
+    } scrambling_fsm_error;
+    struct packed {
+      logic        d;
+    } lfsr_fsm_error;
+    struct packed {
+      logic        d;
+    } timeout_error;
+    struct packed {
+      logic        d;
+    } lci_error;
+    struct packed {
+      logic        d;
+    } dai_error;
+    struct packed {
+      logic        d;
+    } life_cycle_error;
+    struct packed {
+      logic        d;
+    } secret3_error;
+    struct packed {
+      logic        d;
+    } secret2_error;
+    struct packed {
+      logic        d;
+    } secret1_error;
+    struct packed {
+      logic        d;
+    } secret0_error;
+    struct packed {
+      logic        d;
+    } hw_cfg1_error;
+    struct packed {
+      logic        d;
+    } hw_cfg0_error;
+    struct packed {
+      logic        d;
+    } rom_patch_error;
+    struct packed {
+      logic        d;
+    } ext_nvm_error;
+    struct packed {
+      logic        d;
+    } plat_owner_auth_slot3_error;
+    struct packed {
+      logic        d;
+    } plat_owner_auth_slot2_error;
+    struct packed {
+      logic        d;
+    } plat_owner_auth_slot1_error;
+    struct packed {
+      logic        d;
+    } plat_owner_auth_slot0_error;
+    struct packed {
+      logic        d;
+    } plat_integ_auth_slot1_error;
+    struct packed {
+      logic        d;
+    } plat_integ_auth_slot0_error;
+    struct packed {
+      logic        d;
+    } rot_owner_auth_slot1_error;
+    struct packed {
+      logic        d;
+    } rot_owner_auth_slot0_error;
+    struct packed {
+      logic        d;
+    } rot_creator_auth_error;
+    struct packed {
+      logic        d;
+    } ownership_slot_state_error;
+    struct packed {
+      logic        d;
+    } owner_sw_cfg_error;
+    struct packed {
+      logic        d;
+    } creator_sw_cfg_error;
+    struct packed {
+      logic        d;
+    } vendor_test_error;
   } otp_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -178,68 +178,68 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } invert;
+      logic [3:0]  d;
+    } drive_strength;
+    struct packed {
+      logic [1:0]  d;
+    } slew_rate;
     struct packed {
       logic        d;
-    } virtual_od_en;
-    struct packed {
-      logic        d;
-    } pull_en;
-    struct packed {
-      logic        d;
-    } pull_select;
-    struct packed {
-      logic        d;
-    } keeper_en;
-    struct packed {
-      logic        d;
-    } schmitt_en;
+    } input_disable;
     struct packed {
       logic        d;
     } od_en;
     struct packed {
       logic        d;
-    } input_disable;
+    } schmitt_en;
     struct packed {
-      logic [1:0]  d;
-    } slew_rate;
+      logic        d;
+    } keeper_en;
     struct packed {
-      logic [3:0]  d;
-    } drive_strength;
+      logic        d;
+    } pull_select;
+    struct packed {
+      logic        d;
+    } pull_en;
+    struct packed {
+      logic        d;
+    } virtual_od_en;
+    struct packed {
+      logic        d;
+    } invert;
   } pinmux_hw2reg_mio_pad_attr_mreg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } invert;
+      logic [3:0]  d;
+    } drive_strength;
+    struct packed {
+      logic [1:0]  d;
+    } slew_rate;
     struct packed {
       logic        d;
-    } virtual_od_en;
-    struct packed {
-      logic        d;
-    } pull_en;
-    struct packed {
-      logic        d;
-    } pull_select;
-    struct packed {
-      logic        d;
-    } keeper_en;
-    struct packed {
-      logic        d;
-    } schmitt_en;
+    } input_disable;
     struct packed {
       logic        d;
     } od_en;
     struct packed {
       logic        d;
-    } input_disable;
+    } schmitt_en;
     struct packed {
-      logic [1:0]  d;
-    } slew_rate;
+      logic        d;
+    } keeper_en;
     struct packed {
-      logic [3:0]  d;
-    } drive_strength;
+      logic        d;
+    } pull_select;
+    struct packed {
+      logic        d;
+    } pull_en;
+    struct packed {
+      logic        d;
+    } virtual_od_en;
+    struct packed {
+      logic        d;
+    } invert;
   } pinmux_hw2reg_dio_pad_attr_mreg_t;
 
   typedef struct packed {

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -146,21 +146,21 @@ package pwrmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [3:0]  d;
-    } reasons;
+      logic        d;
+    } abort;
     struct packed {
       logic        d;
     } fall_through;
     struct packed {
-      logic        d;
-    } abort;
+      logic [3:0]  d;
+    } reasons;
   } pwrmgr_hw2reg_wake_info_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
+    } main_pd_glitch;
     struct packed {
       logic        d;
       logic        de;
@@ -168,7 +168,7 @@ package pwrmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } main_pd_glitch;
+    } reg_intg_err;
   } pwrmgr_hw2reg_fault_status_reg_t;
 
   // Register -> HW type

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -84,9 +84,17 @@ package racl_ctrl_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [4:0]  d;
+      logic        de;
+    } ctn_uid;
+    struct packed {
+      logic [3:0]  d;
+      logic        de;
+    } role;
+    struct packed {
       logic        d;
       logic        de;
-    } valid;
+    } read_access;
     struct packed {
       logic        d;
       logic        de;
@@ -94,15 +102,7 @@ package racl_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } read_access;
-    struct packed {
-      logic [3:0]  d;
-      logic        de;
-    } role;
-    struct packed {
-      logic [4:0]  d;
-      logic        de;
-    } ctn_uid;
+    } valid;
   } racl_ctrl_hw2reg_error_log_reg_t;
 
   typedef struct packed {

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -89,17 +89,17 @@ package rstmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [4:0]  d;
       logic        de;
-    } low_power_exit;
+    } hw_req;
     struct packed {
       logic        d;
       logic        de;
     } sw_reset;
     struct packed {
-      logic [4:0]  d;
+      logic        d;
       logic        de;
-    } hw_req;
+    } low_power_exit;
   } rstmgr_hw2reg_reset_info_reg_t;
 
   typedef struct packed {
@@ -136,7 +136,7 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
+    } fsm_err;
     struct packed {
       logic        d;
       logic        de;
@@ -144,7 +144,7 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fsm_err;
+    } reg_intg_err;
   } rstmgr_hw2reg_err_code_reg_t;
 
   // Register -> HW type

--- a/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -105,22 +105,18 @@ package rv_core_ibex_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } alert;
+    } wdog;
     struct packed {
       logic        d;
       logic        de;
-    } wdog;
+    } alert;
   } rv_core_ibex_hw2reg_nmi_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fatal_intg_err;
+    } recov_core_err;
     struct packed {
       logic        d;
       logic        de;
@@ -128,7 +124,11 @@ package rv_core_ibex_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } recov_core_err;
+    } fatal_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_err;
   } rv_core_ibex_hw2reg_err_status_reg_t;
 
   typedef struct packed {
@@ -138,10 +138,10 @@ package rv_core_ibex_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } rnd_data_valid;
+    } rnd_data_fips;
     struct packed {
       logic        d;
-    } rnd_data_fips;
+    } rnd_data_valid;
   } rv_core_ibex_hw2reg_rnd_status_reg_t;
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -102,11 +102,11 @@ package sensor_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } io_status_change;
+    } init_status_change;
     struct packed {
       logic        d;
       logic        de;
-    } init_status_change;
+    } io_status_change;
   } sensor_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -121,25 +121,25 @@ package sensor_ctrl_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-      logic        de;
-    } ast_init_done;
-    struct packed {
       logic [1:0]  d;
       logic        de;
     } io_pok;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ast_init_done;
   } sensor_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } pull_en;
+    } input_disable;
     struct packed {
       logic        d;
     } pull_select;
     struct packed {
       logic        d;
-    } input_disable;
+    } pull_en;
   } sensor_ctrl_hw2reg_manual_pad_attr_mreg_t;
 
   // Register -> HW type

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -525,11 +525,7 @@ package alert_handler_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } classa;
-    struct packed {
-      logic        d;
-      logic        de;
-    } classb;
+    } classd;
     struct packed {
       logic        d;
       logic        de;
@@ -537,7 +533,11 @@ package alert_handler_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } classd;
+    } classb;
+    struct packed {
+      logic        d;
+      logic        de;
+    } classa;
   } alert_handler_hw2reg_intr_state_reg_t;
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -165,11 +165,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_aes_val;
-    struct packed {
-      logic        d;
-      logic        de;
-    } clk_main_hmac_val;
+    } clk_main_otbn_val;
     struct packed {
       logic        d;
       logic        de;
@@ -177,7 +173,11 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_otbn_val;
+    } clk_main_hmac_val;
+    struct packed {
+      logic        d;
+      logic        de;
+    } clk_main_aes_val;
   } clkmgr_hw2reg_clk_hints_status_reg_t;
 
   typedef struct packed {
@@ -214,39 +214,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadow_update_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div2_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div4_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } main_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } usb_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_timeout_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div2_timeout_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div4_timeout_err;
+    } usb_timeout_err;
     struct packed {
       logic        d;
       logic        de;
@@ -254,14 +222,46 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } usb_timeout_err;
+    } io_div4_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div2_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } usb_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div4_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div2_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } shadow_update_err;
   } clkmgr_hw2reg_recov_err_code_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg;
+    } shadow_storage_err;
     struct packed {
       logic        d;
       logic        de;
@@ -269,7 +269,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadow_storage_err;
+    } reg_intg;
   } clkmgr_hw2reg_fatal_err_code_reg_t;
 
   // Register -> HW type

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -499,19 +499,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prog_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_lvl;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_lvl;
+    } corr_err;
     struct packed {
       logic        d;
       logic        de;
@@ -519,7 +507,19 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } corr_err;
+    } rd_lvl;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_full;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_lvl;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_empty;
   } flash_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -542,30 +542,18 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } done;
+    } err;
     struct packed {
       logic        d;
       logic        de;
-    } err;
+    } done;
   } flash_ctrl_hw2reg_op_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } rd_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_empty;
+    } initialized;
     struct packed {
       logic        d;
       logic        de;
@@ -573,7 +561,19 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } initialized;
+    } prog_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_full;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_full;
   } flash_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -584,27 +584,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } op_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } mp_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_win_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_type_err;
+    } macro_err;
     struct packed {
       logic        d;
       logic        de;
@@ -612,65 +592,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } macro_err;
-  } flash_ctrl_hw2reg_err_code_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } reg_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } lcmgr_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } lcmgr_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } arb_fsm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } storage_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } phy_fsm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_cnt_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fifo_err;
-  } flash_ctrl_hw2reg_std_fault_status_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } op_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } mp_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_err;
+    } prog_type_err;
     struct packed {
       logic        d;
       logic        de;
@@ -678,23 +600,65 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prog_type_err;
+    } prog_err;
     struct packed {
       logic        d;
       logic        de;
-    } seed_err;
+    } rd_err;
     struct packed {
       logic        d;
       logic        de;
-    } phy_relbl_err;
+    } mp_err;
     struct packed {
       logic        d;
       logic        de;
-    } phy_storage_err;
+    } op_err;
+  } flash_ctrl_hw2reg_err_code_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } spurious_ack;
+    } fifo_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_cnt_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_fsm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } arb_fsm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } lcmgr_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } lcmgr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_err;
+  } flash_ctrl_hw2reg_std_fault_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } host_gnt_err;
     struct packed {
       logic        d;
       logic        de;
@@ -702,7 +666,43 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } host_gnt_err;
+    } spurious_ack;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_relbl_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } seed_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_type_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_win_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } mp_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } op_err;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -724,7 +724,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } init_wip;
+    } prog_repair_avail;
     struct packed {
       logic        d;
       logic        de;
@@ -732,16 +732,16 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prog_repair_avail;
+    } init_wip;
   } flash_ctrl_hw2reg_phy_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [4:0]  d;
-    } prog;
+    } rd;
     struct packed {
       logic [4:0]  d;
-    } rd;
+    } prog;
   } flash_ctrl_hw2reg_curr_fifo_lvl_reg_t;
 
   // Register -> HW type for core interface
@@ -1393,27 +1393,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } field0;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field1;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field2;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field3;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field4;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field5;
+    } field7;
     struct packed {
       logic        d;
       logic        de;
@@ -1421,14 +1401,19 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } field7;
-  } flash_ctrl_hw2reg_csr2_reg_t;
-
-  typedef struct packed {
+    } field5;
     struct packed {
       logic        d;
       logic        de;
-    } field0;
+    } field4;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field3;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
     struct packed {
       logic        d;
       logic        de;
@@ -1436,7 +1421,22 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } field0;
+  } flash_ctrl_hw2reg_csr2_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
     } field2;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field0;
   } flash_ctrl_hw2reg_csr20_reg_t;
 
   // Register -> HW type for prim interface

--- a/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -138,19 +138,19 @@ package gpio_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_out_lower_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_out_upper_reg_t;
 
   typedef struct packed {
@@ -160,19 +160,19 @@ package gpio_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_oe_lower_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_oe_upper_reg_t;
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl.sv
@@ -440,8 +440,7 @@ module otp_ctrl
     // Aggregate all the remaining errors / alerts from the partitions and the DAI/LCI
     for (int k = 0; k < NumPart+2; k++) begin
       // Set the error bit if the error status of the corresponding partition is nonzero.
-      // Need to reverse the order here since the field enumeration in hw2reg.status is reversed.
-      part_errors_reduced[NumPart+1-k] = |part_error[k];
+      part_errors_reduced[k] = |part_error[k];
       // Filter for integrity and consistency check failures.
       fatal_check_error_d |= part_error[k] inside {CheckFailError, FsmStateError};
 
@@ -507,15 +506,17 @@ module otp_ctrl
     hw2reg.direct_access_rdata = dai_rdata;
     // ANDing this state with dai_idle write-protects all DAI regs during pending operations.
     hw2reg.direct_access_regwen.d = direct_access_regwen_q & dai_idle;
-    // Assign these to the status register.
-    hw2reg.status = {part_errors_reduced,
-                     chk_timeout,
-                     lfsr_fsm_err,
-                     scrmbl_fsm_err,
-                     part_fsm_err[KdiIdx],
-                     fatal_bus_integ_error_q,
-                     dai_idle,
-                     chk_pending};
+    // Report partition errors in the status register; relies upon the field ordering and the
+    // presence of only the scalar signal 'd' in each partition-specific field.
+    hw2reg.status = otp_ctrl_hw2reg_status_reg_t'(part_errors_reduced);
+    // Overwrite the other fields of the status register with specific error conditions.
+    hw2reg.status.timeout_error.d = chk_timeout;
+    hw2reg.status.lfsr_fsm_error.d = lfsr_fsm_err;
+    hw2reg.status.scrambling_fsm_error.d = scrmbl_fsm_err;
+    hw2reg.status.key_deriv_fsm_error.d = part_fsm_err[KdiIdx];
+    hw2reg.status.bus_integ_error.d = fatal_bus_integ_error_q;
+    hw2reg.status.dai_idle.d = dai_idle;
+    hw2reg.status.check_pending.d = chk_pending;
     // Error code registers.
     hw2reg.err_code = part_error;
     // Interrupt signals

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -410,74 +410,74 @@ package otp_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } otp_operation_done;
+    } otp_error;
     struct packed {
       logic        d;
       logic        de;
-    } otp_error;
+    } otp_operation_done;
   } otp_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
-    } vendor_test_error;
-    struct packed {
-      logic        d;
-    } creator_sw_cfg_error;
-    struct packed {
-      logic        d;
-    } owner_sw_cfg_error;
-    struct packed {
-      logic        d;
-    } rot_creator_auth_codesign_error;
-    struct packed {
-      logic        d;
-    } rot_creator_auth_state_error;
-    struct packed {
-      logic        d;
-    } hw_cfg0_error;
-    struct packed {
-      logic        d;
-    } hw_cfg1_error;
-    struct packed {
-      logic        d;
-    } secret0_error;
-    struct packed {
-      logic        d;
-    } secret1_error;
-    struct packed {
-      logic        d;
-    } secret2_error;
-    struct packed {
-      logic        d;
-    } life_cycle_error;
-    struct packed {
-      logic        d;
-    } dai_error;
-    struct packed {
-      logic        d;
-    } lci_error;
-    struct packed {
-      logic        d;
-    } timeout_error;
-    struct packed {
-      logic        d;
-    } lfsr_fsm_error;
-    struct packed {
-      logic        d;
-    } scrambling_fsm_error;
-    struct packed {
-      logic        d;
-    } key_deriv_fsm_error;
-    struct packed {
-      logic        d;
-    } bus_integ_error;
+    } check_pending;
     struct packed {
       logic        d;
     } dai_idle;
     struct packed {
       logic        d;
-    } check_pending;
+    } bus_integ_error;
+    struct packed {
+      logic        d;
+    } key_deriv_fsm_error;
+    struct packed {
+      logic        d;
+    } scrambling_fsm_error;
+    struct packed {
+      logic        d;
+    } lfsr_fsm_error;
+    struct packed {
+      logic        d;
+    } timeout_error;
+    struct packed {
+      logic        d;
+    } lci_error;
+    struct packed {
+      logic        d;
+    } dai_error;
+    struct packed {
+      logic        d;
+    } life_cycle_error;
+    struct packed {
+      logic        d;
+    } secret2_error;
+    struct packed {
+      logic        d;
+    } secret1_error;
+    struct packed {
+      logic        d;
+    } secret0_error;
+    struct packed {
+      logic        d;
+    } hw_cfg1_error;
+    struct packed {
+      logic        d;
+    } hw_cfg0_error;
+    struct packed {
+      logic        d;
+    } rot_creator_auth_state_error;
+    struct packed {
+      logic        d;
+    } rot_creator_auth_codesign_error;
+    struct packed {
+      logic        d;
+    } owner_sw_cfg_error;
+    struct packed {
+      logic        d;
+    } creator_sw_cfg_error;
+    struct packed {
+      logic        d;
+    } vendor_test_error;
   } otp_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -178,68 +178,68 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } invert;
+      logic [3:0]  d;
+    } drive_strength;
+    struct packed {
+      logic [1:0]  d;
+    } slew_rate;
     struct packed {
       logic        d;
-    } virtual_od_en;
-    struct packed {
-      logic        d;
-    } pull_en;
-    struct packed {
-      logic        d;
-    } pull_select;
-    struct packed {
-      logic        d;
-    } keeper_en;
-    struct packed {
-      logic        d;
-    } schmitt_en;
+    } input_disable;
     struct packed {
       logic        d;
     } od_en;
     struct packed {
       logic        d;
-    } input_disable;
+    } schmitt_en;
     struct packed {
-      logic [1:0]  d;
-    } slew_rate;
+      logic        d;
+    } keeper_en;
     struct packed {
-      logic [3:0]  d;
-    } drive_strength;
+      logic        d;
+    } pull_select;
+    struct packed {
+      logic        d;
+    } pull_en;
+    struct packed {
+      logic        d;
+    } virtual_od_en;
+    struct packed {
+      logic        d;
+    } invert;
   } pinmux_hw2reg_mio_pad_attr_mreg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } invert;
+      logic [3:0]  d;
+    } drive_strength;
+    struct packed {
+      logic [1:0]  d;
+    } slew_rate;
     struct packed {
       logic        d;
-    } virtual_od_en;
-    struct packed {
-      logic        d;
-    } pull_en;
-    struct packed {
-      logic        d;
-    } pull_select;
-    struct packed {
-      logic        d;
-    } keeper_en;
-    struct packed {
-      logic        d;
-    } schmitt_en;
+    } input_disable;
     struct packed {
       logic        d;
     } od_en;
     struct packed {
       logic        d;
-    } input_disable;
+    } schmitt_en;
     struct packed {
-      logic [1:0]  d;
-    } slew_rate;
+      logic        d;
+    } keeper_en;
     struct packed {
-      logic [3:0]  d;
-    } drive_strength;
+      logic        d;
+    } pull_select;
+    struct packed {
+      logic        d;
+    } pull_en;
+    struct packed {
+      logic        d;
+    } virtual_od_en;
+    struct packed {
+      logic        d;
+    } invert;
   } pinmux_hw2reg_dio_pad_attr_mreg_t;
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -154,21 +154,21 @@ package pwrmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [5:0]  d;
-    } reasons;
+      logic        d;
+    } abort;
     struct packed {
       logic        d;
     } fall_through;
     struct packed {
-      logic        d;
-    } abort;
+      logic [5:0]  d;
+    } reasons;
   } pwrmgr_hw2reg_wake_info_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
+    } main_pd_glitch;
     struct packed {
       logic        d;
       logic        de;
@@ -176,7 +176,7 @@ package pwrmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } main_pd_glitch;
+    } reg_intg_err;
   } pwrmgr_hw2reg_fault_status_reg_t;
 
   // Register -> HW type

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -89,17 +89,17 @@ package rstmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [4:0]  d;
       logic        de;
-    } low_power_exit;
+    } hw_req;
     struct packed {
       logic        d;
       logic        de;
     } sw_reset;
     struct packed {
-      logic [4:0]  d;
+      logic        d;
       logic        de;
-    } hw_req;
+    } low_power_exit;
   } rstmgr_hw2reg_reset_info_reg_t;
 
   typedef struct packed {
@@ -136,7 +136,7 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
+    } fsm_err;
     struct packed {
       logic        d;
       logic        de;
@@ -144,7 +144,7 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fsm_err;
+    } reg_intg_err;
   } rstmgr_hw2reg_err_code_reg_t;
 
   // Register -> HW type

--- a/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -105,22 +105,18 @@ package rv_core_ibex_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } alert;
+    } wdog;
     struct packed {
       logic        d;
       logic        de;
-    } wdog;
+    } alert;
   } rv_core_ibex_hw2reg_nmi_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fatal_intg_err;
+    } recov_core_err;
     struct packed {
       logic        d;
       logic        de;
@@ -128,7 +124,11 @@ package rv_core_ibex_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } recov_core_err;
+    } fatal_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_err;
   } rv_core_ibex_hw2reg_err_status_reg_t;
 
   typedef struct packed {
@@ -138,10 +138,10 @@ package rv_core_ibex_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } rnd_data_valid;
+    } rnd_data_fips;
     struct packed {
       logic        d;
-    } rnd_data_fips;
+    } rnd_data_valid;
   } rv_core_ibex_hw2reg_rnd_status_reg_t;
 
   typedef struct packed {

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/rtl/clkmgr_reg_pkg.sv
@@ -171,31 +171,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadow_update_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div4_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } main_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } usb_measure_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_timeout_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } io_div4_timeout_err;
+    } usb_timeout_err;
     struct packed {
       logic        d;
       logic        de;
@@ -203,14 +179,38 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } usb_timeout_err;
+    } io_div4_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } usb_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div4_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } shadow_update_err;
   } clkmgr_hw2reg_recov_err_code_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg;
+    } shadow_storage_err;
     struct packed {
       logic        d;
       logic        de;
@@ -218,7 +218,7 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } shadow_storage_err;
+    } reg_intg;
   } clkmgr_hw2reg_fatal_err_code_reg_t;
 
   // Register -> HW type

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -499,19 +499,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prog_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_lvl;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_lvl;
+    } corr_err;
     struct packed {
       logic        d;
       logic        de;
@@ -519,7 +507,19 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } corr_err;
+    } rd_lvl;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_full;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_lvl;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_empty;
   } flash_ctrl_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -542,30 +542,18 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } done;
+    } err;
     struct packed {
       logic        d;
       logic        de;
-    } err;
+    } done;
   } flash_ctrl_hw2reg_op_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } rd_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_empty;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_full;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_empty;
+    } initialized;
     struct packed {
       logic        d;
       logic        de;
@@ -573,7 +561,19 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } initialized;
+    } prog_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_full;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_empty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_full;
   } flash_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -584,27 +584,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } op_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } mp_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_win_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_type_err;
+    } macro_err;
     struct packed {
       logic        d;
       logic        de;
@@ -612,65 +592,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } macro_err;
-  } flash_ctrl_hw2reg_err_code_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } reg_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } lcmgr_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } lcmgr_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } arb_fsm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } storage_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } phy_fsm_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } ctrl_cnt_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fifo_err;
-  } flash_ctrl_hw2reg_std_fault_status_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } op_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } mp_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } rd_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } prog_err;
+    } prog_type_err;
     struct packed {
       logic        d;
       logic        de;
@@ -678,23 +600,65 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prog_type_err;
+    } prog_err;
     struct packed {
       logic        d;
       logic        de;
-    } seed_err;
+    } rd_err;
     struct packed {
       logic        d;
       logic        de;
-    } phy_relbl_err;
+    } mp_err;
     struct packed {
       logic        d;
       logic        de;
-    } phy_storage_err;
+    } op_err;
+  } flash_ctrl_hw2reg_err_code_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } spurious_ack;
+    } fifo_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_cnt_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_fsm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } arb_fsm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } lcmgr_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } lcmgr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_err;
+  } flash_ctrl_hw2reg_std_fault_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } host_gnt_err;
     struct packed {
       logic        d;
       logic        de;
@@ -702,7 +666,43 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } host_gnt_err;
+    } spurious_ack;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_relbl_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } seed_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_type_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_win_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prog_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rd_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } mp_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } op_err;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -724,7 +724,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } init_wip;
+    } prog_repair_avail;
     struct packed {
       logic        d;
       logic        de;
@@ -732,16 +732,16 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } prog_repair_avail;
+    } init_wip;
   } flash_ctrl_hw2reg_phy_status_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [4:0]  d;
-    } prog;
+    } rd;
     struct packed {
       logic [4:0]  d;
-    } rd;
+    } prog;
   } flash_ctrl_hw2reg_curr_fifo_lvl_reg_t;
 
   // Register -> HW type for core interface
@@ -1393,27 +1393,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } field0;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field1;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field2;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field3;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field4;
-    struct packed {
-      logic        d;
-      logic        de;
-    } field5;
+    } field7;
     struct packed {
       logic        d;
       logic        de;
@@ -1421,14 +1401,19 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } field7;
-  } flash_ctrl_hw2reg_csr2_reg_t;
-
-  typedef struct packed {
+    } field5;
     struct packed {
       logic        d;
       logic        de;
-    } field0;
+    } field4;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field3;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field2;
     struct packed {
       logic        d;
       logic        de;
@@ -1436,7 +1421,22 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } field0;
+  } flash_ctrl_hw2reg_csr2_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
     } field2;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field1;
+    struct packed {
+      logic        d;
+      logic        de;
+    } field0;
   } flash_ctrl_hw2reg_csr20_reg_t;
 
   // Register -> HW type for prim interface

--- a/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/rtl/gpio_reg_pkg.sv
@@ -138,19 +138,19 @@ package gpio_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_out_lower_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_out_upper_reg_t;
 
   typedef struct packed {
@@ -160,19 +160,19 @@ package gpio_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_oe_lower_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] d;
-    } data;
+    } mask;
     struct packed {
       logic [15:0] d;
-    } mask;
+    } data;
   } gpio_hw2reg_masked_oe_upper_reg_t;
 
   typedef struct packed {

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/rtl/pinmux_reg_pkg.sv
@@ -178,68 +178,68 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } invert;
+      logic [3:0]  d;
+    } drive_strength;
+    struct packed {
+      logic [1:0]  d;
+    } slew_rate;
     struct packed {
       logic        d;
-    } virtual_od_en;
-    struct packed {
-      logic        d;
-    } pull_en;
-    struct packed {
-      logic        d;
-    } pull_select;
-    struct packed {
-      logic        d;
-    } keeper_en;
-    struct packed {
-      logic        d;
-    } schmitt_en;
+    } input_disable;
     struct packed {
       logic        d;
     } od_en;
     struct packed {
       logic        d;
-    } input_disable;
+    } schmitt_en;
     struct packed {
-      logic [1:0]  d;
-    } slew_rate;
+      logic        d;
+    } keeper_en;
     struct packed {
-      logic [3:0]  d;
-    } drive_strength;
+      logic        d;
+    } pull_select;
+    struct packed {
+      logic        d;
+    } pull_en;
+    struct packed {
+      logic        d;
+    } virtual_od_en;
+    struct packed {
+      logic        d;
+    } invert;
   } pinmux_hw2reg_mio_pad_attr_mreg_t;
 
   typedef struct packed {
     struct packed {
-      logic        d;
-    } invert;
+      logic [3:0]  d;
+    } drive_strength;
+    struct packed {
+      logic [1:0]  d;
+    } slew_rate;
     struct packed {
       logic        d;
-    } virtual_od_en;
-    struct packed {
-      logic        d;
-    } pull_en;
-    struct packed {
-      logic        d;
-    } pull_select;
-    struct packed {
-      logic        d;
-    } keeper_en;
-    struct packed {
-      logic        d;
-    } schmitt_en;
+    } input_disable;
     struct packed {
       logic        d;
     } od_en;
     struct packed {
       logic        d;
-    } input_disable;
+    } schmitt_en;
     struct packed {
-      logic [1:0]  d;
-    } slew_rate;
+      logic        d;
+    } keeper_en;
     struct packed {
-      logic [3:0]  d;
-    } drive_strength;
+      logic        d;
+    } pull_select;
+    struct packed {
+      logic        d;
+    } pull_en;
+    struct packed {
+      logic        d;
+    } virtual_od_en;
+    struct packed {
+      logic        d;
+    } invert;
   } pinmux_hw2reg_dio_pad_attr_mreg_t;
 
   typedef struct packed {

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -151,21 +151,21 @@ package pwrmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [2:0]  d;
-    } reasons;
+      logic        d;
+    } abort;
     struct packed {
       logic        d;
     } fall_through;
     struct packed {
-      logic        d;
-    } abort;
+      logic [2:0]  d;
+    } reasons;
   } pwrmgr_hw2reg_wake_info_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
+    } main_pd_glitch;
     struct packed {
       logic        d;
       logic        de;
@@ -173,7 +173,7 @@ package pwrmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } main_pd_glitch;
+    } reg_intg_err;
   } pwrmgr_hw2reg_fault_status_reg_t;
 
   // Register -> HW type

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/rtl/rstmgr_reg_pkg.sv
@@ -89,17 +89,17 @@ package rstmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [3:0]  d;
       logic        de;
-    } low_power_exit;
+    } hw_req;
     struct packed {
       logic        d;
       logic        de;
     } sw_reset;
     struct packed {
-      logic [3:0]  d;
+      logic        d;
       logic        de;
-    } hw_req;
+    } low_power_exit;
   } rstmgr_hw2reg_reset_info_reg_t;
 
   typedef struct packed {
@@ -136,7 +136,7 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
+    } fsm_err;
     struct packed {
       logic        d;
       logic        de;
@@ -144,7 +144,7 @@ package rstmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } fsm_err;
+    } reg_intg_err;
   } rstmgr_hw2reg_err_code_reg_t;
 
   // Register -> HW type

--- a/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/top_englishbreakfast/ip_autogen/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -105,22 +105,18 @@ package rv_core_ibex_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } alert;
+    } wdog;
     struct packed {
       logic        d;
       logic        de;
-    } wdog;
+    } alert;
   } rv_core_ibex_hw2reg_nmi_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } reg_intg_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } fatal_intg_err;
+    } recov_core_err;
     struct packed {
       logic        d;
       logic        de;
@@ -128,7 +124,11 @@ package rv_core_ibex_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } recov_core_err;
+    } fatal_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_err;
   } rv_core_ibex_hw2reg_err_status_reg_t;
 
   typedef struct packed {
@@ -138,10 +138,10 @@ package rv_core_ibex_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } rnd_data_valid;
+    } rnd_data_fips;
     struct packed {
       logic        d;
-    } rnd_data_fips;
+    } rnd_data_valid;
   } rv_core_ibex_hw2reg_rnd_status_reg_t;
 
   typedef struct packed {

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -118,7 +118,7 @@ ${hdr}
       ## We are inhomogeneous, which means there is more than one different
       ## field. Generate a hw2reg typedef that packs together all the fields of
       ## the register.
-      % for f in r0.fields:
+      % for f in reversed(r0.fields):
 <%
           field_d_width = f.get_n_bits(r0.hwext, r0.hwre, ["d"])
 %>\


### PR DESCRIPTION
Reverse the order of the sub-fields within hw2reg packed structs to mirror the change that was made to reg2hw in 61a237e.

This helps with consistency but also addresses a direct structure assignment discovered in soc_dbg_ctrl. An independent fix for that issue proposed in PR #27212 but the change proposed in the current PR is thought to be beneficial to help avoid such issues in future.

Although changing reggen in this manner necessarily changes the '_reg_pkg' files of many IP blocks, the elaborated logic of existing designs should be unaffected.

Generally, however, treating these structures as being a direct bit-level representation of the register content, or even the defined bits within the register, is fragile and should be avoided.