### PR TITLE
[base] Increase the period of decoy pairs in `hardened_memory.c`.

### DIFF
--- a/sw/device/lib/base/hardened_memory.c
+++ b/sw/device/lib/base/hardened_memory.c
@@ -57,7 +57,8 @@ void hardened_memcpy(uint32_t *restrict dest, const uint32_t *restrict src,
     uintptr_t destp = dest_addr + byte_idx;
     uintptr_t decoy1 = decoy_addr + (byte_idx % sizeof(decoys));
     uintptr_t decoy2 =
-        decoy_addr + ((byte_idx + sizeof(decoys) / 2) % sizeof(decoys));
+        decoy_addr +
+        ((byte_idx + (sizeof(decoys) / 2) + sizeof(uint32_t)) % sizeof(decoys));
 
     // Branchlessly select whether to do a "real" copy or a decoy copy,
     // depending on whether we've gone off the end of the array or not.
@@ -143,7 +144,8 @@ hardened_bool_t hardened_memeq(const uint32_t *lhs, const uint32_t *rhs,
     uintptr_t bp = rhs_addr + byte_idx;
     uintptr_t decoy1 = decoy_addr + (byte_idx % sizeof(decoys));
     uintptr_t decoy2 =
-        decoy_addr + ((byte_idx + sizeof(decoys) / 2) % sizeof(decoys));
+        decoy_addr +
+        ((byte_idx + (sizeof(decoys) / 2) + sizeof(uint32_t)) % sizeof(decoys));
 
     void *av = (void *)launderw(
         ct_cmovw(ct_sltuw(launderw(byte_idx), byte_len), ap, decoy1));


### PR DESCRIPTION
Follow-up from @pqcfox 's review on #27242 : https://github.com/lowRISC/opentitan/pull/27242#discussion_r2096310740

Adds a word-offset of 1 to the index of the second decoy in `hardened_memcpy` so that we have more possible source/d
destination pairs. Otherwise, there would only be 4 possible unique pairs; 4 word-sized increments after `decoy[3] = decoy[7]` would be `decoy[7] = decoy[3]`. Adding an offset results in 8 unique pairs for minimal overhead.

This doesn't really have an effect on `hardened_memeq` since all the decoys have to be equal there, but I changed it there anyway just to keep the pattern consistent.