### PR TITLE
[racl_ctrl,dv] Add some error_log tests for racl_ctrl

### DIFF
--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.core
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.core
@@ -14,6 +14,7 @@ filesets:
       - racl_ctrl_policies_if.sv
       - racl_ctrl_env_pkg.sv
       - racl_ctrl_reg_window.sv: {is_include_file: true}
+      - racl_ctrl_env_wrapper_cfg.sv: {is_include_file: true}
       - racl_ctrl_env_cfg.sv: {is_include_file: true}
       - racl_ctrl_env_cov.sv: {is_include_file: true}
       - racl_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.core
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:racl_ctrl_ral
+      - lowrisc:dv:racl_error_log_agent
     files:
       - racl_ctrl_policies_if.sv
       - racl_ctrl_env_pkg.sv

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.core
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.core
@@ -18,6 +18,7 @@ filesets:
       - racl_ctrl_env_cov.sv: {is_include_file: true}
       - racl_ctrl_virtual_sequencer.sv: {is_include_file: true}
       - racl_ctrl_scoreboard.sv: {is_include_file: true}
+      - racl_ctrl_error_arb_predictor.sv: {is_include_file: true}
       - racl_ctrl_env.sv: {is_include_file: true}
       - seq_lib/racl_ctrl_vseq_list.sv: {is_include_file: true}
       - seq_lib/racl_ctrl_base_vseq.sv: {is_include_file: true}

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env.sv
@@ -8,6 +8,10 @@ class racl_ctrl_env extends cip_base_env #(.CFG_T              (racl_ctrl_env_cf
                                            .SCOREBOARD_T       (racl_ctrl_scoreboard));
   `uvm_component_utils(racl_ctrl_env)
 
+  // Agents to drive the racl_error_i and racl_error_external_i input ports
+  racl_error_log_agent internal_error_agent;
+  racl_error_log_agent external_error_agent;
+
   extern function new (string name="", uvm_component parent=null);
   extern function void build_phase(uvm_phase phase);
 endclass
@@ -19,7 +23,28 @@ endfunction
 function void racl_ctrl_env::build_phase(uvm_phase phase);
   super.build_phase(phase);
 
+  if (!uvm_config_db#(int unsigned)::get(null, "*.env",
+                                         "num_subscribing_ips",
+                                         cfg.internal_error_agent_cfg.num_subscribing_ips)) begin
+    `uvm_info(`gfn, "No num_subscribing_ips value in config db. Default to zero.", UVM_LOW)
+  end
+
+  if (!uvm_config_db#(int unsigned)::get(null, "*.env",
+                                         "num_external_subscribing_ips",
+                                         cfg.external_error_agent_cfg.num_subscribing_ips)) begin
+    `uvm_info(`gfn, "No num_external_subscribing_ips value in config db. Default to zero.", UVM_LOW)
+  end
+
+  internal_error_agent = racl_error_log_agent::type_id::create("internal_error_agent", this);
+  uvm_config_db#(racl_error_log_agent_cfg)::set(this, "internal_error_agent*", "cfg",
+                                                cfg.internal_error_agent_cfg);
+
+  external_error_agent = racl_error_log_agent::type_id::create("external_error_agent", this);
+  uvm_config_db#(racl_error_log_agent_cfg)::set(this, "external_error_agent*", "cfg",
+                                                cfg.external_error_agent_cfg);
+
   if (!uvm_config_db#(virtual racl_ctrl_policies_if)::get(null, "*.env",
-                                                          "policies_if", cfg.policies_vif))
+                                                          "policies_if", cfg.policies_vif)) begin
     `uvm_fatal(`gfn, "failed to get policies_if handle from config db")
+  end
 endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_cfg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_cfg.sv
@@ -12,6 +12,10 @@ class racl_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(racl_ctrl_reg_block));
   // An interface that will be bound to the racl_policies_o output of the dut.
   virtual racl_ctrl_policies_if policies_vif;
 
+  // Configuration for the two error log agents
+  rand racl_error_log_agent_cfg internal_error_agent_cfg;
+  rand racl_error_log_agent_cfg external_error_agent_cfg;
+
   extern function new (string name="");
   extern virtual function void initialize(bit [31:0] csr_base_addr = '1);
 endclass
@@ -30,4 +34,7 @@ function void racl_ctrl_env_cfg::initialize(bit [31:0] csr_base_addr = '1);
 
   // Tell regs about ral, which contains the actual register model.
   regs.set_reg_block(ral);
+
+  internal_error_agent_cfg = racl_error_log_agent_cfg::type_id::create("internal_error_agent_cfg");
+  external_error_agent_cfg = racl_error_log_agent_cfg::type_id::create("external_error_agent_cfg");
 endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
@@ -36,6 +36,7 @@ package racl_ctrl_env_pkg;
 
   // package sources
   `include "racl_ctrl_reg_window.sv"
+  `include "racl_ctrl_env_wrapper_cfg.sv"
   `include "racl_ctrl_env_cfg.sv"
   `include "racl_ctrl_env_cov.sv"
   `include "racl_ctrl_virtual_sequencer.sv"

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
@@ -17,6 +17,7 @@ package racl_ctrl_env_pkg;
   import racl_error_log_agent_pkg::racl_error_log_agent;
   import racl_error_log_agent_pkg::racl_error_log_agent_cfg;
   import racl_error_log_agent_pkg::racl_error_log_sequencer;
+  import racl_error_log_agent_pkg::racl_error_log_sporadic_seq;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
@@ -17,6 +17,8 @@ package racl_ctrl_env_pkg;
   import racl_error_log_agent_pkg::racl_error_log_agent;
   import racl_error_log_agent_pkg::racl_error_log_agent_cfg;
   import racl_error_log_agent_pkg::racl_error_log_sequencer;
+  import racl_error_log_agent_pkg::racl_error_log_item;
+  import racl_error_log_agent_pkg::racl_error_log_vec_item;
   import racl_error_log_agent_pkg::racl_error_log_sporadic_seq;
 
   // macro includes
@@ -37,6 +39,7 @@ package racl_ctrl_env_pkg;
   `include "racl_ctrl_env_cfg.sv"
   `include "racl_ctrl_env_cov.sv"
   `include "racl_ctrl_virtual_sequencer.sv"
+  `include "racl_ctrl_error_arb_predictor.sv"
   `include "racl_ctrl_scoreboard.sv"
   `include "racl_ctrl_env.sv"
   `include "racl_ctrl_vseq_list.sv"

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_pkg.sv
@@ -14,6 +14,10 @@ package racl_ctrl_env_pkg;
   import csr_utils_pkg::*;
   import racl_ctrl_ral_pkg::*;
 
+  import racl_error_log_agent_pkg::racl_error_log_agent;
+  import racl_error_log_agent_pkg::racl_error_log_agent_cfg;
+  import racl_error_log_agent_pkg::racl_error_log_sequencer;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_wrapper_cfg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_env_wrapper_cfg.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A simple "wrapper" class that holds the virtual interfaces and the configuration knobs needed by
+// racl_ctrl_env. This avoids the tb and environment having to do several uvm_config_db
+// transactions.
+
+class racl_ctrl_env_wrapper_cfg;
+  // The NumSubscribingIps dut parameter
+  int unsigned num_subscribing_ips;
+
+  // The NumExternalSubscribingIps dut parameter
+  int unsigned num_external_subscribing_ips;
+
+  // An interface bound to the racl_policies_o output port
+  virtual racl_ctrl_policies_if policies_vif;
+
+  // An interface bound to the racl_error_i input port
+  virtual racl_error_log_if internal_error_vif;
+
+  // An interface bound to the racl_error_external_i input port
+  virtual racl_error_log_if external_error_vif;
+endclass

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_error_arb_predictor.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_error_arb_predictor.sv
@@ -1,0 +1,98 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A predictor for the arbiter that listens to updates in the error_logs at racl_error_i and
+// racl_error_external_i.
+
+class racl_ctrl_error_arb_predictor extends uvm_component;
+  `uvm_component_utils(racl_ctrl_error_arb_predictor)
+
+  // A handle to the environment cfg
+  racl_ctrl_env_cfg cfg;
+
+  // Analysis fifos for messages from the monitors of the two error log agents.
+  uvm_tlm_analysis_fifo #(racl_error_log_vec_item) internal_errors_fifo;
+  uvm_tlm_analysis_fifo #(racl_error_log_vec_item) external_errors_fifo;
+
+  // An output with merged errors
+  uvm_tlm_analysis_fifo #(racl_error_log_item) merged_errors_fifo;
+
+  extern function new(string name="", uvm_component parent=null);
+  extern function void build_phase(uvm_phase phase);
+
+  // Watch error inputs, collecting up values in the two fifos and pairing them up.
+  extern local task watch_errors();
+
+endclass
+
+function racl_ctrl_error_arb_predictor::new(string name="", uvm_component parent=null);
+  super.new(name, parent);
+endfunction
+
+function void racl_ctrl_error_arb_predictor::build_phase(uvm_phase phase);
+  internal_errors_fifo = new("internal_errors_fifo", this);
+  external_errors_fifo = new("external_errors_fifo", this);
+  merged_errors_fifo = new("merged_errors_fifo", this);
+endfunction
+
+task racl_ctrl_error_arb_predictor::watch_errors();
+  forever begin
+    racl_error_log_item items[int unsigned];
+    bit                 saw_internal, saw_external;
+
+    // Wait until something appears in a fifo. Since the two fifos are on the same clock, we add a
+    // tiny delay to collect both sides if something turns up in both at the same time.
+    fork begin : isolation_fork
+      fork
+        begin
+          racl_error_log_vec_item internal_item;
+          internal_errors_fifo.peek(internal_item);
+          saw_internal = 1'b1;
+          #1ps;
+        end
+        begin
+          racl_error_log_vec_item external_item;
+          external_errors_fifo.peek(external_item);
+          saw_external = 1'b1;
+          #1ps;
+        end
+      join_any
+      disable fork;
+    end join
+
+    // At this point we're just after a clock edge and we have seen an error log item on at least
+    // one fifo. Pair up the last item on each of the two inputs, writing its components to items.
+    if (saw_internal) begin
+      racl_error_log_vec_item vec_item;
+      while (internal_errors_fifo.try_get(vec_item)) begin end
+      foreach (vec_item.errors[i]) begin
+        `DV_CHECK(`gfn, i < cfg.internal_error_agent_cfg.num_subscribing_ips)
+        items[i] = vec_item.errors[i];
+      end
+    end
+    if (saw_external) begin
+      racl_error_log_vec_item vec_item;
+      while (external_errors_fifo.try_get(vec_item)) begin end
+      foreach (vec_item.errors[i]) begin
+        `DV_CHECK(`gfn, i < cfg.external_error_agent_cfg.num_subscribing_ips)
+        items[cfg.internal_error_agent_cfg.num_subscribing_ips + i] = vec_item.errors[i];
+      end
+    end
+
+    // We've now got a single array of errors in items and it's time to do the arbitration. Take the
+    // first error, which will be the first item in the array, but unconditionally register an
+    // overflow if there is more than one item.
+    begin
+      int unsigned first_idx;
+      uvm_object   arb_item_obj;
+      racl_error_log_item arb_item;
+
+      `DV_CHECK(items.first(first_idx));
+      `downcast(arb_item, items[first_idx].clone())
+      arb_item.overflow |= items.size() > 1;
+
+      merged_errors_fifo.write(arb_item);
+    end
+  end
+endtask

--- a/hw/ip/racl_ctrl/dv/env/racl_ctrl_scoreboard.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_ctrl_scoreboard.sv
@@ -13,9 +13,6 @@ class racl_ctrl_scoreboard extends cip_base_scoreboard #(.CFG_T(racl_ctrl_env_cf
   extern task run_phase(uvm_phase phase);
   extern task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
 
-  // A dynamic array of bits (used as a return value)
-  typedef bit bit_vec_t[];
-
   // A function that looks at cfg.policies_vif and checks that its values match those requested in
   // the policy registers.
   extern function void check_policies();

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.core
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:racl_error_log_agent"
+description: "UVM agent for RACL error_log signals"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_lib
+      - lowrisc:virtual_constants:top_racl_pkg
+    files:
+      - racl_error_log_if.sv
+      - racl_error_log_agent_pkg.sv
+      - racl_error_log_agent_cfg.sv: {is_include_file: true}
+      - racl_error_log_item.sv: {is_include_file: true}
+      - racl_error_log_vec_item.sv: {is_include_file: true}
+      - racl_error_log_vec_driver_item.sv: {is_include_file: true}
+      - racl_error_log_driver.sv: {is_include_file: true}
+      - racl_error_log_monitor.sv: {is_include_file: true}
+      - racl_error_log_sequencer.sv: {is_include_file: true}
+      - racl_error_log_agent.sv: {is_include_file: true}
+
+      - seq_lib/racl_error_log_sporadic_seq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.sv
@@ -20,9 +20,7 @@ endfunction
 function void racl_error_log_agent::build_phase(uvm_phase phase);
   super.build_phase(phase);
 
-  if (!uvm_config_db#(virtual racl_error_log_if)::get(this, "", "vif", cfg.vif)) begin
-    `uvm_fatal(`gfn, "failed to get racl_ctrl_error_log_if handle from uvm_config_db")
-  end
+  if (cfg.vif == null) `uvm_fatal(`gfn, "Cannot use agent with no log interface.")
 endfunction
 
 function void racl_error_log_agent::connect_phase(uvm_phase phase);

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class racl_error_log_agent extends dv_base_agent#(.CFG_T      (racl_error_log_agent_cfg),
+                                                  .DRIVER_T   (racl_error_log_driver),
+                                                  .SEQUENCER_T(racl_error_log_sequencer),
+                                                  .MONITOR_T  (racl_error_log_monitor));
+  `uvm_component_utils(racl_error_log_agent)
+
+  extern function new (string name="", uvm_component parent=null);
+  extern function void build_phase(uvm_phase phase);
+  extern function void connect_phase(uvm_phase phase);
+endclass
+
+function racl_error_log_agent::new (string name="", uvm_component parent=null);
+  super.new(name, parent);
+endfunction
+
+function void racl_error_log_agent::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+
+  if (!uvm_config_db#(virtual racl_error_log_if)::get(this, "", "vif", cfg.vif)) begin
+    `uvm_fatal(`gfn, "failed to get racl_ctrl_error_log_if handle from uvm_config_db")
+  end
+endfunction
+
+function void racl_error_log_agent::connect_phase(uvm_phase phase);
+  super.connect_phase(phase);
+
+  driver.vif = cfg.vif;
+  monitor.vif = cfg.vif;
+endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent_cfg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent_cfg.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class racl_error_log_agent_cfg extends dv_base_agent_cfg;
+
+  `uvm_object_utils(racl_error_log_agent_cfg)
+
+  // This is the number of subscribing IPs that can log errors. It can be recovered from the
+  // parameters passed to racl_ctrl by looking at NumSubscribingIps or NumExternalSubscribingIps.
+  //
+  // The class variable defaults to zero (which means error logs won't have any errors!) but a
+  // testbench will probably want to supply a sensible value.
+  int unsigned num_subscribing_ips;
+
+  virtual racl_error_log_if vif;
+
+  extern function new (string name="");
+endclass
+
+function racl_error_log_agent_cfg::new(string name="");
+  super.new(name);
+endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent_pkg.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_agent_pkg.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package racl_error_log_agent_pkg;
+  import uvm_pkg::*;
+
+  import dv_lib_pkg::dv_base_agent;
+  import dv_lib_pkg::dv_base_agent_cfg;
+  import dv_lib_pkg::dv_base_driver;
+  import dv_lib_pkg::dv_base_monitor;
+  import dv_lib_pkg::dv_base_sequencer;
+  import dv_lib_pkg::dv_base_seq;
+
+  `include "uvm_macros.svh"
+
+  `include "racl_error_log_agent_cfg.sv"
+
+  `include "racl_error_log_item.sv"
+  `include "racl_error_log_vec_item.sv"
+  `include "racl_error_log_vec_driver_item.sv"
+
+  `include "racl_error_log_driver.sv"
+  `include "racl_error_log_monitor.sv"
+
+  `include "racl_error_log_sequencer.sv"
+  `include "racl_error_log_agent.sv"
+
+  `include "seq_lib/racl_error_log_sporadic_seq.sv"
+endpackage

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_driver.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_driver.sv
@@ -1,0 +1,117 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A driver for an error log interface. This behaves as a set of subscribers to racl_ctrl and
+// reports errors.
+
+class racl_error_log_driver extends dv_base_driver #(.ITEM_T (racl_error_log_vec_driver_item),
+                                                     .CFG_T  (racl_error_log_agent_cfg));
+  `uvm_component_utils(racl_error_log_driver)
+
+  // The interface that gets driven. This is set up by the agent in the build phase.
+  virtual racl_error_log_if vif;
+
+  extern function new (string name="", uvm_component parent=null);
+
+  // Drive items received from the sequencer. This runs forever implementing a task declared in
+  // dv_base_driver.
+  extern task get_and_drive();
+
+  // Watch for resets, clearing the error log signals when one is asserted. This runs forever
+  // implementing a task declared in dv_base_driver.
+  extern task reset_signals();
+
+  // Drive this item over the interface.
+  //
+  // If this task starts in reset, it clears the error log input, then waits until reset is cleared
+  // before driving the item. It returns immediately (not sending the errors) if reset is asserted
+  // in the middle of the delay.
+  extern local task drive_item(racl_error_log_vec_driver_item item);
+
+  // Reset all the signals in the interface
+  //
+  // This is used on reset so drives the interface signals directly (instead of using a clocking
+  // block)
+  extern local task reset_lines();
+
+  // Clear the error log signal from subscriber i
+  //
+  // The valid signal is set to 0 and all other signals are set to 'x.
+  extern local task clear_line(int unsigned i);
+
+  // Set the error log signal from subscriber i to the values from item
+  extern local task set_line(int unsigned i, racl_error_log_item item);
+endclass
+
+function racl_error_log_driver::new (string name="", uvm_component parent=null);
+  super.new(name, parent);
+endfunction
+
+task racl_error_log_driver::get_and_drive();
+  if (vif == null) `uvm_fatal(`gfn, "Cannot drive items with no vif.")
+
+  forever begin
+    racl_error_log_vec_driver_item item;
+    seq_item_port.get_next_item(item);
+    drive_item(item);
+    seq_item_port.item_done();
+  end
+endtask
+
+task racl_error_log_driver::reset_signals();
+  forever begin
+    wait(!vif.rst_ni);
+    reset_lines();
+    wait(vif.rst_ni);
+  end
+endtask
+
+task racl_error_log_driver::drive_item(racl_error_log_vec_driver_item item);
+  if (!vif.rst_ni) begin
+    vif.subscriber_cb.errors <= '0;
+    wait(vif.rst_ni);
+  end
+
+  vif.wait_ctrl_clks_or_rst(item.delay);
+  if (!vif.rst_ni) return;
+
+  // Drive the relevant errors to the pins
+  for (int i = 0; i < 63; i++)
+    if (item.errors.exists(i)) set_line(i, item.errors[i]); else clear_line(i);
+
+  // Wait one cycle. racl_ctrl will see the error(s) on the clock edge.
+  vif.wait_ctrl_clks_or_rst(1);
+  if (!vif.rst_ni) return;
+
+  // Now clear everything again. Don't wait another cycle: if the next item has a zero delay, it
+  // will be back-to-back with this one.
+  for (int i = 0; i < 63; i++) clear_line(i);
+endtask
+
+task racl_error_log_driver::reset_lines();
+  // Reset the signals through subscriber_cb as well as the raw signals. This ensures that we clear
+  // any "pending value" that was written on the final clock edge before reset.
+
+  vif.errors <= 'x;
+  vif.subscriber_cb.errors <= 'x;
+
+  for (int i = 0; i < 63; i++) begin
+    vif.errors[i].valid <= 1'b0;
+    vif.subscriber_cb.errors[i].valid <= 1'b0;
+  end
+endtask
+
+task racl_error_log_driver::clear_line(int unsigned i);
+  vif.subscriber_cb.errors[i] <= 'x;
+  vif.subscriber_cb.errors[i].valid <= 1'b0;
+endtask
+
+task racl_error_log_driver::set_line(int unsigned i, racl_error_log_item item);
+  vif.subscriber_cb.errors[i].valid           <= 1'b1;
+  vif.subscriber_cb.errors[i].overflow        <= item.overflow;
+  vif.subscriber_cb.errors[i].racl_role       <= item.role;
+  vif.subscriber_cb.errors[i].ctn_uid         <= item.ctn_uid;
+  vif.subscriber_cb.errors[i].read_access     <= item.read_not_write;
+  vif.subscriber_cb.errors[i].request_address <= item.request_address;
+endtask

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_if.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_if.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A very simple interface that represents RACL error log signals. This uses the "maximum footprint"
+// approach, sizing for the maximum plausible number of subscribers
+//
+// The interface has an associated clock and reset because we expect all devices interacting with
+// the interface to share a clock and reset domain.
+
+interface racl_error_log_if (input logic clk_i, input logic rst_ni);
+
+  // 64 error log signals (using the maximum-footprint approach and assuming there are at most 64
+  // subscribers)
+  top_racl_pkg::racl_error_log_t [63:0] errors;
+
+  // A clocking block that should be used by subscribers (blocks that subscribe to policies from
+  // racl_ctrl and report errors back to it)
+  clocking subscriber_cb @(posedge clk_i);
+    output errors;
+  endclocking
+
+  // A clocking block that should be used by racl_ctrl
+  clocking ctrl_cb @(posedge clk_i);
+    input errors;
+  endclocking
+
+  // Wait for num_clks clock edges on ctrl_cb, exiting early on reset
+  task automatic wait_ctrl_clks_or_rst(int unsigned num_clks);
+    fork begin : isolation_fork
+      fork
+        repeat (num_clks) @(ctrl_cb);
+        wait(!rst_ni);
+      join_any
+      disable fork;
+    end join
+  endtask
+
+endinterface

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_item.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_item.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A UVM sequence item that represents an error reported in an error log (the signal that a single
+// RACL subscriber sends back to racl_ctrl).
+//
+// This is intended to wrap a value encoded in top_racl_pkg::racl_racl_error_log_t (when its valid
+// flag is high)
+
+class racl_error_log_item extends uvm_sequence_item;
+  `uvm_object_utils(racl_error_log_item)
+
+  // If this is true, it shows that the error log sender has seen more than one error log since last
+  // being cleared (but is just reporting the first)
+  rand bit          overflow;
+
+  // The RACL role that was assigned to the actor trying to make the faulting access.
+  rand int unsigned role;
+
+  // The UID on the CTN of the actor trying to make the faulting access.
+  rand int unsigned ctn_uid;
+
+  // A flag that shows whether this was a read or write access.
+  rand bit          read_not_write;
+
+  // The address that the faulting access was trying to read/write.
+  rand int unsigned request_address;
+
+  extern function new (string name="");
+endclass
+
+function racl_error_log_item::new(string name="");
+  super.new(name);
+endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_monitor.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_monitor.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A monitor for an error log interface
+
+class racl_error_log_monitor extends dv_base_monitor #(.ITEM_T (racl_error_log_vec_item),
+                                                       .REQ_ITEM_T (racl_error_log_vec_driver_item),
+                                                       .RSP_ITEM_T (racl_error_log_vec_driver_item),
+                                                       .CFG_T (racl_error_log_agent_cfg));
+  `uvm_component_utils(racl_error_log_monitor)
+
+  // The interface that is monitored. This is set up by the agent in the build phase.
+  virtual racl_error_log_if vif;
+
+  extern function new(string name, uvm_component parent);
+
+  extern task run_phase(uvm_phase phase);
+endclass
+
+function racl_error_log_monitor::new(string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task racl_error_log_monitor::run_phase(uvm_phase phase);
+  if (vif == null) `uvm_fatal(`gfn, "No vif to monitor.")
+
+  forever begin
+    logic valid = 1'b0;
+
+    // Monitor the interface on every clock edge when we are not in reset
+    @(vif.ctrl_cb)
+    if(!vif.rst_ni) continue;
+
+    // Should we produce a sequence item? We only need one if there is at least one subscriber
+    // reporting an error.
+    for (int i = 0; i < 64; i++) if (vif.ctrl_cb.errors[i].valid) valid = 1'b1;
+    if (valid) begin
+      racl_error_log_vec_item item = racl_error_log_vec_item::type_id::create("item");
+
+      for (int i = 0; i < 64; i++) begin
+        if (vif.ctrl_cb.errors[i].valid) begin
+          item.errors[i] = racl_error_log_item::type_id::create($sformatf("errors[%0d]", i));
+          item.errors[i].overflow        = vif.ctrl_cb.errors[i].overflow;
+          item.errors[i].role            = vif.ctrl_cb.errors[i].racl_role;
+          item.errors[i].ctn_uid         = vif.ctrl_cb.errors[i].ctn_uid;
+          item.errors[i].read_not_write  = vif.ctrl_cb.errors[i].read_access;
+          item.errors[i].request_address = vif.ctrl_cb.errors[i].request_address;
+        end
+      end
+      analysis_port.write(item);
+    end
+  end
+endtask

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_sequencer.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_sequencer.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class racl_error_log_sequencer extends dv_base_sequencer#(.ITEM_T (racl_error_log_vec_driver_item),
+                                                          .CFG_T  (racl_error_log_agent_cfg));
+  `uvm_component_utils(racl_error_log_sequencer)
+
+  extern function new (string name="", uvm_component parent=null);
+endclass
+
+function racl_error_log_sequencer::new(string name="", uvm_component parent=null);
+  super.new(name, parent);
+endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_vec_driver_item.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_vec_driver_item.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A small extension of racl_error_log_vec_item that adds a delay field, for use with a driver. This
+// allows a sequence to send back-to-back items but not change value every cycle.
+
+class racl_error_log_vec_driver_item extends racl_error_log_vec_item;
+  `uvm_object_utils(racl_error_log_vec_driver_item)
+
+  // The number of cycles to wait before driving the underlying item.
+  rand int unsigned delay;
+
+  extern function new (string name="");
+endclass
+
+function racl_error_log_vec_driver_item::new(string name="");
+  super.new(name);
+endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_vec_item.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/racl_error_log_vec_item.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A UVM sequence item that represents a state of a vector of error logs. It holds an associative
+// array that gives items for each valid error.
+
+class racl_error_log_vec_item extends uvm_sequence_item;
+  `uvm_object_utils(racl_error_log_vec_item)
+
+  // An associative array of items that give error signals in the vector. If subscriber i is
+  // reporting an error, a racl_error_log_item representing that error will appear at index i in the
+  // array.
+  //
+  // Although it's not marked "rand", this array *is* randomised, but the randomisation is done by
+  // the post_randomize function.
+  racl_error_log_item errors[int unsigned];
+
+  // Subscribers with errors
+  //
+  // This is the set of indices for RACL subscribers that are reporting errors. It will be used in
+  // the post_randomize function to randomize the errors array.
+  rand int unsigned subscribers_with_errors[];
+
+  extern function new (string name="");
+  extern function void post_randomize();
+endclass
+
+function racl_error_log_vec_item::new(string name="");
+  super.new(name);
+endfunction
+
+function void racl_error_log_vec_item::post_randomize();
+  foreach(subscribers_with_errors[i]) begin
+    int unsigned sub_idx = subscribers_with_errors[i];
+    errors[sub_idx] = racl_error_log_item::type_id::create($sformatf("errors[%d]", sub_idx));
+    if (!errors[sub_idx].randomize()) begin
+      `uvm_error(`gfn, $sformatf("Failed to randomize errors[%d]", sub_idx));
+    end
+  end
+endfunction

--- a/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/seq_lib/racl_error_log_sporadic_seq.sv
+++ b/hw/ip/racl_ctrl/dv/env/racl_error_log_agent/seq_lib/racl_error_log_sporadic_seq.sv
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// An infinite sequence that generates occasional single error log items. These alternate between
+// "one error" and "no errors" and each item has a large delay.
+
+class racl_error_log_sporadic_seq
+  extends dv_base_seq #(.REQ        (racl_error_log_vec_driver_item),
+                        .CFG_T      (racl_error_log_agent_cfg),
+                        .SEQUENCER_T(racl_error_log_sequencer));
+
+  `uvm_object_utils(racl_error_log_sporadic_seq)
+
+  // If this bit is set then the sequence will finish as soon as is practical (completing as soon as
+  // the driver finishes the current item, rather than starting the next item).
+  local bit stopping;
+
+  extern function new (string name="");
+
+  extern task body();
+
+  // Tell the sequence to stop sending new items to the driver. This does not cause an instant stop
+  // if there is an item currently being driven (which may take a while, because of delays).
+  // Instead, the task waits until the sequence is no longer running (either because it has finished
+  // or because it has never been started).
+  extern task request_end();
+endclass
+
+function racl_error_log_sporadic_seq::new(string name="");
+  super.new(name);
+endfunction
+
+task racl_error_log_sporadic_seq::body();
+  while (!stopping) begin
+    racl_error_log_vec_driver_item item = racl_error_log_vec_driver_item::type_id::create("item");
+
+    start_item(item);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(item,
+                                   subscribers_with_errors.size() dist { 0 :/ 1, 1 :/ 10, 2 :/ 1 };
+                                   foreach(subscribers_with_errors[i]) {
+                                     subscribers_with_errors[i] < cfg.num_subscribing_ips;
+                                   }
+                                   delay dist { [1:99] :/ 1, [100:1000] :/ 10 };)
+    finish_item(item);
+  end
+endtask
+
+task racl_error_log_sporadic_seq::request_end();
+  stopping = 1'b1;
+  wait_for_sequence_state(UVM_CREATED | UVM_STOPPED | UVM_FINISHED);
+endtask

--- a/hw/ip/racl_ctrl/dv/env/seq_lib/racl_ctrl_base_vseq.sv
+++ b/hw/ip/racl_ctrl/dv/env/seq_lib/racl_ctrl_base_vseq.sv
@@ -10,6 +10,10 @@ class racl_ctrl_base_vseq
 
   `uvm_object_utils(racl_ctrl_base_vseq)
 
+  // Handles to the sequencers for the internal and external error log agents
+  racl_error_log_sequencer internal_error_log_sequencer_h;
+  racl_error_log_sequencer external_error_log_sequencer_h;
+
   extern function new (string name="");
   extern task body();
 endclass

--- a/hw/ip/racl_ctrl/dv/env/seq_lib/racl_ctrl_base_vseq.sv
+++ b/hw/ip/racl_ctrl/dv/env/seq_lib/racl_ctrl_base_vseq.sv
@@ -11,8 +11,13 @@ class racl_ctrl_base_vseq
   `uvm_object_utils(racl_ctrl_base_vseq)
 
   extern function new (string name="");
+  extern task body();
 endclass
 
 function racl_ctrl_base_vseq::new (string name="");
   super.new(name);
 endfunction
+
+task racl_ctrl_base_vseq::body();
+
+endtask

--- a/hw/ip/racl_ctrl/dv/env/seq_lib/racl_ctrl_base_vseq.sv
+++ b/hw/ip/racl_ctrl/dv/env/seq_lib/racl_ctrl_base_vseq.sv
@@ -16,12 +16,103 @@ class racl_ctrl_base_vseq
 
   extern function new (string name="");
   extern task body();
+  extern task post_start();
+
+  // Occasionally write 1 to the the error_log register, which will clear the valid bit (clearing
+  // the error). Stop once the stopping flag goes high.
+  extern local task clear_error_log();
+
+  // The sequences that we send to the two error log agents. These are started at the start of
+  // body() but then told to stop (and waited for) in post_start().
+  local racl_error_log_sporadic_seq int_seq, ext_seq;
+
+  // Once the body of this sequence has completed, this bit gets set (which tells the
+  // clear_error_log background sequence to stop)
+  local bit stopping;
+
+  // This flag gets set by clear_error_log when it is still running.
+  local bit clear_error_log_running;
 endclass
 
 function racl_ctrl_base_vseq::new (string name="");
   super.new(name);
+
+  int_seq = racl_error_log_sporadic_seq::type_id::create("int_seq");
+  ext_seq = racl_error_log_sporadic_seq::type_id::create("ext_seq");
 endfunction
 
 task racl_ctrl_base_vseq::body();
+  // Start "sporadic" sequences on the two error log agents. These are spawned into background
+  // threads which are asked to stop in the post_start() task (which will run when the body() task
+  // has completed, including any subclass implementation)
+  fork
+    int_seq.start(internal_error_log_sequencer_h, this);
+    ext_seq.start(external_error_log_sequencer_h, this);
+    clear_error_log();
+  join_none
+endtask
 
+task racl_ctrl_base_vseq::post_start();
+  super.post_start();
+
+  fork
+    int_seq.request_end();
+    ext_seq.request_end();
+  join
+
+  // Once the error log sequences have finished, wait one cycle for any error log values to make it
+  // to the register file. Then set the stopping flag. This will cause the clear_error_log task to
+  // try one more time to clear any log and then exit.
+  cfg.clk_rst_vif.wait_clks_or_rst(1);
+  stopping = 1'b1;
+  wait(!clear_error_log_running);
+endtask
+
+task racl_ctrl_base_vseq::clear_error_log();
+  dv_base_reg error_log_reg;
+  dv_base_reg_field valid_field;
+
+  if (clear_error_log_running) `uvm_fatal(`gfn, "Nested call to clear_error_log")
+  clear_error_log_running = 1'b1;
+
+  error_log_reg = cfg.ral.get_dv_base_reg_by_name("error_log");
+  if (!error_log_reg) `uvm_fatal(`gfn, "Cannot find the ERROR_LOG register.")
+
+  valid_field = error_log_reg.get_field_by_name("valid");
+  if (!valid_field) `uvm_fatal(`gfn, "Cannot find a VALID field in the ERROR_LOG register.")
+
+  while (!stopping) begin
+    uvm_status_e status;
+    uvm_reg_data_t field_value;
+
+    // Insert a gap between each time we consider clearing the logged error. If the stopping flag
+    // goes high, stop waiting immediately (but possibly still clear errors)
+    fork begin : isolation_fork
+      fork
+        #100ns;
+        wait(stopping);
+      join_any
+      disable fork;
+    end join
+
+    // We can clear the error_log.valid flag by writing 1 to the register. But we don't want to do
+    // this every iteration of the loop: the TL traffic will get in the way of other users. Instead
+    // of doing that, we only clear the flag if it was previously set.
+    valid_field.peek(status, field_value, .kind("BkdrRegPathRtl"));
+    if (status != UVM_IS_OK) begin
+      `uvm_error(`gfn, "Failed to peek at ERORR_LOG.VALID.")
+      field_value = 1'b1;
+    end
+
+    if (field_value) error_log_reg.write(status, 1);
+
+    if (status != UVM_IS_OK && !cfg.under_reset) begin
+      `uvm_error(`gfn, "Failed to write error_log register")
+    end
+
+    // Pause this task if we have gone into reset
+    wait(!cfg.under_reset);
+  end
+
+  clear_error_log_running = 1'b0;
 endtask

--- a/hw/ip/racl_ctrl/dv/tests/racl_ctrl_base_test.sv
+++ b/hw/ip/racl_ctrl/dv/tests/racl_ctrl_base_test.sv
@@ -2,19 +2,30 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class racl_ctrl_base_test extends cip_base_test #(
-    .CFG_T(racl_ctrl_env_cfg),
-    .ENV_T(racl_ctrl_env)
-  );
+class racl_ctrl_base_test extends cip_base_test #(.CFG_T(racl_ctrl_env_cfg),
+                                                  .ENV_T(racl_ctrl_env));
 
   `uvm_component_utils(racl_ctrl_base_test)
-  `uvm_component_new
 
-  // the base class dv_base_test creates the following instances:
-  // racl_ctrl_env_cfg: cfg
-  // racl_ctrl_env:     env
+  extern function new (string name="", uvm_component parent=null);
 
-  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
-  // the run_phase; as such, nothing more needs to be done
+  // Configure the given sequence, installing sequencers for the error log agents. This test can
+  // only run (virtual) sequences that derive from racl_ctrl_base_vseq.
+  //
+  // Overridden from dv_base_test
+  extern function void configure_sequence(uvm_sequence seq);
+endclass
 
-endclass : racl_ctrl_base_test
+function racl_ctrl_base_test::new (string name="", uvm_component parent=null);
+  super.new(name, parent);
+endfunction
+
+function void racl_ctrl_base_test::configure_sequence(uvm_sequence seq);
+  racl_ctrl_base_vseq seq_;
+  `downcast(seq_, seq)
+
+  super.configure_sequence(seq);
+
+  seq_.internal_error_log_sequencer_h = env.internal_error_agent.sequencer;
+  seq_.external_error_log_sequencer_h = env.external_error_agent.sequencer;
+endfunction

--- a/hw/ip_templates/racl_ctrl/dv/racl_ctrl_sim.core.tpl
+++ b/hw/ip_templates/racl_ctrl/dv/racl_ctrl_sim.core.tpl
@@ -13,6 +13,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:racl_ctrl_test
+      - lowrisc:dv:racl_error_log_agent
       - ${instance_vlnv(f"lowrisc:dv:{module_instance_name}_sva")}
     files:
       - tb.sv

--- a/hw/ip_templates/racl_ctrl/dv/tb.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/dv/tb.sv.tpl
@@ -59,24 +59,24 @@ module tb;
   );
 
   initial begin
+    import racl_ctrl_env_pkg::racl_ctrl_env_wrapper_cfg;
+
+    automatic racl_ctrl_env_wrapper_cfg wrapper_cfg = new();
+
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual rst_shadowed_if)::set(null, "*.env", "rst_shadowed_vif", rst_shad_if);
-    uvm_config_db#(virtual racl_ctrl_policies_if)::set(null, "*.env", "policies_if", policies_if);
-    uvm_config_db#(int unsigned)::set(null, "*.env",
-                                      "num_subscribing_ips", NumSubscribingIps);
-    uvm_config_db#(int unsigned)::set(null, "*.env",
-                                      "num_external_subscribing_ips", NumExternalSubscribingIps);
 
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
 
-    uvm_config_db#(virtual racl_error_log_if)::set(null,
-                                                   "*.env.internal_error_agent",
-                                                   "vif", int_err_if);
-    uvm_config_db#(virtual racl_error_log_if)::set(null,
-                                                   "*.env.external_error_agent",
-                                                   "vif", ext_err_if);
+    wrapper_cfg.num_subscribing_ips          = NumSubscribingIps;
+    wrapper_cfg.num_external_subscribing_ips = NumExternalSubscribingIps;
+    wrapper_cfg.policies_vif                 = policies_if;
+    wrapper_cfg.internal_error_vif           = int_err_if;
+    wrapper_cfg.external_error_vif           = ext_err_if;
+
+    uvm_config_db#(racl_ctrl_env_wrapper_cfg)::set(null, "*.env", "wrapper", wrapper_cfg);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_sim.core
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/racl_ctrl_sim.core
@@ -13,6 +13,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:racl_ctrl_test
+      - lowrisc:dv:racl_error_log_agent
       - lowrisc:darjeeling_dv:racl_ctrl_sva
     files:
       - tb.sv

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/tb.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/tb.sv
@@ -16,12 +16,21 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // NOTE: These values come from the top-level instantiation. For now, we're fixing them to
+  // something reasonable, but we don't intend the testing to have an opinion about their values
+  //
+  // *These* values get passed through to the environment through the config db.
+  localparam int unsigned NumSubscribingIps = 5;
+  localparam int unsigned NumExternalSubscribingIps = 5;
+
   wire clk, rst_n, rst_shadowed_n;
 
   clk_rst_if            clk_rst_if  (.clk(clk), .rst_n(rst_n));
   rst_shadowed_if       rst_shad_if (.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
   tl_if                 tl_if       (.clk(clk), .rst_n(rst_n));
   racl_ctrl_policies_if policies_if ();
+  racl_error_log_if     int_err_if  (.clk_i(clk), .rst_ni(rst_n));
+  racl_error_log_if     ext_err_if  (.clk_i(clk), .rst_ni(rst_n));
 
   // Information about the names of alerts and their indices (used by DV_ALERT_IF_CONNECT to attach
   // interfaces to the ports and register them with the config db)
@@ -30,20 +39,23 @@ module tb;
 
   `DV_ALERT_IF_CONNECT()
 
-  racl_ctrl dut (
-    .clk_i                 (clk                                                     ),
-    .rst_ni                (rst_n                                                   ),
-    .rst_shadowed_ni       (rst_shadowed_n                                          ),
+  racl_ctrl #(
+    .NumSubscribingIps(NumSubscribingIps),
+    .NumExternalSubscribingIps(NumExternalSubscribingIps)
+  ) dut (
+    .clk_i                 (clk                                             ),
+    .rst_ni                (rst_n                                           ),
+    .rst_shadowed_ni       (rst_shadowed_n                                  ),
 
-    .tl_i                  (tl_if.h2d                                               ),
-    .tl_o                  (tl_if.d2h                                               ),
+    .tl_i                  (tl_if.h2d                                       ),
+    .tl_o                  (tl_if.d2h                                       ),
 
-    .alert_rx_i            (alert_rx                                                ),
-    .alert_tx_o            (alert_tx                                                ),
+    .alert_rx_i            (alert_rx                                        ),
+    .alert_tx_o            (alert_tx                                        ),
 
-    .racl_policies_o       (policies_if.policies                                    ),
-    .racl_error_i          ( /* TODO: Not yet connecting error input */ '0          ),
-    .racl_error_external_i ( /* TODO: Not yet connecting external error input */ '0 )
+    .racl_policies_o       (policies_if.policies                            ),
+    .racl_error_i          (int_err_if.errors[NumSubscribingIps-1:0]        ),
+    .racl_error_external_i (ext_err_if.errors[NumExternalSubscribingIps-1:0])
   );
 
   initial begin
@@ -51,8 +63,20 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual rst_shadowed_if)::set(null, "*.env", "rst_shadowed_vif", rst_shad_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual racl_ctrl_policies_if)::set(null, "*.env", "policies_if", policies_if);
+    uvm_config_db#(int unsigned)::set(null, "*.env",
+                                      "num_subscribing_ips", NumSubscribingIps);
+    uvm_config_db#(int unsigned)::set(null, "*.env",
+                                      "num_external_subscribing_ips", NumExternalSubscribingIps);
+
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+
+    uvm_config_db#(virtual racl_error_log_if)::set(null,
+                                                   "*.env.internal_error_agent",
+                                                   "vif", int_err_if);
+    uvm_config_db#(virtual racl_error_log_if)::set(null,
+                                                   "*.env.external_error_agent",
+                                                   "vif", ext_err_if);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/tb.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/dv/tb.sv
@@ -59,24 +59,24 @@ module tb;
   );
 
   initial begin
+    import racl_ctrl_env_pkg::racl_ctrl_env_wrapper_cfg;
+
+    automatic racl_ctrl_env_wrapper_cfg wrapper_cfg = new();
+
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual rst_shadowed_if)::set(null, "*.env", "rst_shadowed_vif", rst_shad_if);
-    uvm_config_db#(virtual racl_ctrl_policies_if)::set(null, "*.env", "policies_if", policies_if);
-    uvm_config_db#(int unsigned)::set(null, "*.env",
-                                      "num_subscribing_ips", NumSubscribingIps);
-    uvm_config_db#(int unsigned)::set(null, "*.env",
-                                      "num_external_subscribing_ips", NumExternalSubscribingIps);
 
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
 
-    uvm_config_db#(virtual racl_error_log_if)::set(null,
-                                                   "*.env.internal_error_agent",
-                                                   "vif", int_err_if);
-    uvm_config_db#(virtual racl_error_log_if)::set(null,
-                                                   "*.env.external_error_agent",
-                                                   "vif", ext_err_if);
+    wrapper_cfg.num_subscribing_ips          = NumSubscribingIps;
+    wrapper_cfg.num_external_subscribing_ips = NumExternalSubscribingIps;
+    wrapper_cfg.policies_vif                 = policies_if;
+    wrapper_cfg.internal_error_vif           = int_err_if;
+    wrapper_cfg.external_error_vif           = ext_err_if;
+
+    uvm_config_db#(racl_ctrl_env_wrapper_cfg)::set(null, "*.env", "wrapper", wrapper_cfg);
 
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
These tests found a silly bug in the RTL when I was writing them, but that is now fixed and they aren't really doing anything particularly interesting any more!

This PR includes a tweak that `dv_base_test.sv` allows a test to register sequencers for interfaces as it constructs virtual sequences. I think that's probably a better structure than the existing virtual sequencer approach, and this approach is designed to allow the two to coexist.

The testbenches are structured to use a specialised "error log agent" to drive the reported errors.

As a minor detail, we also include a commit that adds a missing dependency because the core file for the register model wasn't depending directly on `dv:dv_base_reg`.