### PR TITLE
[ujson] enable skipping CRC sent with UJSON payloads

### DIFF
--- a/sw/device/lib/testing/test_framework/ujson_ottf.h
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.h
@@ -61,6 +61,22 @@ ujson_t ujson_ottf_console(void);
   })
 
 /**
+ * Adds an empty CRC field to the response.
+ *
+ * Should not be used directly.
+ * It is used by other macros such as `RESP_OK_NO_CRC`.
+ *
+ * @param uj_ctx_ A `ujson_t` representing the IO context.
+ */
+#define RESP_NO_CRC(uj_ctx_)                \
+  ({                                        \
+    TRY(ujson_putbuf(uj_ctx_, " CRC:", 5)); \
+    TRY(ujson_putbuf(uj_ctx_, "0\n", 2));   \
+    TRY(ujson_flushbuf(uj));                \
+    OK_STATUS();                            \
+  })
+
+/**
  * Add a CRC to the response.
  * Should not be used directly.
  * It is used by other macros such as `RESP_ERR`.
@@ -78,7 +94,22 @@ ujson_t ujson_ottf_console(void);
   })
 
 /**
- * Respond with an OK result and JSON encoded data.
+ * Respond with an OK result, JSON encoded data, and empty CRC.
+ *
+ * @param responder_ A ujson serializer function for `data_`.
+ * @param uj_ctx_ A `ujson_t` representing the IO context.
+ * @param data_ A pointer to the data to send.
+ */
+#define RESP_OK_NO_CRC(responder_, uj_ctx_, data_) \
+  ({                                               \
+    TRY(ujson_putbuf(uj_ctx_, "RESP_OK:", 8));     \
+    TRY(responder_(uj_ctx_, data_));               \
+    RESP_NO_CRC(uj_ctx_);                          \
+    OK_STATUS();                                   \
+  })
+
+/**
+ * Respond with an OK result, JSON encoded data, and valid CRC.
  *
  * @param responder_ A ujson serializer function for `data_`.
  * @param uj_ctx_ A `ujson_t` representing the IO context.

--- a/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/ujson_msg_size_functest.c
@@ -77,10 +77,11 @@ static status_t send_ujson_msgs(ujson_t *uj) {
   memset(&perso_blob_msg.body, UINT8_MAX, sizeof(perso_blob_msg.body));
 
   // TX payloads to the host.
-  RESP_OK(ujson_serialize_serdes_sha256_hash_t, uj, &sha256_hash_msg);
-  RESP_OK(ujson_serialize_lc_token_hash_t, uj, &lc_token_hash_msg);
-  RESP_OK(ujson_serialize_manuf_certgen_inputs_t, uj, &certgen_inputs_msg);
-  RESP_OK(ujson_serialize_perso_blob_t, uj, &perso_blob_msg);
+  RESP_OK_NO_CRC(ujson_serialize_serdes_sha256_hash_t, uj, &sha256_hash_msg);
+  RESP_OK_NO_CRC(ujson_serialize_lc_token_hash_t, uj, &lc_token_hash_msg);
+  RESP_OK_NO_CRC(ujson_serialize_manuf_certgen_inputs_t, uj,
+                 &certgen_inputs_msg);
+  RESP_OK_NO_CRC(ujson_serialize_perso_blob_t, uj, &perso_blob_msg);
 
   // RX payloads echoed back by host.
   TRY(ujson_deserialize_serdes_sha256_hash_t(uj, &sha256_hash_msg));

--- a/sw/host/opentitanlib/src/test_utils/gpio.rs
+++ b/sw/host/opentitanlib/src/test_utils/gpio.rs
@@ -17,7 +17,7 @@ impl GpioSet {
     fn execute(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::GpioSet.send(uart)?;
         self.send(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 
@@ -148,7 +148,7 @@ impl GpioSet {
 impl GpioGet {
     pub fn read_all(uart: &dyn Uart) -> Result<u32> {
         TestCommand::GpioGet.send(uart)?;
-        let data = GpioGet::recv(uart, Duration::from_secs(300), false)?;
+        let data = GpioGet::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(data.state)
     }
 }

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -17,7 +17,7 @@ impl I2cTargetAddress {
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::I2cTargetAddress.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -42,7 +42,7 @@ impl I2cTransferStart {
         TestCommand::I2cStartTransferRead.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
         f()?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 
@@ -52,7 +52,7 @@ impl I2cTransferStart {
     {
         TestCommand::I2cStartTransferWrite.send_with_crc(uart)?;
         f()?;
-        Self::recv(uart, Duration::from_secs(300), false)
+        Self::recv(uart, Duration::from_secs(300), false, false)
     }
 
     pub fn execute_write_slow<F>(uart: &dyn Uart, f: F) -> Result<Self>
@@ -61,7 +61,7 @@ impl I2cTransferStart {
     {
         TestCommand::I2cStartTransferWriteSlow.send_with_crc(uart)?;
         f()?;
-        Self::recv(uart, Duration::from_secs(300), false)
+        Self::recv(uart, Duration::from_secs(300), false, false)
     }
 
     pub fn execute_write_read<F>(&self, uart: &dyn Uart, f: F) -> Result<Self>
@@ -71,7 +71,7 @@ impl I2cTransferStart {
         TestCommand::I2cStartTransferWriteRead.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
         f()?;
-        Self::recv(uart, Duration::from_secs(300), false)
+        Self::recv(uart, Duration::from_secs(300), false, false)
     }
 }
 
@@ -79,7 +79,7 @@ impl I2cTestConfig {
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::I2cTestConfig.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/test_utils/mem.rs
+++ b/sw/host/opentitanlib/src/test_utils/mem.rs
@@ -22,7 +22,7 @@ impl MemRead32Req {
         TestCommand::MemRead32.send_with_crc(device)?;
         let op = MemRead32Req { address };
         op.send_with_crc(device)?;
-        let resp = MemRead32Resp::recv(device, Duration::from_secs(300), false)?;
+        let resp = MemRead32Resp::recv(device, Duration::from_secs(300), false, false)?;
         Ok(resp.value)
     }
 }
@@ -46,7 +46,7 @@ impl MemReadReq {
                 data_len: op_size.try_into().unwrap(),
             };
             op.send_with_crc(device)?;
-            let resp = MemReadResp::recv(device, Duration::from_secs(300), false)?;
+            let resp = MemReadResp::recv(device, Duration::from_secs(300), false, false)?;
             data[bytes_read..(bytes_read + op_size)].copy_from_slice(resp.data.as_slice());
             bytes_read += op_size;
         }
@@ -62,7 +62,7 @@ impl MemWrite32Req {
         TestCommand::MemWrite32.send_with_crc(device)?;
         let op = MemWrite32Req { address, value };
         op.send_with_crc(device)?;
-        Status::recv(device, Duration::from_secs(300), false)?;
+        Status::recv(device, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -86,7 +86,7 @@ impl MemWriteReq {
                 .try_extend_from_slice(&data[bytes_written..(bytes_written + op_size)])?;
             op.data_len = op_size.try_into().unwrap();
             op.send_with_crc(device)?;
-            let _ = Status::recv(device, Duration::from_secs(300), false)?;
+            let _ = Status::recv(device, Duration::from_secs(300), false, false)?;
             bytes_written += op_size;
         }
         Ok(())

--- a/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
+++ b/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
@@ -73,7 +73,7 @@ impl PinmuxConfig {
             }
             TestCommand::PinmuxConfig.send(uart)?;
             config.send(uart)?;
-            Status::recv(uart, Duration::from_secs(300), false)?;
+            Status::recv(uart, Duration::from_secs(300), false, false)?;
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/test_utils/rpc.rs
+++ b/sw/host/opentitanlib/src/test_utils/rpc.rs
@@ -52,7 +52,7 @@ pub trait ConsoleRecv<T>
 where
     T: ConsoleDevice + ?Sized,
 {
-    fn recv(device: &T, timeout: Duration, quiet: bool) -> Result<Self>
+    fn recv(device: &T, timeout: Duration, quiet: bool, skip_crc: bool) -> Result<Self>
     where
         Self: Sized;
 }
@@ -62,7 +62,7 @@ where
     T: ConsoleDevice + ?Sized,
     U: DeserializeOwned,
 {
-    fn recv(device: &T, timeout: Duration, quiet: bool) -> Result<Self>
+    fn recv(device: &T, timeout: Duration, quiet: bool, skip_crc: bool) -> Result<Self>
     where
         Self: Sized,
     {
@@ -90,7 +90,9 @@ where
                     .expect("RESP_OK capture");
                 let json_str = cap.get(1).expect("RESP_OK group").as_str();
                 let crc_str = cap.get(2).expect("CRC group").as_str();
-                check_crc(json_str, crc_str)?;
+                if !skip_crc {
+                    check_crc(json_str, crc_str)?;
+                }
                 Ok(serde_json::from_str::<Self>(json_str)?)
             }
             ExitStatus::ExitFailure => {

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -17,7 +17,7 @@ impl ConfigJedecId {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiConfigureJedecId.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -25,13 +25,13 @@ impl ConfigJedecId {
 impl StatusRegister {
     pub fn read(uart: &dyn Uart) -> Result<Self> {
         TestCommand::SpiReadStatus.send_with_crc(uart)?;
-        Self::recv(uart, Duration::from_secs(300), false)
+        Self::recv(uart, Duration::from_secs(300), false, false)
     }
 
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiWriteStatus.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -40,7 +40,7 @@ impl SfdpData {
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiWriteSfdp.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -52,14 +52,14 @@ impl UploadInfo {
     {
         TestCommand::SpiWaitForUpload.send_with_crc(uart)?;
         f()?;
-        Self::recv(uart, Duration::from_secs(300), false)
+        Self::recv(uart, Duration::from_secs(300), false, false)
     }
 }
 
 impl SpiFlashReadId {
     pub fn execute(uart: &dyn Uart) -> Result<Self> {
         TestCommand::SpiFlashReadId.send_with_crc(uart)?;
-        let data = SpiFlashReadId::recv(uart, Duration::from_secs(300), false)?;
+        let data = SpiFlashReadId::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(data)
     }
 }
@@ -68,7 +68,7 @@ impl SpiFlashReadSfdp {
     pub fn execute(&self, uart: &dyn Uart) -> Result<SfdpData> {
         TestCommand::SpiFlashReadSfdp.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        let sfdp = SfdpData::recv(uart, Duration::from_secs(300), false)?;
+        let sfdp = SfdpData::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(sfdp)
     }
 }
@@ -77,7 +77,7 @@ impl SpiFlashEraseSector {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiFlashEraseSector.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -86,7 +86,7 @@ impl SpiFlashWrite {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiFlashWrite.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -95,7 +95,7 @@ impl SpiPassthruSwapMap {
     pub fn apply_address_swap(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiPassthruSetAddressMap.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -104,13 +104,13 @@ impl SpiMailboxMap {
     pub fn apply(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiMailboxMap.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 
     pub fn disable(uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiMailboxUnmap.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }
@@ -119,7 +119,7 @@ impl SpiMailboxWrite {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
         TestCommand::SpiMailboxWrite.send_with_crc(uart)?;
         self.send_with_crc(uart)?;
-        Status::recv(uart, Duration::from_secs(300), false)?;
+        Status::recv(uart, Duration::from_secs(300), false, false)?;
         Ok(())
     }
 }

--- a/sw/host/provisioning/cp_lib/src/lib.rs
+++ b/sw/host/provisioning/cp_lib/src/lib.rs
@@ -135,7 +135,7 @@ pub fn run_sram_cp_provision(
 
     // Wait to receive CP device ID, and encode in big-endian in response.
     let _ = UartConsole::wait_for(spi_console, r"Exporting CP device ID ...", timeout)?;
-    response.cp_device_id = ManufCpProvisioningDataOut::recv(spi_console, timeout, true)?
+    response.cp_device_id = ManufCpProvisioningDataOut::recv(spi_console, timeout, true, false)?
         .cp_device_id
         .iter()
         .rev()

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -355,7 +355,12 @@ fn provision_certificates(
     // Wait until the device exports the TBS certificates.
     let t0 = Instant::now();
     let _ = UartConsole::wait_for(spi_console, r"Exporting TBS certificates ...", timeout)?;
-    let perso_blob = PersoBlob::recv(spi_console, timeout, /*quite=*/ true)?;
+    let perso_blob = PersoBlob::recv(
+        spi_console,
+        timeout,
+        /*quiet=*/ true,
+        /*skip_crc=*/ true,
+    )?;
     response.stats.log_elapsed_time("perso-tbs-export", t0);
 
     // Extract certificate byte vectors, endorse TBS certs, and ensure they parse with OpenSSL.
@@ -517,7 +522,13 @@ fn provision_certificates(
 
     // Check the integrity of the certificates written to the device's flash by comparing a
     // SHA256 over all certificates computed on the host and device sides.
-    let device_computed_certs_hash = SerdesSha256Hash::recv(spi_console, timeout, false)?;
+    let device_computed_certs_hash = SerdesSha256Hash::recv(
+        spi_console,
+        timeout,
+        /*quiet=*/ false,
+        /*skip_crc=*/ true,
+    )?;
+
     if !device_computed_certs_hash
         .data
         .as_bytes()

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -138,7 +138,7 @@ fn test_wakeup_normal_sleep(opts: &Opts, transport: &TransportWrapper, address: 
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
     let result = i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut buf)]);
     log::info!("Transaction error: {}", result.is_err());
-    Status::recv(&*uart, Duration::from_secs(5), false)?;
+    Status::recv(&*uart, Duration::from_secs(5), false, false)?;
     log::info!("Chip is awake.  Reissuing read transaction.");
     test_read_transaction(opts, transport, address)
 }
@@ -157,7 +157,7 @@ fn test_wakeup_deep_sleep(
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
     let result = i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut buf)]);
     log::info!("Transaction error: {}", result.is_err());
-    Status::recv(&*uart, Duration::from_secs(5), false)?;
+    Status::recv(&*uart, Duration::from_secs(5), false, false)?;
     log::info!("Chip is awake.  Reissuing read transaction.");
     test_set_target_address(opts, transport, instance)?;
     test_read_transaction(opts, transport, address)

--- a/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
+++ b/sw/host/tests/chip/ottf_console_with_gpio_tx_indicator/src/main.rs
@@ -64,7 +64,7 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     }
 
     // Receive the UJSON string transmitted and verify its contents.
-    let perso_blob = PersoBlob::recv(&spi_console_device, opts.timeout, true)?;
+    let perso_blob = PersoBlob::recv(&spi_console_device, opts.timeout, true, false)?;
     for i in 0..perso_blob.body.len() {
         assert_eq!(perso_blob.body[i], (i % 256) as u8);
     }

--- a/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
@@ -40,7 +40,7 @@ const SYNC_MSG: &str = r"SYNC:.*\r\n";
 
 fn test_perso_blob_strcut(opts: &Opts, spi_console: &SpiConsoleDevice) -> Result<()> {
     UartConsole::wait_for(spi_console, SYNC_MSG, opts.timeout)?;
-    let perso_blob = PersoBlob::recv(spi_console, opts.timeout, true)?;
+    let perso_blob = PersoBlob::recv(spi_console, opts.timeout, true, false)?;
     UartConsole::wait_for(spi_console, SYNC_MSG, opts.timeout)?;
     perso_blob.send(spi_console)?;
     Ok(())

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -120,7 +120,7 @@ fn run_aes_testcase(
     }
     .send(spi_console)?;
 
-    let aes_output = CryptotestAesOutput::recv(spi_console, opts.timeout, false)?;
+    let aes_output = CryptotestAesOutput::recv(spi_console, opts.timeout, false, false)?;
     assert_eq!(
         aes_output.output[0..input_len],
         expected_output[0..input_len]

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -98,7 +98,7 @@ fn run_drbg_testcase(
     .send(spi_console)?;
 
     // Get output
-    let drbg_output = CryptotestDrbgOutput::recv(spi_console, opts.timeout, false)?;
+    let drbg_output = CryptotestDrbgOutput::recv(spi_console, opts.timeout, false, false)?;
     // The expected output is in a mixed-endian format (32-bit words
     // are in little-endian order, but the bytes within the words are
     // in big-endian order). Convert the actual output to match this

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -196,7 +196,7 @@ fn run_ecdh_testcase(
     }
     .send(spi_console)?;
 
-    let ecdh_output = CryptotestEcdhDeriveOutput::recv(spi_console, opts.timeout, false)?;
+    let ecdh_output = CryptotestEcdhDeriveOutput::recv(spi_console, opts.timeout, false, false)?;
     let out_len = ecdh_output.shared_secret_len;
     if out_len > ecdh_output.shared_secret.len() {
         panic!("ECDH returned shared secret was too long for device firmware configuration.");

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -450,7 +450,7 @@ fn run_ecdsa_testcase(
     let success = match operation {
         CryptotestEcdsaOperation::Sign => {
             let mut output_signature =
-                CryptotestEcdsaSignature::recv(spi_console, opts.timeout, false)?;
+                CryptotestEcdsaSignature::recv(spi_console, opts.timeout, false, false)?;
             // Truncate signature values to correct size for curve and convert to big-endian
             output_signature.r.truncate(output_signature.r_len);
             output_signature.s.truncate(output_signature.s_len);
@@ -477,7 +477,8 @@ fn run_ecdsa_testcase(
             }
         }
         CryptotestEcdsaOperation::Verify => {
-            let ecdsa_output = CryptotestEcdsaVerifyOutput::recv(spi_console, opts.timeout, false)?;
+            let ecdsa_output =
+                CryptotestEcdsaVerifyOutput::recv(spi_console, opts.timeout, false, false)?;
             match ecdsa_output {
                 CryptotestEcdsaVerifyOutput::Success => true,
                 CryptotestEcdsaVerifyOutput::Failure => false,

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -114,7 +114,7 @@ fn run_hash_testcase(
     .send(spi_console)?;
 
     // Get hash output
-    let hash_output = CryptotestHashOutput::recv(spi_console, opts.timeout, false)?;
+    let hash_output = CryptotestHashOutput::recv(spi_console, opts.timeout, false, false)?;
     // Stepwise hashing is currently supported by SHA2 only.
     let mut failed = false;
     match test_case.algorithm.as_str() {

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -100,7 +100,7 @@ fn run_hmac_testcase(
     }
     .send(spi_console)?;
 
-    let hmac_tag = CryptotestHmacTag::recv(spi_console, opts.timeout, false)?;
+    let hmac_tag = CryptotestHmacTag::recv(spi_console, opts.timeout, false, false)?;
     let success = if test_case.tag.len() > hmac_tag.tag_len {
         // If we got a shorter tag back then the test asks for, we can't accept the tag, even if
         // the beginning bytes match.

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -121,7 +121,7 @@ fn run_kmac_testcase(
     }
     .send(spi_console)?;
 
-    let kmac_tag = CryptotestKmacTag::recv(spi_console, opts.timeout, false)?;
+    let kmac_tag = CryptotestKmacTag::recv(spi_console, opts.timeout, false, false)?;
     // Cryptolib could have chosen to return more tag bytes than we asked for. If it did, we can
     // ignore the extra ones.
     let success = test_case.tag[..] == kmac_tag.tag[..test_case.tag.len()];

--- a/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
+++ b/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
@@ -105,13 +105,14 @@ fn run_sphincsplus_testcase(
     .send(spi_console)?;
 
     // Get verification output
-    let success = match CryptotestSphincsPlusVerifyOutput::recv(spi_console, opts.timeout, false)? {
-        CryptotestSphincsPlusVerifyOutput::Success => true,
-        CryptotestSphincsPlusVerifyOutput::Failure => false,
-        CryptotestSphincsPlusVerifyOutput::IntValue(i) => {
-            panic!("Invalid SPHINCS+ verify result: {}", i)
-        }
-    };
+    let success =
+        match CryptotestSphincsPlusVerifyOutput::recv(spi_console, opts.timeout, false, false)? {
+            CryptotestSphincsPlusVerifyOutput::Success => true,
+            CryptotestSphincsPlusVerifyOutput::Failure => false,
+            CryptotestSphincsPlusVerifyOutput::IntValue(i) => {
+                panic!("Invalid SPHINCS+ verify result: {}", i)
+            }
+        };
     if test_case.result != success {
         log::info!(
             "FAILED test #{}: expected = {}, actual = {}",

--- a/sw/host/tests/manuf/manuf_ujson_msg_size/src/main.rs
+++ b/sw/host/tests/manuf/manuf_ujson_msg_size/src/main.rs
@@ -50,11 +50,30 @@ fn main() -> Result<()> {
     )?;
 
     // Receive the payloads from the device.
-    let sha256_hash = SerdesSha256Hash::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
-    let lc_token_hash = LcTokenHash::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
-    let certgen_inputs =
-        ManufCertgenInputs::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
-    let perso_blob = PersoBlob::recv(&spi_console, opts.timeout, /*quiet=*/ true)?;
+    let sha256_hash = SerdesSha256Hash::recv(
+        &spi_console,
+        opts.timeout,
+        /*quiet=*/ true,
+        /*skip_crc=*/ true,
+    )?;
+    let lc_token_hash = LcTokenHash::recv(
+        &spi_console,
+        opts.timeout,
+        /*quiet=*/ true,
+        /*skip_crc=*/ true,
+    )?;
+    let certgen_inputs = ManufCertgenInputs::recv(
+        &spi_console,
+        opts.timeout,
+        /*quiet=*/ true,
+        /*skip_crc=*/ true,
+    )?;
+    let perso_blob = PersoBlob::recv(
+        &spi_console,
+        opts.timeout,
+        /*quiet=*/ true,
+        /*skip_crc=*/ true,
+    )?;
 
     // Send the payloads back to the device.
     let sha256_hash_str = sha256_hash.send(&spi_console)?;

--- a/sw/host/tests/rescue/rescue_test.rs
+++ b/sw/host/tests/rescue/rescue_test.rs
@@ -98,11 +98,14 @@ fn get_boot_log_test(
     let image = image::Image::read_from_file(binary)?;
     let rescue = params.create(transport)?;
     rescue.enter(transport, EntryMode::Reset)?;
-    let boot_log = rescue.get_boot_log().context("Failed to get boot log from rescue")?;
-    let rom_ext_manifest = image.subimages()?
-    .get(0)
-    .ok_or_else(|| anyhow!("No subimages found in the image"))?
-    .manifest;
+    let boot_log = rescue
+        .get_boot_log()
+        .context("Failed to get boot log from rescue")?;
+    let rom_ext_manifest = image
+        .subimages()?
+        .get(0)
+        .ok_or_else(|| anyhow!("No subimages found in the image"))?
+        .manifest;
     if boot_log.rom_ext_major != rom_ext_manifest.version_major {
         return Err(anyhow!(
             "rom_ext_major mismatch. Expected: {}, but got: {}",

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -322,7 +322,7 @@ fn test_chip_specific_startup(opts: &Opts, transport: &TransportWrapper) -> Resu
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
 
     TestCommand::ChipStartup.send(&*uart)?;
-    let response = ChipStartup::recv(&*uart, opts.timeout, false)?;
+    let response = ChipStartup::recv(&*uart, opts.timeout, false, false)?;
     log::info!("{:#x?}", response);
 
     check_ast(opts, &response)?;

--- a/sw/host/tests/rom/sw_strap_value/src/main.rs
+++ b/sw/host/tests/rom/sw_strap_value/src/main.rs
@@ -122,7 +122,7 @@ fn test_sw_strap_values(opts: &Opts, transport: &TransportWrapper) -> Result<()>
             sw_strap_set_verilator(transport, value)?;
         }
         TestCommand::SwStrapRead.send(&*uart)?;
-        let response = Status::recv(&*uart, opts.timeout, false)?;
+        let response = Status::recv(&*uart, opts.timeout, false, false)?;
         assert_eq!(value, u8::try_from(response)?);
     }
     Ok(())


### PR DESCRIPTION
In manufacturing ATE environments, constant sized UJSON strings are preferred. CRCs are variable in length. Therefore, we enable setting the CRC to a fixed value of 0 and skipping the check on the host side.

Note: this depends on #27255, only review the last commit.