### PR TITLE
[crypto] Create a test target to measure post-link cryptolib size.

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -13,6 +13,7 @@ load(
     "EARLGREY_TEST_ENVS",
     "cw310_params",
     "fpga_params",
+    "opentitan_binary",
     "opentitan_test",
     "silicon_params",
     "verilator_params",
@@ -28,6 +29,26 @@ package(default_visibility = ["//visibility:public"])
 CRYPTOTEST_EXEC_ENVS = dicts.add(
     EARLGREY_TEST_ENVS,
     EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+)
+
+cc_library(
+    name = "otcrypto_interface",
+    srcs = ["otcrypto_interface.c"],
+    hdrs = ["otcrypto_interface.h"],
+    deps = [
+        "//sw/device/lib/crypto:crypto_exported_for_test",
+    ],
+)
+
+cc_binary(
+    name = "otcrypto_export_size",
+    srcs = ["otcrypto_export_size.c"],
+    # Disable link-time optimization to preserve unused cryptolib functions.
+    copts = ["-fno-lto"],
+    deps = [
+        ":otcrypto_interface",
+        "//sw/device/lib/arch:silicon",
+    ],
 )
 
 opentitan_test(

--- a/sw/device/tests/crypto/otcrypto_export_size.c
+++ b/sw/device/tests/crypto/otcrypto_export_size.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/crypto/otcrypto_interface.h"
+
+// Simple main function so the linker doesn't discard the inerface struct.
+int main(void) {
+  uint32_t digest_data[8];
+  otcrypto_hash_digest_t digest = {.data = digest_data, .len = 8};
+  otcrypto.sha2_256((otcrypto_const_byte_buf_t){.data = NULL, .len = 0},
+                    &digest);
+
+  // SHA256('') is a constant value; this will always be 0.
+  return digest_data[0] & 1;
+}

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -1,0 +1,204 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/crypto/otcrypto_interface.h"
+
+const otcrypto_interface_t otcrypto = {
+    // Symmetric key generation.
+    .symmetric_keygen = &otcrypto_symmetric_keygen,
+    .hw_backed_key = &otcrypto_hw_backed_key,
+
+    // Secret key import/export.
+    .import_blinded_key = &otcrypto_import_blinded_key,
+    .export_blinded_key = &otcrypto_export_blinded_key,
+
+    // Key wrapping.
+    .wrapped_key_len = &otcrypto_wrapped_key_len,
+    .key_wrap = &otcrypto_key_wrap,
+    .key_unwrap = &otcrypto_key_unwrap,
+
+    // AES
+    .aes = &otcrypto_aes,
+    .aes_padded_plaintext_length = &otcrypto_aes_padded_plaintext_length,
+
+    // AES-GCM (one-shot).
+    .aes_gcm_encrypt = &otcrypto_aes_gcm_encrypt,
+    .aes_gcm_decrypt = &otcrypto_aes_gcm_decrypt,
+
+    // AES-GCM (streaming).
+    .aes_gcm_encrypt_init = &otcrypto_aes_gcm_encrypt_init,
+    .aes_gcm_decrypt_init = &otcrypto_aes_gcm_decrypt_init,
+    .aes_gcm_update_aad = &otcrypto_aes_gcm_update_aad,
+    .aes_gcm_update_encrypted_data = &otcrypto_aes_gcm_update_encrypted_data,
+    .aes_gcm_encrypt_final = &otcrypto_aes_gcm_encrypt_final,
+    .aes_gcm_decrypt_final = &otcrypto_aes_gcm_decrypt_final,
+
+    // DRBG
+    .drbg_instantiate = &otcrypto_drbg_instantiate,
+    .drbg_reseed = &otcrypto_drbg_reseed,
+    .drbg_generate = &otcrypto_drbg_generate,
+    .drbg_uninstantiate = &otcrypto_drbg_uninstantiate,
+
+    // Manual DRBG (user-supplied entropy, for example for known-answer
+    // testing).
+    .drbg_manual_instantiate = &otcrypto_drbg_manual_instantiate,
+    .drbg_manual_reseed = &otcrypto_drbg_manual_reseed,
+    .drbg_manual_generate = &otcrypto_drbg_manual_generate,
+
+    // HKDF
+    .hkdf = &otcrypto_hkdf,
+    .hkdf_extract = &otcrypto_hkdf_extract,
+    .hkdf_expand = &otcrypto_hkdf_expand,
+
+    // HMAC (one-shot).
+    .hmac = &otcrypto_hmac,
+
+    // HMAC (streaming).
+    .hmac_init = &otcrypto_hmac_init,
+    .hmac_update = &otcrypto_hmac_update,
+    .hmac_final = &otcrypto_hmac_final,
+
+    // KDF-CTR with HMAC
+    .kdf_ctr_hmac = &otcrypto_kdf_ctr_hmac,
+
+    // KMAC
+    .kmac = &otcrypto_kmac,
+
+    // KMAC-KDF
+    .kmac_kdf = &otcrypto_kmac_kdf,
+
+    // SHA-2 (one-shot).
+    .sha2_256 = &otcrypto_sha2_256,
+    .sha2_384 = &otcrypto_sha2_384,
+    .sha2_512 = &otcrypto_sha2_512,
+
+    // SHA-2 (streaming).
+    .sha2_init = &otcrypto_sha2_init,
+    .sha2_update = &otcrypto_sha2_update,
+    .sha2_final = &otcrypto_sha2_final,
+
+    // SHA-3
+    .sha3_224 = &otcrypto_sha3_224,
+    .sha3_256 = &otcrypto_sha3_256,
+    .sha3_384 = &otcrypto_sha3_384,
+    .sha3_512 = &otcrypto_sha3_512,
+
+    // (c)SHAKE
+    .shake128 = &otcrypto_shake128,
+    .shake256 = &otcrypto_shake256,
+    .cshake128 = &otcrypto_cshake128,
+    .cshake256 = &otcrypto_cshake256,
+
+    // ECDSA P-256 (blocking).
+    .ecdsa_p256_keygen = &otcrypto_ecdsa_p256_keygen,
+    .ecdsa_p256_sign = &otcrypto_ecdsa_p256_sign,
+    .ecdsa_p256_verify = &otcrypto_ecdsa_p256_verify,
+
+    // ECDSA P-256 (async).
+    .ecdsa_p256_keygen_async_start = &otcrypto_ecdsa_p256_keygen_async_start,
+    .ecdsa_p256_keygen_async_finalize =
+        &otcrypto_ecdsa_p256_keygen_async_finalize,
+    .ecdsa_p256_sign_async_start = &otcrypto_ecdsa_p256_sign_async_start,
+    .ecdsa_p256_sign_async_finalize = &otcrypto_ecdsa_p256_sign_async_finalize,
+    .ecdsa_p256_verify_async_start = &otcrypto_ecdsa_p256_verify_async_start,
+    .ecdsa_p256_verify_async_finalize =
+        &otcrypto_ecdsa_p256_verify_async_finalize,
+
+    // ECDH P-256 (blocking).
+    .ecdh_p256_keygen = &otcrypto_ecdh_p256_keygen,
+    .ecdh_p256 = &otcrypto_ecdh_p256,
+
+    // ECDH P-256 (async).
+    .ecdh_p256_keygen_async_start = &otcrypto_ecdh_p256_keygen_async_start,
+    .ecdh_p256_keygen_async_finalize =
+        &otcrypto_ecdh_p256_keygen_async_finalize,
+    .ecdh_p256_async_start = &otcrypto_ecdh_p256_async_start,
+    .ecdh_p256_async_finalize = &otcrypto_ecdh_p256_async_finalize,
+
+    // ECDSA P-384 (blocking).
+    .ecdsa_p384_keygen = &otcrypto_ecdsa_p384_keygen,
+    .ecdsa_p384_sign = &otcrypto_ecdsa_p384_sign,
+    .ecdsa_p384_verify = &otcrypto_ecdsa_p384_verify,
+
+    // ECDSA P-384 (async).
+    .ecdsa_p384_keygen_async_start = &otcrypto_ecdsa_p384_keygen_async_start,
+    .ecdsa_p384_keygen_async_finalize =
+        &otcrypto_ecdsa_p384_keygen_async_finalize,
+    .ecdsa_p384_sign_async_start = &otcrypto_ecdsa_p384_sign_async_start,
+    .ecdsa_p384_sign_async_finalize = &otcrypto_ecdsa_p384_sign_async_finalize,
+    .ecdsa_p384_verify_async_start = &otcrypto_ecdsa_p384_verify_async_start,
+    .ecdsa_p384_verify_async_finalize =
+        &otcrypto_ecdsa_p384_verify_async_finalize,
+
+    // ECDH P-384 (blocking).
+    .ecdh_p384_keygen = &otcrypto_ecdh_p384_keygen,
+    .ecdh_p384 = &otcrypto_ecdh_p384,
+
+    // ECDH P-384 (async).
+    .ecdh_p384_keygen_async_start = &otcrypto_ecdh_p384_keygen_async_start,
+    .ecdh_p384_keygen_async_finalize =
+        &otcrypto_ecdh_p384_keygen_async_finalize,
+    .ecdh_p384_async_start = &otcrypto_ecdh_p384_async_start,
+    .ecdh_p384_async_finalize = &otcrypto_ecdh_p384_async_finalize,
+
+    // Ed25519 (blocking).
+    .ed25519_keygen = &otcrypto_ed25519_keygen,
+    .ed25519_sign = &otcrypto_ed25519_sign,
+    .ed25519_verify = &otcrypto_ed25519_verify,
+
+    // Ed25519 (async).
+    .ed25519_keygen_async_start = &otcrypto_ed25519_keygen_async_start,
+    .ed25519_keygen_async_finalize = &otcrypto_ed25519_keygen_async_finalize,
+    .ed25519_sign_async_start = &otcrypto_ed25519_sign_async_start,
+    .ed25519_sign_async_finalize = &otcrypto_ed25519_sign_async_finalize,
+    .ed25519_verify_async_start = &otcrypto_ed25519_verify_async_start,
+    .ed25519_verify_async_finalize = &otcrypto_ed25519_verify_async_finalize,
+
+    // X25519 (blocking).
+    .x25519_keygen = &otcrypto_x25519_keygen,
+    .x25519 = &otcrypto_x25519,
+
+    // X25519 (async).
+    .x25519_keygen_async_start = &otcrypto_x25519_keygen_async_start,
+    .x25519_keygen_async_finalize = &otcrypto_x25519_keygen_async_finalize,
+    .x25519_async_start = &otcrypto_x25519_async_start,
+    .x25519_async_finalize = &otcrypto_x25519_async_finalize,
+
+    // RSA key construction.
+    .rsa_public_key_construct = &otcrypto_rsa_public_key_construct,
+    .rsa_private_key_from_exponents = &otcrypto_rsa_private_key_from_exponents,
+
+    // RSA key generation (blocking).
+    .rsa_keygen = &otcrypto_rsa_keygen,
+    .rsa_keypair_from_cofactor = &otcrypto_rsa_keypair_from_cofactor,
+
+    // RSA key generation (async).
+    .rsa_keygen_async_start = &otcrypto_rsa_keygen_async_start,
+    .rsa_keygen_async_finalize = &otcrypto_rsa_keygen_async_finalize,
+    .rsa_keypair_from_cofactor_async_start =
+        &otcrypto_rsa_keypair_from_cofactor_async_start,
+    .rsa_keypair_from_cofactor_async_finalize =
+        &otcrypto_rsa_keypair_from_cofactor_async_finalize,
+
+    // RSA signatures (blocking).
+    .rsa_sign = &otcrypto_rsa_sign,
+    .rsa_verify = &otcrypto_rsa_verify,
+
+    // RSA signatures (async).
+    .rsa_sign_async_start = &otcrypto_rsa_sign_async_start,
+    .rsa_sign_async_finalize = &otcrypto_rsa_sign_async_finalize,
+    .rsa_verify_async_start = &otcrypto_rsa_verify_async_start,
+    .rsa_verify_async_finalize = &otcrypto_rsa_verify_async_finalize,
+
+    // RSA encryption (blocking).
+    .rsa_encrypt = &otcrypto_rsa_encrypt,
+    .rsa_decrypt = &otcrypto_rsa_decrypt,
+
+    // RSA encryption (async).
+    .rsa_encrypt_async_start = &otcrypto_rsa_encrypt_async_start,
+    .rsa_encrypt_async_finalize = &otcrypto_rsa_encrypt_async_finalize,
+    .rsa_decrypt_async_start = &otcrypto_rsa_decrypt_async_start,
+    .rsa_decrypt_async_finalize = &otcrypto_rsa_decrypt_async_finalize,
+
+};

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -1,0 +1,349 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_OTCRYPTO_INTERFACE_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_OTCRYPTO_INTERFACE_H_
+
+#include "sw/device/lib/crypto/include/otcrypto.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Function pointers to the OpenTitan cryptography library.
+ */
+typedef struct otcrypto_interface_t {
+  // Key utilities
+  otcrypto_status_t (*symmetric_keygen)(otcrypto_const_byte_buf_t,
+                                        otcrypto_blinded_key_t *);
+  otcrypto_status_t (*hw_backed_key)(uint32_t, const uint32_t salt[7],
+                                     otcrypto_blinded_key_t *);
+  otcrypto_status_t (*wrapped_key_len)(const otcrypto_key_config_t, size_t *);
+  otcrypto_status_t (*key_wrap)(const otcrypto_blinded_key_t *,
+                                const otcrypto_blinded_key_t *,
+                                otcrypto_word32_buf_t);
+  otcrypto_status_t (*key_unwrap)(otcrypto_const_word32_buf_t,
+                                  const otcrypto_blinded_key_t *,
+                                  hardened_bool_t *, otcrypto_blinded_key_t *);
+  otcrypto_status_t (*import_blinded_key)(
+      const otcrypto_const_word32_buf_t key_share0,
+      const otcrypto_const_word32_buf_t key_share1, otcrypto_blinded_key_t *);
+  otcrypto_status_t (*export_blinded_key)(const otcrypto_blinded_key_t *,
+                                          otcrypto_word32_buf_t key_share0,
+                                          otcrypto_word32_buf_t key_share1);
+
+  // AES
+  otcrypto_status_t (*aes)(const otcrypto_blinded_key_t *,
+                           otcrypto_word32_buf_t, otcrypto_aes_mode_t,
+                           otcrypto_aes_operation_t, otcrypto_const_byte_buf_t,
+                           otcrypto_aes_padding_t, otcrypto_byte_buf_t);
+  otcrypto_status_t (*aes_padded_plaintext_length)(size_t,
+                                                   otcrypto_aes_padding_t,
+                                                   size_t *);
+
+  // AES-GCM
+  otcrypto_status_t (*aes_gcm_encrypt)(
+      const otcrypto_blinded_key_t *, otcrypto_const_byte_buf_t,
+      otcrypto_const_word32_buf_t, otcrypto_const_byte_buf_t,
+      otcrypto_aes_gcm_tag_len_t, otcrypto_byte_buf_t, otcrypto_word32_buf_t);
+  otcrypto_status_t (*aes_gcm_decrypt)(const otcrypto_blinded_key_t *,
+                                       otcrypto_const_byte_buf_t,
+                                       otcrypto_const_word32_buf_t,
+                                       otcrypto_const_byte_buf_t,
+                                       otcrypto_aes_gcm_tag_len_t,
+                                       otcrypto_const_word32_buf_t,
+                                       otcrypto_byte_buf_t, hardened_bool_t *);
+  otcrypto_status_t (*aes_gcm_encrypt_init)(const otcrypto_blinded_key_t *,
+                                            otcrypto_const_word32_buf_t,
+                                            otcrypto_aes_gcm_context_t *);
+  otcrypto_status_t (*aes_gcm_decrypt_init)(const otcrypto_blinded_key_t *,
+                                            otcrypto_const_word32_buf_t,
+                                            otcrypto_aes_gcm_context_t *);
+  otcrypto_status_t (*aes_gcm_update_aad)(otcrypto_aes_gcm_context_t *,
+                                          otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*aes_gcm_update_encrypted_data)(
+      otcrypto_aes_gcm_context_t *, otcrypto_const_byte_buf_t,
+      otcrypto_byte_buf_t, size_t *);
+  otcrypto_status_t (*aes_gcm_encrypt_final)(otcrypto_aes_gcm_context_t *,
+                                             otcrypto_aes_gcm_tag_len_t,
+                                             otcrypto_byte_buf_t, size_t *,
+                                             otcrypto_word32_buf_t);
+  otcrypto_status_t (*aes_gcm_decrypt_final)(otcrypto_aes_gcm_context_t *,
+                                             otcrypto_const_word32_buf_t,
+                                             otcrypto_aes_gcm_tag_len_t,
+                                             otcrypto_byte_buf_t, size_t *,
+                                             hardened_bool_t *);
+
+  // DRBG
+  otcrypto_status_t (*drbg_instantiate)(otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*drbg_reseed)(otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*drbg_manual_instantiate)(otcrypto_const_byte_buf_t,
+                                               otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*drbg_manual_reseed)(otcrypto_const_byte_buf_t,
+                                          otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*drbg_generate)(otcrypto_const_byte_buf_t,
+                                     otcrypto_word32_buf_t);
+  otcrypto_status_t (*drbg_manual_generate)(otcrypto_const_byte_buf_t,
+                                            otcrypto_word32_buf_t);
+  otcrypto_status_t (*drbg_uninstantiate)(void);
+
+  // HKDF
+  otcrypto_status_t (*hkdf)(const otcrypto_blinded_key_t *,
+                            otcrypto_const_byte_buf_t,
+                            otcrypto_const_byte_buf_t,
+                            otcrypto_blinded_key_t *);
+  otcrypto_status_t (*hkdf_extract)(const otcrypto_blinded_key_t *,
+                                    otcrypto_const_byte_buf_t,
+                                    otcrypto_blinded_key_t *);
+  otcrypto_status_t (*hkdf_expand)(const otcrypto_blinded_key_t *,
+                                   otcrypto_const_byte_buf_t,
+                                   otcrypto_blinded_key_t *);
+
+  // HMAC
+  otcrypto_status_t (*hmac)(const otcrypto_blinded_key_t *,
+                            otcrypto_const_byte_buf_t, otcrypto_word32_buf_t);
+  otcrypto_status_t (*hmac_init)(otcrypto_hmac_context_t *,
+                                 const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*hmac_update)(otcrypto_hmac_context_t *const,
+                                   otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*hmac_final)(otcrypto_hmac_context_t *const,
+                                  otcrypto_word32_buf_t);
+
+  // KDF-CTR
+  otcrypto_status_t (*kdf_ctr_hmac)(const otcrypto_blinded_key_t *,
+                                    const otcrypto_const_byte_buf_t,
+                                    const otcrypto_const_byte_buf_t,
+                                    otcrypto_blinded_key_t *);
+
+  // KMAC
+  otcrypto_status_t (*kmac)(const otcrypto_blinded_key_t *,
+                            otcrypto_const_byte_buf_t,
+                            otcrypto_const_byte_buf_t, size_t,
+                            otcrypto_word32_buf_t);
+
+  // KMAC-KDF
+  otcrypto_status_t (*kmac_kdf)(otcrypto_blinded_key_t *,
+                                const otcrypto_const_byte_buf_t,
+                                const otcrypto_const_byte_buf_t,
+                                otcrypto_blinded_key_t *);
+
+  // SHA-2
+  otcrypto_status_t (*sha2_256)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*sha2_384)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*sha2_512)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*sha2_init)(otcrypto_hash_mode_t,
+                                 otcrypto_sha2_context_t *);
+  otcrypto_status_t (*sha2_update)(otcrypto_sha2_context_t *,
+                                   otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*sha2_final)(otcrypto_sha2_context_t *,
+                                  otcrypto_hash_digest_t *);
+
+  // SHA-3
+  otcrypto_status_t (*sha3_224)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*sha3_256)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*sha3_384)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*sha3_512)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*shake128)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*shake256)(otcrypto_const_byte_buf_t,
+                                otcrypto_hash_digest_t *);
+  otcrypto_status_t (*cshake128)(otcrypto_const_byte_buf_t,
+                                 otcrypto_const_byte_buf_t,
+                                 otcrypto_const_byte_buf_t,
+                                 otcrypto_hash_digest_t *);
+  otcrypto_status_t (*cshake256)(otcrypto_const_byte_buf_t,
+                                 otcrypto_const_byte_buf_t,
+                                 otcrypto_const_byte_buf_t,
+                                 otcrypto_hash_digest_t *);
+
+  // ED25519
+  otcrypto_status_t (*ed25519_keygen)(otcrypto_blinded_key_t *,
+                                      otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ed25519_sign)(const otcrypto_blinded_key_t *,
+                                    otcrypto_const_byte_buf_t,
+                                    otcrypto_eddsa_sign_mode_t,
+                                    otcrypto_word32_buf_t);
+  otcrypto_status_t (*ed25519_verify)(const otcrypto_unblinded_key_t *,
+                                      otcrypto_const_byte_buf_t,
+                                      otcrypto_eddsa_sign_mode_t,
+                                      otcrypto_const_word32_buf_t,
+                                      hardened_bool_t *);
+  otcrypto_status_t (*ed25519_keygen_async_start)(
+      const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ed25519_keygen_async_finalize)(
+      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ed25519_sign_async_start)(const otcrypto_blinded_key_t *,
+                                                otcrypto_const_byte_buf_t,
+                                                otcrypto_eddsa_sign_mode_t,
+                                                otcrypto_word32_buf_t);
+  otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_word32_buf_t);
+  otcrypto_status_t (*ed25519_verify_async_start)(
+      const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t,
+      otcrypto_eddsa_sign_mode_t, otcrypto_const_word32_buf_t);
+  otcrypto_status_t (*ed25519_verify_async_finalize)(hardened_bool_t *);
+
+  // X25519
+  otcrypto_status_t (*x25519_keygen)(otcrypto_blinded_key_t *,
+                                     otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*x25519)(const otcrypto_blinded_key_t *,
+                              const otcrypto_unblinded_key_t *,
+                              otcrypto_blinded_key_t *);
+  otcrypto_status_t (*x25519_keygen_async_start)(
+      const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*x25519_keygen_async_finalize)(otcrypto_blinded_key_t *,
+                                                    otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*x25519_async_start)(const otcrypto_blinded_key_t *,
+                                          const otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*x25519_async_finalize)(otcrypto_blinded_key_t *);
+
+  // RSA
+  otcrypto_status_t (*rsa_keygen)(otcrypto_rsa_size_t,
+                                  otcrypto_unblinded_key_t *,
+                                  otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_public_key_construct)(otcrypto_rsa_size_t,
+                                                otcrypto_const_word32_buf_t,
+                                                uint32_t,
+                                                otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*rsa_private_key_from_exponents)(
+      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_keypair_from_cofactor)(
+      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_unblinded_key_t *, otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_sign)(const otcrypto_blinded_key_t *,
+                                const otcrypto_hash_digest_t,
+                                otcrypto_rsa_padding_t, otcrypto_word32_buf_t);
+  otcrypto_status_t (*rsa_verify)(const otcrypto_unblinded_key_t *,
+                                  const otcrypto_hash_digest_t,
+                                  otcrypto_rsa_padding_t,
+                                  otcrypto_const_word32_buf_t,
+                                  hardened_bool_t *);
+  otcrypto_status_t (*rsa_encrypt)(const otcrypto_unblinded_key_t *,
+                                   const otcrypto_hash_mode_t,
+                                   otcrypto_const_byte_buf_t,
+                                   otcrypto_const_byte_buf_t,
+                                   otcrypto_word32_buf_t);
+  otcrypto_status_t (*rsa_decrypt)(const otcrypto_blinded_key_t *,
+                                   const otcrypto_hash_mode_t,
+                                   otcrypto_const_word32_buf_t,
+                                   otcrypto_const_byte_buf_t,
+                                   otcrypto_byte_buf_t, size_t *);
+  otcrypto_status_t (*rsa_keygen_async_start)(otcrypto_rsa_size_t);
+  otcrypto_status_t (*rsa_keygen_async_finalize)(otcrypto_unblinded_key_t *,
+                                                 otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_keypair_from_cofactor_async_start)(
+      otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
+      otcrypto_const_word32_buf_t cofactor_share0,
+      otcrypto_const_word32_buf_t cofactor_share1);
+  otcrypto_status_t (*rsa_keypair_from_cofactor_async_finalize)(
+      otcrypto_unblinded_key_t *, otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_sign_async_start)(const otcrypto_blinded_key_t *,
+                                            const otcrypto_hash_digest_t,
+                                            otcrypto_rsa_padding_t);
+  otcrypto_status_t (*rsa_sign_async_finalize)(otcrypto_word32_buf_t);
+  otcrypto_status_t (*rsa_verify_async_start)(const otcrypto_unblinded_key_t *,
+                                              otcrypto_const_word32_buf_t);
+  otcrypto_status_t (*rsa_verify_async_finalize)(const otcrypto_hash_digest_t,
+                                                 otcrypto_rsa_padding_t,
+                                                 hardened_bool_t *);
+  otcrypto_status_t (*rsa_encrypt_async_start)(const otcrypto_unblinded_key_t *,
+                                               const otcrypto_hash_mode_t,
+                                               otcrypto_const_byte_buf_t,
+                                               otcrypto_const_byte_buf_t);
+  otcrypto_status_t (*rsa_encrypt_async_finalize)(otcrypto_word32_buf_t);
+  otcrypto_status_t (*rsa_decrypt_async_start)(const otcrypto_blinded_key_t *,
+                                               otcrypto_const_word32_buf_t);
+  otcrypto_status_t (*rsa_decrypt_async_finalize)(const otcrypto_hash_mode_t,
+                                                  otcrypto_const_byte_buf_t,
+                                                  otcrypto_byte_buf_t,
+                                                  size_t *);
+  // P-256
+  otcrypto_status_t (*ecdsa_p256_keygen)(otcrypto_blinded_key_t *,
+                                         otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdsa_p256_sign)(const otcrypto_blinded_key_t *,
+                                       const otcrypto_hash_digest_t,
+                                       otcrypto_word32_buf_t);
+  otcrypto_status_t (*ecdsa_p256_verify)(const otcrypto_unblinded_key_t *,
+                                         const otcrypto_hash_digest_t,
+                                         otcrypto_const_word32_buf_t,
+                                         hardened_bool_t *);
+  otcrypto_status_t (*ecdh_p256_keygen)(otcrypto_blinded_key_t *,
+                                        otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdh_p256)(const otcrypto_blinded_key_t *,
+                                 const otcrypto_unblinded_key_t *,
+                                 otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdsa_p256_keygen_async_start)(
+      const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdsa_p256_keygen_async_finalize)(
+      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdsa_p256_sign_async_start)(
+      const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t);
+  otcrypto_status_t (*ecdsa_p256_sign_async_finalize)(otcrypto_word32_buf_t);
+  otcrypto_status_t (*ecdsa_p256_verify_async_start)(
+      const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
+      otcrypto_const_word32_buf_t);
+  otcrypto_status_t (*ecdsa_p256_verify_async_finalize)(
+      otcrypto_const_word32_buf_t, hardened_bool_t *);
+  otcrypto_status_t (*ecdh_p256_keygen_async_start)(
+      const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdh_p256_keygen_async_finalize)(
+      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdh_p256_async_start)(const otcrypto_blinded_key_t *,
+                                             const otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdh_p256_async_finalize)(otcrypto_blinded_key_t *);
+
+  // P-384
+  otcrypto_status_t (*ecdsa_p384_keygen)(otcrypto_blinded_key_t *,
+                                         otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdsa_p384_sign)(const otcrypto_blinded_key_t *,
+                                       const otcrypto_hash_digest_t,
+                                       otcrypto_word32_buf_t);
+  otcrypto_status_t (*ecdsa_p384_verify)(const otcrypto_unblinded_key_t *,
+                                         const otcrypto_hash_digest_t,
+                                         otcrypto_const_word32_buf_t,
+                                         hardened_bool_t *);
+  otcrypto_status_t (*ecdh_p384_keygen)(otcrypto_blinded_key_t *,
+                                        otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdh_p384)(const otcrypto_blinded_key_t *,
+                                 const otcrypto_unblinded_key_t *,
+                                 otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdsa_p384_keygen_async_start)(
+      const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdsa_p384_keygen_async_finalize)(
+      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdsa_p384_sign_async_start)(
+      const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t);
+  otcrypto_status_t (*ecdsa_p384_sign_async_finalize)(otcrypto_word32_buf_t);
+  otcrypto_status_t (*ecdsa_p384_verify_async_start)(
+      const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
+      otcrypto_const_word32_buf_t);
+  otcrypto_status_t (*ecdsa_p384_verify_async_finalize)(
+      otcrypto_const_word32_buf_t, hardened_bool_t *);
+  otcrypto_status_t (*ecdh_p384_keygen_async_start)(
+      const otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdh_p384_keygen_async_finalize)(
+      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdh_p384_async_start)(const otcrypto_blinded_key_t *,
+                                             const otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*ecdh_p384_async_finalize)(otcrypto_blinded_key_t *);
+
+} otcrypto_interface_t;
+
+extern const otcrypto_interface_t otcrypto;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_OTCRYPTO_INTERFACE_H_


### PR DESCRIPTION
Developed with help from @cfrantz 

Create a struct to hold all the cryptolib algorithms, and a thin `main` function that uses it. Requires LTO to be turned off so that the whole struct is preserved. This is useful for measuring the size of the cryptolib itself when built for on-device targets.

Part of https://github.com/lowRISC/opentitan/pull/26322