### PR TITLE
[prim] removing default prim_generic to enable partner integration

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -14,8 +14,8 @@ filesets:
       - "fileset_partner ? (partner:systems:top_earlgrey_ast)"
       - "fileset_partner ? (partner:systems:top_earlgrey_scan_role_pkg)"
       - "fileset_partner ? (partner:prim:prim_legacy_pkg)"
-      - "fileset_partner ? (partner:prim_generic:all)"
-      - "fileset_partner ? (partner:prim_generic:flash)"
+      - "fileset_partner ? (partner:prim_tech:all)"
+      - "fileset_partner ? (partner:prim_tech:flash)"
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast)"
       - "!fileset_partner ? (lowrisc:earlgrey_systems:scan_role_pkg)"
       # TODO(#27347): prim_legacy_pkg is deprecated

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -28,7 +28,6 @@ filesets:
       - lowrisc:ip:hmac
       - lowrisc:ip:kmac
       - lowrisc:ip:otbn
-      - lowrisc:ip:otp_macro
       - lowrisc:prim:ram_1p_scr
       - lowrisc:prim:flash
       - lowrisc:ip:sram_ctrl
@@ -63,6 +62,8 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - "fileset_partner  ? (partner:systems:top_earlgrey_ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast_pkg)"
+      - "fileset_partner  ? (partner:ip:otp_macro)"
+      - "!fileset_partner ? (lowrisc:ip:otp_macro)"
     files:
       - rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
       - rtl/autogen/top_earlgrey.sv


### PR DESCRIPTION
1. Removed default lowrisc:prim:prim_legacy_pkg from to file to enable partner integration.
2. Renamed prim_generic to prim_tech as it is technology related.
3. Added support for partner otp_macro.