### PR TITLE
[topgen,rv_plic] Explicitly specify interrupt controller connections

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -447,6 +447,10 @@
     ]
   }
   num_cores: "1"
+  interrupts:
+  {
+    default_plic: rv_plic
+  }
   addr_spaces:
   [
     {
@@ -18930,6 +18934,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_watermark
@@ -18940,6 +18946,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_tx_done
@@ -18950,6 +18958,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_overflow
@@ -18960,6 +18970,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_frame_err
@@ -18970,6 +18982,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_break_err
@@ -18980,6 +18994,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_timeout
@@ -18990,6 +19006,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_parity_err
@@ -19000,6 +19018,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_tx_empty
@@ -19010,6 +19030,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: gpio_gpio
@@ -19020,6 +19042,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_cmdfifo_not_empty
@@ -19030,6 +19054,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_payload_not_empty
@@ -19040,6 +19066,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_payload_overflow
@@ -19050,6 +19078,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_readbuf_watermark
@@ -19060,6 +19090,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_readbuf_flip
@@ -19070,6 +19102,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_header_not_empty
@@ -19080,6 +19114,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_rdfifo_cmd_end
@@ -19090,6 +19126,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_rdfifo_drop
@@ -19100,6 +19138,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_fmt_threshold
@@ -19110,6 +19150,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_rx_threshold
@@ -19120,6 +19162,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_acq_threshold
@@ -19130,6 +19174,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_rx_overflow
@@ -19140,6 +19186,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_controller_halt
@@ -19150,6 +19198,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_scl_interference
@@ -19160,6 +19210,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_sda_interference
@@ -19170,6 +19222,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_stretch_timeout
@@ -19180,6 +19234,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_sda_unstable
@@ -19190,6 +19246,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_cmd_complete
@@ -19200,6 +19258,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_tx_stretch
@@ -19210,6 +19270,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_tx_threshold
@@ -19220,6 +19282,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_acq_stretch
@@ -19230,6 +19294,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_unexp_stop
@@ -19240,6 +19306,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_host_timeout
@@ -19250,6 +19318,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: rv_timer_timer_expired_hart0_timer0
@@ -19260,6 +19330,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: otp_ctrl_otp_operation_done
@@ -19270,6 +19342,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: otp_ctrl_otp_error
@@ -19280,6 +19354,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classa
@@ -19290,6 +19366,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classb
@@ -19300,6 +19378,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classc
@@ -19310,6 +19390,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classd
@@ -19320,6 +19402,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host0_error
@@ -19330,6 +19414,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host0_spi_event
@@ -19340,6 +19426,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: pwrmgr_aon_wakeup
@@ -19350,6 +19438,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: aon_timer_aon_wkup_timer_expired
@@ -19360,6 +19450,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: aon_timer_aon_wdog_timer_bark
@@ -19370,6 +19462,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: soc_proxy_external
@@ -19380,6 +19474,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: hmac_hmac_done
@@ -19390,6 +19486,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: hmac_fifo_empty
@@ -19400,6 +19498,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: hmac_hmac_err
@@ -19410,6 +19510,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: kmac_kmac_done
@@ -19420,6 +19522,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: kmac_fifo_empty
@@ -19430,6 +19534,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: kmac_kmac_err
@@ -19440,6 +19546,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: otbn_done
@@ -19450,6 +19558,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: keymgr_dpe_op_done
@@ -19460,6 +19570,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_cmd_req_done
@@ -19470,6 +19582,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_entropy_req
@@ -19480,6 +19594,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_hw_inst_exc
@@ -19490,6 +19606,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_fatal_err
@@ -19500,6 +19618,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn0_edn_cmd_req_done
@@ -19510,6 +19630,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn0_edn_fatal_err
@@ -19520,6 +19642,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn1_edn_cmd_req_done
@@ -19530,6 +19654,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn1_edn_fatal_err
@@ -19540,6 +19666,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: dma_dma_done
@@ -19550,6 +19678,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: dma_dma_chunk_done
@@ -19560,6 +19690,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: dma_dma_error
@@ -19570,6 +19702,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx0_mbx_ready
@@ -19580,6 +19714,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx0_mbx_abort
@@ -19590,6 +19726,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx0_mbx_error
@@ -19600,6 +19738,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx1_mbx_ready
@@ -19610,6 +19750,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx1_mbx_abort
@@ -19620,6 +19762,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx1_mbx_error
@@ -19630,6 +19774,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx2_mbx_ready
@@ -19640,6 +19786,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx2_mbx_abort
@@ -19650,6 +19798,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx2_mbx_error
@@ -19660,6 +19810,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx3_mbx_ready
@@ -19670,6 +19822,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx3_mbx_abort
@@ -19680,6 +19834,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx3_mbx_error
@@ -19690,6 +19846,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx4_mbx_ready
@@ -19700,6 +19858,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx4_mbx_abort
@@ -19710,6 +19870,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx4_mbx_error
@@ -19720,6 +19882,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx5_mbx_ready
@@ -19730,6 +19894,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx5_mbx_abort
@@ -19740,6 +19906,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx5_mbx_error
@@ -19750,6 +19918,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx6_mbx_ready
@@ -19760,6 +19930,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx6_mbx_abort
@@ -19770,6 +19942,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx6_mbx_error
@@ -19780,6 +19954,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_jtag_mbx_ready
@@ -19790,6 +19966,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_jtag_mbx_abort
@@ -19800,6 +19978,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_jtag_mbx_error
@@ -19810,6 +19990,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_pcie0_mbx_ready
@@ -19820,6 +20002,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_pcie0_mbx_abort
@@ -19830,6 +20014,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_pcie0_mbx_error
@@ -19840,6 +20026,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_pcie1_mbx_ready
@@ -19850,6 +20038,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_pcie1_mbx_abort
@@ -19860,6 +20050,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: mbx_pcie1_mbx_error
@@ -19870,6 +20062,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: racl_ctrl_racl_error
@@ -19880,6 +20074,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: ac_range_check_deny_cnt_reached
@@ -19890,6 +20086,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
   ]
   outgoing_interrupt: {}

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -5102,6 +5102,10 @@
         }
       }
       attr: ipgen
+      targets:
+      [
+        rv_core_ibex
+      ]
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -706,6 +706,7 @@
         hart: "0x28000000",
       },
       attr: "ipgen",
+      targets: ["rv_core_ibex"]
     },
     { name: "aes",
       type: "aes",

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -196,6 +196,13 @@
   // Number of cores: used in rv_plic and timer
   num_cores: "1",
 
+  // Interrupt handler information for the design
+  interrupts: {
+    // Any module with interrupts that doesn't specify plic
+    // will have its interrupts sent here
+    default_plic: "rv_plic"
+  }
+
   // `addr_spaces` names the distinct address spaces present in the device.
   // All hosts in the same address space share the same base addresses for
   // all peripherals, though not every peripheral will be accessible to every

--- a/hw/top_darjeeling/sw/autogen/top_darjeeling.h
+++ b/hw/top_darjeeling/sw/autogen/top_darjeeling.h
@@ -1260,6 +1260,7 @@ typedef enum top_darjeeling_plic_target {
   kTopDarjeelingPlicTargetLast = 0, /**< \internal Final PLIC target */
 } top_darjeeling_plic_target_t;
 
+
 /**
  * Alert Handler Source Peripheral.
  *

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -65,6 +65,9 @@ for m in top['memory']:
 
 last_modidx_with_params = lib.idx_of_last_module_with_params(top)
 
+# plic -> {count, prefix}
+plic_info = {}
+
 %>\
 `include "prim_assert.sv"
 
@@ -258,28 +261,7 @@ module top_${top["name"]} #(
 % endif
 
 
-<%
-  # Interrupt source 0 is tied to 0 to conform RISC-V PLIC spec.
-  # So, total number of interrupts are the number of entries in the list + 1
-  interrupt_num = sum([x["width"] if "width" in x else 1 for x in top["interrupt"]]) + 1
-%>\
-  logic [${interrupt_num-1}:0]  intr_vector;
-  // Interrupt source list
-% for m in top["module"]:
-<%
-  block = name_to_block[m['type']]
-%>\
-    % if not lib.is_inst(m) or "outgoing_interrupt" in m:
-<% continue %>
-    % endif
-    % for intr in block.interrupts:
-        % if intr.bits.width() != 1:
-  logic [${intr.bits.width()-1}:0] intr_${m["name"]}_${intr.name};
-        % else:
-  logic intr_${m["name"]}_${intr.name};
-        % endif
-    % endfor
-% endfor
+<%include file="/toplevel_interrupts.tpl" args="lib=lib,top=top,name_to_block=name_to_block,plic_info=plic_info" />\
 
 % if top_has_alert_handler:
   // Alert list
@@ -620,7 +602,7 @@ slice = f"{lo+w-1}:{lo}"
       % endfor
     % endif
     % if m.get("template_type") == "rv_plic":
-      .intr_src_i (intr_vector),
+      .intr_src_i (${plic_info[m["name"]]["vector"]}),
     % endif
     % if m.get("template_type") == "pinmux":
 
@@ -695,21 +677,7 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
 % endfor
 
   // interrupt assignments
-<% base = interrupt_num %>\
-  assign intr_vector = {
-  % for irq_group, irqs in reversed(top['incoming_interrupt'].items()):
-  <% base -= len(irqs) %>\
-    incoming_interrupt_${irq_group}_i, // IDs [${base} +: ${len(irqs)}]
-  % endfor
-  % for intr in top["interrupt"][::-1]:
-    % if intr['incoming']:
-<% continue %>\
-    % endif
-<% base -= intr["width"] %>\
-      intr_${intr["name"]}, // IDs [${base} +: ${intr['width']}]
-  % endfor
-      1'b 0 // ID [0 +: 1] is a special case and tied to zero.
-  };
+<%include file="/toplevel_interrupt_assignments.tpl" args="top=top,plic_info=plic_info" />\
 
   // TL-UL Crossbar
 % for xbar in top["xbar"]:

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7016,6 +7016,10 @@
         }
       }
       attr: ipgen
+      targets:
+      [
+        rv_core_ibex
+      ]
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -559,6 +559,10 @@
     ]
   }
   num_cores: "1"
+  interrupts:
+  {
+    default_plic: rv_plic
+  }
   addr_spaces:
   [
     {
@@ -16373,6 +16377,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_watermark
@@ -16383,6 +16389,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_tx_done
@@ -16393,6 +16401,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_overflow
@@ -16403,6 +16413,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_frame_err
@@ -16413,6 +16425,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_break_err
@@ -16423,6 +16437,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_timeout
@@ -16433,6 +16449,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_parity_err
@@ -16443,6 +16461,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_tx_empty
@@ -16453,6 +16473,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_tx_watermark
@@ -16463,6 +16485,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_watermark
@@ -16473,6 +16497,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_tx_done
@@ -16483,6 +16509,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_overflow
@@ -16493,6 +16521,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_frame_err
@@ -16503,6 +16533,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_break_err
@@ -16513,6 +16545,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_timeout
@@ -16523,6 +16557,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_parity_err
@@ -16533,6 +16569,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_tx_empty
@@ -16543,6 +16581,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_tx_watermark
@@ -16553,6 +16593,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_rx_watermark
@@ -16563,6 +16605,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_tx_done
@@ -16573,6 +16617,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_rx_overflow
@@ -16583,6 +16629,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_rx_frame_err
@@ -16593,6 +16641,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_rx_break_err
@@ -16603,6 +16653,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_rx_timeout
@@ -16613,6 +16665,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_rx_parity_err
@@ -16623,6 +16677,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart2_tx_empty
@@ -16633,6 +16689,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_tx_watermark
@@ -16643,6 +16701,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_rx_watermark
@@ -16653,6 +16713,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_tx_done
@@ -16663,6 +16725,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_rx_overflow
@@ -16673,6 +16737,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_rx_frame_err
@@ -16683,6 +16749,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_rx_break_err
@@ -16693,6 +16761,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_rx_timeout
@@ -16703,6 +16773,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_rx_parity_err
@@ -16713,6 +16785,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart3_tx_empty
@@ -16723,6 +16797,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: gpio_gpio
@@ -16733,6 +16809,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_cmdfifo_not_empty
@@ -16743,6 +16821,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_payload_not_empty
@@ -16753,6 +16833,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_payload_overflow
@@ -16763,6 +16845,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_readbuf_watermark
@@ -16773,6 +16857,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_readbuf_flip
@@ -16783,6 +16869,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_header_not_empty
@@ -16793,6 +16881,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_rdfifo_cmd_end
@@ -16803,6 +16893,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_rdfifo_drop
@@ -16813,6 +16905,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_fmt_threshold
@@ -16823,6 +16917,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_rx_threshold
@@ -16833,6 +16929,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_acq_threshold
@@ -16843,6 +16941,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_rx_overflow
@@ -16853,6 +16953,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_controller_halt
@@ -16863,6 +16965,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_scl_interference
@@ -16873,6 +16977,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_sda_interference
@@ -16883,6 +16989,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_stretch_timeout
@@ -16893,6 +17001,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_sda_unstable
@@ -16903,6 +17013,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_cmd_complete
@@ -16913,6 +17025,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_tx_stretch
@@ -16923,6 +17037,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_tx_threshold
@@ -16933,6 +17049,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_acq_stretch
@@ -16943,6 +17061,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_unexp_stop
@@ -16953,6 +17073,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c0_host_timeout
@@ -16963,6 +17085,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_fmt_threshold
@@ -16973,6 +17097,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_rx_threshold
@@ -16983,6 +17109,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_acq_threshold
@@ -16993,6 +17121,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_rx_overflow
@@ -17003,6 +17133,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_controller_halt
@@ -17013,6 +17145,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_scl_interference
@@ -17023,6 +17157,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_sda_interference
@@ -17033,6 +17169,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_stretch_timeout
@@ -17043,6 +17181,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_sda_unstable
@@ -17053,6 +17193,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_cmd_complete
@@ -17063,6 +17205,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_tx_stretch
@@ -17073,6 +17217,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_tx_threshold
@@ -17083,6 +17229,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_acq_stretch
@@ -17093,6 +17241,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_unexp_stop
@@ -17103,6 +17253,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c1_host_timeout
@@ -17113,6 +17265,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_fmt_threshold
@@ -17123,6 +17277,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_rx_threshold
@@ -17133,6 +17289,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_acq_threshold
@@ -17143,6 +17301,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_rx_overflow
@@ -17153,6 +17313,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_controller_halt
@@ -17163,6 +17325,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_scl_interference
@@ -17173,6 +17337,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_sda_interference
@@ -17183,6 +17349,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_stretch_timeout
@@ -17193,6 +17361,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_sda_unstable
@@ -17203,6 +17373,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_cmd_complete
@@ -17213,6 +17385,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_tx_stretch
@@ -17223,6 +17397,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_tx_threshold
@@ -17233,6 +17409,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_acq_stretch
@@ -17243,6 +17421,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_unexp_stop
@@ -17253,6 +17433,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: i2c2_host_timeout
@@ -17263,6 +17445,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: pattgen_done_ch0
@@ -17273,6 +17457,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: pattgen_done_ch1
@@ -17283,6 +17469,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: rv_timer_timer_expired_hart0_timer0
@@ -17293,6 +17481,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: otp_ctrl_otp_operation_done
@@ -17303,6 +17493,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: otp_ctrl_otp_error
@@ -17313,6 +17505,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classa
@@ -17323,6 +17517,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classb
@@ -17333,6 +17529,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classc
@@ -17343,6 +17541,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: alert_handler_classd
@@ -17353,6 +17553,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host0_error
@@ -17363,6 +17565,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host0_spi_event
@@ -17373,6 +17577,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host1_error
@@ -17383,6 +17589,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host1_spi_event
@@ -17393,6 +17601,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_pkt_received
@@ -17403,6 +17613,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_pkt_sent
@@ -17413,6 +17625,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_disconnected
@@ -17423,6 +17637,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_host_lost
@@ -17433,6 +17649,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_reset
@@ -17443,6 +17661,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_suspend
@@ -17453,6 +17673,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_resume
@@ -17463,6 +17685,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_av_out_empty
@@ -17473,6 +17697,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_full
@@ -17483,6 +17709,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_av_overflow
@@ -17493,6 +17721,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_in_err
@@ -17503,6 +17733,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_crc_err
@@ -17513,6 +17745,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_pid_err
@@ -17523,6 +17757,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_bitstuff_err
@@ -17533,6 +17769,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_frame
@@ -17543,6 +17781,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_powered
@@ -17553,6 +17793,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_out_err
@@ -17563,6 +17805,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_av_setup_empty
@@ -17573,6 +17817,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: pwrmgr_aon_wakeup
@@ -17583,6 +17829,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: sysrst_ctrl_aon_event_detected
@@ -17593,6 +17841,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: adc_ctrl_aon_match_pending
@@ -17603,6 +17853,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: aon_timer_aon_wkup_timer_expired
@@ -17613,6 +17865,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: aon_timer_aon_wdog_timer_bark
@@ -17623,6 +17877,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: sensor_ctrl_aon_io_status_change
@@ -17633,6 +17889,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: sensor_ctrl_aon_init_status_change
@@ -17643,6 +17901,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_prog_empty
@@ -17653,6 +17913,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_prog_lvl
@@ -17663,6 +17925,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_rd_full
@@ -17673,6 +17937,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_rd_lvl
@@ -17683,6 +17949,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_op_done
@@ -17693,6 +17961,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_corr_err
@@ -17703,6 +17973,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: hmac_hmac_done
@@ -17713,6 +17985,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: hmac_fifo_empty
@@ -17723,6 +17997,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: hmac_hmac_err
@@ -17733,6 +18009,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: kmac_kmac_done
@@ -17743,6 +18021,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: kmac_fifo_empty
@@ -17753,6 +18033,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: kmac_kmac_err
@@ -17763,6 +18045,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: otbn_done
@@ -17773,6 +18057,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: keymgr_op_done
@@ -17783,6 +18069,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_cmd_req_done
@@ -17793,6 +18081,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_entropy_req
@@ -17803,6 +18093,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_hw_inst_exc
@@ -17813,6 +18105,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: csrng_cs_fatal_err
@@ -17823,6 +18117,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: entropy_src_es_entropy_valid
@@ -17833,6 +18129,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: entropy_src_es_health_test_failed
@@ -17843,6 +18141,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: entropy_src_es_observe_fifo_ready
@@ -17853,6 +18153,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: entropy_src_es_fatal_err
@@ -17863,6 +18165,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn0_edn_cmd_req_done
@@ -17873,6 +18177,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn0_edn_fatal_err
@@ -17883,6 +18189,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn1_edn_cmd_req_done
@@ -17893,6 +18201,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: edn1_edn_fatal_err
@@ -17903,6 +18213,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
   ]
   outgoing_interrupt: {}

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -203,6 +203,13 @@
   // Number of cores: used in rv_plic and timer
   num_cores: "1",
 
+  // Interrupt handler information for the design
+  interrupts: {
+    // Any module with interrupts that doesn't specify plic
+    // will have its interrupts sent here
+    default_plic: "rv_plic"
+  }
+
   // `addr_spaces` names the distinct address spaces present in the device.
   // All hosts in the same address space share the same base addresses for
   // all peripherals, though not every peripheral will be accessible to every

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -855,6 +855,7 @@
         hart: "0x48000000",
       },
       attr: "ipgen",
+      targets: ["rv_core_ibex"]
     },
     { name: "aes",
       type: "aes",

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1265,6 +1265,7 @@ typedef enum top_earlgrey_plic_target {
   kTopEarlgreyPlicTargetLast = 0, /**< \internal Final PLIC target */
 } top_earlgrey_plic_target_t;
 
+
 /**
  * Alert Handler Source Peripheral.
  *

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3444,6 +3444,10 @@
         }
       }
       attr: ipgen
+      targets:
+      [
+        rv_core_ibex
+      ]
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -442,6 +442,10 @@
     ]
   }
   num_cores: "1"
+  interrupts:
+  {
+    default_plic: rv_plic
+  }
   addr_spaces:
   [
     {
@@ -8171,6 +8175,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_watermark
@@ -8181,6 +8187,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_tx_done
@@ -8191,6 +8199,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_overflow
@@ -8201,6 +8211,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_frame_err
@@ -8211,6 +8223,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_break_err
@@ -8221,6 +8235,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_timeout
@@ -8231,6 +8247,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_rx_parity_err
@@ -8241,6 +8259,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart0_tx_empty
@@ -8251,6 +8271,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_tx_watermark
@@ -8261,6 +8283,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_watermark
@@ -8271,6 +8295,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_tx_done
@@ -8281,6 +8307,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_overflow
@@ -8291,6 +8319,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_frame_err
@@ -8301,6 +8331,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_break_err
@@ -8311,6 +8343,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_timeout
@@ -8321,6 +8355,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_rx_parity_err
@@ -8331,6 +8367,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: uart1_tx_empty
@@ -8341,6 +8379,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: gpio_gpio
@@ -8351,6 +8391,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_cmdfifo_not_empty
@@ -8361,6 +8403,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_payload_not_empty
@@ -8371,6 +8415,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_upload_payload_overflow
@@ -8381,6 +8427,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_readbuf_watermark
@@ -8391,6 +8439,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_readbuf_flip
@@ -8401,6 +8451,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_header_not_empty
@@ -8411,6 +8463,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_rdfifo_cmd_end
@@ -8421,6 +8475,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_device_tpm_rdfifo_drop
@@ -8431,6 +8487,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host0_error
@@ -8441,6 +8499,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: spi_host0_spi_event
@@ -8451,6 +8511,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_pkt_received
@@ -8461,6 +8523,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_pkt_sent
@@ -8471,6 +8535,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_disconnected
@@ -8481,6 +8547,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_host_lost
@@ -8491,6 +8559,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_reset
@@ -8501,6 +8571,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_suspend
@@ -8511,6 +8583,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_resume
@@ -8521,6 +8595,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_av_out_empty
@@ -8531,6 +8607,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_full
@@ -8541,6 +8619,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_av_overflow
@@ -8551,6 +8631,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_in_err
@@ -8561,6 +8643,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_crc_err
@@ -8571,6 +8655,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_pid_err
@@ -8581,6 +8667,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_rx_bitstuff_err
@@ -8591,6 +8679,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_frame
@@ -8601,6 +8691,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_powered
@@ -8611,6 +8703,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_link_out_err
@@ -8621,6 +8715,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: usbdev_av_setup_empty
@@ -8631,6 +8727,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: pwrmgr_aon_wakeup
@@ -8641,6 +8739,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: aon_timer_aon_wkup_timer_expired
@@ -8651,6 +8751,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: aon_timer_aon_wdog_timer_bark
@@ -8661,6 +8763,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_prog_empty
@@ -8671,6 +8775,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_prog_lvl
@@ -8681,6 +8787,8 @@
       intr_type: IntrType.Status
       default_val: true
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_rd_full
@@ -8691,6 +8799,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_rd_lvl
@@ -8701,6 +8811,8 @@
       intr_type: IntrType.Status
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_op_done
@@ -8711,6 +8823,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
     {
       name: flash_ctrl_corr_err
@@ -8721,6 +8835,8 @@
       intr_type: IntrType.Event
       default_val: false
       incoming: false
+      plic: rv_plic
+      outgoing: false
     }
   ]
   outgoing_interrupt: {}

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -203,6 +203,13 @@
   // Number of cores: used in rv_plic and timer
   num_cores: "1",
 
+  // Interrupt handler information for the design
+  interrupts: {
+    // Any module with interrupts that doesn't specify plic
+    // will have its interrupts sent here
+    default_plic: "rv_plic"
+  }
+
   // `addr_spaces` names the distinct address spaces present in the device.
   // All hosts in the same address space share the same base addresses for
   // all peripherals, though not every peripheral will be accessible to every

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -516,6 +516,7 @@
         hart: "0x48000000",
       },
       attr: "ipgen",
+      targets: ["rv_core_ibex"]
     },
     { name: "aes",
       type: "aes",

--- a/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.h
+++ b/hw/top_englishbreakfast/sw/autogen/top_englishbreakfast.h
@@ -613,6 +613,7 @@ typedef enum top_englishbreakfast_plic_target {
   kTopEnglishbreakfastPlicTargetLast = 0, /**< \internal Final PLIC target */
 } top_englishbreakfast_plic_target_t;
 
+
 #define PINMUX_MIO_PERIPH_INSEL_IDX_OFFSET 2
 
 // PERIPH_INSEL ranges from 0 to NUM_MIO_PADS + 2 -1}

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -393,20 +393,26 @@ def generate_outgoing_interrupts(top: ConfigT, out_path: Path) -> None:
                         interrupts=interrupts)
 
 
-def _get_rv_plic_params(top: ConfigT) -> ParamsT:
+def _get_rv_plic_params(top: ConfigT, name: str) -> ParamsT:
     """Gets parameters for plic ipgen from top config."""
-    # Get the PLIC instance
-    module = lib.find_module(top["module"], "rv_plic")
+    # Get this PLIC instance
+    module = lib.find_module(top["module"], name, use_base_template_type=False)
 
     # Count number of interrupts
     # Interrupt source 0 is tied to 0 to conform RISC-V PLIC spec.
     # So, total number of interrupts are the number of entries in the list + 1
-    num_srcs = sum(
-        [int(x["width"]) if "width" in x else 1 for x in top["interrupt"]]) + 1
+    num_srcs = 1
+    for intr in top["interrupt"]:
+        if intr.get("plic") == name:
+            num_srcs += int(intr["width"]) if "width" in intr else 1
     num_cores = int(top["num_cores"], 0) if "num_cores" in top else 1
     uniquified_modules.add_module(module["template_type"], module["type"])
+
+    if num_srcs <= 1:
+        log.warning(f"no interrupts are connected to {name}, is it needed?")
+
     return {
-        "module_instance_name": module["type"],
+        "module_instance_name": name,
         "src": num_srcs,
         "target": num_cores,
         "prio": 3,
@@ -415,7 +421,7 @@ def _get_rv_plic_params(top: ConfigT) -> ParamsT:
 
 def generate_plic(top: ConfigT, module: ConfigT, out_path: Path) -> None:
     log.info("Generating rv_plic with ipgen")
-    params = _get_rv_plic_params(top)
+    params = _get_rv_plic_params(top, module["type"])
     generate_ipgen(top, module, params, out_path)
 
 
@@ -1136,7 +1142,8 @@ def create_ipgen_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
     multi_instance_ipgens = []
     for inst in topcfg["module"]:
         if lib.is_ipgen(inst):
-            if inst["template_type"] in ipgen_instances:
+            template_type = inst["template_type"]
+            if template_type != "rv_plic" and template_type in ipgen_instances:
                 multi_instance_ipgens.append(inst)
             else:
                 ipgen_instances[inst["template_type"]].append(inst)
@@ -1197,9 +1204,9 @@ def create_ipgen_blocks(topcfg: ConfigT, alias_cfgs: Dict[str, ConfigT],
                         _get_alert_handler_params(topcfg))
     # Add rv_plic
     amend_interrupt(topcfg, name_to_block, allow_missing_blocks=True)
-    if "rv_plic" in ipgen_instances:
-        insert_ip_attrs(ipgen_instances["rv_plic"][0],
-                        _get_rv_plic_params(topcfg))
+    for inst in ipgen_instances.get("rv_plic", []):
+        insert_ip_attrs(inst, _get_rv_plic_params(topcfg, inst["type"]))
+
     return ip_attrs
 
 
@@ -1294,7 +1301,7 @@ def generate_full_ipgens(args: argparse.Namespace, topcfg: ConfigT,
     if not args.no_plic and \
        not args.alert_handler_only and \
        not args.xbar_only:
-        generate_modules("rv_plic", generate_plic, single_instance=True)
+        generate_modules("rv_plic", generate_plic, single_instance=False)
     if args.plic_only:
         sys.exit()
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -405,16 +405,20 @@ def _get_rv_plic_params(top: ConfigT, name: str) -> ParamsT:
     for intr in top["interrupt"]:
         if intr.get("plic") == name:
             num_srcs += int(intr["width"]) if "width" in intr else 1
-    num_cores = int(top["num_cores"], 0) if "num_cores" in top else 1
+
+    num_targets = len(module.get("targets", []))
     uniquified_modules.add_module(module["template_type"], module["type"])
 
     if num_srcs <= 1:
         log.warning(f"no interrupts are connected to {name}, is it needed?")
 
+    if num_targets < 1:
+        log.warning(f"{name} specifies no targets, is it needed?")
+
     return {
         "module_instance_name": name,
         "src": num_srcs,
-        "target": num_cores,
+        "target": num_targets,
         "prio": 3,
     }
 

--- a/util/topgen/c_test.py
+++ b/util/topgen/c_test.py
@@ -18,7 +18,7 @@ from reggen.interrupt import IntrType
 from reggen.ip_block import IpBlock
 
 from .c import TopGenC
-from .lib import find_module
+from .lib import find_module, find_modules
 
 
 class TestPeripheral:
@@ -82,12 +82,18 @@ class TopGenCTest(TopGenC):
         # TODO: Don't require that the handler's module_instance_name be the
         # same as the template name.
         self.alert_handler = find_module(self.top['module'], 'alert_handler')
-        self.rv_plic = find_module(self.top['module'], 'rv_plic')
+        self.rv_plics = find_modules(self.top['module'], 'rv_plic')
 
-        self.irq_peripherals = {
-            x['name']: self._get_irq_peripherals(self.rv_plic, x['name'])
-            for x in top_info['addr_spaces']
-        }
+        self.default_plic = None
+        if "interrupts" in self.top:
+            self.default_plic = self.top["interrupts"].get("default_plic")
+
+        self.irq_peripherals = {}
+        for plic in self.rv_plics:
+            self.irq_peripherals[plic["name"]] = {
+                x['name']: self._get_irq_peripherals(plic, x['name'])
+                for x in top_info['addr_spaces']
+            }
 
         # Only generate alert_handler and mappings if there is an alert_handler
         if self.alert_handler is not None:
@@ -105,13 +111,18 @@ class TopGenCTest(TopGenC):
         accessed by the host(s) to perform the tests.
         """
         irq_peripherals = []
-        # TODO: Model interrupt domains with explicit connectivity, an
-        # orthogonal concept to address spaces. There may be multiple PLICs, for
-        # example, in one address space. Or devices with core interfaces in
-        # address spaces that are different from the CPU's and PLIC's.
+        # There may be multiple PLICs, for example, in one address space.
+        # Or devices with core # interfaces in address spaces that are different
+        # from the CPU's and PLIC's.
         rv_plic_addr_spaces = rv_plic['base_addrs'][None]
         if addr_space not in rv_plic_addr_spaces:
             return irq_peripherals
+
+        # A lot of code counts on this being named "Plic" and not "RvPlic"
+        suffix = rv_plic["name"]
+        if suffix.startswith("rv_plic"):
+            suffix = rv_plic["name"][3:]
+        unsnaked_name = Name.from_snake_case(suffix)
 
         device_regions = self.all_device_regions()
         # TODO: We only know how to directly access irq test CSRs in this
@@ -123,16 +134,17 @@ class TopGenCTest(TopGenC):
             if inst_name not in self.top["interrupt_module"]:
                 continue
 
+            module_plic = entry.get("plic", self.default_plic)
+            if rv_plic["name"] != module_plic:
+                continue
+
             name = entry['type']
-            plic_name = (self._top_name + Name(["plic", "peripheral"]) +
+            plic_name = (self._top_name + unsnaked_name + Name(["peripheral"]) +
                          Name.from_snake_case(inst_name))
             plic_name = plic_name.as_c_enum()
 
             # Device regions may have multiple TL interfaces. Pick the region
             # associated with the 'core' interface.
-            # TODO: Model interrupt domains with explicit connectivity. This
-            # method of associating interrupts with a PLIC leads to inflexible
-            # architectures that do not cover all use cases.
             if_name = 'core'
             periph_addr_space = addr_space
             if inst_name in direct_device_regions:
@@ -167,13 +179,13 @@ class TopGenCTest(TopGenC):
                         "one entry keyed with 'None' or 'core'.")
                     sys.exit(1)
 
-            plic_name = (self._top_name + Name(["plic", "peripheral"]) +
+            plic_name = (self._top_name + unsnaked_name + Name(["peripheral"]) +
                          Name.from_snake_case(inst_name))
             plic_name = plic_name.as_c_enum()
 
-            start_irq = self.device_irqs[inst_name][0]
-            end_irq = self.device_irqs[inst_name][-1]
-            plic_start_irq = (self._top_name + Name(["plic", "irq", "id"]) +
+            start_irq = self.device_irqs[rv_plic["name"]][inst_name][0]
+            end_irq = self.device_irqs[rv_plic["name"]][inst_name][-1]
+            plic_start_irq = (self._top_name + unsnaked_name + Name(["irq", "id"]) +
                               Name.from_snake_case(start_irq))
             plic_start_irq = plic_start_irq.as_c_enum()
 

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -12,7 +12,8 @@ import topgen.lib as lib
 ## ALERT_TEST registers). While this issue remains, we specifically hard-code
 ## for excluding these IRQs/Alerts from the tests.
 IGNORE_PERIPHERALS = [("ac_range_check", "darjeeling"), ("racl_ctrl", "darjeeling")]
-irq_peripheral_names = sorted({p.name for p in helper.irq_peripherals[addr_space]
+plics = lib.find_modules(top["module"], "rv_plic")
+irq_peripheral_names = sorted({p.name for plic in plics for p in helper.irq_peripherals[plic["name"]][addr_space]
                                if (p.inst_name, top["name"]) not in IGNORE_PERIPHERALS})
 has_alert_handler = lib.find_module(top['module'], 'alert_handler')
 alert_peripheral_names = sorted({p.name for p in helper.alert_peripherals[addr_space]

--- a/util/topgen/templates/toplevel.c.tpl
+++ b/util/topgen/templates/toplevel.c.tpl
@@ -11,11 +11,9 @@ if alert_handler is not None:
 else:
     has_alert_handler = False
 
-plic = lib.find_module(top['module'], 'rv_plic')
-if plic is not None:
-    has_plic = addr_space in plic['base_addrs'][None]
-else:
-    has_plic = False
+plics = lib.find_modules(top['module'], 'rv_plic')
+has_plic = any(addr_space in plic['base_addrs'][None] for plic in plics)
+plics = [x["name"] for x in plics]
 %>\
 
 #include "${helper.header_path}"
@@ -30,12 +28,14 @@ else:
 ${helper.alert_mapping.render_definition()}
 % endif
 % if has_plic:
+%   for plic in plics:
 
 /**
  * PLIC Interrupt Source to Peripheral Map
  *
- * This array is a mapping from `${helper.plic_interrupts.name.as_c_type()}` to
- * `${helper.plic_sources.name.as_c_type()}`.
+ * This array is a mapping from `${helper.plic_interrupts[plic].name.as_c_type()}` to
+ * `${helper.plic_sources[plic].name.as_c_type()}`.
  */
-${helper.plic_mapping.render_definition()}
+${helper.plic_mapping[plic].render_definition()}
+% endfor
 %endif

--- a/util/topgen/templates/toplevel.h.tpl
+++ b/util/topgen/templates/toplevel.h.tpl
@@ -38,11 +38,9 @@ if rstmgr is not None:
 else:
     has_rstmgr = False
 
-plic = lib.find_module(top['module'], 'rv_plic')
-if plic is not None:
-    has_plic = addr_space in plic['base_addrs'][None]
-else:
-    has_plic = False
+plics = lib.find_modules(top['module'], 'rv_plic')
+has_plic = any(addr_space in plic['base_addrs'][None] for plic in plics)
+plics = [x["name"] for x in plics]
 
 addr_space_obj = lib.get_addr_space(top, addr_space)
 addr_space_suffix = lib.get_addr_space_suffix(addr_space_obj)
@@ -138,31 +136,40 @@ extern "C" {
  * Enumeration used to determine which peripheral asserted the corresponding
  * interrupt.
  */
-${helper.plic_sources.render()}
+%   for plic in plics:
+${helper.plic_sources[plic].render()}
 
+%   endfor
 /**
  * PLIC Interrupt Source.
  *
  * Enumeration of all PLIC interrupt sources. The interrupt sources belonging to
  * the same peripheral are guaranteed to be consecutive.
  */
-${helper.plic_interrupts.render()}
+%   for plic in plics:
+${helper.plic_interrupts[plic].render()}
 
+%   endfor
 /**
  * PLIC Interrupt Source to Peripheral Map
  *
- * This array is a mapping from `${helper.plic_interrupts.name.as_c_type()}` to
- * `${helper.plic_sources.name.as_c_type()}`.
+ * This array is a mapping from `${helper.plic_interrupts[plic].name.as_c_type()}` to
+ * `${helper.plic_sources[plic].name.as_c_type()}`.
  */
-${helper.plic_mapping.render_declaration()}
+%   for plic in plics:
+${helper.plic_mapping[plic].render_declaration()}
 
+%   endfor
 /**
  * PLIC Interrupt Target.
  *
  * Enumeration used to determine which set of IE, CC, threshold registers to
  * access for a given interrupt target.
  */
-${helper.plic_targets.render()}
+%   for plic in plics:
+${helper.plic_targets[plic].render()}
+
+%   endfor
 % endif
 % if has_alert_handler:
 

--- a/util/topgen/templates/toplevel.rs.tpl
+++ b/util/topgen/templates/toplevel.rs.tpl
@@ -36,11 +36,9 @@ else:
     has_rstmgr = False
 
 
-plic = lib.find_module(top['module'], 'rv_plic')
-if plic is not None:
-    has_plic = addr_space in plic['base_addrs'][None]
-else:
-    has_plic = False
+plics = lib.find_modules(top['module'], 'rv_plic')
+has_plic = any(addr_space in plic['base_addrs'][None] for plic in plics)
+plics = [x["name"] for x in plics]
 %>\
 ${helper.file_header.render()}
 // This file was generated automatically.
@@ -112,25 +110,33 @@ pub const ${size_bytes_name}: usize = ${hex_size_bytes};
 ///
 /// Enumeration used to determine which peripheral asserted the corresponding
 /// interrupt.
-${helper.plic_sources.render(gen_cast=True)}
+%   for plic in plics:
+${helper.plic_sources[plic].render(gen_cast=True)}
+%  endfor
 
 /// PLIC Interrupt Source.
 ///
 /// Enumeration of all PLIC interrupt sources. The interrupt sources belonging to
 /// the same peripheral are guaranteed to be consecutive.
-${helper.plic_interrupts.render(gen_cast=True)}
+%   for plic in plics:
+${helper.plic_interrupts[plic].render(gen_cast=True)}
+%   endfor
 
 /// PLIC Interrupt Target.
 ///
 /// Enumeration used to determine which set of IE, CC, threshold registers to
 /// access for a given interrupt target.
-${helper.plic_targets.render()}
+%   for plic in plics:
+${helper.plic_targets[plic].render()}
+%   endfor
 
 /// PLIC Interrupt Source to Peripheral Map
 ///
-/// This array is a mapping from `${helper.plic_interrupts.short_name.as_rust_type()}` to
-/// `${helper.plic_sources.short_name.as_rust_type()}`.
-${helper.plic_mapping.render_definition()}
+/// This array is a mapping from `${helper.plic_interrupts[plic].short_name.as_rust_type()}` to
+/// `${helper.plic_sources[plic].short_name.as_rust_type()}`.
+%   for plic in plics:
+${helper.plic_mapping[plic].render_definition()}
+%   endfor
 %endif
 % if has_alert_handler:
 

--- a/util/topgen/templates/toplevel_interrupt_assignments.tpl
+++ b/util/topgen/templates/toplevel_interrupt_assignments.tpl
@@ -1,0 +1,28 @@
+## Copyright lowRISC contributors (OpenTitan project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+<%page args="top, plic_info"/>\
+% for plic, info in plic_info.items():
+<%
+   base = info["count"]
+   default_plic = None
+   if "interrupts" in top and "default_plic" in top["interrupts"]:
+     default_plic = top["interrupts"]["default_plic"]
+%>\
+  assign ${info["vector"]} = {
+  % if plic == default_plic:
+  %   for irq_group, irqs in reversed(top['incoming_interrupt'].items()):
+  <%    base -= len(irqs) %>\
+    incoming_interrupt_${irq_group}_i, // IDs [${base} +: ${len(irqs)}]
+  %   endfor
+  % endif
+  % for intr in top["interrupt"][::-1]:
+    % if intr['incoming'] or intr['plic'] != plic:
+<%      continue %>\
+    % endif
+<% base -= intr["width"] %>\
+      intr_${intr["name"]}, // IDs [${base} +: ${intr['width']}]
+  % endfor
+      1'b 0 // ID [0 +: 1] is a special case and tied to zero.
+  };
+% endfor

--- a/util/topgen/templates/toplevel_interrupts.tpl
+++ b/util/topgen/templates/toplevel_interrupts.tpl
@@ -1,0 +1,43 @@
+## Copyright lowRISC contributors (OpenTitan project).
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+<%page args="lib, top, name_to_block, plic_info"/>\
+<%
+  # Interrupt source 0 is tied to 0 to conform to the RISC-V PLIC spec.
+  # The total number of interrupts is the sum of the widths of each entry
+  # in the list, plus 1.
+  plics = lib.find_modules(top["module"], "rv_plic", use_base_template_type=True)
+  plics = [x["name"] for x in plics]
+  for plic in plics:
+    count = 1
+    for x in top["interrupt"]:
+      if x["outgoing"]:
+        continue
+      if x.get("plic") == plic:
+        count += x.get("width", 1)
+    prefix = (plic + "_") if len(plics) > 1 else ""
+    vector = prefix + "intr_vector"
+    plic_info[plic] = {"count": count, "vector": vector}
+%>\
+% for plic in plic_info.values():
+  logic [${plic["count"]-1}:0]  ${plic["vector"]};
+% endfor
+  // Interrupt source list
+% for m in top["module"]:
+<%
+  block = name_to_block[m['type']]
+%>\
+    % if not lib.is_inst(m) or "outgoing_interrupt" in m:
+<% continue %>
+    % endif
+    % for intr in block.interrupts:
+        % if "outgoing_interrupt" in m:
+            <% continue %>
+        % endif
+        % if intr.bits.width() != 1:
+  logic [${intr.bits.width()-1}:0] intr_${m["name"]}_${intr.name};
+        % else:
+  logic intr_${m["name"]}_${intr.name};
+        % endif
+    % endfor
+% endfor

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -64,6 +64,7 @@ top_optional = {
     'exported_clks': ['g', 'clock signal routing rules'],
     'host': ['g', 'list of host-only components in the system'],
     'inter_module': ['g', 'define the signal connections between the modules'],
+    'interrupts': ['g', 'interrupt controller configuration'],
     'interrupt_module': ['l', 'list of the modules that connects to rv_plic'],
     'num_cores': ['pn', "number of computing units"],
     'outgoing_alert': ['g', 'the outgoing alert groups'],
@@ -290,6 +291,7 @@ module_optional = {
         'represent a dict that associates all interfaces with the given '
         'mapping. It is an error to specify both this and racl_mappings.'
     ],
+    'plic': ['s', 'Interrupt controller managing this module'],
 }
 
 module_added = {
@@ -384,10 +386,12 @@ interrupt_required = {
     'intr_type': ['s', 'The IntrType, either Event or Status'],
     'default_val': ['s', 'a string interpreted as boolean'],
     'incoming': ['s', 'a string interpreted as boolean'],
+    'outgoing': ['s', 'boolean (as string) whether interrupt leaves toplevel'],
 }
 interrupt_optional = {
     'desc': ['s', 'the description of the interrupt'],
     'type': ['s', 'should contain "interrupt"'],
+    'plic': ['s', 'controller for this interrupt'],
 }
 interrupt_added = {}
 

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -292,6 +292,7 @@ module_optional = {
         'mapping. It is an error to specify both this and racl_mappings.'
     ],
     'plic': ['s', 'Interrupt controller managing this module'],
+    'targets': ['l', 'Optional list of targets for this PLIC'],
 }
 
 module_added = {


### PR DESCRIPTION
Currently, each IP block's HJSON defines some number of interrupts in its interrupt_list, and these are all implicitly connected to the top's rv_plic instance, if present.

With an eye towards more flexible interrupt topologies, with potentially multiple interrupt controllers, this PR makes interrupt controller connections explicit by having each toplevel module define a `plic` key defining where its interrupts should go, e.g.

```
...
    { name: "csrng",
      type: "csrng",
      clock_srcs: {clk_i: "main"},
      clock_group: "secure",
      reset_connections: {rst_ni: "lc"},
+     plic: "rv_plic",
      base_addr: {
        hart: "0x21150000",
      },
    },
...
```

For brevity, there's support for a toplevel default interrupt controller:

```
...
  num_cores: "1",

  // Interrupt handler information for the design
  interrupts: {
    // Any module with interrupts that doesn't specify plic
    // will have its interrupts sent here
    default_plic: "rv_plic"
  }
...
```

This PR is extremely similar in spirit and implementation to #26885. Analogously to that PR, it's straightforward, but not yet implemented, to fold in the existing support for [incoming](https://github.com/lowRISC/opentitan/pull/25607)/[outgoing](https://github.com/lowRISC/opentitan/pull/26822) interrupts. Incoming interrupts, for now, are routed to the default PLIC.

To test this PR, create a new rv_plic instance of a different "type" and "name", and set at least one other module's `plic` to this new PLIC. Also remove the code in topgen complaining about "There are ipgen modules with multiple instances".