### PR TITLE
[dv] fix disjoint bootstrap test

### DIFF
--- a/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_manuf_ate_tests.hjson
@@ -38,11 +38,11 @@
       sw_images: ["//sw/device/silicon_creator/manuf/tests:multislot_empty_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=160_000_000"
+        "+sw_test_timeout_ns=1_000_000_000"
         "+skip_flash_bkdr_load=1",
         "+use_spi_load_bootstrap=1",
       ]
-      run_timeout_mins: 180
+      run_timeout_mins: 800
     }
     {
       name: rom_e2e_bootstrap_ate_smoke


### PR DESCRIPTION
The test was timing out and there was also a logic error in the code that verifies the contents of flash after a bootstrap operation.