### PR TITLE
[hw,prim_diff_flop,rtl] No generic instantiation of prim_flop_2sync

### DIFF
--- a/hw/ip/prim/rtl/prim_diff_to_alert.sv
+++ b/hw/ip/prim/rtl/prim_diff_to_alert.sv
@@ -24,7 +24,7 @@ module prim_diff_to_alert #(
   logic diff_p_sync, diff_n_sync;
 
   if (AsyncOn) begin : gen_async
-    prim_generic_flop_2sync #(
+    prim_flop_2sync #(
       .Width(2),
       .ResetValue(2'b10)
     ) u_sync (


### PR DESCRIPTION
Use the abstract implementation rather than an instance from a prim lib.