### PR TITLE
[ci] Allow BLOCKFILE checker to handle many files

### DIFF
--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -17,21 +17,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Get whole Git history.
 
       - name: Determine changed files
         run: |
-          pr_url="https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"
-          echo $pr_url
-          gh pr diff $pr_url --name-only > $HOME/changed_files
+          git fetch origin "${{ github.head_ref }}"
+          git diff "origin/${{ github.head_ref }}" --name-only | tee "${{ runner.temp }}/changed_files"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show files changed
-        run: cat $HOME/changed_files
-
       - name: Check for blocked changes
         run: |
-          ./ci/scripts/check-pr-changes-allowed.py $HOME/changed_files \
+          ./ci/scripts/check-pr-changes-allowed.py "${{ runner.temp }}/changed_files" \
             --gh-repo ${{ github.repository }} \
             --gh-token ${{ secrets.GITHUB_TOKEN }} \
             --pr-number ${{ github.event.number }}


### PR DESCRIPTION
The GitHub API refuses to give the list of changed files when there are too many of them.

This PR uses Git directly to get this list.

Note that the *master* branch version of this CI check is running on this PR, not the updated one.