### PR TITLE
[perso] Erase all owner-reserved INFO pages

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -59,9 +59,8 @@ static owner_page_status_t owner_page_validity_check(size_t page,
   return kOwnerPageStatusSigned;
 }
 
-OT_WEAK rom_error_t
-sku_creator_owner_init(boot_data_t *bootdata, owner_config_t *config,
-                       owner_application_keyring_t *keyring) {
+OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
+  OT_DISCARD(bootdata);
   return kErrorOk;
 }
 
@@ -250,7 +249,7 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   // When we settle on a default ownership configuration, we'll remove this
   // function and possibly relegate it to the `default` case below, only to
   // be used should the chip enter the "no owner recovery" state.
-  HARDENED_RETURN_IF_ERROR(sku_creator_owner_init(bootdata, config, keyring));
+  HARDENED_RETURN_IF_ERROR(sku_creator_owner_init(bootdata));
 
   rom_error_t error = kErrorOwnershipNoOwner;
   // TODO(#22386): Harden this switch/case statement.

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -95,9 +95,7 @@
       kBootSvcOwnershipUnlockReqType,
 #endif
 
-rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
-                                   owner_config_t *config,
-                                   owner_application_keyring_t *keyring) {
+rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   owner_keydata_t owner = OWNER_KEYDATA;
   ownership_state_t state = bootdata->ownership_state;
 
@@ -284,14 +282,18 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
                (uintptr_t)end;
   memset((void *)end, 0x5a, len);
 
+  // Check that the owner_block will parse correctly.
+  RETURN_IF_ERROR(owner_block_parse(&owner_page[0],
+                                    /*check_only=*/kHardenedBoolTrue, NULL,
+                                    NULL));
   ownership_seal_page(/*page=*/0);
-  memcpy(&owner_page[1], &owner_page[0], sizeof(owner_page[0]));
 
   // Since this module should only get linked in to FPGA builds, we can simply
   // thunk the ownership state to LockedOwner.
   bootdata->ownership_state = kOwnershipStateLockedOwner;
 
-  // Write the configuration to both owner pages.
+  // Write the configuration to both owner page 0.  The next boot of the ROM_EXT
+  // will make a redundant copyh in page 1.
   OT_DISCARD(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot0,
                                    kFlashCtrlEraseTypePage));
   OT_DISCARD(flash_ctrl_info_write(&kFlashCtrlInfoPageOwnerSlot0, 0,

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -192,12 +192,8 @@ static cert_flash_info_layout_t cert_flash_layout[] = {
 /**
  * Ownership initialization function.
  */
-OT_WEAK rom_error_t
-sku_creator_owner_init(boot_data_t *bootdata, owner_config_t *config,
-                       owner_application_keyring_t *keyring) {
+OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   OT_DISCARD(bootdata);
-  OT_DISCARD(config);
-  OT_DISCARD(keyring);
   LOG_ERROR("No ownership initialization");
   return kErrorOk;
 }
@@ -734,10 +730,7 @@ static status_t install_owner(void) {
   // Initialize ownership.  This will write the owner block into OwnerSlot0 and
   // set the ownership_state to LockedOwner.  The first boot of the ROM_EXT
   // will create a redundanty copy in OwnerSlot1.
-  owner_config_t config;
-  owner_config_default(&config);
-  owner_application_keyring_t keyring = {0};
-  TRY(sku_creator_owner_init(&boot_data, &config, &keyring));
+  TRY(sku_creator_owner_init(&boot_data);
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -275,6 +275,45 @@ static status_t config_and_erase_certificate_flash_pages(void) {
 }
 
 /**
+ * Erase all of the owner's INFO pages so that they're in a known state.
+ */
+static status_t erase_owner_info_pages(owner_config_t *config) {
+  const flash_ctrl_info_page_t *pages[] = {
+      &kFlashCtrlInfoPageOwnerReserved0, &kFlashCtrlInfoPageOwnerReserved1,
+      &kFlashCtrlInfoPageOwnerReserved2, &kFlashCtrlInfoPageOwnerReserved3,
+      &kFlashCtrlInfoPageOwnerReserved4, &kFlashCtrlInfoPageOwnerReserved5,
+      &kFlashCtrlInfoPageOwnerReserved6, &kFlashCtrlInfoPageOwnerReserved7,
+  };
+
+  // First, initialize all of the owner INFO pages with ECC & Scrambling.
+  for (size_t i = 0; i < ARRAYSIZE(pages); ++i) {
+    flash_ctrl_cfg_t cfg = {
+        .scrambling = kMultiBitBool4True,
+        .ecc = kMultiBitBool4True,
+        .he = kMultiBitBool4False,
+    };
+    flash_ctrl_info_cfg_set(pages[i], cfg);
+  }
+
+  // Next, overwrite the INFO page configuration for those pages defined
+  // in the owner block.
+  TRY(owner_block_info_apply(config->info));
+
+  // Finally, erase each page.
+  for (size_t i = 0; i < ARRAYSIZE(pages); ++i) {
+    flash_ctrl_perms_t perms = {
+        .read = kMultiBitBool4True,
+        .write = kMultiBitBool4True,
+        .erase = kMultiBitBool4True,
+    };
+    flash_ctrl_info_perms_set(pages[i], perms);
+    TRY(flash_ctrl_info_erase(pages[i], kFlashCtrlEraseTypePage));
+  }
+
+  return OK_STATUS();
+}
+
+/**
  * Helper function to compute measurements of various OTP partitions that are to
  * be included in attestation certificates.
  */
@@ -700,7 +739,8 @@ static status_t boot_data_cfg_initialize(void) {
   return OK_STATUS();
 }
 
-static status_t install_owner(void) {
+static status_t install_owner(owner_config_t *config,
+                              owner_application_keyring_t *keyring) {
   // Get the boot_data; installing the owner will write it back with the
   // ownership_state set to LockedOwner.
   boot_data_t boot_data;
@@ -730,7 +770,9 @@ static status_t install_owner(void) {
   // Initialize ownership.  This will write the owner block into OwnerSlot0 and
   // set the ownership_state to LockedOwner.  The first boot of the ROM_EXT
   // will create a redundanty copy in OwnerSlot1.
-  TRY(sku_creator_owner_init(&boot_data);
+  TRY(sku_creator_owner_init(&boot_data));
+  TRY(owner_block_parse(&owner_page[0],
+                        /*check_only=*/kHardenedBoolFalse, config, keyring));
   return OK_STATUS();
 }
 
@@ -1051,8 +1093,16 @@ static status_t provision(ujson_t *uj) {
   // Provision OTP, flash secrets, certs, and install the first owner.
   TRY(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
   TRY(personalize_otp_and_flash_secrets(uj));
+
   TRY(personalize_gen_dice_certificates(uj));
-  TRY(install_owner());
+  owner_config_t owner_config;
+  owner_application_keyring_t owner_keyring = {0};
+  TRY(install_owner(&owner_config, &owner_keyring));
+
+  // Erase all of the owner-reserved INFO pages before performing any
+  // DICE or owner-customized certificate generation.
+  TRY(erase_owner_info_pages(&owner_config));
+
   personalize_extension_pre_endorse_t pre_endorse = {
       .uj = uj,
       .certgen_inputs = &certgen_inputs,


### PR DESCRIPTION
Erase all owner-reserved INFO pages during personalization to ensure that they're all known to be in the erased state.