### PR TITLE
[crypto] Store P-256 and P-384 keys in the scratchpad.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -18,16 +18,16 @@ OTBN_DECLARE_APP_SYMBOLS(run_p256);  // The OTBN P-256 app.
 static const otbn_app_t kOtbnAppP256 = OTBN_APP_T_INIT(run_p256);
 
 // Declare offsets for input and output buffers.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, mode);  // Mode of operation.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, msg);   // ECDSA message digest.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, r);     // ECDSA signature scalar R.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, s);     // ECDSA signature scalar S.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, x);     // Public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, y);     // Public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, d0);    // Private key scalar d (share 0).
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, d1);    // Private key scalar d (share 1).
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, x_r);   // ECDSA verification result.
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, ok);    // Status code.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, mode);   // Mode of operation.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, msg);    // ECDSA message digest.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, r);      // ECDSA signature scalar R.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, s);      // ECDSA signature scalar S.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, x);      // Public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, y);      // Public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, d0_io);  // Private key scalar d (share 0).
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, d1_io);  // Private key scalar d (share 1).
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, x_r);    // ECDSA verification result.
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, ok);     // Status code.
 
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(run_p256, mode);
 static const otbn_addr_t kOtbnVarMsg = OTBN_ADDR_T_INIT(run_p256, msg);
@@ -35,8 +35,8 @@ static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(run_p256, r);
 static const otbn_addr_t kOtbnVarS = OTBN_ADDR_T_INIT(run_p256, s);
 static const otbn_addr_t kOtbnVarX = OTBN_ADDR_T_INIT(run_p256, x);
 static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(run_p256, y);
-static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(run_p256, d0);
-static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(run_p256, d1);
+static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(run_p256, d0_io);
+static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(run_p256, d1_io);
 static const otbn_addr_t kOtbnVarXr = OTBN_ADDR_T_INIT(run_p256, x_r);
 static const otbn_addr_t kOtbnVarOk = OTBN_ADDR_T_INIT(run_p256, ok);
 

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -18,16 +18,16 @@ OTBN_DECLARE_APP_SYMBOLS(run_p384);
 static const otbn_app_t kOtbnAppP384 = OTBN_APP_T_INIT(run_p384);
 
 // Declare offsets for input and output buffers.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, mode);  // Mode of operation.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, msg);   // ECDSA message digest.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, r);     // ECDSA signature scalar R.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, s);     // ECDSA signature scalar S.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, x);     // Public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, y);     // Public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, d0);    // Private key scalar d (share 0).
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, d1);    // Private key scalar d (share 1).
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, x_r);   // ECDSA verification result.
-OTBN_DECLARE_SYMBOL_ADDR(run_p384, ok);    // Status code.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, mode);   // Mode of operation.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, msg);    // ECDSA message digest.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, r);      // ECDSA signature scalar R.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, s);      // ECDSA signature scalar S.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, x);      // Public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, y);      // Public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, d0_io);  // Private key scalar d (share 0).
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, d1_io);  // Private key scalar d (share 1).
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, x_r);    // ECDSA verification result.
+OTBN_DECLARE_SYMBOL_ADDR(run_p384, ok);     // Status code.
 
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(run_p384, mode);
 static const otbn_addr_t kOtbnVarMsg = OTBN_ADDR_T_INIT(run_p384, msg);
@@ -35,8 +35,8 @@ static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(run_p384, r);
 static const otbn_addr_t kOtbnVarS = OTBN_ADDR_T_INIT(run_p384, s);
 static const otbn_addr_t kOtbnVarX = OTBN_ADDR_T_INIT(run_p384, x);
 static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(run_p384, y);
-static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(run_p384, d0);
-static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(run_p384, d1);
+static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(run_p384, d0_io);
+static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(run_p384, d1_io);
 static const otbn_addr_t kOtbnVarXr = OTBN_ADDR_T_INIT(run_p384, x_r);
 static const otbn_addr_t kOtbnVarOk = OTBN_ADDR_T_INIT(run_p384, ok);
 

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -43,8 +43,8 @@ OTBN_DECLARE_SYMBOL_ADDR(run_p256, r);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, s);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, x);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, y);
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, d0);
-OTBN_DECLARE_SYMBOL_ADDR(run_p256, d1);
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, d0_io);
+OTBN_DECLARE_SYMBOL_ADDR(run_p256, d1_io);
 OTBN_DECLARE_SYMBOL_ADDR(run_p256, x_r);
 
 static const otbn_app_t kOtbnAppP256Ecdsa = OTBN_APP_T_INIT(run_p256);
@@ -55,8 +55,8 @@ static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(run_p256, r);
 static const otbn_addr_t kOtbnVarS = OTBN_ADDR_T_INIT(run_p256, s);
 static const otbn_addr_t kOtbnVarX = OTBN_ADDR_T_INIT(run_p256, x);
 static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(run_p256, y);
-static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(run_p256, d0);
-static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(run_p256, d1);
+static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(run_p256, d0_io);
+static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(run_p256, d1_io);
 static const otbn_addr_t kOtbnVarXR = OTBN_ADDR_T_INIT(run_p256, x_r);
 
 // Declare mode constants.

--- a/sw/otbn/crypto/run_p256.s
+++ b/sw/otbn/crypto/run_p256.s
@@ -113,6 +113,9 @@ start:
  * clobbered flag groups: none
  */
 copy_share:
+  /* Randomize the content of w10 to prevent leakage. */
+  bn.wsrr  w10, URND
+
   /* Copy the secret key shares into Ibex-visible memory. */
   li       x10, 10
   bn.lid   x10, 0(x13)

--- a/sw/otbn/crypto/run_p384.s
+++ b/sw/otbn/crypto/run_p384.s
@@ -112,6 +112,9 @@ start:
  * clobbered flag groups: none
  */
 copy_share:
+  /* Randomize the content of w10 to prevent leakage. */
+  bn.wsrr  w10, URND
+
   /* Copy the secret key shares into Ibex-visible memory. */
   li       x10, 10
   bn.lid   x10, 0(x13)

--- a/sw/otbn/crypto/run_p384.s
+++ b/sw/otbn/crypto/run_p384.s
@@ -15,7 +15,7 @@
  * 7. MODE_SIDELOAD_ECDH: ECDH key exchange using a secret key from a sideloaded seed
  */
 
- /**
+/**
  * Mode magic values generated with
  * $ ./util/design/sparse-fsm-encode.py -d 6 -m 4 -n 11 --avoid-zero -s 1654842154
  *
@@ -64,14 +64,8 @@ start:
   addi  x3, x0, MODE_KEYGEN
   beq   x2, x3, keypair_random
 
-  addi  x3, x0, MODE_SIGN
-  beq   x2, x3, ecdsa_sign
-
   addi  x3, x0, MODE_VERIFY
   beq   x2, x3, ecdsa_verify
-
-  addi  x3, x0, MODE_ECDH
-  beq   x2, x3, shared_key
 
   addi  x3, x0, MODE_SIDELOAD_KEYGEN
   beq   x2, x3, keypair_from_seed
@@ -82,10 +76,49 @@ start:
   addi  x3, x0, MODE_SIDELOAD_ECDH
   beq   x2, x3, shared_key_from_seed
 
+  /* Copy the caller-provided secret key shares into scratchpad memory.
+       dmem[d0] <= dmem[d0_io]
+       dmem[d1] <= dmem[d1_io] */
+  la       x13, d0_io
+  la       x14, d0
+  jal      x1, copy_share
+  la       x13, d1_io
+  la       x14, d1
+  jal      x1, copy_share
+
+  addi  x3, x0, MODE_SIGN
+  beq   x2, x3, ecdsa_sign
+
+  addi  x3, x0, MODE_ECDH
+  beq   x2, x3, shared_key
+
   /* Invalid mode; fail. */
   unimp
   unimp
   unimp
+
+/**
+ * Helper routine to copy secret key shares.
+ *
+ * Copies 64 bytes from the source to destination location in DMEM. The source
+ * and destination may be the same but should not otherwise overlap.
+ *
+ * @param x13: dptr_src, pointer to source DMEM location
+ * @param x14: dptr_dst, pointer to destination DMEM location
+ * @param      dmem[dptr_src..dptr_src+64]: source data
+ * @param[out] dmem[dptr_dst..dptr_dst+64]: copied data
+ *
+ * clobbered registers: x10, w10
+ * clobbered flag groups: none
+ */
+copy_share:
+  /* Copy the secret key shares into Ibex-visible memory. */
+  li       x10, 10
+  bn.lid   x10, 0(x13)
+  bn.sid   x10, 0(x14)
+  bn.lid   x10, 32(x13)
+  bn.sid   x10, 32(x14)
+  ret
 
 /**
  * Generate a fresh random keypair.
@@ -116,6 +149,16 @@ keypair_random:
        dmem[x] <= (d*G).x
        dmem[y] <= (d*G).y */
   jal       x1, p384_base_mult
+
+  /* Copy the secret key shares into Ibex-visible memory.
+       dmem[d0_io] <= dmem[d0]
+       dmem[d1_io] <= dmem[d1] */
+  la       x13, d0
+  la       x14, d0_io
+  jal      x1, copy_share
+  la       x13, d1
+  la       x14, d1_io
+  jal      x1, copy_share
 
   ecall
 
@@ -378,14 +421,14 @@ x:
 y:
   .zero 64
 
-/* Private key (d) in two shares: d = (d0 + d1) mod n. */
-.globl d0
+/* Private key input/output buffer. */
+.globl d0_io
 .balign 32
-d0:
+d0_io:
   .zero 64
-.globl d1
+.globl d1_io
 .balign 32
-d1:
+d1_io:
   .zero 64
 
 /* Verification result x_r (aka x_1). */
@@ -405,4 +448,14 @@ k0:
 .globl k1
 .balign 32
 k1:
+  .zero 64
+
+/* Private key (d) in two shares: d = (d0 + d1) mod n. */
+.globl d0
+.balign 32
+d0:
+  .zero 64
+.globl d1
+.balign 32
+d1:
   .zero 64


### PR DESCRIPTION
Resolves #19875 

This was planned anyway but actually ends up being a helpful step to do before the ECC part of https://github.com/lowRISC/opentitan/issues/27243, because now we have an easy place to apply re-masking (at the same time the keys are moved).