### PR TITLE
[rom_ctrl,rtl] Fix parameter value in prim_count instantiation

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
@@ -128,7 +128,7 @@ module rom_ctrl_compare
   logic addr_ctr_alert;
   prim_count #(
     .Width(AW),
-    .PossibleActions(prim_count_pkg::Incr)
+    .PossibleActions({prim_count_pkg::Incr})
   ) u_prim_count_addr (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
The previous version didn't get turned from an enum value to the underlying bits, which means that it generated a lint error from AscentLint (oops).