### PR TITLE
Expose ipgen parameter to dtgen

### DIFF
--- a/hw/ip_templates/gpio/data/gpio.tpldesc.hjson
+++ b/hw/ip_templates/gpio/data/gpio.tpldesc.hjson
@@ -26,6 +26,11 @@
       desc: "number of input period counters"
       type: "int"
       default: 0
+      dtgen:
+      {
+        type: "uint8"
+        name: "input_period_counter_count"
+      }
     }
   ]
 }

--- a/hw/ip_templates/gpio/defs.bzl.tpl
+++ b/hw/ip_templates/gpio/defs.bzl.tpl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 ${module_instance_name.upper()} = opentitan_ip(
     name = "${module_instance_name}",
     hjson = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:${module_instance_name}.hjson",
+    ipconfig = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:top_${topname}_${module_instance_name}.ipconfig.hjson",
 )

--- a/hw/ip_templates/pwm/data/pwm.tpldesc.hjson
+++ b/hw/ip_templates/pwm/data/pwm.tpldesc.hjson
@@ -26,6 +26,11 @@
       desc: "Number of output channels"
       type: "int"
       default: "6"
+      dtgen:
+      {
+        type: "uint8"
+        name: "output_channel_count"
+      }
     }
   ]
 }

--- a/hw/ip_templates/pwm/defs.bzl.tpl
+++ b/hw/ip_templates/pwm/defs.bzl.tpl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 ${module_instance_name.upper()} = opentitan_ip(
     name = "${module_instance_name}",
     hjson = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:${module_instance_name}.hjson",
+    ipconfig = "//hw/top_${topname}/ip_autogen/${module_instance_name}/data:top_${topname}_${module_instance_name}.ipconfig.hjson",
 )

--- a/hw/ip_templates/pwrmgr/util/dt.py
+++ b/hw/ip_templates/pwrmgr/util/dt.py
@@ -89,7 +89,7 @@ size_t dt_pwrmgr_wakeup_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_wakeup_src_t dt_pwrmgr_wakeup_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_wakeup_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .wakeup = 0};
-  return TRY_GET_DT(dt, invalid)->ext.wakeup_src[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.wakeup_src[idx];
 }
 
 size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
@@ -98,7 +98,7 @@ size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_reset_req_src_t dt_pwrmgr_reset_request_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_reset_req_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .reset_req = 0};
-  return TRY_GET_DT(dt, invalid)->ext.rst_reqs[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.rst_reqs[idx];
 }
 """
 
@@ -149,7 +149,7 @@ class PwrmgrExt(Extension):
         if ip_helper.ip.name == "pwrmgr":
             return PwrmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         wakeup_count = len(self.ipconfig.wakeup_list())
         rstreq_count = len(self.ipconfig.peripheral_reset_req_list())
 
@@ -174,7 +174,7 @@ class PwrmgrExt(Extension):
             ),
             docstring = "List of reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["pwrmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Optional[dict]:
         wakeup_srcs = {}

--- a/hw/ip_templates/rstmgr/util/dt.py
+++ b/hw/ip_templates/rstmgr/util/dt.py
@@ -6,7 +6,6 @@ files.
 """
 from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
-from typing import Optional
 from collections import OrderedDict
 import os
 import sys
@@ -80,7 +79,7 @@ dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
   if (idx >= %(sw_reset_count)d) {
     return kDtResetUnknown;
   }
-  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+  return TRY_GET_DT(dt, kDtResetUnknown)->rstmgr_ext.sw_rst[idx];
 }
 """
 
@@ -116,7 +115,7 @@ class RstmgrExt(Extension):
         if ip_helper.ip.name == "rstmgr":
             return RstmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_rsts_count = len(self.ipconfig.sw_rsts_list())
         hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
 
@@ -141,7 +140,7 @@ class RstmgrExt(Extension):
             ),
             docstring = "List of hardware reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["rstmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> dict:
         sw_rsts = {}

--- a/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/gpio/data/top_darjeeling_gpio.ipconfig.hjson
@@ -10,4 +10,13 @@
     topname: darjeeling
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_inp_period_counters:
+    {
+      type: uint8
+      name: input_period_counter_count
+      doc: number of input period counters
+    }
+  }
 }

--- a/hw/top_darjeeling/ip_autogen/gpio/defs.bzl
+++ b/hw/top_darjeeling/ip_autogen/gpio/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 GPIO = opentitan_ip(
     name = "gpio",
     hjson = "//hw/top_darjeeling/ip_autogen/gpio/data:gpio.hjson",
+    ipconfig = "//hw/top_darjeeling/ip_autogen/gpio/data:top_darjeeling_gpio.ipconfig.hjson",
 )

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/util/dt.py
@@ -89,7 +89,7 @@ size_t dt_pwrmgr_wakeup_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_wakeup_src_t dt_pwrmgr_wakeup_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_wakeup_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .wakeup = 0};
-  return TRY_GET_DT(dt, invalid)->ext.wakeup_src[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.wakeup_src[idx];
 }
 
 size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
@@ -98,7 +98,7 @@ size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_reset_req_src_t dt_pwrmgr_reset_request_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_reset_req_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .reset_req = 0};
-  return TRY_GET_DT(dt, invalid)->ext.rst_reqs[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.rst_reqs[idx];
 }
 """
 
@@ -149,7 +149,7 @@ class PwrmgrExt(Extension):
         if ip_helper.ip.name == "pwrmgr":
             return PwrmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         wakeup_count = len(self.ipconfig.wakeup_list())
         rstreq_count = len(self.ipconfig.peripheral_reset_req_list())
 
@@ -174,7 +174,7 @@ class PwrmgrExt(Extension):
             ),
             docstring = "List of reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["pwrmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Optional[dict]:
         wakeup_srcs = {}

--- a/hw/top_darjeeling/ip_autogen/rstmgr/util/dt.py
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/util/dt.py
@@ -6,7 +6,6 @@ files.
 """
 from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
-from typing import Optional
 from collections import OrderedDict
 import os
 import sys
@@ -80,7 +79,7 @@ dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
   if (idx >= %(sw_reset_count)d) {
     return kDtResetUnknown;
   }
-  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+  return TRY_GET_DT(dt, kDtResetUnknown)->rstmgr_ext.sw_rst[idx];
 }
 """
 
@@ -116,7 +115,7 @@ class RstmgrExt(Extension):
         if ip_helper.ip.name == "rstmgr":
             return RstmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_rsts_count = len(self.ipconfig.sw_rsts_list())
         hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
 
@@ -141,7 +140,7 @@ class RstmgrExt(Extension):
             ),
             docstring = "List of hardware reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["rstmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> dict:
         sw_rsts = {}

--- a/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/gpio/data/top_earlgrey_gpio.ipconfig.hjson
@@ -10,4 +10,13 @@
     topname: earlgrey
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_inp_period_counters:
+    {
+      type: uint8
+      name: input_period_counter_count
+      doc: number of input period counters
+    }
+  }
 }

--- a/hw/top_earlgrey/ip_autogen/gpio/defs.bzl
+++ b/hw/top_earlgrey/ip_autogen/gpio/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 GPIO = opentitan_ip(
     name = "gpio",
     hjson = "//hw/top_earlgrey/ip_autogen/gpio/data:gpio.hjson",
+    ipconfig = "//hw/top_earlgrey/ip_autogen/gpio/data:top_earlgrey_gpio.ipconfig.hjson",
 )

--- a/hw/top_earlgrey/ip_autogen/pwm/data/top_earlgrey_pwm.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwm/data/top_earlgrey_pwm.ipconfig.hjson
@@ -10,4 +10,13 @@
     uniquified_modules: {}
     nr_output_channels: 6
   }
+  dtgen:
+  {
+    nr_output_channels:
+    {
+      type: uint8
+      name: output_channel_count
+      doc: Number of output channels
+    }
+  }
 }

--- a/hw/top_earlgrey/ip_autogen/pwm/defs.bzl
+++ b/hw/top_earlgrey/ip_autogen/pwm/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 PWM = opentitan_ip(
     name = "pwm",
     hjson = "//hw/top_earlgrey/ip_autogen/pwm/data:pwm.hjson",
+    ipconfig = "//hw/top_earlgrey/ip_autogen/pwm/data:top_earlgrey_pwm.ipconfig.hjson",
 )

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/util/dt.py
@@ -89,7 +89,7 @@ size_t dt_pwrmgr_wakeup_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_wakeup_src_t dt_pwrmgr_wakeup_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_wakeup_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .wakeup = 0};
-  return TRY_GET_DT(dt, invalid)->ext.wakeup_src[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.wakeup_src[idx];
 }
 
 size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
@@ -98,7 +98,7 @@ size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_reset_req_src_t dt_pwrmgr_reset_request_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_reset_req_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .reset_req = 0};
-  return TRY_GET_DT(dt, invalid)->ext.rst_reqs[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.rst_reqs[idx];
 }
 """
 
@@ -149,7 +149,7 @@ class PwrmgrExt(Extension):
         if ip_helper.ip.name == "pwrmgr":
             return PwrmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         wakeup_count = len(self.ipconfig.wakeup_list())
         rstreq_count = len(self.ipconfig.peripheral_reset_req_list())
 
@@ -174,7 +174,7 @@ class PwrmgrExt(Extension):
             ),
             docstring = "List of reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["pwrmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Optional[dict]:
         wakeup_srcs = {}

--- a/hw/top_earlgrey/ip_autogen/rstmgr/util/dt.py
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/util/dt.py
@@ -6,7 +6,6 @@ files.
 """
 from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
-from typing import Optional
 from collections import OrderedDict
 import os
 import sys
@@ -80,7 +79,7 @@ dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
   if (idx >= %(sw_reset_count)d) {
     return kDtResetUnknown;
   }
-  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+  return TRY_GET_DT(dt, kDtResetUnknown)->rstmgr_ext.sw_rst[idx];
 }
 """
 
@@ -116,7 +115,7 @@ class RstmgrExt(Extension):
         if ip_helper.ip.name == "rstmgr":
             return RstmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_rsts_count = len(self.ipconfig.sw_rsts_list())
         hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
 
@@ -141,7 +140,7 @@ class RstmgrExt(Extension):
             ),
             docstring = "List of hardware reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["rstmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> dict:
         sw_rsts = {}

--- a/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/data/top_englishbreakfast_gpio.ipconfig.hjson
@@ -10,4 +10,13 @@
     topname: englishbreakfast
     uniquified_modules: {}
   }
+  dtgen:
+  {
+    num_inp_period_counters:
+    {
+      type: uint8
+      name: input_period_counter_count
+      doc: number of input period counters
+    }
+  }
 }

--- a/hw/top_englishbreakfast/ip_autogen/gpio/defs.bzl
+++ b/hw/top_englishbreakfast/ip_autogen/gpio/defs.bzl
@@ -6,4 +6,5 @@ load("//rules/opentitan:hw.bzl", "opentitan_ip")
 GPIO = opentitan_ip(
     name = "gpio",
     hjson = "//hw/top_englishbreakfast/ip_autogen/gpio/data:gpio.hjson",
+    ipconfig = "//hw/top_englishbreakfast/ip_autogen/gpio/data:top_englishbreakfast_gpio.ipconfig.hjson",
 )

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/util/dt.py
@@ -89,7 +89,7 @@ size_t dt_pwrmgr_wakeup_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_wakeup_src_t dt_pwrmgr_wakeup_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_wakeup_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .wakeup = 0};
-  return TRY_GET_DT(dt, invalid)->ext.wakeup_src[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.wakeup_src[idx];
 }
 
 size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
@@ -98,7 +98,7 @@ size_t dt_pwrmgr_reset_request_src_count(dt_pwrmgr_t dt) {
 
 dt_pwrmgr_reset_req_src_t dt_pwrmgr_reset_request_src(dt_pwrmgr_t dt, size_t idx) {
   dt_pwrmgr_reset_req_src_t invalid = {.inst_id = kDtInstanceIdUnknown, .reset_req = 0};
-  return TRY_GET_DT(dt, invalid)->ext.rst_reqs[idx];
+  return TRY_GET_DT(dt, invalid)->pwrmgr_ext.rst_reqs[idx];
 }
 """
 
@@ -149,7 +149,7 @@ class PwrmgrExt(Extension):
         if ip_helper.ip.name == "pwrmgr":
             return PwrmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         wakeup_count = len(self.ipconfig.wakeup_list())
         rstreq_count = len(self.ipconfig.peripheral_reset_req_list())
 
@@ -174,7 +174,7 @@ class PwrmgrExt(Extension):
             ),
             docstring = "List of reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["pwrmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> Optional[dict]:
         wakeup_srcs = {}

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/util/dt.py
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/util/dt.py
@@ -6,7 +6,6 @@ files.
 """
 from dtgen.helper import IpHelper, Extension, StructType, ScalarType, ArrayMapType
 from topgen.lib import Name
-from typing import Optional
 from collections import OrderedDict
 import os
 import sys
@@ -80,7 +79,7 @@ dt_reset_t dt_rstmgr_sw_reset(dt_rstmgr_t dt, size_t idx) {
   if (idx >= %(sw_reset_count)d) {
     return kDtResetUnknown;
   }
-  return TRY_GET_DT(dt, kDtResetUnknown)->ext.sw_rst[idx];
+  return TRY_GET_DT(dt, kDtResetUnknown)->rstmgr_ext.sw_rst[idx];
 }
 """
 
@@ -116,7 +115,7 @@ class RstmgrExt(Extension):
         if ip_helper.ip.name == "rstmgr":
             return RstmgrExt(ip_helper)
 
-    def extend_dt_ip(self) -> Optional[StructType]:
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
         sw_rsts_count = len(self.ipconfig.sw_rsts_list())
         hw_reqs_count = len(self.ipconfig.hw_reset_req_list())
 
@@ -141,7 +140,7 @@ class RstmgrExt(Extension):
             ),
             docstring = "List of hardware reset requests, in the order of the register fields",
         )
-        return st
+        return Name(["rstmgr_ext"]), st
 
     def fill_dt_ip(self, m) -> dict:
         sw_rsts = {}

--- a/util/BUILD
+++ b/util/BUILD
@@ -91,6 +91,7 @@ py_binary(
     ],
     deps = [
         "//util/dtgen:helper",
+        "//util/dtgen:ipgen_ext",
         "//util/ipgen",
         "//util/reggen:ip_block",
         "//util/reggen:version",

--- a/util/dtgen/BUILD
+++ b/util/dtgen/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,6 +11,15 @@ py_library(
     name = "helper",
     srcs = ["helper.py"],
     deps = ["//util/topgen:lib"],
+)
+
+py_library(
+    name = "ipgen_ext",
+    srcs = ["ipgen_ext.py"],
+    deps = [
+        "//util/topgen:lib",
+        requirement("jsonschema"),
+    ],
 )
 
 filegroup(

--- a/util/dtgen/ipgen_ext.py
+++ b/util/dtgen/ipgen_ext.py
@@ -1,0 +1,156 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""This extension generates extra DT fields automatically based on the `dtgen`
+instructions in the ipconfig.
+"""
+
+from .helper import IpHelper, Extension, StructType, ScalarType
+from topgen.lib import Name
+from typing import Optional
+from jsonschema import validate
+from dataclasses import dataclass
+
+# Map from scalar type names (used in `dtgen`) to tuples:
+# - C type name
+# - Default value to return if the dt function is called with
+#   an invalid argument
+SCALAR_TYPES = {
+    "uint8": {
+        "c_typename": "uint8_t",
+        "c_invalid_value": 0,
+    },
+}
+
+# Schema of the "dtgen" attribute in the ipconfig.
+dtgen_schema = {
+    "type": "object",
+    "patternProperties": {
+        ".*": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": list(SCALAR_TYPES.keys()),
+                },
+                "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z_]+[a-zA-Z0-9_]*$",
+                },
+                "doc": {
+                    "type": "string",
+                }
+            },
+            "required": ["type"],
+        }
+    }
+}
+
+SCALAR_GETTER_HDR_TEMPLATE = """
+/**
+ * Get the {docshort}.
+ *
+ * @param dt Instance of {ipname}.
+ * @return {docshort}.
+ */
+{rettype} dt_{ipname}_{fnname}(dt_{ipname}_t dt);
+"""
+
+SCALAR_GETTER_SRC_TEMPLATE = """
+{rettype} dt_{ipname}_{fnname}(dt_{ipname}_t dt) {{
+  return TRY_GET_DT(dt, {invalid_value})->ipgen_ext.{attrname};
+}}
+"""
+
+
+@dataclass
+class IpgenDtGenParam:
+    type: str
+    value: object
+    name: str
+    doc: str
+
+    @staticmethod
+    def from_raw(param_name: str, value: object, dtgen: dict[str, object]) -> "IpgenDtGenParam":
+        name = dtgen.get('name', param_name)
+        return IpgenDtGenParam(type = dtgen['type'], value = value, name = name,
+                               doc = dtgen.get('doc', ""))
+
+
+@dataclass
+class IpgenDtGen:
+    params: list[IpgenDtGenParam]
+
+    @staticmethod
+    def from_ipconfig(ipconfig: dict[str, object]) -> "IpgenDtGen":
+        param_values = ipconfig["param_values"]
+        dtgen = ipconfig.get('dtgen', {})
+        validate(instance = dtgen, schema = dtgen_schema)
+        params = []
+        for (name, param) in dtgen.items():
+            if name not in param_values:
+                raise ValueError(f"dtgen refers to ipconfig parameter '{name}' " +
+                                 "which does not appear in 'param_values'")
+            params.append(IpgenDtGenParam.from_raw(name, param_values[name], param))
+        return IpgenDtGen(params = params)
+
+
+class IpgenExt(Extension):
+    def __init__(self, ip_helper: IpHelper):
+        self.ip_helper = ip_helper
+        # Ignore IPs without ipconfig
+        assert self.ip_helper.ipconfig, "IpgenExt requires ipconfig"
+        assert "dtgen" in self.ip_helper.ipconfig, "IpgenExt requires ipconfig.dtgen"
+
+        self.dtgen = IpgenDtGen.from_ipconfig(self.ip_helper.ipconfig)
+
+    def create_ext(ip_helper: IpHelper) -> Optional["Extension"]:
+        if ip_helper.ipconfig and 'dtgen' in ip_helper.ipconfig:
+            return IpgenExt(ip_helper)
+
+    def extend_dt_ip(self) -> tuple[Name, StructType]:
+        st = StructType()
+
+        for param in self.dtgen.params:
+            # At the moment, only simple scalar types are supported
+            st.add_field(
+                name = Name.from_snake_case(param.name),
+                field_type = ScalarType(SCALAR_TYPES[param.type]["c_typename"]),
+                docstring = param.doc,
+            )
+
+        return Name(["ipgen_ext"]), st
+
+    def fill_dt_ip(self, m) -> dict:
+        values = {}
+
+        for param in self.dtgen.params:
+            values[Name.from_snake_case(param.name)] = param.value
+
+        return values
+
+    def render_dt_ip(self, pos: Extension.DtIpPos) -> str:
+        res = ""
+        if pos == Extension.DtIpPos.HeaderEnd:
+            # Generate one function per attribute
+            for param in self.dtgen.params:
+                res += SCALAR_GETTER_HDR_TEMPLATE.format(
+                    rettype = SCALAR_TYPES[param.type]["c_typename"],
+                    ipname = self.ip_helper.ip_name.as_snake_case(),
+                    fnname = param.name,
+                    docshort = param.doc,
+                )
+        elif pos == Extension.DtIpPos.SourceEnd:
+            # Generate one function per attribute
+            for param in self.dtgen.params:
+                res += SCALAR_GETTER_SRC_TEMPLATE.format(
+                    rettype = SCALAR_TYPES[param.type]["c_typename"],
+                    ipname = self.ip_helper.ip_name.as_snake_case(),
+                    fnname = param.name,
+                    attrname = param.name,
+                    docshort = param.doc,
+                    invalid_value = SCALAR_TYPES[param.type]["c_invalid_value"],
+                )
+
+        return res

--- a/util/dttool.py
+++ b/util/dttool.py
@@ -44,10 +44,10 @@ def load_extension(plugin_path: Path):
 
 def find_extension_class(ext_mod, cls):
     if ext_mod is None:
-        return None
+        return []
 
     # Look for a class extended `cls`
-    ext_cls = None
+    ext_cls = []
     for (name, obj) in inspect.getmembers(ext_mod):
         if not inspect.isclass(obj):
             continue
@@ -57,12 +57,9 @@ def find_extension_class(ext_mod, cls):
         if not issubclass(obj, cls):
             continue
         # Found one.
-        if ext_cls is not None:
-            logging.error(f"extension defines several extension classes: {ext_cls} and {obj}")
-            raise RuntimeError("invalid extension")
-        ext_cls = obj
+        ext_cls.append(obj)
 
-    if ext_cls is None:
+    if not ext_cls:
         logging.error("extension does not define any extension class")
         raise RuntimeError("invalid extension")
 

--- a/util/dttool.py
+++ b/util/dttool.py
@@ -15,6 +15,7 @@ from importlib.util import module_from_spec, spec_from_file_location
 
 from reggen.ip_block import IpBlock
 from dtgen.helper import TopHelper, IpHelper, Extension
+from dtgen.ipgen_ext import IpgenExt
 from topgen.lib import CArrayMapping, CEnum
 
 TOPGEN_TEMPLATE_PATH = Path(__file__).parents[1].resolve() / "util" / "dtgen"
@@ -188,6 +189,7 @@ def main():
                                     f"but no default was specified, will use {default_node}")
 
             extension_cls = find_extension_class(ext_mod, Extension)
+            extension_cls.append(IpgenExt)
 
             # The instance name is 'top_{topname}_{ipname}'.
             ipconfig = name_to_ipconfig.get('top_{}_{}'.format(topcfg["name"], ipname), None)

--- a/util/ipgen/lib.py
+++ b/util/ipgen/lib.py
@@ -41,16 +41,19 @@ class TemplateParameter(BaseParam):
     )
 
     def __init__(self, name: str, desc: Optional[str], param_type: str,
-                 default: str):
+                 default: str, dtgen: object):
         assert param_type in self.VALID_PARAM_TYPES
 
         super().__init__(name, desc, param_type, None)
         self.default = default
         self.value = None
+        self.dtgen = dtgen
 
     def as_dict(self) -> Dict[str, object]:
         rd = super().as_dict()
         rd['default'] = self.default
+        if self.dtgen:
+            rd['dtgen'] = self.dtgen
         return rd
 
 
@@ -62,7 +65,7 @@ def _parse_template_parameter(where: str, raw: object) -> TemplateParameter:
     the required type. For 'object' types we just check the value can be
     de-serialized by hjson. Perhaps this could perform a type-check instead.
     """
-    rd = check_keys(raw, where, ['name', 'desc', 'type'], ['default'])
+    rd = check_keys(raw, where, ['name', 'desc', 'type'], ['default', 'dtgen'])
 
     name = check_str(rd['name'], 'name field of ' + where)
 
@@ -95,7 +98,16 @@ def _parse_template_parameter(where: str, raw: object) -> TemplateParameter:
     else:
         assert False, f"Unknown parameter type found: {param_type!r}"
 
-    return TemplateParameter(name, desc, param_type, default)
+    # DT generator dictionary is not checked here, it is only forwarded to dtgen
+    # but we at least check that it is a dictionary!
+    dtgen = rd.get('dtgen', None)
+    assert dtgen is None or isinstance(dtgen, dict), \
+        f"At {where}, the 'dtgen' field must be a dictionary."
+    # We add a 'doc' field if not present.
+    if dtgen is not None and 'doc' not in dtgen:
+        dtgen['doc'] = raw['desc']
+
+    return TemplateParameter(name, desc, param_type, default, dtgen)
 
 
 class TemplateParams(Params):
@@ -200,6 +212,7 @@ class IpConfig:
         self.instance_name = instance_name
         self.param_values = IpConfig._check_param_values(
             template_params, param_values)
+        self.dtgen_params = IpConfig._extract_dtgen(template_params)
 
     @staticmethod
     def _check_object(obj: object, what: str) -> object:
@@ -222,6 +235,15 @@ class IpConfig:
             raise ValueError(
                 f'{what} cannot be serialized as Hjson: {e!s}') from None
         return obj_checked
+
+    @staticmethod
+    def _extract_dtgen(template_params: TemplateParams) -> Dict[str, object]:
+        dtgen_params = {}
+        for param_name in template_params:
+            param = template_params[param_name]
+            if param.dtgen:
+                dtgen_params[param_name] = param.dtgen
+        return dtgen_params
 
     @staticmethod
     def _check_param_values(template_params: TemplateParams,
@@ -306,6 +328,8 @@ class IpConfig:
         obj = {}
         obj['instance_name'] = self.instance_name
         obj['param_values'] = self.param_values
+        if self.dtgen_params:
+            obj['dtgen'] = self.dtgen_params
 
         try:
             with open(file_path, 'w') as fp:


### PR DESCRIPTION
This PR adds basic support for exposing some ipgen parameters through dtgen automatically. At the high level, what we are trying to achieve is the following:
- we add some information to the `tpldesc` of an IP, e.g.
```javascript
{
  template_param_list: [
    ...
    {
      name: "num_inp_period_counters"
      desc: "number of input period counters"
      type: "int"
      default: 0
      // NEW
      dtgen:
      {
        type: "uint8"
        name: "input_period_counter_count"
      }
    }
  ]
}
```
and `dtgen` automatically adds the following API to `dt_gpio.h`:
```c
/**
 * Get the number of input period counters.
 *
 * @param dt Instance of gpio.
 * @return number of input period counters.
 */
uint8_t dt_gpio_input_period_counter_count(dt_gpio_t dt);
```

**Changes to `topgen`***

The first necessary change is to make topgen take the `dtgen` dictionary in `tpldesc` and copy it to the generated `ipconfig` files. For the GPIO this looks like this:
```javascript
{
  instance_name: top_earlgrey_gpio
  param_values:
  {
    num_inp_period_counters: 0
    module_instance_name: gpio
    topname: earlgrey
    uniquified_modules: {}
  }
  // NEW
  dtgen:
  {
    num_inp_period_counters:
    {
      type: uint8
      name: input_period_counter_count
      doc: number of input period counters
    }
  }
}
```
I elected to put the `dtgen` information in its own sections for several reasons. First it avoids changing the layout of the existing structures which would required to change code everything. Second, this allows topgen to copy the `dtgen` dictionary as-in without really understanding the content. Then `dttool` can take the content and validate it without having to know anything about the format of the rest of `ipconfig`. In other words, separation of concerns.

**Changes to the build system**

For technical reasons, `dttool` cannot "see" the ipconfig file unless it is registered in the `opentitan_ip` description of the IP. Therefore IPs which want to opt-in for this generation must register it. In this PR, I did it for the `gpio` and `pwm` block.

**Changes to `dttool`**

Since `dttool` already supports the concept of extension, I decided to implement this support through an extension. Therefore the first change was to modify `dtool` to support multiple extensions (a relatively easy if a bit verbose change). Then, a new `IpgenExt` extension is created that automatically looks at the ipconfig, check if it has `dtgen` dictionary and then uses it to generate code.

**Limitations**
Currently, I only added support for scalar attributes and there is a manually specified list of supported type. For this initial prototype, only `uint8` is supported but we could add more types of course. There are other things which are not done but probably should:
- [ ] type cross checking: the code does not check that the template parameter type (e.g. `int`) is consistent with the `dtgen` type (e.g. `uint8`). If something goes wrong, the `dtgen` machine will eventually catch it (so it shouldn't generate invalid code) but the error message will be terrible. 
- [ ] document the content of the `dtgen` dictionary better: the content is validated through a json schema but there isn't really any user friendly documentation anywhere yet. I don't know where to put it.
- [x] for some reason, if a top does not specify a parameter (like the PWM count in earlgrey), the default value is used but it not written to the generated ipconfig. This is a blocker for enabling this machinary for the PWM. It looks to me like a bug/oversight and the value should be written to the generated ipconfig file unconditionally. Fixed by #27291