### PR TITLE
[hw,ac_range_check,rtl] Switch to status interrupt and better clear behavior

### DIFF
--- a/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
+++ b/hw/ip_templates/ac_range_check/data/ac_range_check.hjson.tpl
@@ -105,7 +105,8 @@ import math
   ]
   interrupt_list: [
     { name: "deny_cnt_reached"
-      desc: "Deny counter has reached threshold."
+      desc: "Deny counter has exceeded threshold."
+      type: "status"
     }
   ]
   alert_list: [
@@ -171,7 +172,7 @@ import math
         { bits: "9:2"
           name: "deny_cnt_threshold"
           resval: 0x0
-          desc: "An interrupt is raised (if enabled) when deny_cnt reaches the configured deny_cnt_threshold."
+          desc: "An interrupt is raised (if enabled) when deny_cnt exceeds the configured deny_cnt_threshold."
         }
         { bits: "1"
           name: "log_clear"

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -274,18 +274,18 @@ module ${module_instance_name}
   prim_count #(
     .Width(DenyCountWidth)
   ) u_deny_count (
-    .clk_i              ( clk_i              ),
-    .rst_ni             ( rst_ni             ),
-    .clr_i              ( clear_log          ),
-    .set_i              ( 1'b0               ),
-    .set_cnt_i          ( '0                 ),
-    .incr_en_i          ( deny_cnt_incr      ),
-    .decr_en_i          ( 1'b0               ),
-    .step_i             ( DenyCountWidth'(1) ),
-    .commit_i           ( 1'b1               ),
-    .cnt_o              ( deny_cnt           ),
-    .cnt_after_commit_o (                    ),
-    .err_o              ( deny_cnt_error     )
+    .clk_i              ( clk_i                          ),
+    .rst_ni             ( rst_ni                         ),
+    .clr_i              ( 1'b0                           ),
+    .set_i              ( clear_log                      ),
+    .set_cnt_i          ( DenyCountWidth'(deny_cnt_incr) ),
+    .incr_en_i          ( deny_cnt_incr                  ),
+    .decr_en_i          ( 1'b0                           ),
+    .step_i             ( DenyCountWidth'(1)             ),
+    .commit_i           ( 1'b1                           ),
+    .cnt_o              ( deny_cnt                       ),
+    .cnt_after_commit_o (                                ),
+    .err_o              ( deny_cnt_error                 )
   );
 
   // Log count is transparently mirrored. Clearing happens on the counter.
@@ -333,7 +333,7 @@ module ${module_instance_name}
   // Interrupt Notification Logic
   //////////////////////////////////////////////////////////////////////////////
 
-  // Create the IRQ condition when the deny counter reaches the configured threshold
+  // Create the IRQ condition when the deny counter is above the configured threshold.
   logic deny_cnt_threshold_reached;
   assign deny_cnt_threshold_reached = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
 

--- a/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
+++ b/hw/ip_templates/ac_range_check/rtl/ac_range_check.sv.tpl
@@ -266,11 +266,10 @@ module ${module_instance_name}
   logic log_first_deny;
   assign log_first_deny = deny_cnt_incr & (deny_cnt == 0);
 
-  // Clear log information when clearing the interrupt or when clearing the log manually via the
-  // writing of a 1 to the log_clear bit.
-  logic intr_state_cleared, clear_log;
-  assign clear_log = intr_state_cleared |
-                     (reg2hw.log_config.log_clear.qe & reg2hw.log_config.log_clear.q);
+  // Clear log information when clearing the log manually via the writing of a 1 to the
+  // log_clear bit.
+  logic clear_log;
+  assign clear_log = (reg2hw.log_config.log_clear.qe & reg2hw.log_config.log_clear.q);
 
   prim_count #(
     .Width(DenyCountWidth)
@@ -334,41 +333,24 @@ module ${module_instance_name}
   // Interrupt Notification Logic
   //////////////////////////////////////////////////////////////////////////////
 
-  logic deny_cnt_threshold_reached_d, deny_cnt_threshold_reached_event;
-
-  // Create a threshold event when the deny counter reaches the configured threshold
-  assign deny_cnt_threshold_reached_d = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
-  prim_edge_detector u_edge_threshold_reached (
-    .clk_i             ( clk_i                            ),
-    .rst_ni            ( rst_ni                           ),
-    .d_i               ( deny_cnt_threshold_reached_d     ),
-    .q_sync_o          (                                  ),
-    .q_posedge_pulse_o ( deny_cnt_threshold_reached_event ),
-    .q_negedge_pulse_o (                                  )
-  );
-
-  prim_edge_detector u_edge_intr_state (
-    .clk_i             ( clk_i               ),
-    .rst_ni            ( rst_ni              ),
-    .d_i               ( reg2hw.intr_state.q ),
-    .q_sync_o          (                     ),
-    .q_posedge_pulse_o (                     ),
-    .q_negedge_pulse_o ( intr_state_cleared  )
-  );
+  // Create the IRQ condition when the deny counter reaches the configured threshold
+  logic deny_cnt_threshold_reached;
+  assign deny_cnt_threshold_reached = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
 
   prim_intr_hw #(
-    .Width(1)
+    .Width ( 1        ),
+    .IntrT ( "Status" )
   ) u_intr_range_check_deny (
-    .clk_i                  ( clk_i                            ),
-    .rst_ni                 ( rst_ni                           ),
-    .event_intr_i           ( deny_cnt_threshold_reached_event ),
-    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.q             ),
-    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.q               ),
-    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.qe              ),
-    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.q              ),
-    .hw2reg_intr_state_de_o ( hw2reg.intr_state.de             ),
-    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.d              ),
-    .intr_o                 ( intr_deny_cnt_reached_o          )
+    .clk_i                  ( clk_i                      ),
+    .rst_ni                 ( rst_ni                     ),
+    .event_intr_i           ( deny_cnt_threshold_reached ),
+    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.q       ),
+    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.q         ),
+    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.qe        ),
+    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.q        ),
+    .hw2reg_intr_state_de_o ( hw2reg.intr_state.de       ),
+    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.d        ),
+    .intr_o                 ( intr_deny_cnt_reached_o    )
   );
 
   //////////////////////////////////////////////////////////////////////////////

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -19838,7 +19838,7 @@
       type: interrupt
       module_name: ac_range_check
       desc: ac_range_check deny_cnt_reached interrupt
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
       incoming: false
     }

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/data/ac_range_check.hjson
@@ -102,7 +102,8 @@
   ]
   interrupt_list: [
     { name: "deny_cnt_reached"
-      desc: "Deny counter has reached threshold."
+      desc: "Deny counter has exceeded threshold."
+      type: "status"
     }
   ]
   alert_list: [
@@ -168,7 +169,7 @@
         { bits: "9:2"
           name: "deny_cnt_threshold"
           resval: 0x0
-          desc: "An interrupt is raised (if enabled) when deny_cnt reaches the configured deny_cnt_threshold."
+          desc: "An interrupt is raised (if enabled) when deny_cnt exceeds the configured deny_cnt_threshold."
         }
         { bits: "1"
           name: "log_clear"

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/doc/interfaces.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/doc/interfaces.md
@@ -23,9 +23,9 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## Interrupts
 
-| Interrupt Name   | Type   | Description                         |
-|:-----------------|:-------|:------------------------------------|
-| deny_cnt_reached | Event  | Deny counter has reached threshold. |
+| Interrupt Name   | Type   | Description                          |
+|:-----------------|:-------|:-------------------------------------|
+| deny_cnt_reached | Status | Deny counter has exceeded threshold. |
 
 ## Security Alerts
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/doc/registers.md
@@ -183,13 +183,13 @@ Interrupt State Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "deny_cnt_reached", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 180}}
+{"reg": [{"name": "deny_cnt_reached", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 180}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name             | Description                         |
-|:------:|:------:|:-------:|:-----------------|:------------------------------------|
-|  31:1  |        |         |                  | Reserved                            |
-|   0    |  rw1c  |   0x0   | deny_cnt_reached | Deny counter has reached threshold. |
+|  Bits  |  Type  |  Reset  | Name             | Description                          |
+|:------:|:------:|:-------:|:-----------------|:-------------------------------------|
+|  31:1  |        |         |                  | Reserved                             |
+|   0    |   ro   |   0x0   | deny_cnt_reached | Deny counter has exceeded threshold. |
 
 ## INTR_ENABLE
 Interrupt Enable Register
@@ -278,7 +278,7 @@ Status of hardware alerts.
 |  Bits  |  Type  |  Reset  | Name               | Description                                                                                   |
 |:------:|:------:|:-------:|:-------------------|:----------------------------------------------------------------------------------------------|
 | 31:10  |        |         |                    | Reserved                                                                                      |
-|  9:2   |   rw   |   0x0   | deny_cnt_threshold | An interrupt is raised (if enabled) when deny_cnt reaches the configured deny_cnt_threshold.  |
+|  9:2   |   rw   |   0x0   | deny_cnt_threshold | An interrupt is raised (if enabled) when deny_cnt exceeds the configured deny_cnt_threshold.  |
 |   1    |   rw   |   0x0   | log_clear          | Clears all log information for the first denied access including: - LOG_STATUS - LOG_ADDRESS. |
 |   0    |   rw   |   0x0   | log_enable         | When set, blocked requests are logged by the deny counter.                                    |
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -274,18 +274,18 @@ module ac_range_check
   prim_count #(
     .Width(DenyCountWidth)
   ) u_deny_count (
-    .clk_i              ( clk_i              ),
-    .rst_ni             ( rst_ni             ),
-    .clr_i              ( clear_log          ),
-    .set_i              ( 1'b0               ),
-    .set_cnt_i          ( '0                 ),
-    .incr_en_i          ( deny_cnt_incr      ),
-    .decr_en_i          ( 1'b0               ),
-    .step_i             ( DenyCountWidth'(1) ),
-    .commit_i           ( 1'b1               ),
-    .cnt_o              ( deny_cnt           ),
-    .cnt_after_commit_o (                    ),
-    .err_o              ( deny_cnt_error     )
+    .clk_i              ( clk_i                          ),
+    .rst_ni             ( rst_ni                         ),
+    .clr_i              ( 1'b0                           ),
+    .set_i              ( clear_log                      ),
+    .set_cnt_i          ( DenyCountWidth'(deny_cnt_incr) ),
+    .incr_en_i          ( deny_cnt_incr                  ),
+    .decr_en_i          ( 1'b0                           ),
+    .step_i             ( DenyCountWidth'(1)             ),
+    .commit_i           ( 1'b1                           ),
+    .cnt_o              ( deny_cnt                       ),
+    .cnt_after_commit_o (                                ),
+    .err_o              ( deny_cnt_error                 )
   );
 
   // Log count is transparently mirrored. Clearing happens on the counter.
@@ -333,7 +333,7 @@ module ac_range_check
   // Interrupt Notification Logic
   //////////////////////////////////////////////////////////////////////////////
 
-  // Create the IRQ condition when the deny counter reaches the configured threshold
+  // Create the IRQ condition when the deny counter is above the configured threshold.
   logic deny_cnt_threshold_reached;
   assign deny_cnt_threshold_reached = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
 

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check.sv
@@ -266,11 +266,10 @@ module ac_range_check
   logic log_first_deny;
   assign log_first_deny = deny_cnt_incr & (deny_cnt == 0);
 
-  // Clear log information when clearing the interrupt or when clearing the log manually via the
-  // writing of a 1 to the log_clear bit.
-  logic intr_state_cleared, clear_log;
-  assign clear_log = intr_state_cleared |
-                     (reg2hw.log_config.log_clear.qe & reg2hw.log_config.log_clear.q);
+  // Clear log information when clearing the log manually via the writing of a 1 to the
+  // log_clear bit.
+  logic clear_log;
+  assign clear_log = (reg2hw.log_config.log_clear.qe & reg2hw.log_config.log_clear.q);
 
   prim_count #(
     .Width(DenyCountWidth)
@@ -334,41 +333,24 @@ module ac_range_check
   // Interrupt Notification Logic
   //////////////////////////////////////////////////////////////////////////////
 
-  logic deny_cnt_threshold_reached_d, deny_cnt_threshold_reached_event;
-
-  // Create a threshold event when the deny counter reaches the configured threshold
-  assign deny_cnt_threshold_reached_d = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
-  prim_edge_detector u_edge_threshold_reached (
-    .clk_i             ( clk_i                            ),
-    .rst_ni            ( rst_ni                           ),
-    .d_i               ( deny_cnt_threshold_reached_d     ),
-    .q_sync_o          (                                  ),
-    .q_posedge_pulse_o ( deny_cnt_threshold_reached_event ),
-    .q_negedge_pulse_o (                                  )
-  );
-
-  prim_edge_detector u_edge_intr_state (
-    .clk_i             ( clk_i               ),
-    .rst_ni            ( rst_ni              ),
-    .d_i               ( reg2hw.intr_state.q ),
-    .q_sync_o          (                     ),
-    .q_posedge_pulse_o (                     ),
-    .q_negedge_pulse_o ( intr_state_cleared  )
-  );
+  // Create the IRQ condition when the deny counter reaches the configured threshold
+  logic deny_cnt_threshold_reached;
+  assign deny_cnt_threshold_reached = deny_cnt > reg2hw.log_config.deny_cnt_threshold.q;
 
   prim_intr_hw #(
-    .Width(1)
+    .Width ( 1        ),
+    .IntrT ( "Status" )
   ) u_intr_range_check_deny (
-    .clk_i                  ( clk_i                            ),
-    .rst_ni                 ( rst_ni                           ),
-    .event_intr_i           ( deny_cnt_threshold_reached_event ),
-    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.q             ),
-    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.q               ),
-    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.qe              ),
-    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.q              ),
-    .hw2reg_intr_state_de_o ( hw2reg.intr_state.de             ),
-    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.d              ),
-    .intr_o                 ( intr_deny_cnt_reached_o          )
+    .clk_i                  ( clk_i                      ),
+    .rst_ni                 ( rst_ni                     ),
+    .event_intr_i           ( deny_cnt_threshold_reached ),
+    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.q       ),
+    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.q         ),
+    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.qe        ),
+    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.q        ),
+    .hw2reg_intr_state_de_o ( hw2reg.intr_state.de       ),
+    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.d        ),
+    .intr_o                 ( intr_deny_cnt_reached_o    )
   );
 
   //////////////////////////////////////////////////////////////////////////////

--- a/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
+++ b/hw/top_darjeeling/ip_autogen/ac_range_check/rtl/ac_range_check_reg_top.sv
@@ -136,9 +136,7 @@ module ac_range_check_reg_top
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic intr_state_we;
   logic intr_state_qs;
-  logic intr_state_wd;
   logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
@@ -1136,7 +1134,7 @@ module ac_range_check_reg_top
   // R[intr_state]: V(False)
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state (
@@ -1144,8 +1142,8 @@ module ac_range_check_reg_top
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.de),
@@ -12392,9 +12390,6 @@ module ac_range_check_reg_top
   end
 
   // Generate write-enables
-  assign intr_state_we = racl_addr_hit_write[0] & reg_we & !reg_error;
-
-  assign intr_state_wd = reg_wdata[0];
   assign intr_enable_we = racl_addr_hit_write[1] & reg_we & !reg_error;
 
   assign intr_enable_wd = reg_wdata[0];
@@ -13251,7 +13246,7 @@ module ac_range_check_reg_top
 
   // Assign write-enables to checker logic vector.
   always_comb begin
-    reg_we_check[0] = intr_state_we;
+    reg_we_check[0] = 1'b0;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;
     reg_we_check[3] = alert_test_we;


### PR DESCRIPTION
This PR refactors the AC range interrupt handling and improves the combined clear and increment operation.

1.  **Interrupt Type:** Changes the AC range interrupt from an event-triggered to a status-based interrupt. This simplifies the logic as the counter's status directly dictates the interrupt condition.
2.  **Combined Clear/Increment:** Updates the clear and increment handling to use the `SET`-interface of the `prim_counter`. This ensures both actions are incorporated simultaneously.
    * A clear without an increment now loads 0.
    * A simultaneous clear and increment now loads 1.
