### PR TITLE
[otp_ctrl,dv] Fix SCB typo for OTP macro RAL

### DIFF
--- a/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip_templates/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv.tpl
@@ -542,7 +542,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    if (ral_name != "otp_maco_reg_block") begin
+    if (ral_name != "otp_macro_reg_block") begin
       process_core_tl_access(item, csr_addr, ral_name, addr_mask,
                              addr_phase_read, addr_phase_write, data_phase_read, data_phase_write);
     end else begin

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -509,7 +509,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    if (ral_name != "otp_maco_reg_block") begin
+    if (ral_name != "otp_macro_reg_block") begin
       process_core_tl_access(item, csr_addr, ral_name, addr_mask,
                              addr_phase_read, addr_phase_write, data_phase_read, data_phase_write);
     end else begin

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -529,7 +529,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     bit data_phase_read   = (!write && channel == DataChannel);
     bit data_phase_write  = (write && channel == DataChannel);
 
-    if (ral_name != "otp_maco_reg_block") begin
+    if (ral_name != "otp_macro_reg_block") begin
       process_core_tl_access(item, csr_addr, ral_name, addr_mask,
                              addr_phase_read, addr_phase_write, data_phase_read, data_phase_write);
     end else begin


### PR DESCRIPTION
- The PR #27001 has introcudced a typo in the SCB when refering to the OTP macro RAL, which was obviously causing errors in simulation.