### PR TITLE
[hw,dv_base_reg_block,dv] Fix Xcelium 24.09 warning of passing a string arg

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -76,9 +76,9 @@ class dv_base_reg_block extends uvm_reg_block;
   endfunction
 
   function string get_ip_name();
-    // `DV_CHECK_NE_FATAL can't take "" as an input
+    // `DV_CHECK_FATAL can't take "" as an input
     string empty_str = "";
-    `DV_CHECK_NE_FATAL(ip_name, empty_str, "ip_name hasn't been set yet")
+    `DV_CHECK_FATAL(ip_name != empty_str, "ip_name hasn't been set yet")
     return ip_name;
   endfunction
 


### PR DESCRIPTION
This fixes the warning: 
```
A variable of type string is supplied to (%d).
```