### PR TITLE
[rom_ext_e2e] Change rescue GPIO to Ioc6

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -73,8 +73,8 @@ TEST_OWNER_CONFIGS = {
             # Trigger 3 is GPIO pin.
             "WITH_RESCUE_TRIGGER=3",
             # When the trigger is GPIO, the index is the MuxedPad to us as the sense
-            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
-            "WITH_RESCUE_INDEX=2",
+            # input. Index 28 is kTopEarlgreyMuxedPadsIoc6.
+            "WITH_RESCUE_INDEX=28",
             # GPIO param 3 means enable the internal pull resistor and trigger
             # rescue when the GPIO is high.
             "WITH_RESCUE_GPIO_PARAM=3",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -47,6 +47,17 @@ _RESCUE_ROMEXT_RESULTS = {
     },
 }
 
+# For tests which use a GPIO trigger, select a pin that doesn't have another
+# use in CI.  We choose Ioc6 because on the Teacup board, that pin is reserved
+# for EXT_CLK.  EXT_CLK is only used for silicon bringup and should have no
+# other use for FPGA-based tests.  Furthermore, IoC6 is not routed to any of
+# the Teacup PMOD connectors, so it should not interfere with any attached
+# periphreals.
+#
+# This pin needs to be consistent with the pin configuration for the spi-dfu
+# ROM_EXT in //sw/device/silicon_creator/rom_ext/defs.bzl.
+_GPIO_PIN = "Ioc6"
+
 _CONFIGS = {
     "xmodem": {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
@@ -65,8 +76,8 @@ _CONFIGS = {
     "spidfu": {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu",
         # Use spi-dfu, trigger with GPIO IOA2 high.
-        "params": "-p spi-dfu -t gpio -v +Ioa2",
-        "setup": "--exec=\"gpio set --mode OpenDrain Ioa2\"",
+        "params": "-p spi-dfu -t gpio -v +{}".format(_GPIO_PIN),
+        "setup": "--exec=\"gpio set --mode OpenDrain {}\"".format(_GPIO_PIN),
         "tags": [],
     },
 }
@@ -392,6 +403,7 @@ opentitan_test(
     },
     fpga = fpga_params(
         changes_otp = True,
+        gpio_pin = _GPIO_PIN,
         # We configure OTP to preserve the reset reason and set the watchdog timeout
         # to one second.
         otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_prod",
@@ -404,7 +416,7 @@ opentitan_test(
             --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {firmware}"
             # Set the trigger with gpio command to simulate the trigger being jammed.
-            --exec="gpio set --mode PushPull --value true Ioa2"
+            --exec="gpio set --mode PushPull --value true {gpio_pin}"
             # Check for firmware execution.  We'll enter rescue, timeout,
             # then reboot and execute firmware.
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
@@ -467,9 +479,9 @@ opentitan_test(
     },
     fpga = fpga_params(
         changes_otp = True,
-        params = "-p spi-dfu -t gpio -v +Ioa2",
+        params = "-p spi-dfu -t gpio -v +{}".format(_GPIO_PIN),
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_restricted_commands",
-        setup = "--exec=\"gpio set --mode OpenDrain Ioa2\"",
+        setup = "--exec=\"gpio set --mode OpenDrain {}\"".format(_GPIO_PIN),
         test_cmd = """
             --exec="transport init"
             --exec="fpga clear-bitstream"


### PR DESCRIPTION
The spi-dfu tests were using Ioa2 to trigger rescue, however, that pin is used to control vbus_sense on the teacup board.  Change to Ioc6 since it appears to be unused.