### PR TITLE
[util] Modernize logger interface

### DIFF
--- a/util/dtgen/helper.py
+++ b/util/dtgen/helper.py
@@ -194,7 +194,7 @@ class StructType(BaseType):
         for (name, (field_type, _)) in self.fields.items():
             assert isinstance(name, Name), "StructType can only render mappings with `Name` keys"
             if name not in value:
-                logging.warn("field {} not found in {}".format(name, value))
+                logging.warning("field {} not found in {}".format(name, value))
                 continue
             text += ".{} = {},\n".format(name.as_snake_case(), field_type.render_value(value[name]))
             unused_keys.remove(name)

--- a/util/i2csvg.py
+++ b/util/i2csvg.py
@@ -101,7 +101,7 @@ def main():
         for filename in args.srcfile:
             if (filename == '-'):
                 if (done_stdin):
-                    log.warn("Ignore stdin after first use\n")
+                    log.warning("Ignore stdin after first use\n")
                     continue
                 done_stdin = True
                 infile = sys.stdin

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -268,7 +268,7 @@ def gen_cdefine_multireg(outstr: TextIO, multireg: MultiRegister,
                                    existing_defines)
     else:
         log.warning("Fieldless multireg " + multireg.reg.name +
-                 " skip multireg specific data generation.")
+                    " skip multireg specific data generation.")
 
     for subreg in multireg.regs:
         gen_cdefine_register(outstr, subreg, component, regwidth, rnames,

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -267,7 +267,7 @@ def gen_cdefine_multireg(outstr: TextIO, multireg: MultiRegister,
                                    len(multireg.regs), regwidth,
                                    existing_defines)
     else:
-        log.warn("Fieldless multireg " + multireg.reg.name +
+        log.warning("Fieldless multireg " + multireg.reg.name +
                  " skip multireg specific data generation.")
 
     for subreg in multireg.regs:

--- a/util/reggen/html_helpers.py
+++ b/util/reggen/html_helpers.py
@@ -63,7 +63,7 @@ def _expand_paragraph(s: str, rnames: Set[str]) -> str:
                 return ('<a href="#' + base + '"><code class=\"reg\">' +
                         match.group(1) + '</code></a>')
         log.warning('!!' + match.group(1).partition('.')[0] +
-                 ' not found in register list.')
+                    ' not found in register list.')
         return match.group(0)
 
     # Split out pre-formatted text. Because the call to re.split has a capture

--- a/util/reggen/html_helpers.py
+++ b/util/reggen/html_helpers.py
@@ -62,7 +62,7 @@ def _expand_paragraph(s: str, rnames: Set[str]) -> str:
             else:
                 return ('<a href="#' + base + '"><code class=\"reg\">' +
                         match.group(1) + '</code></a>')
-        log.warn('!!' + match.group(1).partition('.')[0] +
+        log.warning('!!' + match.group(1).partition('.')[0] +
                  ' not found in register list.')
         return match.group(0)
 

--- a/util/topgen/secure_prng.py
+++ b/util/topgen/secure_prng.py
@@ -61,7 +61,7 @@ class secure_prng():
 
         CTR_DRBG_Update process
         Described in NIST SP 800-90A, page 51
-        For convenience, input provided_data is devided in two 128 bit chunks.
+        For convenience, input provided_data is divided in two 128 bit chunks.
         """
         cipher = AES.new(self.Key.to_bytes(16, 'big'), AES.MODE_ECB)
 
@@ -181,7 +181,7 @@ class secure_prng():
         if seed.bit_length() < 250:
             # Warn, but don't fail, because the DV logic always passes in 32-bit
             # seeds and this can naturally happen about 1% of the time.
-            log.warn(
+            log.warning(
                 f'PRNG seed is only {seed.bit_length()} bits long, which is '
                 'unlikely for a sample from a 256-bit distribution. Please '
                 'double-check the logic.')


### PR DESCRIPTION
### PR content/description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
This small PR resolves it.