### PR TITLE
[rom_ctrl,rtl] Weaken an assertion to make it true!

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -314,6 +314,7 @@ module rom_ctrl_fsm
 
   assign alert_o = fsm_alert | checker_alert | unexpected_counter_change;
 
-  `ASSERT(CounterLntImpliesKmacRomVldO_A, counter_lnt -> kmac_rom_vld_o)
+  `ASSERT(CounterLntImpliesKmacRomVldO_A,
+          state_q == ReadingLow && counter_lnt -> kmac_rom_vld_o)
 
 endmodule


### PR DESCRIPTION
In the main FSM, there is an edge from ReadingLow to ReadingHigh which is supposed to be taken when we pass the last word to KMAC.

Originally, it was encoded as this:

    if (counter_lnt && kmac_rom_rdy_i && kmac_rom_vld_o) begin
      state_d = ReadingHigh;
    end

which means "if we are sending the last word (so counter_lnt is true) and the transfer goes through (rdy & vld), then we should jump to the ReadingHigh state.

We noticed that you never see it when kmac_rom_vld_o is false and realised that this *can't* happen. The counter_lnt signal says that we presented the last word to KMAC on the previous cycle (and the valid signal was definitely high).

The code changed to

    if (counter_lnt && kmac_rom_rdy_i) begin
      state_d = ReadingHigh;
    end

which is slightly simpler and (to make sure we didn't get it wrong), we added the CounterLntImpliesKmacRomVldO_A assertion. These changes happened in bbc658ebfa4.

Unfortunately, the assertion isn't necessarily true! This is because it doesn't also assume we're in the ReadingLow state (the only time it matters). Make the precondition more precise. It is now provable with Jasper (and the assertion still covers the check we need).