### PR TITLE
[crypto] Adjust keyblob remask routine.

### DIFF
--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -6,7 +6,10 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/random_order.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
@@ -204,22 +207,84 @@ status_t keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
   return keyblob_from_shares(share0, mask, config, keyblob);
 }
 
-status_t keyblob_remask(otcrypto_blinded_key_t *key, const uint32_t *mask) {
+/**
+ * Combines two word buffers with XOR.
+ *
+ * Callers should ensure the entropy complex is up before calling this
+ * function.  The implementation uses random-order hardening primitives for
+ * side-channel defense.
+ *
+ * @param[in,out] x Pointer to the first operand (modified in-place).
+ * @param y Pointer to the second operand.
+ * @param word_len Length in words of each operand.
+ */
+void hardened_xor(uint32_t *restrict x, const uint32_t *restrict y,
+                  size_t word_len) {
+  // Generate a random ordering.
+  random_order_t order;
+  random_order_init(&order, word_len);
+  size_t count = 0;
+  size_t expected_count = random_order_len(&order);
+
+  // Create some random values for decoy operations.
+  uint32_t decoys[8];
+  hardened_memshred(decoys, ARRAYSIZE(decoys));
+
+  // Cast pointers to `uintptr_t` to erase their provenance.
+  uintptr_t x_addr = (uintptr_t)x;
+  uintptr_t y_addr = (uintptr_t)y;
+  uintptr_t decoy_addr = (uintptr_t)&decoys;
+
+  // XOR the mask with the first share. This loop is modelled off the one in
+  // `hardened_memcpy`; see the comments there for more details.
+  size_t byte_len = word_len * sizeof(uint32_t);
+  for (; launderw(count) < expected_count; count = launderw(count) + 1) {
+    size_t byte_idx = launderw(random_order_advance(&order)) * sizeof(uint32_t);
+
+    // Prevent the compiler from re-ordering the loop.
+    barrierw(byte_idx);
+
+    // Calculate pointers. The x and y pointers might not be valid, but in this
+    // case they will not be selected.
+    uintptr_t xp = x_addr + byte_idx;
+    uintptr_t yp = y_addr + byte_idx;
+    uintptr_t decoy1 = decoy_addr + (byte_idx % sizeof(decoys));
+    uintptr_t decoy2 =
+        decoy_addr +
+        ((byte_idx + (sizeof(decoys) / 2) + sizeof(uint32_t)) % sizeof(decoys));
+
+    // Select in constant-time either the real pointers or decoys.
+    void *xv = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(byte_idx), byte_len), xp, decoy1));
+    void *yv = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(byte_idx), byte_len), yp, decoy2));
+
+    // Perform an XOR in either the decoy array or the real array.
+    write_32(read_32(xv) ^ read_32(yv), xv);
+  }
+  RANDOM_ORDER_HARDENED_CHECK_DONE(order);
+  HARDENED_CHECK_EQ(count, expected_count);
+}
+
+status_t keyblob_remask(otcrypto_blinded_key_t *key) {
   // Check that the key is masked with XOR.
   HARDENED_TRY(keyblob_ensure_xor_masked(key->config));
 
-  // Double-check the length of the keyblob.
-  HARDENED_TRY(check_keyblob_length(key));
+  // Check that the entropy complex is up and properly configured.
+  HARDENED_TRY(entropy_complex_check());
 
+  uint32_t *share0;
+  uint32_t *share1;
+  HARDENED_TRY(keyblob_to_shares(key, &share0, &share1));
+
+  // Generate a fresh mask the size of one share.
   size_t key_share_words = keyblob_share_num_words(key->config);
-  size_t keyblob_words = keyblob_num_words(key->config);
+  uint32_t mask[key_share_words];
+  hardened_memshred(mask, key_share_words);
 
-  // Construct a new keyblob by re-masking.
-  size_t i = 0;
-  for (; launder32(i) < keyblob_words; i++) {
-    key->keyblob[i] ^= mask[i % key_share_words];
-  }
-  HARDENED_CHECK_EQ(i, keyblob_words);
+  // XOR each share with the mask.
+  hardened_xor(share0, mask, key_share_words);
+  hardened_xor(share1, mask, key_share_words);
 
   // Update the key checksum.
   key->checksum = integrity_blinded_checksum(key);

--- a/sw/device/lib/crypto/impl/keyblob.h
+++ b/sw/device/lib/crypto/impl/keyblob.h
@@ -158,12 +158,14 @@ status_t keyblob_from_key_and_mask(const uint32_t *key, const uint32_t *mask,
  * keys are likely to be masked with arithmetic rather than boolean (XOR)
  * schemes, and this function cannot be used for them.
  *
+ * The entropy complex should be up and running when this function is called
+ * because of its internal use of hardening primitives like `random_order`.
+ *
  * @param key Blinded key to re-mask. Modified in-place.
- * @param mask Blinding parameter (fresh random mask).
  * @return Result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t keyblob_remask(otcrypto_blinded_key_t *key, const uint32_t *mask);
+status_t keyblob_remask(otcrypto_blinded_key_t *key);
 
 /**
  * Unmask and return the effective key from blinded key struct.

--- a/sw/device/lib/crypto/impl/keyblob_unittest.cc
+++ b/sw/device/lib/crypto/impl/keyblob_unittest.cc
@@ -8,6 +8,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 
@@ -313,21 +314,18 @@ TEST(Keyblob, ToKeymgrDiversificationDifferentModes) {
 TEST(Keyblob, RemaskDoesNotChangeKey) {
   std::array<uint32_t, 4> test_key = {0x01234567, 0x89abcdef, 0x00010203,
                                       0x04050607};
-  std::array<uint32_t, 4> test_mask0 = {0x08090a0b, 0x0c0d0e0f, 0x10111213,
-                                        0x14151617};
-  std::array<uint32_t, 4> test_mask1 = {0x18191a1b, 0x1c1d1e1f, 0x20212223,
-                                        0x24252627};
+  std::array<uint32_t, 4> test_mask = {0x08090a0b, 0x0c0d0e0f, 0x10111213,
+                                       0x14151617};
 
-  // Test assumption; key and masks are the correct size.
+  // Test assumption; key and mask are the correct size.
   ASSERT_EQ(test_key.size(), keyblob_share_num_words(kConfigCtr128));
-  ASSERT_EQ(test_mask0.size(), keyblob_share_num_words(kConfigCtr128));
-  ASSERT_EQ(test_mask1.size(), keyblob_share_num_words(kConfigCtr128));
+  ASSERT_EQ(test_mask.size(), keyblob_share_num_words(kConfigCtr128));
 
-  // Convert key and first mask to keyblob array.
+  // Convert key and initial mask to keyblob array.
   uint32_t keyblob_words = keyblob_num_words(kConfigCtr128);
   uint32_t keyblob_bytes = keyblob_words * sizeof(uint32_t);
   uint32_t keyblob[keyblob_words] = {0};
-  EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask0.data(),
+  EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask.data(),
                                       kConfigCtr128, keyblob));
 
   // Construct blinded key.
@@ -338,41 +336,39 @@ TEST(Keyblob, RemaskDoesNotChangeKey) {
       .checksum = 0,
   };
 
-  // Remask the key using the second mask.
-  EXPECT_OK(keyblob_remask(&key, test_mask1.data()));
+  // Copy the keyblob for later comparison.
+  uint32_t keyblob_copy[ARRAYSIZE(keyblob)];
+  memcpy(keyblob_copy, keyblob, sizeof(keyblob));
 
-  // Retrieve pointers to each share.
-  uint32_t *share0;
-  uint32_t *share1;
-  EXPECT_OK(keyblob_to_shares(&key, &share0, &share1));
+  // Remask the key.
+  EXPECT_OK(keyblob_remask(&key));
+
+  // Check that every word of the keyblob changed.
+  for (size_t i = 0; i < ARRAYSIZE(keyblob); i++) {
+    EXPECT_NE(keyblob[i], keyblob_copy[i]);
+  }
 
   // Unmask the key and check that it matches the original.
-  for (size_t i = 0; i < test_key.size(); i++) {
-    uint32_t share0 = keyblob[i];
-    uint32_t share1 = keyblob[test_key.size() + i];
-    EXPECT_EQ(share1, test_mask0[i] ^ test_mask1[i]);
-    EXPECT_EQ(share0 ^ share1, test_key[i]);
-  }
+  uint32_t unmasked_key[test_key.size()];
+  EXPECT_OK(keyblob_key_unmask(&key, test_key.size(), unmasked_key));
+  EXPECT_THAT(unmasked_key, testing::ElementsAreArray(test_key));
 }
 
-TEST(Keyblob, RemaskWithZero) {
+TEST(Keyblob, RemaskPassesIntegrity) {
   std::array<uint32_t, 4> test_key = {0x01234567, 0x89abcdef, 0x00010203,
                                       0x04050607};
-  std::array<uint32_t, 4> test_mask0 = {0x08090a0b, 0x0c0d0e0f, 0x10111213,
-                                        0x14151617};
-  std::array<uint32_t, 4> test_mask1 = {0x18191a1b, 0x1c1d1e1f, 0x20212223,
-                                        0x24252627};
+  std::array<uint32_t, 4> test_mask = {0x08090a0b, 0x0c0d0e0f, 0x10111213,
+                                       0x14151617};
 
-  // Test assumption; key and masks are the correct size.
+  // Test assumption; key and mask are the correct size.
   ASSERT_EQ(test_key.size(), keyblob_share_num_words(kConfigCtr128));
-  ASSERT_EQ(test_mask0.size(), keyblob_share_num_words(kConfigCtr128));
-  ASSERT_EQ(test_mask1.size(), keyblob_share_num_words(kConfigCtr128));
+  ASSERT_EQ(test_mask.size(), keyblob_share_num_words(kConfigCtr128));
 
-  // Convert key and first mask to keyblob array.
+  // Convert key and initial mask to keyblob array.
   uint32_t keyblob_words = keyblob_num_words(kConfigCtr128);
   uint32_t keyblob_bytes = keyblob_words * sizeof(uint32_t);
   uint32_t keyblob[keyblob_words] = {0};
-  EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask0.data(),
+  EXPECT_OK(keyblob_from_key_and_mask(test_key.data(), test_mask.data(),
                                       kConfigCtr128, keyblob));
 
   // Construct blinded key.
@@ -383,21 +379,15 @@ TEST(Keyblob, RemaskWithZero) {
       .checksum = 0,
   };
 
-  // Remask the key using the second mask.
-  EXPECT_OK(keyblob_remask(&key, test_mask1.data()));
+  // Copy the keyblob for later comparison.
+  uint32_t keyblob_copy[ARRAYSIZE(keyblob)];
+  memcpy(keyblob_copy, keyblob, sizeof(keyblob));
 
-  // Retrieve pointers to each share.
-  uint32_t *share0;
-  uint32_t *share1;
-  EXPECT_OK(keyblob_to_shares(&key, &share0, &share1));
+  // Remask the key.
+  EXPECT_OK(keyblob_remask(&key));
 
-  // Unmask the key and check that it matches the original.
-  for (size_t i = 0; i < test_key.size(); i++) {
-    uint32_t share0 = keyblob[i];
-    uint32_t share1 = keyblob[test_key.size() + i];
-    EXPECT_EQ(share1, test_mask0[i] ^ test_mask1[i]);
-    EXPECT_EQ(share0 ^ share1, test_key[i]);
-  }
+  // Check that the integrity checksum was updated.
+  EXPECT_EQ(integrity_blinded_key_check(&key), kHardenedBoolTrue);
 }
 
 }  // namespace


### PR DESCRIPTION
Use the newly filled-in `random_order` primitive to harden the loop, and get randomness with `hardened_memshred` rather than an argument.