### PR TITLE
[ipgen] Ensure that ipconfig has all parameters set

### DIFF
--- a/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/data/top_darjeeling_alert_handler.ipconfig.hjson
@@ -227,5 +227,6 @@
     ]
     topname: darjeeling
     uniquified_modules: {}
+    racl_support: false
   }
 }

--- a/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/data/top_darjeeling_clkmgr.ipconfig.hjson
@@ -215,5 +215,6 @@
     with_alert_handler: true
     topname: darjeeling
     uniquified_modules: {}
+    module_instance_name: clkmgr
   }
 }

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/data/top_darjeeling_otp_ctrl.ipconfig.hjson
@@ -1977,5 +1977,6 @@
     enable_flash_key: false
     topname: darjeeling
     uniquified_modules: {}
+    module_instance_name: otp_ctrl
   }
 }

--- a/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pinmux/data/top_darjeeling_pinmux.ipconfig.hjson
@@ -17,5 +17,6 @@
     enable_strap_sampling: false
     topname: darjeeling
     uniquified_modules: {}
+    module_instance_name: pinmux
   }
 }

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/top_darjeeling_pwrmgr.ipconfig.hjson
@@ -79,5 +79,6 @@
     ]
     topname: darjeeling
     uniquified_modules: {}
+    module_instance_name: pwrmgr
   }
 }

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/data/top_darjeeling_racl_ctrl.ipconfig.hjson
@@ -64,5 +64,6 @@
     ]
     topname: darjeeling
     uniquified_modules: {}
+    enable_shadow_reg: true
   }
 }

--- a/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/data/top_darjeeling_rstmgr.ipconfig.hjson
@@ -485,5 +485,6 @@
     with_alert_handler: true
     topname: darjeeling
     uniquified_modules: {}
+    module_instance_name: rstmgr
   }
 }

--- a/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/data/top_darjeeling_rv_plic.ipconfig.hjson
@@ -11,5 +11,6 @@
     prio: 3
     topname: darjeeling
     uniquified_modules: {}
+    racl_support: false
   }
 }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/top_earlgrey_alert_handler.ipconfig.hjson
@@ -151,5 +151,6 @@
     ]
     topname: earlgrey
     uniquified_modules: {}
+    racl_support: false
   }
 }

--- a/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/data/top_earlgrey_clkmgr.ipconfig.hjson
@@ -261,5 +261,6 @@
     with_alert_handler: true
     topname: earlgrey
     uniquified_modules: {}
+    module_instance_name: clkmgr
   }
 }

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/top_earlgrey_flash_ctrl.ipconfig.hjson
@@ -25,5 +25,6 @@
     size: 1048576
     topname: earlgrey
     uniquified_modules: {}
+    module_instance_name: flash_ctrl
   }
 }

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/data/top_earlgrey_otp_ctrl.ipconfig.hjson
@@ -1988,5 +1988,6 @@
     enable_flash_key: true
     topname: earlgrey
     uniquified_modules: {}
+    module_instance_name: otp_ctrl
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pinmux/data/top_earlgrey_pinmux.ipconfig.hjson
@@ -17,5 +17,6 @@
     enable_strap_sampling: true
     topname: earlgrey
     uniquified_modules: {}
+    module_instance_name: pinmux
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pwm/data/top_earlgrey_pwm.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwm/data/top_earlgrey_pwm.ipconfig.hjson
@@ -8,5 +8,6 @@
     module_instance_name: pwm
     topname: earlgrey
     uniquified_modules: {}
+    nr_output_channels: 6
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -90,5 +90,6 @@
     ]
     topname: earlgrey
     uniquified_modules: {}
+    module_instance_name: pwrmgr
   }
 }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/top_earlgrey_rstmgr.ipconfig.hjson
@@ -693,5 +693,6 @@
     with_alert_handler: true
     topname: earlgrey
     uniquified_modules: {}
+    module_instance_name: rstmgr
   }
 }

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/top_earlgrey_rv_plic.ipconfig.hjson
@@ -11,5 +11,6 @@
     prio: 3
     topname: earlgrey
     uniquified_modules: {}
+    racl_support: false
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/clkmgr/data/top_englishbreakfast_clkmgr.ipconfig.hjson
@@ -238,5 +238,6 @@
     with_alert_handler: false
     topname: englishbreakfast
     uniquified_modules: {}
+    module_instance_name: clkmgr
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/data/top_englishbreakfast_flash_ctrl.ipconfig.hjson
@@ -25,5 +25,6 @@
     size: 65536
     topname: englishbreakfast
     uniquified_modules: {}
+    module_instance_name: flash_ctrl
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pinmux/data/top_englishbreakfast_pinmux.ipconfig.hjson
@@ -17,5 +17,6 @@
     enable_strap_sampling: true
     topname: englishbreakfast
     uniquified_modules: {}
+    module_instance_name: pinmux
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/data/top_englishbreakfast_pwrmgr.ipconfig.hjson
@@ -69,5 +69,6 @@
     ]
     topname: englishbreakfast
     uniquified_modules: {}
+    module_instance_name: pwrmgr
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/data/top_englishbreakfast_rstmgr.ipconfig.hjson
@@ -453,5 +453,6 @@
     with_alert_handler: false
     topname: englishbreakfast
     uniquified_modules: {}
+    module_instance_name: rstmgr
   }
 }

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/data/top_englishbreakfast_rv_plic.ipconfig.hjson
@@ -11,5 +11,6 @@
     prio: 3
     topname: englishbreakfast
     uniquified_modules: {}
+    racl_support: false
   }
 }

--- a/util/ipgen/lib.py
+++ b/util/ipgen/lib.py
@@ -267,6 +267,12 @@ class IpConfig:
 
             param_values_typed[key] = param_value_typed
 
+        # Ensure that params dict is fully populated. Defaults are passed for params that
+        # are not explicitly specified.
+        for key, value in template_params.items():
+            if key not in param_values_typed:
+                param_values_typed[key] = value.default
+
         return param_values_typed
 
     @classmethod


### PR DESCRIPTION
Non-explicit parameters are set to their default values defined in the tpldesc.hjson file.

This is needed such that DT can infer the type for _all_ parameter and create proper constants for software.