### PR TITLE
[entropy_src,rtl] Tidy up license in entropy_src_main_sm_pkg.core

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm_pkg.core
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm_pkg.core
@@ -2,8 +2,6 @@ CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 
 name: "lowrisc:ip:entropy_src_main_sm_pkg:0.1"
 description: "entropy_src"


### PR DESCRIPTION
This seems to have been mangled in the original version. Drop the duplicated lines.