### PR TITLE
[dv,otp_macro] otp_macro_env was missing it's dependency on cip_lib

### DIFF
--- a/hw/ip/otp_macro/dv/env/otp_macro_env.core
+++ b/hw/ip/otp_macro/dv/env/otp_macro_env.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:ralgen
+      - lowrisc:dv:cip_lib
 
 generate:
   ral:


### PR DESCRIPTION
Splitting this out into it's own PR was suggested in https://github.com/lowRISC/opentitan/pull/23555#discussion_r2099944630