### PR TITLE
[rom_ctrl,rtl] Use the PossibleActions parameter in rom_ctrl_compare

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
@@ -127,7 +127,8 @@ module rom_ctrl_compare
   // SEC_CM: COMPARE.CTR.REDUN
   logic addr_ctr_alert;
   prim_count #(
-    .Width(AW)
+    .Width(AW),
+    .PossibleActions(prim_count_pkg::Incr)
   ) u_prim_count_addr (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This parameter recently arrived in prim_count and lets the instantiation site tell the counter what actions might be requested. This *might* simplify the generated hardware very slightly and also avoids some correctness assertions (which turn out to be irrelevant).