### PR TITLE
[hw,prim_subreg,rtl] Assert qe only on SW writes

### DIFF
--- a/hw/ip/prim/rtl/prim_subreg.sv
+++ b/hw/ip/prim/rtl/prim_subreg.sv
@@ -62,7 +62,7 @@ module prim_subreg
 
   // feed back out for consolidation
   assign ds = wr_en ? wr_data : qs;
-  assign qe = wr_en;
+  assign qe = we;
 
   if (SwAccess == SwAccessRC) begin : gen_rc
     // In case of a SW RC colliding with a HW write, SW gets the value written by HW


### PR DESCRIPTION
It is documented that .qe only asserts on SW writes. In particular, the [docs](https://opentitan.org/book/util/reggen/index.html#register-definitions-per-type) say:

qe | output | Output register enable, scalar, true when bus interface writes to subreg
-- | -- | --

The current RTL, however, asserts this signal for both writes from software, but also from hardware.

This PR changes the behavior ot only assert the signal for SW writes.