### PR TITLE
[rescue] Print the rescue protocol type

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -389,13 +389,19 @@ hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config) {
     default:
         /* do nothing and continue with trigger detection */;
   }
+  rescue_protocol_t protocol = kRescueProtocolXmodem;
   rescue_detect_t detect = kRescueDetectBreak;
   uint32_t index = 0;
   uint32_t gpio_val = 0;
   if ((hardened_bool_t)config != kHardenedBoolFalse) {
+    protocol = config->protocol;
     detect = bitfield_field32_read(config->detect, RESCUE_DETECT);
     index = bitfield_field32_read(config->detect, RESCUE_DETECT_INDEX);
     gpio_val = bitfield_bit32_read(config->gpio, RESCUE_GPIO_VALUE_BIT);
+  }
+  dbg_printf("info: rescue protocol %c\r\n", rescue_type);
+  if (protocol != rescue_type) {
+    dbg_printf("warning: rescue configured for protocol %c\r\n", protocol);
   }
   switch (detect) {
     case kRescueDetectNone:

--- a/sw/device/silicon_creator/lib/rescue/rescue.h
+++ b/sw/device/silicon_creator/lib/rescue/rescue.h
@@ -101,6 +101,8 @@ typedef struct RescueState {
   uint8_t data[2048];
 } rescue_state_t;
 
+extern const uint32_t rescue_type;
+
 /**
  * Handle rescue modes that involve sending data to the host.
  *

--- a/sw/device/silicon_creator/lib/rescue/rescue_spi.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_spi.c
@@ -21,6 +21,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+const uint32_t rescue_type = kRescueProtocolSpiDfu;
+
 enum {
   /**
    * Base address of the spi_device registers.

--- a/sw/device/silicon_creator/lib/rescue/rescue_usb.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_usb.c
@@ -19,6 +19,8 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+const uint32_t rescue_type = kRescueProtocolUsbDfu;
+
 static const usb_device_descriptor_t device_desc = {
     .length = (uint8_t)sizeof(usb_device_descriptor_t),
     .descriptor_type = kUsbDescTypeDevice,

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -11,6 +11,8 @@
 #include "sw/device/silicon_creator/lib/rescue/rescue.h"
 #include "sw/device/silicon_creator/lib/rescue/xmodem.h"
 
+const uint32_t rescue_type = kRescueProtocolXmodem;
+
 // All of the xmodem functions accept an opaque iohandle pointer.
 // The iohandle is used to facilitate unit tests and doesn't have
 // any function in real firmware.


### PR DESCRIPTION
1. Print the type of rescue protocol linked into the ROM_EXT.
2. Emit a warning of the owner config protocol is inconsistent with the type of protocol linked into the ROM_EXT.