### PR TITLE
[ci] Allow BLOCKFILE checker to handle many files

### DIFF
--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -17,21 +17,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Get whole Git history.
 
       - name: Determine changed files
         run: |
-          pr_url="https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"
-          echo $pr_url
-          gh pr diff $pr_url --name-only > $HOME/changed_files
+          git fetch origin "${{ github.event.pull_request.merge_commit_sha }}"
+          git diff "${{ github.event.pull_request.merge_commit_sha }}" --name-only \
+            | tee "${{ runner.temp }}/changed_files"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show files changed
-        run: cat $HOME/changed_files
-
       - name: Check for blocked changes
         run: |
-          ./ci/scripts/check-pr-changes-allowed.py $HOME/changed_files \
+          ./ci/scripts/check-pr-changes-allowed.py "${{ runner.temp }}/changed_files" \
             --gh-repo ${{ github.repository }} \
             --gh-token ${{ secrets.GITHUB_TOKEN }} \
             --pr-number ${{ github.event.number }}


### PR DESCRIPTION
This PR fixes the `BLOCKFILE` checking script when many files have changed.

The current script uses `gh pr diff` which cannot handle large pull requests. This PR changes it to fetch the branch with Git directly and do the diff ourselves.

This is a second attempt at #27325 that also works for branches that come from forks.

Here's a PR showing it work (from a fork this time): https://github.com/lowRISC/opentitan/actions/runs/16800823677/job/47581599572?pr=27391