### PR TITLE
[WIP] Completely revamp the OTTF console code

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -12,9 +12,6 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
-#include "sw/device/lib/dif/dif_gpio.h"
-#include "sw/device/lib/dif/dif_spi_device.h"
-#include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 
 // This is declared as an enum to force the values to be
@@ -55,6 +52,8 @@ static const char kUnknownSpec[15] = "%<unknown spec>";
 static const char kErrorTooWide[12] = "%<bad width>";
 
 static size_t base_dev_null(void *data, const char *buf, size_t len) {
+  OT_DISCARD(data);
+  OT_DISCARD(buf);
   return len;
 }
 static buffer_sink_t base_stdout = {
@@ -64,259 +63,11 @@ static buffer_sink_t base_stdout = {
     .sink = NULL,
 };
 
-// The GPIO TX indicator pin that can be used with the SPI console.
-static dif_gpio_t *spi_console_gpio = NULL;
-static dif_gpio_pin_t spi_console_tx_ready_gpio = UINT32_MAX;
-
 void base_set_stdout(buffer_sink_t out) {
   if (out.sink == NULL) {
     out.sink = &base_dev_null;
   }
   base_stdout = out;
-}
-
-static uint32_t spi_device_frame_num = 0;
-
-static status_t spi_device_send_data(dif_spi_device_handle_t *spi_device,
-                                     const uint8_t *buf, size_t len,
-                                     size_t address) {
-  if (len == 0) {
-    return OK_STATUS();
-  }
-
-  size_t space_to_end_of_buffer = kSpiDeviceReadBufferSizeBytes - address;
-  size_t first_part_size =
-      space_to_end_of_buffer < len ? space_to_end_of_buffer : len;
-
-  TRY(dif_spi_device_write_flash_buffer(spi_device,
-                                        kDifSpiDeviceFlashBufferTypeEFlash,
-                                        address, first_part_size, buf));
-
-  // Handle wrap-around.
-  if (first_part_size < len) {
-    size_t second_part_size = len - first_part_size;
-    TRY(dif_spi_device_write_flash_buffer(
-        spi_device, kDifSpiDeviceFlashBufferTypeEFlash, 0, second_part_size,
-        (uint8_t *)(buf + first_part_size)));
-  }
-
-  return OK_STATUS();
-}
-
-/**
- * Sends data out of the SPI device.
- *
- * Data is packaged into a frame that is described below.
- * The host side reads the header first, then decides how many words
- * to read from the data section.
- *
- * -----------------------------------------------
- * |      Magic Number     | 4-bytes  |          |
- * -----------------------------------|          |
- * |      Frame Number     | 4-bytes  |  Header  |
- * -----------------------------------|          |
- * |   Data Length (bytes) | 4-bytes  |          |
- * -----------------------------------|----------|
- * |      Data (word aligned)         |          |
- * -----------------------------------|   Data   |
- * |     0xFF Pad Bytes    | <4-bytes |          |
- * -----------------------------------|----------|
- */
-static size_t spi_device_send_frame(void *data, const char *buf, size_t len) {
-  dif_spi_device_handle_t *spi_device = (dif_spi_device_handle_t *)data;
-  const size_t data_packet_size_bytes = ((len + 3u) & ~3u);
-  const size_t frame_size_bytes =
-      kSpiDeviceFrameHeaderSizeBytes + data_packet_size_bytes;
-  uint8_t frame_header_bytes[kSpiDeviceFrameHeaderSizeBytes];
-
-  static uint32_t next_write_address = 0;
-
-  if (frame_size_bytes >= kSpiDeviceReadBufferSizeBytes) {
-    return 0;
-  }
-
-  // Add the magic bytes.
-  for (size_t i = 0; i < 4; ++i) {
-    frame_header_bytes[i] = (kSpiDeviceFrameMagicNumber >> (i * 8)) & 0xff;
-  }
-  // Add the frame number.
-  for (size_t i = 0; i < 4; ++i) {
-    frame_header_bytes[i + 4] = (spi_device_frame_num >> (i * 8)) & 0xff;
-  }
-  // Add the data length.
-  for (size_t i = 0; i < 4; ++i) {
-    frame_header_bytes[i + 8] = (len >> (i * 8)) & 0xff;
-  }
-
-  // Wait for enough space to free up in the SPI flash buffer if we are in
-  // operating in polling mode.
-  if (spi_console_gpio == NULL) {
-    uint32_t available_buffer_size = 0;
-    uint32_t last_read_address = 0;
-    do {
-      if (dif_spi_device_get_last_read_address(spi_device,
-                                               &last_read_address) != kDifOk) {
-        return 0;
-      }
-
-      // If we are not using the GPIO TX-ready indicator pin (which is the
-      // default) the host SPI console is constantly polling the spi_device to
-      // see if data is available to be read out. In this case, we need to
-      // adjust the last read address.
-      //
-      // Specifically, when the host is continuously reading from the read
-      // buffer, it is unaware of whether it is going to find a valid new frame
-      // (marked by a magic number in the frame header), an frame header all
-      // zeros, or garbage, since it is operating in polling mode. This could
-      // result in the reported last_read_address being one header size ahead of
-      // the actual address of the last valid frame if all the frames in the
-      // read buffer has been consumed by the host. While it's harmless to use
-      // the last read address even if the reported value is a frame header
-      // ahead, doing so might temporarily underestimate the available buffer
-      // size by the size of a frame header (or 12 bytes to be specific).
-      //
-      // However, if we are using the GPIO TX-ready indicator pin, the host will
-      // only ever attempt to read out data if it was signaled to do so by the
-      // device. In which case the next write address will always be 0, i.e.,
-      // the beginning of the buffer.
-      uint32_t adjusted_last_read_address =
-          (kSpiDeviceReadBufferSizeBytes + last_read_address -
-           kSpiDeviceFrameHeaderSizeBytes) %
-          kSpiDeviceReadBufferSizeBytes;
-
-      // Frames are always word aligned, so ensure the last read address is word
-      // aligned too.
-      uint32_t next_read_address = ((adjusted_last_read_address + 1) & ~3u) %
-                                   kSpiDeviceReadBufferSizeBytes;
-
-      // Compute the remaining free space in the SPI flash buffer.
-      if (next_read_address > next_write_address) {
-        available_buffer_size = next_read_address - next_write_address - 1;
-      } else {
-        available_buffer_size =
-            next_read_address +
-            (kSpiDeviceReadBufferSizeBytes - next_write_address) - 1;
-      }
-    } while ((frame_size_bytes + kSpiDeviceBufferPreservedSizeBytes) >
-             available_buffer_size);
-  }
-
-  // Send aligned data.
-  size_t data_write_address =
-      (next_write_address + kSpiDeviceFrameHeaderSizeBytes) %
-      kSpiDeviceReadBufferSizeBytes;
-  size_t aligned_data_len = len & (~3u);
-  if (!status_ok(spi_device_send_data(spi_device, (uint8_t *)buf,
-                                      aligned_data_len, data_write_address))) {
-    return 0;
-  }
-
-  // Send unaligned data.
-  if (len != aligned_data_len) {
-    uint8_t pad_bytes[4] = {0xff, 0xff, 0xff, 0xff};
-    size_t pad_write_address =
-        (data_write_address + aligned_data_len) % kSpiDeviceReadBufferSizeBytes;
-
-    for (size_t i = 0; i + aligned_data_len < len; i++) {
-      pad_bytes[i] = buf[aligned_data_len + i];
-    }
-    if (!status_ok(spi_device_send_data(spi_device, pad_bytes, 4,
-                                        pad_write_address))) {
-      return 0;
-    }
-  }
-
-  // Send frame header.
-  if (!status_ok(spi_device_send_data(spi_device, frame_header_bytes,
-                                      kSpiDeviceFrameHeaderSizeBytes,
-                                      next_write_address))) {
-    return 0;
-  }
-
-  // Update the next write address and frame number.
-  next_write_address =
-      (next_write_address + frame_size_bytes) % kSpiDeviceReadBufferSizeBytes;
-  spi_device_frame_num++;
-
-  // Block until the host to reads out the frame by toggling the GPIO TX-ready
-  // indicator pin to signal to the host to clock out data from the spi_device
-  // egress buffer.
-  if (spi_console_gpio != NULL) {
-    OT_DISCARD(
-        dif_gpio_write(spi_console_gpio, spi_console_tx_ready_gpio, true));
-    bool cs_state = true;
-    bool target_cs_state = false;
-    // There will be two bulk transfers that can be synchronized by the
-    // chip-select action. First the host will read out the 12-byte frame
-    // header, followed by the N-byte payload. Each transfer can be observed by
-    // the chip-select toggling low then high. After the first toggle low, when
-    // the host begins reading out the frame header, we can deassert the
-    // TX-ready pin as the host has already initiated the two SPI transactions.
-    for (size_t i = 0; i < 4; ++i) {
-      do {
-        if (dif_spi_device_get_csb_status(spi_device, &cs_state) != kDifOk) {
-          return 0;
-        }
-      } while (cs_state != target_cs_state);
-      if (i == 0) {
-        OT_DISCARD(
-            dif_gpio_write(spi_console_gpio, spi_console_tx_ready_gpio, false));
-      }
-      target_cs_state = !target_cs_state;
-    }
-    next_write_address = 0;
-  }
-
-  return len;
-}
-
-static size_t base_dev_spi_device(void *data, const char *buf, size_t len) {
-  size_t write_data_len = 0;
-
-  while (write_data_len < len) {
-    size_t payload_len = len - write_data_len;
-    if (payload_len > kSpiDeviceMaxFramePayloadSizeBytes) {
-      payload_len = kSpiDeviceMaxFramePayloadSizeBytes;
-    }
-    if (spi_device_send_frame(data, buf + write_data_len, payload_len) ==
-        payload_len) {
-      write_data_len += payload_len;
-    }
-  }
-
-  return write_data_len;
-}
-
-sink_func_ptr get_spi_device_sink(void) { return &base_dev_spi_device; }
-
-static size_t base_dev_uart(void *data, const char *buf, size_t len) {
-  const dif_uart_t *uart = (const dif_uart_t *)data;
-  for (size_t i = 0; i < len; ++i) {
-    if (dif_uart_byte_send_polled(uart, (uint8_t)buf[i]) != kDifOk) {
-      return i;
-    }
-  }
-  return len;
-}
-
-sink_func_ptr get_uart_sink(void) { return &base_dev_uart; }
-
-void base_spi_device_set_gpio_tx_indicator(dif_gpio_t *gpio,
-                                           dif_gpio_pin_t tx_indicator_pin) {
-  spi_console_gpio = gpio;
-  spi_console_tx_ready_gpio = tx_indicator_pin;
-}
-
-void base_spi_device_stdout(const dif_spi_device_handle_t *spi_device) {
-  // Reset the frame counter.
-  spi_device_frame_num = 0;
-  base_set_stdout((buffer_sink_t){.data = (void *)spi_device,
-                                  .sink = &base_dev_spi_device});
-}
-
-void base_uart_stdout(const dif_uart_t *uart) {
-  base_set_stdout(
-      (buffer_sink_t){.data = (void *)uart, .sink = &base_dev_uart});
 }
 
 size_t base_printf(const char *format, ...) {

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -305,9 +305,16 @@ cc_library(
 dual_cc_library(
     name = "ottf_console",
     srcs = dual_inputs(
-        device = ["ottf_console.c"],
+        device = [
+            "ottf_console.c",
+            "ottf_console_uart.c",
+            "ottf_console_spi.c",
+        ],
     ),
-    hdrs = ["ottf_console.h"],
+    hdrs = [
+        "ottf_console.h",
+        "ottf_console_internal.h",
+    ],
     deps = dual_inputs(
         device = [
             ":check",

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -8,7 +8,11 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
 /**
  * Flow control state.
@@ -31,41 +35,119 @@ typedef enum ottf_console_flow_control {
 } ottf_console_flow_control_t;
 
 /**
- * Returns a pointer to the OTTF console device DIF handle.
+ * OTTF console state.
  */
-void *ottf_console_get(void);
+typedef struct ottf_console {
+  /** Console type. */
+  ottf_console_type_t type;
+  /* Function pointer to the currently active data sink. */
+  sink_func_ptr sink;
+  /* Function pointer to a function that retrieves a single character. */
+  status_t (*getc)(void *);
+  /* Enable SW buffering. */
+  bool buffered;
+  /** Staging buffer. */
+  char *buf;
+  /** Staging buffer size. */
+  size_t buf_sz;
+  /** Where to write next to the staging buffer. */
+  size_t buf_end;
+  /** Auxiliary data, per console type */
+  union {
+    /** UART data. */
+    struct {
+      /** DIF handle. */
+      dif_uart_t dif;
+    } uart;
+    /** SPI device data. */
+    struct {
+      /** DIF handle. */
+      dif_spi_device_handle_t dif;
+      /** SPI device frame number. */
+      uint32_t frame_num;
+      /** TX ready GPIO, set to kOttfSpiNoTxGpio if not used. */
+      dif_gpio_pin_t tx_ready_gpio;
+    } spi;
+  } data;
+} ottf_console_t;
 
 /**
- * Initializes the OTTF console device and connects to the printf buffer.
+ * Returns a pointer to the main OTTF console.
+ */
+ottf_console_t *ottf_console_get(void);
+
+/**
+ * Set the main console.
+ *
+ * The main console is the one used by the ujson console by default
+ * and by base_printf.
+ *
+ * @param console Pointer to the console.
+ */
+
+void ottf_console_set_main(ottf_console_t *console);
+
+/**
+ * Initializes the OTTF main console device according to the
+ * test settings, and connects it to the printf buffer.
+ *
+ * Also initialize some global variables which are necessary
+ * for the OTTF console subsystem to work.
  */
 void ottf_console_init(void);
 
 /**
- * Configures the given UART to be used by the OTTF console.
+ * Configures the given OTTF console.
  *
- * @param base_addr The base address of the UART to use.
+ * If `base_addr` is set to 0, the default peripheral for the
+ * type will be used.
+ *
+ * @param console Pointer to the console to setup.
+ * @param type Console type.
+ * @param base_addr Pointer to the peripheral's base address.
  */
-void ottf_console_configure_uart(uintptr_t base_addr);
+void ottf_console_setup(ottf_console_t *console, ottf_console_type_t type,
+                        uintptr_t base_addr);
 
 /**
- * Configures the given SPI device to be used by the OTTF console.
+ * Configure OTTF SPI TX GPIO indicator of a console.
  *
- * @param base_addr The base address of the SPI device to use.
+ * @param console Pointer to the console to configure
+ * @param enable Enable/Disable indicator.
+ * @param gpio The GPIO to use to signal to the host that the SPI console buffer
+ * is not empty.
+ * @param mio The MIO to connect to the GPIO pin above
  */
-void ottf_console_configure_spi_device(uintptr_t base_addr);
+void ottf_console_spi_setup_tx_indicator(ottf_console_t *console, bool enable,
+                                         uint32_t gpio, uint32_t mio);
+
+/**
+ * Configures software buffering of the console.
+ *
+ * If the console previously had buffering enabled, disabling buffering will
+ * simply drop the content of the staging buffer. Therefore the content should
+ * be flushed before disabling buffering.
+ *
+ * @param console Pointer to the console to configure
+ * @param enable Enable/Disable buffering.
+ * @param buffer Staging buffer used for buffering.
+ * @param size Length of the staging buffer.
+ */
+void ottf_console_set_buffering(ottf_console_t *console, bool enabled,
+                                char *buffer, size_t size);
 
 /**
  * Manage flow control by inspecting the OTTF console device's receive FIFO.
  *
- * @param uart A UART handle.
+ * @param console Pointer to the console to configure
  * @param ctrl Set the next desired flow-control state.
  * @return The new state.
  */
-status_t ottf_console_flow_control(const dif_uart_t *uart,
+status_t ottf_console_flow_control(ottf_console_t *console,
                                    ottf_console_flow_control_t ctrl);
 
 /**
- * Enable flow control for the OTTF console.
+ * Enable flow control for a console.
  *
  * Enables flow control on the UART associated with the OTTF console. Flow
  * control is managed by enabling the RX watermark IRQ and sending a `Pause`
@@ -74,13 +156,22 @@ status_t ottf_console_flow_control(const dif_uart_t *uart,
  *
  * This function configures UART interrupts at the PLIC and enables interrupts
  * at the CPU.
+ *
+ * WARNING Control requires IRQ dispatching. The main console will automatically
+ * dispatch control IRQs on calls to `ottf_console_flow_control_isr`. If you
+ * want to dispatch control flow IRQs for non-main console, you must call
+ * manually call `ottf_console_uart_flow_control_isr` on the console from your
+ * IRQ handler.
+ *
+ * @param console Pointer to the console.
  */
-void ottf_console_flow_control_enable(void);
+void ottf_console_flow_control_enable(ottf_console_t *console);
 
 /**
- * Manage console flow control from interrupt context.
+ * Manage console flow control *for the main console* from interrupt context.
  *
- * Call this when a console UART interrupt triggers.
+ * Call this when a console UART interrupt triggers. If you want to manage
+ * control flow for non-main consoles, use `ottf_console_uart_flow_control_isr`.
  *
  * @param exc_info The OTTF execution info passed to all ISRs.
  * @return True if an RX Watermark IRQ was detected and handled. False
@@ -89,10 +180,26 @@ void ottf_console_flow_control_enable(void);
 bool ottf_console_flow_control_isr(uint32_t *exc_info);
 
 /**
+ * Manage console flow control from interrupt context.
+ *
+ * You should only call this function directly for *non-main* consoles.
+ *
+ * @param exc_info The OTTF execution info passed to all ISRs.
+ * @return True if an RX Watermark IRQ was detected and handled. False
+ * otherwise.
+ */
+bool ottf_console_uart_flow_control_isr(ottf_console_t *console);
+
+/**
  * Returns the number of OTTF console flow control interrupts that have
  * occurred.
  */
 uint32_t ottf_console_get_flow_control_irqs(void);
+
+/**
+ * TODO
+ */
+size_t ottf_console_write(ottf_console_t *console, const char *buf, size_t len);
 
 /**
  * Read data from the host via the OTTF SPI device console into a provided
@@ -103,16 +210,18 @@ uint32_t ottf_console_get_flow_control_irqs(void);
  * from the host is greater than the provided buffer, then the excess data will
  * be discarded.
  *
+ * @param console Console to use, must of SPI device type.
  * @param buf_size The size, in bytes, of the `buf`.
  * @param[out] buf A pointer to the location where the data should be stored.
  * @return The number of bytes actually received from the host.
  */
-size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf);
+size_t ottf_console_spi_device_read(ottf_console_t *console, size_t buf_size,
+                                    uint8_t *const buf);
 
 /**
  * Write a buffer to the OTTF console.
  *
- * @param context An IO context
+ * @param io An IO context: pointer to an `ottf_console_t`
  * @param buf The buffer to write to the OTTF console.
  * @param len The length of the buffer.
  * @return OK or an error.
@@ -122,7 +231,7 @@ status_t ottf_console_putbuf(void *io, const char *buf, size_t len);
 /**
  * Flush remaining buffered data to the OTTF console.
  *
- * @param context An IO context
+ * @param io An IO context: pointer to an `ottf_console_t`
  * @return OK or an error.
  */
 status_t ottf_console_flushbuf(void *io);
@@ -130,8 +239,14 @@ status_t ottf_console_flushbuf(void *io);
 /**
  * Get a single character from the OTTF console.
  *
+ * @param io An IO context: pointer to an `ottf_console_t`
  * @return The next character or an error.
  */
 status_t ottf_console_getc(void *io);
+
+/**
+ * TODO
+ */
+buffer_sink_t ottf_console_buffer_sink(ottf_console_t *console);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_

--- a/sw/device/lib/testing/test_framework/ottf_console_internal.h
+++ b/sw/device/lib/testing/test_framework/ottf_console_internal.h
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_INTERNAL_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_INTERNAL_H_
+
+#include <stdint.h>
+
+// Defined in ottf_console.c
+extern dif_gpio_t ottf_console_gpio;
+extern dif_pinmux_t ottf_console_pinmux;
+
+// Defined in ottf_console_uart.c
+void ottf_console_configure_uart(ottf_console_t *console, uintptr_t base_addr);
+size_t ottf_console_uart_sink(void *console, const char *buf, size_t len);
+status_t ottf_console_uart_getc(void *console);
+void ottf_console_uart_flow_control_enable(ottf_console_t *console, dif_rv_plic_t *plic);
+status_t ottf_console_uart_flow_control(ottf_console_t *console,
+                                   ottf_console_flow_control_t ctrl);
+
+// Defined in ottf_console_spi.c
+void ottf_console_configure_spi_device(ottf_console_t *console, uintptr_t base_addr);
+size_t ottf_console_spi_sink(void *console, const char *buf, size_t len);
+status_t ottf_console_spi_getc(void *console);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_INTERNAL_H_

--- a/sw/device/lib/testing/test_framework/ottf_console_spi.c
+++ b/sw/device/lib/testing/test_framework/ottf_console_spi.c
@@ -1,0 +1,428 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_isrs.h"
+#include "sw/device/lib/testing/test_framework/ottf_console_internal.h"
+
+// TODO: make this toplevel agnostic.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  /* Placeholder used to indicate that no TX GPIO indicator is enabled. */
+  kOttfSpiNoTxGpio = UINT32_MAX,
+};
+
+static status_t spi_device_send_data(dif_spi_device_handle_t *spi_device,
+                                     const uint8_t *buf, size_t len,
+                                     size_t address) {
+  if (len == 0) {
+    return OK_STATUS();
+  }
+
+  size_t space_to_end_of_buffer = kSpiDeviceReadBufferSizeBytes - address;
+  size_t first_part_size =
+      space_to_end_of_buffer < len ? space_to_end_of_buffer : len;
+
+  TRY(dif_spi_device_write_flash_buffer(spi_device,
+                                        kDifSpiDeviceFlashBufferTypeEFlash,
+                                        address, first_part_size, buf));
+
+  // Handle wrap-around.
+  if (first_part_size < len) {
+    size_t second_part_size = len - first_part_size;
+    TRY(dif_spi_device_write_flash_buffer(
+        spi_device, kDifSpiDeviceFlashBufferTypeEFlash, 0, second_part_size,
+        (uint8_t *)(buf + first_part_size)));
+  }
+
+  return OK_STATUS();
+}
+
+/**
+ * Sends data out of the SPI device.
+ *
+ * Data is packaged into a frame that is described below.
+ * The host side reads the header first, then decides how many words
+ * to read from the data section.
+ *
+ * -----------------------------------------------
+ * |      Magic Number     | 4-bytes  |          |
+ * -----------------------------------|          |
+ * |      Frame Number     | 4-bytes  |  Header  |
+ * -----------------------------------|          |
+ * |   Data Length (bytes) | 4-bytes  |          |
+ * -----------------------------------|----------|
+ * |      Data (word aligned)         |          |
+ * -----------------------------------|   Data   |
+ * |     0xFF Pad Bytes    | <4-bytes |          |
+ * -----------------------------------|----------|
+ */
+static size_t spi_device_send_frame(ottf_console_t *console, const char *buf, size_t len) {
+  dif_spi_device_handle_t *spi_device = &console->data.spi.dif;
+  const size_t data_packet_size_bytes = ((len + 3u) & ~3u);
+  const size_t frame_size_bytes =
+      kSpiDeviceFrameHeaderSizeBytes + data_packet_size_bytes;
+  uint8_t frame_header_bytes[kSpiDeviceFrameHeaderSizeBytes];
+
+  static uint32_t next_write_address = 0;
+
+  if (frame_size_bytes >= kSpiDeviceReadBufferSizeBytes) {
+    return 0;
+  }
+
+  // Add the magic bytes.
+  for (size_t i = 0; i < 4; ++i) {
+    frame_header_bytes[i] = (kSpiDeviceFrameMagicNumber >> (i * 8)) & 0xff;
+  }
+  // Add the frame number.
+  for (size_t i = 0; i < 4; ++i) {
+    frame_header_bytes[i + 4] = (console->data.spi.frame_num >> (i * 8)) & 0xff;
+  }
+  // Add the data length.
+  for (size_t i = 0; i < 4; ++i) {
+    frame_header_bytes[i + 8] = (len >> (i * 8)) & 0xff;
+  }
+
+  // Wait for enough space to free up in the SPI flash buffer if we are in
+  // operating in polling mode.
+  if (console->data.spi.tx_ready_gpio == kOttfSpiNoTxGpio) {
+    uint32_t available_buffer_size = 0;
+    uint32_t last_read_address = 0;
+    do {
+      if (dif_spi_device_get_last_read_address(spi_device,
+                                               &last_read_address) != kDifOk) {
+        return 0;
+      }
+
+      // If we are not using the GPIO TX-ready indicator pin (which is the
+      // default) the host SPI console is constantly polling the spi_device to
+      // see if data is available to be read out. In this case, we need to
+      // adjust the last read address.
+      //
+      // Specifically, when the host is continuously reading from the read
+      // buffer, it is unaware of whether it is going to find a valid new frame
+      // (marked by a magic number in the frame header), an frame header all
+      // zeros, or garbage, since it is operating in polling mode. This could
+      // result in the reported last_read_address being one header size ahead of
+      // the actual address of the last valid frame if all the frames in the
+      // read buffer has been consumed by the host. While it's harmless to use
+      // the last read address even if the reported value is a frame header
+      // ahead, doing so might temporarily underestimate the available buffer
+      // size by the size of a frame header (or 12 bytes to be specific).
+      //
+      // However, if we are using the GPIO TX-ready indicator pin, the host will
+      // only ever attempt to read out data if it was signaled to do so by the
+      // device. In which case the next write address will always be 0, i.e.,
+      // the beginning of the buffer.
+      uint32_t adjusted_last_read_address =
+          (kSpiDeviceReadBufferSizeBytes + last_read_address -
+           kSpiDeviceFrameHeaderSizeBytes) %
+          kSpiDeviceReadBufferSizeBytes;
+
+      // Frames are always word aligned, so ensure the last read address is word
+      // aligned too.
+      uint32_t next_read_address = ((adjusted_last_read_address + 1) & ~3u) %
+                                   kSpiDeviceReadBufferSizeBytes;
+
+      // Compute the remaining free space in the SPI flash buffer.
+      if (next_read_address > next_write_address) {
+        available_buffer_size = next_read_address - next_write_address - 1;
+      } else {
+        available_buffer_size =
+            next_read_address +
+            (kSpiDeviceReadBufferSizeBytes - next_write_address) - 1;
+      }
+    } while ((frame_size_bytes + kSpiDeviceBufferPreservedSizeBytes) >
+             available_buffer_size);
+  }
+
+  // Send aligned data.
+  size_t data_write_address =
+      (next_write_address + kSpiDeviceFrameHeaderSizeBytes) %
+      kSpiDeviceReadBufferSizeBytes;
+  size_t aligned_data_len = len & (~3u);
+  if (!status_ok(spi_device_send_data(spi_device, (uint8_t *)buf,
+                                      aligned_data_len, data_write_address))) {
+    return 0;
+  }
+
+  // Send unaligned data.
+  if (len != aligned_data_len) {
+    uint8_t pad_bytes[4] = {0xff, 0xff, 0xff, 0xff};
+    size_t pad_write_address =
+        (data_write_address + aligned_data_len) % kSpiDeviceReadBufferSizeBytes;
+
+    for (size_t i = 0; i + aligned_data_len < len; i++) {
+      pad_bytes[i] = buf[aligned_data_len + i];
+    }
+    if (!status_ok(spi_device_send_data(spi_device, pad_bytes, 4,
+                                        pad_write_address))) {
+      return 0;
+    }
+  }
+
+  // Send frame header.
+  if (!status_ok(spi_device_send_data(spi_device, frame_header_bytes,
+                                      kSpiDeviceFrameHeaderSizeBytes,
+                                      next_write_address))) {
+    return 0;
+  }
+
+  // Update the next write address and frame number.
+  next_write_address =
+      (next_write_address + frame_size_bytes) % kSpiDeviceReadBufferSizeBytes;
+  console->data.spi.frame_num++;
+
+  // Block until the host to reads out the frame by toggling the GPIO TX-ready
+  // indicator pin to signal to the host to clock out data from the spi_device
+  // egress buffer.
+  if (console->data.spi.tx_ready_gpio != kOttfSpiNoTxGpio) {
+    OT_DISCARD(
+        dif_gpio_write(&ottf_console_gpio, console->data.spi.tx_ready_gpio, true));
+    bool cs_state = true;
+    bool target_cs_state = false;
+    // There will be two bulk transfers that can be synchronized by the
+    // chip-select action. First the host will read out the 12-byte frame
+    // header, followed by the N-byte payload. Each transfer can be observed by
+    // the chip-select toggling low then high. After the first toggle low, when
+    // the host begins reading out the frame header, we can deassert the
+    // TX-ready pin as the host has already initiated the two SPI transactions.
+    for (size_t i = 0; i < 4; ++i) {
+      do {
+        if (dif_spi_device_get_csb_status(spi_device, &cs_state) != kDifOk) {
+          return 0;
+        }
+      } while (cs_state != target_cs_state);
+      if (i == 0) {
+        OT_DISCARD(
+            dif_gpio_write(&ottf_console_gpio, console->data.spi.tx_ready_gpio, false));
+      }
+      target_cs_state = !target_cs_state;
+    }
+    next_write_address = 0;
+  }
+
+  return len;
+}
+
+static void spi_device_clear_flash_buffer(dif_spi_device_handle_t *spi_device) {
+  const uint8_t kEmptyPattern[4] = {0};
+  for (size_t i = 0; i < SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH; i++) {
+    CHECK_DIF_OK(dif_spi_device_write_flash_buffer(
+        spi_device, kDifSpiDeviceFlashBufferTypeEFlash,
+        i * ARRAYSIZE(kEmptyPattern), ARRAYSIZE(kEmptyPattern), kEmptyPattern));
+  }
+  CHECK_DIF_OK(dif_spi_device_set_flash_status_registers(spi_device, 0x00));
+}
+
+static void spi_device_wait_for_sync(dif_spi_device_handle_t *spi_device) {
+  // Write the boot synchronization data to the flash buffer.
+  const uint8_t kBootMagicPattern[4] = {0x02, 0xb0, 0xfe, 0xca};
+  for (size_t i = 0; i < SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH; i++) {
+    CHECK_DIF_OK(dif_spi_device_write_flash_buffer(
+        spi_device, kDifSpiDeviceFlashBufferTypeEFlash,
+        i * ARRAYSIZE(kBootMagicPattern), ARRAYSIZE(kBootMagicPattern),
+        kBootMagicPattern));
+  }
+
+  // Wait for host to read out the boot synchronization data.
+  upload_info_t info = {0};
+  CHECK_STATUS_OK(spi_device_testutils_wait_for_upload(spi_device, &info));
+
+  // Clear the boot magic data in the flash buffer that the host echoed back.
+  spi_device_clear_flash_buffer(spi_device);
+}
+
+static bool spi_tx_last_data_chunk(upload_info_t *info) {
+  const static size_t kSpiTxTerminateMagicAddress = 0x100;
+  return info->address == kSpiTxTerminateMagicAddress;
+}
+
+void ottf_console_spi_setup_tx_indicator(ottf_console_t *console, bool enable,
+  uint32_t tx_ready_gpio, uint32_t tx_ready_mio) {
+  if (enable) {
+    console->data.spi.tx_ready_gpio = tx_ready_gpio;
+    CHECK_DIF_OK(dif_pinmux_output_select(
+        &ottf_console_pinmux, tx_ready_mio,
+        kTopEarlgreyPinmuxOutselGpioGpio0 + tx_ready_gpio));
+    CHECK_DIF_OK(dif_gpio_write(&ottf_console_gpio, tx_ready_gpio, false));
+    CHECK_DIF_OK(dif_gpio_output_set_enabled(&ottf_console_gpio, tx_ready_gpio, true));
+  } else {
+    console->data.spi.tx_ready_gpio = kOttfSpiNoTxGpio;
+  }
+}
+
+void ottf_console_configure_spi_device(ottf_console_t *console, uintptr_t base_addr) {
+  // Configure spi_device SPI flash emulation.
+  dif_spi_device_handle_t *spi_device = &console->data.spi.dif;
+  CHECK_DIF_OK(dif_spi_device_init_handle(mmio_region_from_addr(base_addr),
+                                          spi_device));
+  CHECK_DIF_OK(dif_spi_device_configure(
+      spi_device,
+      (dif_spi_device_config_t){
+          .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+          .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+          .device_mode = kDifSpiDeviceModeFlashEmulation,
+      }));
+  dif_spi_device_flash_command_t read_commands[] = {
+      {
+          // Slot 0: ReadStatus1
+          .opcode = kSpiDeviceFlashOpReadStatus1,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 1: ReadStatus2
+          .opcode = kSpiDeviceFlashOpReadStatus2,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 2: ReadStatus3
+          .opcode = kSpiDeviceFlashOpReadStatus3,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 3: ReadJedecID
+          .opcode = kSpiDeviceFlashOpReadJedec,
+          .address_type = kDifSpiDeviceFlashAddrDisabled,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 4: ReadSfdp
+          .opcode = kSpiDeviceFlashOpReadSfdp,
+          .address_type = kDifSpiDeviceFlashAddr3Byte,
+          .dummy_cycles = 8,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+      {
+          // Slot 5: ReadNormal
+          .opcode = kSpiDeviceFlashOpReadNormal,
+          .address_type = kDifSpiDeviceFlashAddr3Byte,
+          .dummy_cycles = 0,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = true,
+      },
+  };
+  for (size_t i = 0; i < ARRAYSIZE(read_commands); ++i) {
+    uint8_t slot = (uint8_t)i + kSpiDeviceReadCommandSlotBase;
+    CHECK_DIF_OK(dif_spi_device_set_flash_command_slot(
+        spi_device, slot, kDifToggleEnabled, read_commands[i]));
+  }
+  dif_spi_device_flash_command_t write_commands[] = {
+      {
+          // Slot 11: PageProgram
+          .opcode = kSpiDeviceFlashOpPageProgram,
+          .address_type = kDifSpiDeviceFlashAddrCfg,
+          .payload_io_type = kDifSpiDevicePayloadIoSingle,
+          .payload_dir_to_host = false,
+          .upload = true,
+          .set_busy_status = true,
+      },
+  };
+  for (size_t i = 0; i < ARRAYSIZE(write_commands); ++i) {
+    uint8_t slot = (uint8_t)i + kSpiDeviceWriteCommandSlotBase;
+    CHECK_DIF_OK(dif_spi_device_set_flash_command_slot(
+        spi_device, slot, kDifToggleEnabled, write_commands[i]));
+  }
+
+  console->data.spi.frame_num = 0;
+
+  // Setup TX GPIO if requested.
+  if (console->data.spi.tx_ready_gpio != UINT32_MAX) {
+    spi_device_clear_flash_buffer(spi_device);
+  } else {
+    spi_device_wait_for_sync(spi_device);
+  }
+
+  console->getc = ottf_console_spi_getc;
+  console->sink = ottf_console_spi_sink;
+}
+
+size_t ottf_console_spi_device_read(ottf_console_t *console, size_t buf_size, uint8_t *const buf) {
+  CHECK(console->type == kOttfConsoleSpiDevice);
+  size_t received_data_len = 0;
+  upload_info_t info;
+  memset(&info, 0, sizeof(upload_info_t));
+  while (!spi_tx_last_data_chunk(&info)) {
+    CHECK_STATUS_OK(
+        spi_device_testutils_wait_for_upload(&console->data.spi.dif, &info));
+    if (received_data_len < buf_size) {
+      size_t remaining_buf_size = buf_size - received_data_len;
+      size_t bytes_to_copy = remaining_buf_size < info.data_len
+                                 ? remaining_buf_size
+                                 : info.data_len;
+      memcpy(buf + received_data_len, info.data, bytes_to_copy);
+    }
+
+    received_data_len += info.data_len;
+    CHECK_DIF_OK(dif_spi_device_set_flash_status_registers(
+        &console->data.spi.dif, 0x00));
+  }
+
+  return received_data_len;
+}
+
+/*
+ * The user of this function needs to be aware of the following:
+ * 1. The exact amount of data expected to be sent from the host side must be
+ * known in advance.
+ * 2. Characters should be retrieved from the console as soon as they become
+ * available. Failure to do so may result in an SPI transaction timeout.
+ */
+status_t ottf_console_spi_getc(void *io) {
+  ottf_console_t *console = io;
+  dif_spi_device_handle_t *spi_device = &console->data.spi.dif;
+  static size_t index = 0;
+  static upload_info_t info = {0};
+  if (index == info.data_len) {
+    memset(&info, 0, sizeof(upload_info_t));
+    CHECK_STATUS_OK(spi_device_testutils_wait_for_upload(spi_device, &info));
+    index = 0;
+    CHECK_DIF_OK(dif_spi_device_set_flash_status_registers(spi_device, 0x00));
+  }
+
+  return OK_STATUS(info.data[index++]);
+}
+
+size_t ottf_console_spi_sink(void *io, const char *buf, size_t len) {
+  ottf_console_t *console = io;
+  size_t write_data_len = 0;
+
+  while (write_data_len < len) {
+    size_t payload_len = len - write_data_len;
+    if (payload_len > kSpiDeviceMaxFramePayloadSizeBytes) {
+      payload_len = kSpiDeviceMaxFramePayloadSizeBytes;
+    }
+    if (spi_device_send_frame(console, buf + write_data_len, payload_len) ==
+        payload_len) {
+      write_data_len += payload_len;
+    }
+  }
+
+  return write_data_len;
+}

--- a/sw/device/lib/testing/test_framework/ottf_console_uart.c
+++ b/sw/device/lib/testing/test_framework/ottf_console_uart.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_isrs.h"
+#include "sw/device/lib/testing/test_framework/ottf_console_internal.h"
+
+// TODO: make this toplevel agnostic.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * OTTF console configuration parameters.
+ */
+enum {
+  /**
+   * Flow control parameters.
+   */
+  kFlowControlLowWatermark = 4,   // bytes
+  kFlowControlHighWatermark = 8,  // bytes
+  kFlowControlRxWatermark = kDifUartWatermarkByte8,
+  /**
+   * HART PLIC Target.
+   */
+  kPlicTarget = kTopEarlgreyPlicTargetIbex0,
+};
+
+#define MODULE_ID MAKE_MODULE_ID('o', 't', 'u')
+
+// This variable is shared between
+// the interrupt service handler and user code.
+static volatile ottf_console_flow_control_t flow_control_state;
+
+void ottf_console_configure_uart(ottf_console_t *console, uintptr_t base_addr) {
+  CHECK_DIF_OK(
+      dif_uart_init(mmio_region_from_addr(base_addr), &console->data.uart.dif));
+  CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
+  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
+        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK_DIF_OK(dif_uart_configure(
+      &console->data.uart.dif, (dif_uart_config_t){
+                              .baudrate = (uint32_t)kUartBaudrate,
+                              .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                              .parity_enable = kDifToggleDisabled,
+                              .parity = kDifUartParityEven,
+                              .tx_enable = kDifToggleEnabled,
+                              .rx_enable = kDifToggleEnabled,
+                          }));
+
+  console->getc = ottf_console_uart_getc;
+  console->sink = ottf_console_uart_sink;
+}
+
+size_t ottf_console_uart_sink(void *io, const char *buf, size_t len) {
+  ottf_console_t *console = io;
+  const dif_uart_t *uart = &console->data.uart.dif;
+  for (size_t i = 0; i < len; ++i) {
+    if (dif_uart_byte_send_polled(uart, (uint8_t)buf[i]) != kDifOk) {
+      return i;
+    }
+  }
+  return len;
+}
+
+status_t ottf_console_uart_getc(void *io) {
+  ottf_console_t *console = io;
+  const dif_uart_t *uart = &console->data.uart.dif;
+  uint8_t byte;
+  TRY(dif_uart_byte_receive_polled(uart, &byte));
+  TRY(ottf_console_flow_control(console, kOttfConsoleFlowControlAuto));
+  return OK_STATUS(byte);
+}
+
+// This version of the function is safe to call from within the ISR.
+static status_t manage_flow_control(const ottf_console_t *console,
+                                    ottf_console_flow_control_t ctrl) {
+  const dif_uart_t *uart = &console->data.uart.dif;
+  if (flow_control_state == kOttfConsoleFlowControlNone) {
+    return OK_STATUS((int32_t)flow_control_state);
+  }
+  if (ctrl == kOttfConsoleFlowControlAuto) {
+    uint32_t avail;
+    TRY(dif_uart_rx_bytes_available(uart, &avail));
+    if (avail < kFlowControlLowWatermark &&
+        flow_control_state != kOttfConsoleFlowControlResume) {
+      // Enable RX watermark interrupt when RX FIFO level is below the
+      // watermark.
+      CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                            kDifToggleEnabled));
+      ctrl = kOttfConsoleFlowControlResume;
+    } else if (avail >= kFlowControlHighWatermark &&
+               flow_control_state != kOttfConsoleFlowControlPause) {
+      ctrl = kOttfConsoleFlowControlPause;
+      // RX watermark interrupt is status type, so disable the interrupt whilst
+      // RX FIFO is above the watermark to avoid an inifite loop of ISRs.
+      CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                            kDifToggleDisabled));
+    } else {
+      return OK_STATUS((int32_t)flow_control_state);
+    }
+  }
+  uint8_t byte = (uint8_t)ctrl;
+  CHECK_DIF_OK(dif_uart_bytes_send(uart, &byte, 1, NULL));
+  flow_control_state = ctrl;
+  return OK_STATUS((int32_t)flow_control_state);
+}
+
+static uint32_t get_flow_control_watermark_plic_id(uint32_t base_addr) {
+  switch (base_addr) {
+#if !OT_IS_ENGLISH_BREAKFAST
+    case TOP_EARLGREY_UART1_BASE_ADDR:
+      return kTopEarlgreyPlicIrqIdUart1RxWatermark;
+    case TOP_EARLGREY_UART2_BASE_ADDR:
+      return kTopEarlgreyPlicIrqIdUart2RxWatermark;
+    case TOP_EARLGREY_UART3_BASE_ADDR:
+      return kTopEarlgreyPlicIrqIdUart3RxWatermark;
+#endif
+    case TOP_EARLGREY_UART0_BASE_ADDR:
+    default:
+      return kTopEarlgreyPlicIrqIdUart0RxWatermark;
+  }
+}
+
+void ottf_console_uart_flow_control_enable(ottf_console_t *console, dif_rv_plic_t *plic) {
+  const dif_uart_t *uart = &console->data.uart.dif;
+  CHECK_DIF_OK(dif_uart_watermark_rx_set(uart, kFlowControlRxWatermark));
+  CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                        kDifToggleEnabled));
+
+  uint32_t plic_id = get_flow_control_watermark_plic_id((uint32_t)console->data.uart.dif.base_addr.base);
+  // Set IRQ priorities to MAX
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, plic_id, kDifRvPlicMaxPriority));
+  // Set Ibex IRQ priority threshold level
+  CHECK_DIF_OK(dif_rv_plic_target_set_threshold(plic, kPlicTarget,
+                                                kDifRvPlicMinPriority));
+  // Enable IRQs in PLIC
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(plic,
+                                           plic_id,
+                                           kPlicTarget, kDifToggleEnabled));
+
+  flow_control_state = kOttfConsoleFlowControlAuto;
+}
+
+// The public API has to save and restore interrupts to avoid an
+// unexpected write to the global `flow_control_state`.
+status_t ottf_console_uart_flow_control(ottf_console_t *console,
+                                   ottf_console_flow_control_t ctrl) {
+  const dif_uart_t *uart = &console->data.uart.dif;
+  dif_uart_irq_enable_snapshot_t snapshot;
+  CHECK_DIF_OK(dif_uart_irq_disable_all(uart, &snapshot));
+  status_t s = manage_flow_control(console, ctrl);
+  CHECK_DIF_OK(dif_uart_irq_restore_all(uart, &snapshot));
+  return s;
+}
+
+bool ottf_console_uart_flow_control_isr(ottf_console_t *console) {
+  const dif_uart_t *uart = &console->data.uart.dif;
+  bool rx;
+  CHECK_DIF_OK(dif_uart_irq_is_pending(uart, kDifUartIrqRxWatermark, &rx));
+  if (rx) {
+    manage_flow_control(console, kOttfConsoleFlowControlAuto);
+    CHECK_DIF_OK(dif_uart_irq_acknowledge(uart, kDifUartIrqRxWatermark));
+    return true;
+  }
+  return false;
+}

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -13,7 +13,7 @@ typedef enum ottf_console_type {
   kOttfConsoleSpiDevice,
 } ottf_console_type_t;
 
-typedef struct ottf_console {
+typedef struct ottf_console_t {
   /**
    * Communication interface type to use for the OTTF console (see
    * `ottf_console_type_t` above).
@@ -38,7 +38,7 @@ typedef struct ottf_console {
    * transmissions.
    */
   bool putbuf_buffered;
-} ottf_console_t;
+} ottf_console_opt_t;
 
 typedef struct ottf_console_tx_indicator {
   /**
@@ -91,7 +91,7 @@ typedef struct ottf_test_config {
    * status and error messages are written to. Typically UART0, but other
    * communication peripherals may be supported.
    */
-  ottf_console_t console;
+  ottf_console_opt_t console;
 
   /**
    * The TX indicator GPIO to use in conjunction with the SPI console, if a

--- a/sw/device/tests/spi_device_ottf_console_test.c
+++ b/sw/device/tests/spi_device_ottf_console_test.c
@@ -104,24 +104,24 @@ bool test_main(void) {
   LOG_INFO("Sending test string to Host...");
   LOG_INFO("%s", kTestStr);
   LOG_INFO("SYNC: Waiting for console data");
-  size_t received_data_len =
-      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  size_t received_data_len = ottf_console_spi_device_read(
+      ottf_console_get(), sizeof(input_buf), input_buf);
   CHECK(received_data_len == sizeof(kTestStr));
   CHECK_ARRAYS_EQ(input_buf, kTestStr, ARRAYSIZE(kTestStr));
 
   LOG_INFO("Sending 64B data to Host...");
   LOG_INFO("%s", kTest64bDataStr);
   LOG_INFO("SYNC: Waiting for console data");
-  received_data_len =
-      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  received_data_len = ottf_console_spi_device_read(
+      ottf_console_get(), sizeof(input_buf), input_buf);
   CHECK(received_data_len == sizeof(kTest64bDataStr));
   CHECK_ARRAYS_EQ(input_buf, kTest64bDataStr, ARRAYSIZE(kTest64bDataStr));
 
   LOG_INFO("Sending 256B data to Host...");
   LOG_INFO("%s", kTest256bDataStr);
   LOG_INFO("SYNC: Waiting for console data");
-  received_data_len =
-      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  received_data_len = ottf_console_spi_device_read(
+      ottf_console_get(), sizeof(input_buf), input_buf);
   CHECK(received_data_len == sizeof(kTest256bDataStr));
   CHECK_ARRAYS_EQ(input_buf, kTest256bDataStr, ARRAYSIZE(kTest256bDataStr));
 
@@ -130,8 +130,8 @@ bool test_main(void) {
     LOG_INFO("Round: %d", i);
     LOG_INFO("%s", kTest1KbDataStr);
     LOG_INFO("SYNC: Waiting for console data");
-    received_data_len =
-        ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+    received_data_len = ottf_console_spi_device_read(
+        ottf_console_get(), sizeof(input_buf), input_buf);
     CHECK(received_data_len == sizeof(kTest1KbDataStr));
     CHECK_ARRAYS_EQ(input_buf, kTest1KbDataStr, ARRAYSIZE(kTest1KbDataStr));
   }
@@ -139,8 +139,8 @@ bool test_main(void) {
   LOG_INFO("Sending 4KB data to Host...");
   LOG_INFO("%s", kTest4KbDataStr);
   LOG_INFO("SYNC: Waiting for console data");
-  received_data_len =
-      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  received_data_len = ottf_console_spi_device_read(
+      ottf_console_get(), sizeof(input_buf), input_buf);
   CHECK(received_data_len == sizeof(kTest4KbDataStr));
   CHECK_ARRAYS_EQ(input_buf, kTest4KbDataStr, ARRAYSIZE(kTest4KbDataStr));
 

--- a/sw/host/tests/chip/mem/src/main.rs
+++ b/sw/host/tests/chip/mem/src/main.rs
@@ -22,7 +22,7 @@ struct Opts {
     init: InitializeTest,
 
     /// Console receive timeout.
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     timeout: Duration,
 
     /// Path to the firmware's ELF file, for querying symbol addresses.


### PR DESCRIPTION
**This is a work in progress**

For manufacturing, we want to be able to have a dual SPI/UART console, that is use one console (typically SPI) for the important data like ujson and another one for debug (typically UART). However the OTTF console code assumes everything that there is a single console, uses global variables and is generally poorly organised.

This PR is a first step: it revamps the console subsystem so that there can be several console. Concretely this means that each console is now backed by a `ottf_console_t` structure and every console function works on this object. To keep backward compatibility, the concept of "main console" is introduced: this is the console used by default (ie returned by `ottf_console_get`) by ujson and `base_printf`. There are other technical changes in the PR:
- console code is pulled out of `print.c` (it should never have been there to start with)
- console code is split between generic (`ottf_console.c`) and device-speicifc (`ottf_console_{uart,spi}.c`) files
- buffering is handled in a device independent way 

**IMPORTANT:** there is also a potential breaking change which is that now buffering (if enabled) applies to *all* writes to the console, not just `putbuf`. This is because it makes little sense to mix buffered and unbuffered writes to the same device.