### PR TITLE
[doc] Update otbn_style_guide.md to correct out-of-date info about bn.mulqacc flags

### DIFF
--- a/doc/contributing/style_guides/otbn_style_guide.md
+++ b/doc/contributing/style_guides/otbn_style_guide.md
@@ -245,7 +245,7 @@ bn.sel w4, w1, w0, FG0.C
 
 It is also necessary to use a dummy instruction to eliminate the transient leakage.
 Be aware there are some [flag blanking limitations](https://github.com/lowRISC/opentitan/blob/82bcfcae473e779a77fdabd789476b479cca0077/hw/ip/otbn/rtl/otbn_alu_bignum.sv#L257-L266) on `bn.mulqacc` instructions.
-Note that only the whole-word writeback version of `bn.mulqacc` (`bn.mulqacc.wo`) affects flags.
+Note that only the writeback versions of `bn.mulqacc` (`bn.mulqacc.wo` and `bn.mulqacc.so`) affect flags.
 ```armasm
 /* Leakage (if w0, w1 contain two shares of a secret) */
 bn.mulqacc.wo w6, w4.0, w0.0, 0, FG0


### PR DESCRIPTION
This is a small change to update out-of-date info in the OTBN Assembly Style Guide re: side channel protections--the `bn.mulqacc.so` instruction as currently documented in OT does set flags, and there is code that relies on `bn.mulqacc.so` setting flags for correctness (e.g. `mod_mul_256x256` in `p256_base.s`).