### PR TITLE
[corefiles] Apply user file type to python files

### DIFF
--- a/hw/check_tool_requirements.core
+++ b/hw/check_tool_requirements.core
@@ -10,6 +10,7 @@ filesets:
     files:
       - check_tool_requirements.py : { copyto: check_tool_requirements.py }
       - tool_requirements.py : { copyto: tool_requirements.py }
+    file_type: user
 
 scripts:
   check_tool_requirements_verible:


### PR DESCRIPTION
A simple fix that was raised during the new Fusesoc integration.