### PR TITLE
[perso] set perso manifest version to the max

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -287,7 +287,7 @@ manifest(d = {
     "visibility": ["//visibility:private"],
     "version_major": ROM_EXT_VERSION.MAJOR,
     "version_minor": ROM_EXT_VERSION.MINOR,
-    "security_version": ROM_EXT_VERSION.SECURITY,
+    "security_version": "0xFFFFFFFF",
 })
 
 [


### PR DESCRIPTION
The personalization firmware emulates a ROM_EXT. To ensure it always boots first. We set its version to the max value.