### PR TITLE
[ROM_EXT] Integrate flash exec in ownership functions

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -164,6 +164,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/sigverify:flash_exec",
     ],
 )
 
@@ -180,6 +181,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_header",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/sigverify:flash_exec",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],
@@ -199,6 +201,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/sigverify:flash_exec",
     ],
 )
 
@@ -214,6 +217,7 @@ cc_test(
         "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_header",
+        "//sw/device/silicon_creator/lib/sigverify:flash_exec",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
@@ -10,9 +10,10 @@ extern "C" {
 rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
                                    uint32_t command, const nonce_t *nonce,
                                    const owner_signature_t *signature,
-                                   const void *message, size_t len) {
-  return MockOwnershipKey::Instance().validate(page, key, command, nonce,
-                                               signature, message, len);
+                                   const void *message, size_t len,
+                                   uint32_t *flash_exec) {
+  return MockOwnershipKey::Instance().validate(
+      page, key, command, nonce, signature, message, len, flash_exec);
 }
 
 rom_error_t ownership_seal_init(void) {

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
@@ -19,7 +19,7 @@ class MockOwnershipKey : public global_mock::GlobalMock<MockOwnershipKey> {
  public:
   MOCK_METHOD(rom_error_t, validate,
               (size_t, ownership_key_t, uint32_t, const nonce_t *,
-               const owner_signature_t *, const void *, size_t));
+               const owner_signature_t *, const void *, size_t, uint32_t *));
   MOCK_METHOD(rom_error_t, seal_init, ());
   MOCK_METHOD(rom_error_t, seal_page, (size_t));
   MOCK_METHOD(rom_error_t, seal_check, (size_t));

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -50,7 +50,7 @@ static owner_page_status_t owner_page_validity_check(size_t page,
 
   rom_error_t result = ownership_key_validate(
       page, kOwnershipKeyOwner, kTlvTagOwner, &bootdata->nonce,
-      &owner_page[page].signature, &owner_page[page], sig_len);
+      &owner_page[page].signature, &owner_page[page], sig_len, NULL);
   if (result != kErrorOk) {
     // If the page is bad, destroy the RAM copy.
     memset(&owner_page[page], 0x5a, sizeof(owner_page[0]));

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -21,10 +21,12 @@
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 #include "sw/device/silicon_creator/lib/ownership/mock_ownership_key.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
+#include "sw/device/silicon_creator/lib/sigverify/flash_exec.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 namespace {
 using ::testing::_;
+using ::testing::DoAll;
 using ::testing::Return;
 using ::testing::SetArgPointee;
 
@@ -138,8 +140,8 @@ TEST_P(OwnershipActivateValidStateTest, InvalidVersion) {
   owner_page[1].header.version.major = 5;
 
   EXPECT_CALL(ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
@@ -155,8 +157,9 @@ TEST_P(OwnershipActivateValidStateTest, InvalidSignature) {
   // message.
   MakePage1Valid(true);
   EXPECT_CALL(ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOwnershipInvalidSignature));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<7>(0), Return(kErrorOwnershipInvalidSignature)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_activate_handler(&message_, &bootdata_);
@@ -171,8 +174,8 @@ TEST_P(OwnershipActivateValidStateTest, InvalidNonce) {
   // message.
   MakePage1Valid(true);
   EXPECT_CALL(ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_activate_handler(&message_, &bootdata_);
@@ -186,8 +189,8 @@ TEST_P(OwnershipActivateValidStateTest, InvalidActivateDin) {
   // message.
   MakePage1Valid(true);
   EXPECT_CALL(ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0, 1, 1}));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
@@ -239,8 +242,8 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
   MakePage1Valid(true);
 
   EXPECT_CALL(ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
 
@@ -309,8 +312,8 @@ TEST_P(OwnershipActivateValidStateTest, UpdateBootdataBl0) {
   owner_page[1].min_security_version_bl0 = 5;
 
   EXPECT_CALL(ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
 

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -52,7 +52,8 @@ const owner_detached_signature_t *ownership_signature_scan(
 rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
                                    uint32_t command, const nonce_t *nonce,
                                    const owner_signature_t *signature,
-                                   const void *message, size_t len) {
+                                   const void *message, size_t len,
+                                   uint32_t *flash_exec) {
   const ecdsa_p256_signature_t *ecdsa = NULL;
   const sigverify_spx_signature_t *spx = NULL;
   uint32_t key_alg = owner_page[page].ownership_key_alg;
@@ -90,25 +91,26 @@ rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
 
   if ((key & kOwnershipKeyUnlock) == kOwnershipKeyUnlock) {
     if (owner_verify(key_alg, &owner_page[page].unlock_key, ecdsa, spx, NULL, 0,
-                     NULL, 0, message, len, &digest, NULL) == kErrorOk) {
+                     NULL, 0, message, len, &digest, flash_exec) == kErrorOk) {
       return kErrorOk;
     }
   }
   if ((key & kOwnershipKeyActivate) == kOwnershipKeyActivate) {
     if (owner_verify(key_alg, &owner_page[page].activate_key, ecdsa, spx, NULL,
-                     0, NULL, 0, message, len, &digest, NULL) == kErrorOk) {
+                     0, NULL, 0, message, len, &digest,
+                     flash_exec) == kErrorOk) {
       return kErrorOk;
     }
   }
   if (kNoOwnerRecoveryKey &&
       (key & kOwnershipKeyRecovery) == kOwnershipKeyRecovery) {
     if (owner_verify(key_alg, kNoOwnerRecoveryKey, ecdsa, spx, NULL, 0, NULL, 0,
-                     message, len, &digest, NULL) == kErrorOk) {
+                     message, len, &digest, flash_exec) == kErrorOk) {
       return kErrorOk;
     }
   }
   if (owner_verify(key_alg, &owner_page[page].owner_key, ecdsa, spx, NULL, 0,
-                   NULL, 0, message, len, &digest, NULL) == kErrorOk) {
+                   NULL, 0, message, len, &digest, flash_exec) == kErrorOk) {
     return kErrorOk;
   }
   return kErrorOwnershipInvalidSignature;

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -51,12 +51,15 @@ typedef struct owner_secret_page {
  * @param signature The signature over the message.
  * @param message Pointer to the message.
  * @param len Size of the message.
+ * @param flash_exec The magic value signifying whether the signature was
+ * verified.
  * @return kErrorOk if the message is valid.
  */
 rom_error_t ownership_key_validate(size_t page, ownership_key_t key,
                                    uint32_t command, const nonce_t *nonce,
                                    const owner_signature_t *signature,
-                                   const void *message, size_t len);
+                                   const void *message, size_t len,
+                                   uint32_t *flash_exec);
 
 /**
  * Initialize sealing.

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
+#include "sw/device/silicon_creator/lib/sigverify/flash_exec.h"
 
 static hardened_bool_t is_locked_none(uint32_t ownership_state) {
   if (ownership_state == kOwnershipStateLockedOwner ||
@@ -24,7 +25,8 @@ static hardened_bool_t is_locked_none(uint32_t ownership_state) {
   return kHardenedBoolTrue;
 }
 
-static rom_error_t do_unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
+static rom_error_t do_unlock(boot_svc_msg_t *msg, boot_data_t *bootdata,
+                             uint32_t *flash_exec) {
   // Verify that the nonce is correct.
   if (!nonce_equal(&msg->ownership_unlock_req.nonce, &bootdata->nonce)) {
     return kErrorOwnershipInvalidNonce;
@@ -37,6 +39,9 @@ static rom_error_t do_unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
       kHardenedBoolTrue) {
     return kErrorOwnershipInvalidDin;
   }
+
+  // Verify that we passed signature verification for the message.
+  HARDENED_CHECK_EQ(*flash_exec, kSigverifyFlashExec);
 
   if (msg->ownership_unlock_req.unlock_mode == kBootSvcUnlockEndorsed) {
     hmac_digest_t digest;
@@ -64,6 +69,9 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   size_t len = (uintptr_t)&msg->ownership_unlock_req.signature -
                (uintptr_t)&msg->ownership_unlock_req.unlock_mode;
   if (bootdata->ownership_state == kOwnershipStateLockedOwner) {
+    // Set the variable checking whether the correct signatures have been
+    // verified
+    uint32_t flash_exec = 0;
     switch (owner_page[0].update_mode) {
       case kOwnershipUpdateModeOpen:
         // The Open mode allows unlock to any unlock state.
@@ -85,16 +93,19 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
         /*page=*/0, kOwnershipKeyUnlock | kOwnershipKeyRecovery,
         msg->header.type, &bootdata->nonce,
         &msg->ownership_unlock_req.signature,
-        &msg->ownership_unlock_req.unlock_mode, len));
-    return do_unlock(msg, bootdata);
+        &msg->ownership_unlock_req.unlock_mode, len, &flash_exec));
+    return do_unlock(msg, bootdata, &flash_exec);
   } else if (is_locked_none(bootdata->ownership_state) == kHardenedBoolTrue) {
     // In the No-Owner state, we check against the silicon_creator's
     // no_owner_recovery_key.
+    // Set the variable checking whether the correct signatures have been
+    // verified
+    uint32_t flash_exec = 0;
     HARDENED_RETURN_IF_ERROR(ownership_key_validate(
         /*page=*/0, kOwnershipKeyRecovery, msg->header.type, &bootdata->nonce,
         &msg->ownership_unlock_req.signature,
-        &msg->ownership_unlock_req.unlock_mode, len));
-    return do_unlock(msg, bootdata);
+        &msg->ownership_unlock_req.unlock_mode, len, &flash_exec));
+    return do_unlock(msg, bootdata, &flash_exec);
   } else {
     return kErrorOwnershipInvalidState;
   }
@@ -103,6 +114,9 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
 static rom_error_t unlock_update(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   size_t len = (uintptr_t)&msg->ownership_unlock_req.signature -
                (uintptr_t)&msg->ownership_unlock_req.unlock_mode;
+  // Set the variable checking whether the correct signatures have been
+  // verified.
+  uint32_t flash_exec = 0;
   if (bootdata->ownership_state == kOwnershipStateLockedOwner) {
     switch (owner_page[0].update_mode) {
       case kOwnershipUpdateModeNewVersion:
@@ -120,8 +134,8 @@ static rom_error_t unlock_update(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     HARDENED_RETURN_IF_ERROR(ownership_key_validate(
         /*page=*/0, kOwnershipKeyUnlock, msg->header.type, &bootdata->nonce,
         &msg->ownership_unlock_req.signature,
-        &msg->ownership_unlock_req.unlock_mode, len));
-    return do_unlock(msg, bootdata);
+        &msg->ownership_unlock_req.unlock_mode, len, &flash_exec));
+    return do_unlock(msg, bootdata, &flash_exec);
   }
   return kErrorOwnershipInvalidState;
 }
@@ -132,11 +146,16 @@ static rom_error_t unlock_abort(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   if (bootdata->ownership_state == kOwnershipStateUnlockedEndorsed ||
       bootdata->ownership_state == kOwnershipStateUnlockedAny ||
       bootdata->ownership_state == kOwnershipStateUnlockedSelf) {
+    // Set the variable checking whether the correct signatures have been
+    // verified.
+    uint32_t flash_exec = 0;
     // Check the signature against the unlock key.
     HARDENED_RETURN_IF_ERROR(ownership_key_validate(
         /*page=*/0, kOwnershipKeyUnlock, msg->header.type, &bootdata->nonce,
         &msg->ownership_unlock_req.signature,
-        &msg->ownership_unlock_req.unlock_mode, len));
+        &msg->ownership_unlock_req.unlock_mode, len, &flash_exec));
+    // Verify that we passed signature verification for the message.
+    HARDENED_CHECK_EQ(flash_exec, kSigverifyFlashExec);
     if (!nonce_equal(&msg->ownership_unlock_req.nonce, &bootdata->nonce)) {
       return kErrorOwnershipInvalidNonce;
     }
@@ -148,6 +167,7 @@ static rom_error_t unlock_abort(boot_svc_msg_t *msg, boot_data_t *bootdata) {
         kHardenedBoolTrue) {
       return kErrorOwnershipInvalidDin;
     }
+
     // Go back to locked owner.
     bootdata->ownership_state = kOwnershipStateLockedOwner;
     nonce_new(&bootdata->nonce);

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
@@ -19,10 +19,12 @@
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 #include "sw/device/silicon_creator/lib/ownership/mock_ownership_key.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
+#include "sw/device/silicon_creator/lib/sigverify/flash_exec.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
 namespace {
 using ::testing::_;
+using ::testing::DoAll;
 using ::testing::Return;
 using ::testing::SetArgPointee;
 
@@ -105,8 +107,8 @@ TEST_F(OwnershipUnlockTest, UnlockAny) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(5));
@@ -127,8 +129,9 @@ TEST_F(OwnershipUnlockTest, UnlockAnyBadSignature) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOwnershipInvalidSignature));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<7>(0), Return(kErrorOwnershipInvalidSignature)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
@@ -144,8 +147,8 @@ TEST_F(OwnershipUnlockTest, UnlockAnyBadDin) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0, 1, 1}));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
@@ -164,8 +167,8 @@ TEST_F(OwnershipUnlockTest, UnlockAnyBadNonce) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
@@ -195,8 +198,8 @@ TEST_F(OwnershipUnlockTest, UnlockEndorsed) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
   EXPECT_CALL(hmac_, sha256_init());
@@ -229,8 +232,9 @@ TEST_F(OwnershipUnlockTest, UnlockEndorsedBadSignature) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOwnershipInvalidSignature));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<7>(0), Return(kErrorOwnershipInvalidSignature)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
@@ -247,8 +251,8 @@ TEST_F(OwnershipUnlockTest, UnlockEndorsedBadNonce) {
               validate(0,
                        static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                     kOwnershipKeyRecovery),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
@@ -276,8 +280,8 @@ TEST_F(OwnershipUnlockTest, UnlockUpdate) {
   message_.ownership_unlock_req.unlock_mode = kBootSvcUnlockUpdate;
   EXPECT_CALL(ownership_key_,
               validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(5));
@@ -296,8 +300,9 @@ TEST_F(OwnershipUnlockTest, UnlockedUpdateBadSignature) {
   message_.ownership_unlock_req.unlock_mode = kBootSvcUnlockUpdate;
   EXPECT_CALL(ownership_key_,
               validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOwnershipInvalidSignature));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(
+          DoAll(SetArgPointee<7>(0), Return(kErrorOwnershipInvalidSignature)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
@@ -313,8 +318,8 @@ TEST_F(OwnershipUnlockTest, UnlockedUpdateBadNonce) {
 
   EXPECT_CALL(ownership_key_,
               validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_unlock_handler(&message_, &bootdata_);
@@ -343,8 +348,8 @@ TEST_P(OwnershipUnlockAbortValidStateTest, UnlockAbort) {
   bootdata_.ownership_state = static_cast<uint32_t>(GetParam());
   EXPECT_CALL(ownership_key_,
               validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(5));
@@ -389,8 +394,9 @@ TEST_P(OwnershipUnlockUpdateModesTest, UnlockAny) {
                   validate(0,
                            static_cast<ownership_key_t>(kOwnershipKeyUnlock |
                                                         kOwnershipKeyRecovery),
-                           kUnlock, _, _, _, _))
-          .WillOnce(Return(kErrorOk));
+                           kUnlock, _, _, _, _, _))
+          .WillOnce(
+              DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
       EXPECT_CALL(lifecycle_, DeviceId(_))
           .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
       EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(5));
@@ -423,8 +429,9 @@ TEST_P(OwnershipUnlockUpdateModesTest, UnlockUpdate) {
     case kOwnershipUpdateModeSelfVersion:
       EXPECT_CALL(ownership_key_,
                   validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
-                           kUnlock, _, _, _, _))
-          .WillOnce(Return(kErrorOk));
+                           kUnlock, _, _, _, _, _))
+          .WillOnce(
+              DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
       EXPECT_CALL(lifecycle_, DeviceId(_))
           .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
       EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(5));

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -243,10 +243,6 @@ cc_library(
 cc_library(
     name = "flash_exec",
     hdrs = ["flash_exec.h"],
-    deps = [
-        ":rsa_verify",
-        ":spx_verify",
-    ],
 )
 
 cc_test(
@@ -254,6 +250,8 @@ cc_test(
     srcs = ["flash_exec_unittest.cc"],
     deps = [
         ":flash_exec",
+        ":rsa_verify",
+        ":spx_verify",
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
@@ -265,6 +263,7 @@ cc_library(
     hdrs = ["sigverify.h"],
     deps = [
         ":ecdsa_p256_verify",
+        ":flash_exec",
         ":rsa_verify",
         ":spx_verify",
         ":usage_constraints",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -109,6 +109,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/ownership:ownership_activate",
         "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
         "//sw/device/silicon_creator/lib/rescue",
+        "//sw/device/silicon_creator/lib/sigverify:flash_exec",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -47,6 +47,7 @@
 #include "sw/device/silicon_creator/lib/rescue/rescue.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/lib/sigverify/flash_exec.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.h"
 #include "sw/device/silicon_creator/rom_ext/imm_section/imm_section_version.h"
@@ -72,11 +73,6 @@ enum {
   kRomExtAEnd = kRomExtAStart + kRomExtSizeInPages,
   kRomExtBStart = kFlashBankSize + kRomExtAStart,
   kRomExtBEnd = kRomExtBStart + kRomExtSizeInPages,
-};
-
-// Parameter to check the ECDSA and SPX signatures with.
-enum {
-  kSigverifySignExec = 0xa26a38f7,
 };
 
 // Declaration for the ROM_EXT manifest start address, populated by the linker
@@ -380,7 +376,7 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   sec_mmio_check_values_except_otp(/*rnd_uint32()*/ 0,
                                    TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR);
 
-  HARDENED_CHECK_EQ(*flash_exec, kSigverifySignExec);
+  HARDENED_CHECK_EQ(*flash_exec, kSigverifyFlashExec);
 
   // Jump to OWNER entry point.
   dbg_printf("entry: 0x%x\r\n", (unsigned int)entry_point);
@@ -405,7 +401,7 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
     if (error != kErrorOk) {
       continue;
     }
-    HARDENED_CHECK_EQ(flash_exec, kSigverifySignExec);
+    HARDENED_CHECK_EQ(flash_exec, kSigverifyFlashExec);
 
     if (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) {
       boot_log->bl0_slot = kBootSlotA;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -18,6 +18,7 @@
 #include "sw/device/silicon_creator/lib/ownership/mock_ownership_key.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_activate.h"
+#include "sw/device/silicon_creator/lib/sigverify/flash_exec.h"
 #include "sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
@@ -324,8 +325,8 @@ TEST_F(RomExtBootServicesTest, BootSvcOwnershipUnlock) {
 
   EXPECT_CALL(mock_ownership_key_,
               validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
-                       kUnlock, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+                       kUnlock, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
   EXPECT_CALL(mock_lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
 
@@ -383,8 +384,8 @@ TEST_F(RomExtBootServicesTest, BootSvcOwnershipActivate) {
       .WillOnce(SetArgPointee<0>((hmac_digest_t){{boot_data.next_owner[0]}}));
 
   EXPECT_CALL(mock_ownership_key_,
-              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _))
-      .WillOnce(Return(kErrorOk));
+              validate(1, kOwnershipKeyActivate, kActivate, _, _, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<7>(kSigverifyFlashExec), Return(kErrorOk)));
 
   EXPECT_CALL(mock_lifecycle_, DeviceId(_))
       .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));


### PR DESCRIPTION
Use the flash_exec variable from the owner_verify functions for an additional check on the signature(s) being verified.