### PR TITLE
[ci] Correct cherry-pick CI trigger information

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -47,7 +47,7 @@ jobs:
             > [!IMPORTANT]
             > This automated pull request cannot trigger CI tests itself.
             >
-            > Please add the `CI:Rerun` label to trigger them manually before merging.
+            > Please close and re-open the pull request manually to start CI.
 
       - name: Apply label for manually cherry picking
         if: ${{ steps.backport.outputs.was_successful == 'false' }}


### PR DESCRIPTION
Adding the label is not enough to trigger CI, the PR must be closed and re-opened.