### PR TITLE
[top_darjeeling/dv] Expand list of smoke tests

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1687,17 +1687,24 @@
     }
     {
       name: smoke
-      tests: ["chip_sw_spi_device_pass_through",
+      tests: [
+              "chip_sw_aes_smoketest"
+              "chip_sw_aon_timer_smoketest",
+              "chip_sw_clkmgr_smoketest",
+              "chip_sw_csrng_smoketest",
               "chip_sw_example_concurrency",
-              // TODO(#26733): fix these tests for Darjeeling or select more appropriate ones.
-              //"xbar_smoke",
-              //"chip_sw_uart_tx_rx",
-              //"chip_sw_spi_host_tx_rx",
-              //"chip_sw_i2c_host_tx_rx",
-              //"chip_sw_i2c_device_tx_rx",
-              //"chip_plic_all_irqs",
-              //"chip_sw_example_rom",
-              //"chip_sw_example_manufacturer",
+              "chip_sw_gpio_smoketest"
+              "chip_sw_hmac_smoketest",
+              "chip_sw_kmac_smoketest",
+              "chip_sw_otbn_smoketest",
+              "chip_sw_otp_ctrl_smoketest",
+              "chip_sw_rstmgr_smoketest",
+              "chip_sw_rv_plic_smoketest",
+              "chip_sw_rv_timer_smoketest",
+              "chip_sw_spi_device_pass_through",
+              "chip_sw_sram_ctrl_smoketest",
+              "chip_sw_uart_smoketest",
+              "xbar_smoke",
               // TODO: add this test after enabling HW verification:
               //"rom_e2e_smoke",
              ]


### PR DESCRIPTION
Darjeeling currently cannot run the same smoke tests that are run for Earlgrey, because not all of these tests have been ported to multi-top yet.  For this reason, Darjeeling's TLT smoke suite currently includes only two tests (issue #26733).

There are many more TLTs that already run and pass on Darjeeling, however.  This commit adds a couple of them to the smoke regression: all tests in the `chip_sw_smoketest` testpoint plus `xbar_smoke`.  All these tests run in less than 8 minutes on a typical workstation, which is quicker than `chip_sw_spi_device_pass_through`, which was already among Darjeeling's smoke tests.

_Edit: Removed `chip_sw_rv_core_ibex_address_translation` because that is already part of the `xcelium_ci_1` regression, which is also run by CI._