### PR TITLE
[racl_ctrl,rtl] Use a more conventional name for the reg top

### DIFF
--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -49,7 +49,7 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   ${module_instance_name}_reg_top #(
     .EnableRacl   ( 1'b1         ),
     .RaclErrorRsp ( RaclErrorRsp )
-  ) u_racl_ctrl_reg (
+  ) u_reg (
     .clk_i                  ( clk_i                    ),
     .rst_ni                 ( rst_ni                   ),
 % if enable_shadow_reg:
@@ -241,6 +241,5 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   `ASSERT_KNOWN(RaclErrorKnown_A, racl_policies_o)
 
   // Alert assertions for reg_we onehot check
-  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_racl_ctrl_reg,
-                                                 alert_tx_o[0])
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
 endmodule

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -43,7 +43,7 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   racl_ctrl_reg_top #(
     .EnableRacl   ( 1'b1         ),
     .RaclErrorRsp ( RaclErrorRsp )
-  ) u_racl_ctrl_reg (
+  ) u_reg (
     .clk_i                  ( clk_i                    ),
     .rst_ni                 ( rst_ni                   ),
     .rst_shadowed_ni        ( rst_shadowed_ni          ),
@@ -216,6 +216,5 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   `ASSERT_KNOWN(RaclErrorKnown_A, racl_policies_o)
 
   // Alert assertions for reg_we onehot check
-  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_racl_ctrl_reg,
-                                                 alert_tx_o[0])
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
 endmodule


### PR DESCRIPTION
The DV code can be told the backdoor RTL path with a hier_path argument in the hjson, but it falls back to "u_reg" (which is the convention across the rest of the project).

Since racl_ctrl only has one reg top, use the conventional value instead.