### PR TITLE
[crypto] Change P-384 data to use .bss.

### DIFF
--- a/sw/otbn/crypto/run_p384.s
+++ b/sw/otbn/crypto/run_p384.s
@@ -334,7 +334,7 @@ shared_key_from_seed:
   jal       x0, shared_key
 
 
-.data
+.bss
 
 /* Operational mode. */
 .globl mode


### PR DESCRIPTION
This means the binary doesn't store a bunch of zeroes for no reason. Saves over 400 bytes of space. Found this in passing while working on https://github.com/lowRISC/opentitan/pull/27249

Requires setting padding on some of the buffers, since otherwise OTBN will lock in response to reading uninitialized memory.