### PR TITLE
[crypto] Implement key integrity checksums.

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -40,6 +40,12 @@ dual_cc_library(
     ),
 )
 
+# Make the non-mock version of CRC32 visible outside of this package.
+alias(
+    name = "crc32_device_library",
+    actual = dual_cc_device_library_of(":crc32"),
+)
+
 cc_test(
     name = "crc32_unittest",
     srcs = ["crc32_unittest.cc"],

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -136,6 +136,7 @@ cc_library(
     srcs = ["integrity.c"],
     hdrs = ["integrity.h"],
     deps = [
+        "//sw/device/lib/base:crc32_device_library",  # force non-mock version in unit tests
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/crypto/include:datatypes",
     ],

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -203,6 +203,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
       .keyblob = salt_keyblob,
       .keyblob_length = sizeof(salt_keyblob),
   };
+  salt_key.checksum = integrity_blinded_checksum(&salt_key);
 
   // Call HMAC(salt, IKM).
   uint32_t tag_data[digest_words];

--- a/sw/device/lib/crypto/impl/integrity.c
+++ b/sw/device/lib/crypto/impl/integrity.c
@@ -4,20 +4,30 @@
 
 #include "sw/device/lib/crypto/impl/integrity.h"
 
+#include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/hardened.h"
 
 uint32_t integrity_unblinded_checksum(const otcrypto_unblinded_key_t *key) {
-  // TODO: decide on a checksum algorithm and implement integrity checks.
-  // TODO: maybe check the key length to make sure it's not pushing UINT32_MAX,
-  // as an overflow protection.
-  return 0;
+  uint32_t ctx;
+  crc32_init(&ctx);
+  crc32_add32(&ctx, key->key_mode);
+  crc32_add32(&ctx, key->key_length);
+  crc32_add(&ctx, (unsigned char *)key->key, key->key_length);
+  return crc32_finish(&ctx);
 }
 
 uint32_t integrity_blinded_checksum(const otcrypto_blinded_key_t *key) {
-  // TODO: decide on a checksum algorithm and implement integrity checks.
-  // TODO: maybe check the key length to make sure it's not pushing UINT32_MAX,
-  // as an overflow protection.
-  return 0;
+  uint32_t ctx;
+  crc32_init(&ctx);
+  crc32_add32(&ctx, key->config.version);
+  crc32_add32(&ctx, key->config.key_mode);
+  crc32_add32(&ctx, key->config.key_length);
+  crc32_add32(&ctx, key->config.hw_backed);
+  crc32_add32(&ctx, key->config.exportable);
+  crc32_add32(&ctx, key->config.security_level);
+  crc32_add32(&ctx, key->keyblob_length);
+  crc32_add(&ctx, (unsigned char *)key->keyblob, key->keyblob_length);
+  return crc32_finish(&ctx);
 }
 
 hardened_bool_t integrity_unblinded_key_check(

--- a/sw/device/lib/crypto/impl/keyblob_unittest.cc
+++ b/sw/device/lib/crypto/impl/keyblob_unittest.cc
@@ -42,7 +42,7 @@ constexpr otcrypto_key_config_t kConfigOddBytes = {
 constexpr otcrypto_key_config_t kConfigHuge = {
     .version = kOtcryptoLibVersion1,
     .key_mode = kOtcryptoKeyModeAesCtr,
-    .key_length = SIZE_MAX,
+    .key_length = UINT32_MAX,
     .hw_backed = kHardenedBoolFalse,
     .security_level = kOtcryptoKeySecurityLevelLow,
 };
@@ -136,7 +136,8 @@ TEST(Keyblob, FromToSharesNoop) {
   ASSERT_EQ(test_share1.size(), keyblob_share_num_words(kConfigCtr128));
 
   // Convert shares to keyblob array.
-  size_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_bytes = keyblob_words * sizeof(uint32_t);
   uint32_t keyblob[keyblob_words] = {0};
   status_t err = keyblob_from_shares(test_share0.data(), test_share1.data(),
                                      kConfigCtr128, keyblob);
@@ -145,7 +146,7 @@ TEST(Keyblob, FromToSharesNoop) {
   // Construct blinded key.
   otcrypto_blinded_key_t key = {
       .config = kConfigCtr128,
-      .keyblob_length = sizeof(keyblob),
+      .keyblob_length = keyblob_bytes,
       .keyblob = keyblob,
       .checksum = 0,
   };
@@ -175,7 +176,8 @@ TEST(Keyblob, FromKeyMaskDoesNotChangeKey) {
   ASSERT_EQ(test_mask.size(), keyblob_share_num_words(kConfigCtr128));
 
   // Convert key/mask to keyblob array.
-  size_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_bytes = keyblob_words * sizeof(uint32_t);
   uint32_t keyblob[keyblob_words] = {0};
   EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask.data(),
                                       kConfigCtr128, keyblob));
@@ -183,7 +185,7 @@ TEST(Keyblob, FromKeyMaskDoesNotChangeKey) {
   // Construct blinded key.
   otcrypto_blinded_key_t key = {
       .config = kConfigCtr128,
-      .keyblob_length = sizeof(keyblob),
+      .keyblob_length = keyblob_bytes,
       .keyblob = keyblob,
       .checksum = 0,
   };
@@ -322,7 +324,8 @@ TEST(Keyblob, RemaskDoesNotChangeKey) {
   ASSERT_EQ(test_mask1.size(), keyblob_share_num_words(kConfigCtr128));
 
   // Convert key and first mask to keyblob array.
-  size_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_bytes = keyblob_words * sizeof(uint32_t);
   uint32_t keyblob[keyblob_words] = {0};
   EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask0.data(),
                                       kConfigCtr128, keyblob));
@@ -330,7 +333,7 @@ TEST(Keyblob, RemaskDoesNotChangeKey) {
   // Construct blinded key.
   otcrypto_blinded_key_t key = {
       .config = kConfigCtr128,
-      .keyblob_length = sizeof(keyblob),
+      .keyblob_length = keyblob_bytes,
       .keyblob = keyblob,
       .checksum = 0,
   };
@@ -366,7 +369,8 @@ TEST(Keyblob, RemaskWithZero) {
   ASSERT_EQ(test_mask1.size(), keyblob_share_num_words(kConfigCtr128));
 
   // Convert key and first mask to keyblob array.
-  size_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_words = keyblob_num_words(kConfigCtr128);
+  uint32_t keyblob_bytes = keyblob_words * sizeof(uint32_t);
   uint32_t keyblob[keyblob_words] = {0};
   EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask0.data(),
                                       kConfigCtr128, keyblob));
@@ -374,7 +378,7 @@ TEST(Keyblob, RemaskWithZero) {
   // Construct blinded key.
   otcrypto_blinded_key_t key = {
       .config = kConfigCtr128,
-      .keyblob_length = sizeof(keyblob),
+      .keyblob_length = keyblob_bytes,
       .keyblob = keyblob,
       .checksum = 0,
   };

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -396,7 +396,7 @@ typedef struct otcrypto_key_config {
   // Mode for which the key usage is intended.
   otcrypto_key_mode_t key_mode;
   // Length in bytes of the unblinded form of this key.
-  size_t key_length;
+  uint32_t key_length;
   // Whether the hardware key manager should produce this key.
   // If this is set to `true`, the keyblob must be exactly 8 words long, where
   // the first word is the version and the remaining 7 words are the salt.
@@ -414,7 +414,7 @@ typedef struct otcrypto_unblinded_key {
   // Mode for which the key usage is intended.
   otcrypto_key_mode_t key_mode;
   // Key length in bytes.
-  size_t key_length;
+  uint32_t key_length;
   // Implementation specific, storage provided by caller.
   uint32_t *key;
   // Implementation specific, checksum for this struct.
@@ -428,7 +428,7 @@ typedef struct otcrypto_blinded_key {
   // Key configuration information.
   const otcrypto_key_config_t config;
   // Length of blinded key material in bytes.
-  const size_t keyblob_length;
+  const uint32_t keyblob_length;
   // Implementation specific, storage provided by caller.
   uint32_t *keyblob;
   // Implementation specific, checksum for this struct.

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -56,6 +56,7 @@ cc_library(
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/impl:ecc_p256",
         "//sw/device/lib/crypto/impl:ecc_p384",
+        "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/include:datatypes",
         "//sw/device/lib/runtime:log",

--- a/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/ecc_p256.h"
 #include "sw/device/lib/crypto/include/ecc_p384.h"
@@ -119,8 +120,8 @@ static status_t ecdh_p256(cryptotest_ecdh_private_key_t d,
           },
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
-      .checksum = 0,
   };
+  private_key.checksum = integrity_blinded_checksum(&private_key);
 
   // Construct the public key object.
   // TODO(#20762): once key-import exists for ECDH, use that instead.
@@ -134,6 +135,7 @@ static status_t ecdh_p256(cryptotest_ecdh_private_key_t d,
       .key_length = sizeof(public_key_buf),
       .key = public_key_buf,
   };
+  public_key.checksum = integrity_unblinded_checksum(&public_key);
 
   // Create a destination for the shared secret.
   size_t shared_secret_words = kP256SharedSecretBytes / sizeof(uint32_t);
@@ -240,8 +242,8 @@ static status_t ecdh_p384(cryptotest_ecdh_private_key_t d,
           },
       .keyblob_length = sizeof(private_keyblob),
       .keyblob = private_keyblob,
-      .checksum = 0,
   };
+  private_key.checksum = integrity_blinded_checksum(&private_key);
 
   // Construct the public key object.
   // TODO(#20762): once key-import exists for ECDH, use that instead.
@@ -255,6 +257,7 @@ static status_t ecdh_p384(cryptotest_ecdh_private_key_t d,
       .key_length = sizeof(public_key_buf),
       .key = public_key_buf,
   };
+  public_key.checksum = integrity_unblinded_checksum(&public_key);
 
   // Create a destination for the shared secret.
   size_t shared_secret_words = kP384SharedSecretBytes / sizeof(uint32_t);


### PR DESCRIPTION
Uses a CRC32 checksum to provide a lightweight integrity check on keys. The basic setup for this already existed, this commit just:
- fills in the stub
- corrects a few places that didn't write the checksum
- changes a couple fields in the key structs from `size_t` to `uint32_t`

The last item is so that we have consistency across platforms in how large the field is and can use `crc_add32` safely for host-side tests as well as device-side ones.