### PR TITLE
[rom_ctrl,rtl] Avoid repetition in the code

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -237,9 +237,11 @@ module rom_ctrl_fsm
 
   // The top bits of rel_addr_wide should always be zero if we're reading the top bits (because TAW
   // bits should be enough to encode the difference between counter_data_addr and TopStartAddr)
-  `ASSERT(RelAddrWide_A, exp_digest_vld_o |-> ~|rel_addr_wide[AW-1:TAW])
+  //
+  // Consider them unused and add an assertion to check that the are indeed zero.
   logic unused_top_rel_addr_wide;
   assign unused_top_rel_addr_wide = |rel_addr_wide[AW-1:TAW];
+  `ASSERT(RelAddrWide_A, exp_digest_vld_o |-> !unused_top_rel_addr_wide)
 
   assign exp_digest_o = rom_data_i;
   assign exp_digest_vld_o = reading_top;


### PR DESCRIPTION
It's now clearer that we're saying "we don't use the top bits, and we have an assertion that says they were zero anyway".