### PR TITLE
[bazel] enable building VMEM image for multislot bins

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -8,6 +8,7 @@ load(
     "//rules:opentitan.bzl",
     "ECDSA_SPX_KEY_STRUCTS",
 )
+load("//rules/opentitan:cc.bzl", "opentitan_binary_assemble")
 load(
     "//rules:otp.bzl",
     "OTP_SIGVERIFY_FAKE_KEYS",
@@ -21,6 +22,10 @@ load(
     "opentitan_test",
     "silicon_params",
     "spx_key_for_lc_state",
+)
+load(
+    "//sw/device/silicon_creator/rom/e2e:defs.bzl",
+    "SLOTS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -507,4 +512,41 @@ opentitan_test(
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/sigverify:spx_verify",
     ],
+)
+
+[
+    opentitan_binary(
+        name = "empty_test_{}".format(slot),
+        testonly = True,
+        srcs = ["empty_functest.c"],
+        exec_env = {
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+        deps = [
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for slot in SLOTS.keys()
+]
+
+opentitan_binary_assemble(
+    name = "multislot_empty_test",
+    testonly = True,
+    bins = {
+        ":empty_test_a": SLOTS["a"],
+        ":empty_test_b": SLOTS["b"],
+    },
+    exec_env = [
+        "//hw/top_earlgrey:sim_dv",
+        "//hw/top_earlgrey:silicon_creator",
+    ],
+)
+
+# The below alias is needed to run the multislot_empty_test in DV.
+alias(
+    name = "multislot_empty_test_sim_dv",
+    actual = "multislot_empty_test",
 )


### PR DESCRIPTION
The personalization binary is combined with the transport image into a multislot binary payload that is bootstrapped during personalization. This updates `opentitan_binary_assemble` rule to build VMEM files for opentitantool-assembled multislot image so they can be loaded in DV to bringup ATE flows for manufacturing. This fixes #25977.