### PR TITLE
[crypto] Re-mask symmetric keys before use.

### DIFF
--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -102,7 +102,7 @@ otcrypto_status_t otcrypto_aes_padded_plaintext_length(
  * @param[out] cipher_output Output data after cipher operation.
  * @return The result of the cipher operation.
  */
-otcrypto_status_t otcrypto_aes(const otcrypto_blinded_key_t *key,
+otcrypto_status_t otcrypto_aes(otcrypto_blinded_key_t *key,
                                otcrypto_word32_buf_t iv,
                                otcrypto_aes_mode_t aes_mode,
                                otcrypto_aes_operation_t aes_operation,

--- a/sw/device/lib/crypto/include/aes_gcm.h
+++ b/sw/device/lib/crypto/include/aes_gcm.h
@@ -66,7 +66,7 @@ typedef struct otcrypto_aes_gcm_context {
  * @return Result of the authenticated encryption.
  * operation
  */
-otcrypto_status_t otcrypto_aes_gcm_encrypt(const otcrypto_blinded_key_t *key,
+otcrypto_status_t otcrypto_aes_gcm_encrypt(otcrypto_blinded_key_t *key,
                                            otcrypto_const_byte_buf_t plaintext,
                                            otcrypto_const_word32_buf_t iv,
                                            otcrypto_const_byte_buf_t aad,
@@ -102,7 +102,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt(const otcrypto_blinded_key_t *key,
  * operation
  */
 otcrypto_status_t otcrypto_aes_gcm_decrypt(
-    const otcrypto_blinded_key_t *key, otcrypto_const_byte_buf_t ciphertext,
+    otcrypto_blinded_key_t *key, otcrypto_const_byte_buf_t ciphertext,
     otcrypto_const_word32_buf_t iv, otcrypto_const_byte_buf_t aad,
     otcrypto_aes_gcm_tag_len_t tag_len, otcrypto_const_word32_buf_t auth_tag,
     otcrypto_byte_buf_t plaintext, hardened_bool_t *success);
@@ -130,7 +130,7 @@ otcrypto_status_t otcrypto_aes_gcm_decrypt(
  * @return Result of the initialization operation.
  */
 otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
-    const otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t iv,
+    otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t iv,
     otcrypto_aes_gcm_context_t *ctx);
 
 /**
@@ -160,7 +160,7 @@ otcrypto_status_t otcrypto_aes_gcm_encrypt_init(
  * @return Result of the initialization operation.
  */
 otcrypto_status_t otcrypto_aes_gcm_decrypt_init(
-    const otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t iv,
+    otcrypto_blinded_key_t *key, otcrypto_const_word32_buf_t iv,
     otcrypto_aes_gcm_context_t *ctx);
 /**
  * Updates additional authenticated data for an AES-GCM operation.

--- a/sw/device/lib/crypto/include/kmac.h
+++ b/sw/device/lib/crypto/include/kmac.h
@@ -47,7 +47,7 @@ extern "C" {
  * @return The result of the KMAC operation.
  */
 OT_WARN_UNUSED_RESULT
-otcrypto_status_t otcrypto_kmac(const otcrypto_blinded_key_t *key,
+otcrypto_status_t otcrypto_kmac(otcrypto_blinded_key_t *key,
                                 otcrypto_const_byte_buf_t input_message,
                                 otcrypto_const_byte_buf_t customization_string,
                                 size_t required_output_len,


### PR DESCRIPTION
Re-mask non-keymgr AES and KMAC keys before use. For HMAC, we have to unmask the keys anyway before passing to the hardware, so it doesn't make sense to re-mask them.

Part of https://github.com/lowRISC/opentitan/issues/27243