### PR TITLE
[racl_ctrl,rtl] Set error_log's valid and overflow bits correctly

### DIFF
--- a/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
+++ b/hw/ip_templates/racl_ctrl/data/racl_ctrl.hjson.tpl
@@ -208,7 +208,7 @@
       desc: "Error logging registers"
       swaccess: "ro"
       hwaccess: "hwo"
-      hwqe: "true"
+      hwqe: "false"
       fields: [
         { bits: "0"
           name: "valid"

--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -177,35 +177,54 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
     .error_log_o ( racl_error_arb      )
   );
 
-  // On the first error, we log the address and other information
+  assign hw2reg.error_log.valid.d  = 1'b1;
+  assign hw2reg.error_log.valid.de = racl_error_arb.valid;
+
+  // Error logging is designed to snapshot information about the first error and then keep that
+  // static until the valid signal is cleared (using the fact that REG2HW.ERROR_LOG is rw1c).
+  //
+  // To make this work, most of the registers (ERROR_LOG_ADDRESS, ERROR_LOG.ERROR_READ_ACCESS,
+  // ERROR_LOG.ROLE and ERROR_LOG.CTN_UID) have a de signal that is high whenever error_log.valid.q
+  // is false. The data to be written is zero unless racl_error_arb.valid is true, in which case we
+  // take the value from racl_error_arb.
+  //
+  // The only register that behaves differently is the ERROR_LOG.OVERFLOW. This should go high if
+  // either of these events happen:
+  //
+  // - The overflow signal from racl_error_arb is true (which means that the arbiter saw more than
+  //   one error reported at once)
+  //
+  // - The register's valid signal is already true but racl_error_arb.valid is true. In this case,
+  //   the overflow has accumulated over time.
+  //
+  // As with the other registers described, this gets cleared again after a write to the VALID
+  // field.
+
+  logic had_error;
+  assign had_error = reg2hw.error_log.valid.q;
+
   logic first_error;
-  assign first_error = ~reg2hw.error_log.valid.q & racl_error_arb.valid;
+  assign first_error = racl_error_arb.valid & ~had_error;
 
-  // Writing 1 to the error valid bit clears the log and log address again
-  logic clear_log;
-  assign clear_log = reg2hw.error_log.valid.q & reg2hw.error_log.valid.qe;
 
-  assign hw2reg.error_log.valid.d  = ~clear_log;
-  assign hw2reg.error_log.valid.de = racl_error_arb.valid | clear_log;
+  assign hw2reg.error_log.overflow.d  = (racl_error_arb.overflow | had_error) &
+                                        racl_error_arb.valid;
 
-  // Overflow is raised when error is valid and a new error is coming in or more than one
-  // error is coming in at the same time
-  assign hw2reg.error_log.overflow.d  = ~clear_log;
-  assign hw2reg.error_log.overflow.de = (reg2hw.error_log.valid.q & racl_error_arb.valid) |
-                                        racl_error_arb.overflow                           |
-                                        clear_log;
+  assign hw2reg.error_log.overflow.de = racl_error_arb.overflow |
+                                        (had_error & racl_error_arb.valid) |
+                                        ~had_error;
 
-  assign hw2reg.error_log.read_access.d  = clear_log ? '0 : racl_error_arb.read_access;
-  assign hw2reg.error_log.read_access.de = first_error | clear_log;
+  assign hw2reg.error_log.read_access.d  = first_error ? racl_error_arb.read_access : '0;
+  assign hw2reg.error_log.read_access.de = ~had_error;
 
-  assign hw2reg.error_log.role.d  = clear_log ? '0 : racl_error_arb.racl_role;
-  assign hw2reg.error_log.role.de = first_error | clear_log;
+  assign hw2reg.error_log.role.d  = first_error ? racl_error_arb.racl_role : '0;
+  assign hw2reg.error_log.role.de = ~had_error;
 
-  assign hw2reg.error_log.ctn_uid.d  = clear_log ? '0 : racl_error_arb.ctn_uid;
-  assign hw2reg.error_log.ctn_uid.de = first_error | clear_log;
+  assign hw2reg.error_log.ctn_uid.d  = first_error ? racl_error_arb.ctn_uid : '0;
+  assign hw2reg.error_log.ctn_uid.de = ~had_error;
 
-  assign hw2reg.error_log_address.d  = clear_log ? '0 : racl_error_arb.request_address;
-  assign hw2reg.error_log_address.de = first_error | clear_log;
+  assign hw2reg.error_log_address.d  = first_error ? racl_error_arb.request_address : '0;
+  assign hw2reg.error_log_address.de = ~had_error;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Interrupt handling

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/racl_ctrl.hjson
@@ -254,7 +254,7 @@
       desc: "Error logging registers"
       swaccess: "ro"
       hwaccess: "hwo"
-      hwqe: "true"
+      hwqe: "false"
       fields: [
         { bits: "0"
           name: "valid"

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_pkg.sv
@@ -73,7 +73,6 @@ package racl_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-      logic        qe;
     } valid;
   } racl_ctrl_reg2hw_error_log_reg_t;
 
@@ -112,14 +111,14 @@ package racl_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    racl_ctrl_reg2hw_policy_all_rd_wr_shadowed_reg_t policy_all_rd_wr_shadowed; // [105:74]
-    racl_ctrl_reg2hw_policy_rot_private_shadowed_reg_t policy_rot_private_shadowed; // [73:42]
-    racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t policy_soc_rot_shadowed; // [41:10]
-    racl_ctrl_reg2hw_intr_state_reg_t intr_state; // [9:9]
-    racl_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [8:8]
-    racl_ctrl_reg2hw_intr_test_reg_t intr_test; // [7:6]
-    racl_ctrl_reg2hw_alert_test_reg_t alert_test; // [5:2]
-    racl_ctrl_reg2hw_error_log_reg_t error_log; // [1:0]
+    racl_ctrl_reg2hw_policy_all_rd_wr_shadowed_reg_t policy_all_rd_wr_shadowed; // [104:73]
+    racl_ctrl_reg2hw_policy_rot_private_shadowed_reg_t policy_rot_private_shadowed; // [72:41]
+    racl_ctrl_reg2hw_policy_soc_rot_shadowed_reg_t policy_soc_rot_shadowed; // [40:9]
+    racl_ctrl_reg2hw_intr_state_reg_t intr_state; // [8:8]
+    racl_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [7:7]
+    racl_ctrl_reg2hw_intr_test_reg_t intr_test; // [6:5]
+    racl_ctrl_reg2hw_alert_test_reg_t alert_test; // [4:1]
+    racl_ctrl_reg2hw_error_log_reg_t error_log; // [0:0]
   } racl_ctrl_reg2hw_t;
 
   // HW -> register type

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl_reg_top.sv
@@ -518,17 +518,6 @@ module racl_ctrl_reg_top
 
 
   // R[error_log]: V(False)
-  logic error_log_qe;
-  logic [4:0] error_log_flds_we;
-  prim_flop #(
-    .Width(1),
-    .ResetValue(0)
-  ) u_error_log0_qe (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .d_i(&(error_log_flds_we | 5'h1e)),
-    .q_o(error_log_qe)
-  );
   //   F[valid]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -548,14 +537,13 @@ module racl_ctrl_reg_top
     .d      (hw2reg.error_log.valid.d),
 
     // to internal hardware
-    .qe     (error_log_flds_we[0]),
+    .qe     (),
     .q      (reg2hw.error_log.valid.q),
     .ds     (),
 
     // to register interface (read)
     .qs     (error_log_valid_qs)
   );
-  assign reg2hw.error_log.valid.qe = error_log_qe;
 
   //   F[overflow]: 1:1
   prim_subreg #(
@@ -576,7 +564,7 @@ module racl_ctrl_reg_top
     .d      (hw2reg.error_log.overflow.d),
 
     // to internal hardware
-    .qe     (error_log_flds_we[1]),
+    .qe     (),
     .q      (),
     .ds     (),
 
@@ -603,7 +591,7 @@ module racl_ctrl_reg_top
     .d      (hw2reg.error_log.read_access.d),
 
     // to internal hardware
-    .qe     (error_log_flds_we[2]),
+    .qe     (),
     .q      (),
     .ds     (),
 
@@ -630,7 +618,7 @@ module racl_ctrl_reg_top
     .d      (hw2reg.error_log.role.d),
 
     // to internal hardware
-    .qe     (error_log_flds_we[3]),
+    .qe     (),
     .q      (),
     .ds     (),
 
@@ -657,7 +645,7 @@ module racl_ctrl_reg_top
     .d      (hw2reg.error_log.ctn_uid.d),
 
     // to internal hardware
-    .qe     (error_log_flds_we[4]),
+    .qe     (),
     .q      (),
     .ds     (),
 


### PR DESCRIPTION
I think the idea of the design was that the hardware might report a racl error, which causes the valid bit to latch high until the software writes to the valid field of the `error_log` register.

The existing code didn't quite do that. The logic seems to have been that we should clear the log on the second write of an error (which includes writes from reported errors from other blocks). As a result, a misconfigured DV sequence that reports an error to `racl_ctrl` for several cycles will see an oscillating valid signal. That didn't seem right to me!

With the new version of the RTL, SW is only able to clear errors and other blocks are only able to report them.

The behaviour of the overflow field ends up a bit awkward. Rather than making this `rw1c` as well, I've kept the design simple by allowing the overflow flag to be cleared a cycle later.

I think that software could theoretically see this. You'd have to have an overflowing error log, then write to the `error_log` register and read from it again on two consecutive cycles. If you managed to do this, you'd see a log with the `valid` flag zero (correctly!) but with the `overflow` flag set.

But it is still not possible to "latch a spurious overflow": an error being reported on that last cycle wouldn't stop the `overflow` flag from being cleared, because *that* only depends on the `valid` flag having been true.