### PR TITLE
[doc] otp_ctrl & lc_ctrl doc tweaks

### DIFF
--- a/hw/ip/lc_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/lc_ctrl/doc/theory_of_operation.md
@@ -64,7 +64,7 @@ All 128bit lock and unlock tokens are passed through a cryptographic one way fun
 This mechanism is used to guard against reverse engineering and brute-forcing attempts.
 An attacker able to extract the hashed token values from the scrambled OTP partitions or from the netlist would first have to find a hash collision in order to perform a life cycle transition, since the values supplied to the life cycle controller must be valid hash pre-images.
 
-The employed one way function is a 128bit cSHAKE hash with the function name "" and customization string "LC_CTRL", see also [kmac documentation](../../kmac/README.md) and [`kmac_pkg.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/kmac_pkg.sv).
+The employed one way function is a 128bit cSHAKE hash with the function name "" (empty string) and customization string "LC_CTRL", see also [kmac documentation](../../kmac/README.md) and AppCfgLcCtrl in [`kmac_pkg.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/kmac_pkg.sv).
 
 ### Post Transition Handling
 

--- a/hw/ip/lc_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/lc_ctrl/doc/theory_of_operation.md
@@ -5,7 +5,7 @@ It begins with life cycle sensing at power up, progresses through how life cycle
 
 ## Power Up Sequence
 
-Upon power up, the life cycle controller will default to "RAW" state and wait for the OTP controller to initialize and sense the contents of the life cycle partition (for example, see earlgrey's [life cycle partition doc](../../../top_earlgrey/ip_autogen/otp_ctrl/README.md#logical-partitions)).
+Upon power up, the life cycle controller will default to "RAW" state and wait for the OTP controller to initialize and sense the contents of the life cycle partition (for example, see earlgrey's [life cycle partition doc](../../../top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md#partition-listing-and-description)).
 When the OTP is ready, the life cycle controller reads the contents of the life cycle partition, decodes the life cycle state and updates its internal state to match.
 This implies that unlike the life cycle definition diagram, there is a one-time "RAW to any state" logical transition that is implicit within the implementation.
 Note during OTP sensing, the life cycle controller does not perform any redundant checks upon the value it reads; instead that responsibility is allocated to the OTP controller.
@@ -64,7 +64,7 @@ All 128bit lock and unlock tokens are passed through a cryptographic one way fun
 This mechanism is used to guard against reverse engineering and brute-forcing attempts.
 An attacker able to extract the hashed token values from the scrambled OTP partitions or from the netlist would first have to find a hash collision in order to perform a life cycle transition, since the values supplied to the life cycle controller must be valid hash pre-images.
 
-The employed one way function is a 128bit cSHAKE hash with the function name "" and customization string "LC_CTRL", see also [kmac documentation](../../kmac/README.md) and [`kmac_pkg.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/kmac_pkg.sv#L148-L155).
+The employed one way function is a 128bit cSHAKE hash with the function name "" and customization string "LC_CTRL", see also [kmac documentation](../../kmac/README.md) and [`kmac_pkg.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/kmac_pkg.sv).
 
 ### Post Transition Handling
 
@@ -169,7 +169,7 @@ This signal is also unconditionally asserted in all INVALID and SCRAP states (in
 #### CHECK_BYP_EN
 
 The CHECK_BYP_EN signal is used to disable the background consistency checks of the life cycle OTP partition during life cycle transitions to prevent spurious consistency check failures (the OTP contents and the buffer registers can get out of sync during state transitions).
-For example, see [earlgrey's background consistency checks](../../../top_earlgrey/ip_autogen/otp_ctrl/README.md#partition-checks).
+For example, see [earlgrey's background consistency checks](../../../top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md#partition-checks).
 The CHECK_BYP_EN signal is only asserted when a transition command is issued.
 
 #### CLK_BYP_REQ
@@ -179,7 +179,7 @@ This functionality is needed in certain life cycle states where the internal clo
 Note that the [`TRANSITION_CTRL.EXT_CLOCK_EN`](registers.md#transition_ctrl) register can only be set to one if the transition interface has been claimed via the [`CLAIM_TRANSITION_IF`](registers.md#claim_transition_if) mutex.
 This function is not available in production life cycle states.
 
-For details on the clock switch, please see top_earlgrey's [clkmgr](../../../top_earlgrey/ip_autogen/clkmgr/README.md#life-cycle-requested-external-clock).
+For details on the clock switch, please see top_earlgrey's [clkmgr](../../../top_earlgrey/ip_autogen/clkmgr/doc/theory_of_operation.md#life-cycle-requested-external-clock).
 
 
 ### Life Cycle Access Control Signals
@@ -228,7 +228,7 @@ Before use, the secrets are unwrapped.
 
 The SECRET0_DIGEST and SECRET2_DIGEST are the digest values computed over the secret partitions in OTP holding the tokens and root keys.
 As described in more detail in the OTP controller specification, these digests have a non-zero value once the partition has been provisioned and write/read access has been locked.
-For example, see earlgey's [OTP controller specification](../../../top_earlgrey/ip_autogen/otp_ctrl/README.md#direct-access-memory-map).
+For example, see earlgey's [OTP controller specification](../../../top_earlgrey/ip_autogen/otp_ctrl/doc/programmers_guide.md#direct-access-memory-map).
 
 ### ID State of the Device
 
@@ -241,7 +241,7 @@ If SECRET2_DIGEST has a nonzero value, the CREATOR_SEED_SW_RW_EN signal will be 
 
 ### Secret Collateral
 
-Among the OTP life cycle collateral, the following are considered secrets (note there may be other secrets unrelated to life cycle, for example please see earlgrey's [OTP controller specification](../../../top_earlgrey/ip_autogen/otp_ctrl/README.md#partition-listing-and-description) for more details):
+Among the OTP life cycle collateral, the following are considered secrets (note there may be other secrets unrelated to life cycle, for example please see earlgrey's [OTP controller specification](../../../top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md#partition-listing-and-description) for more details):
 
 - *_TOKEN
 - CREATOR_ROOT_KEY*
@@ -255,7 +255,7 @@ Thus the system cannot be abused to generate a large number of traces for inform
 
 Note also, a global key is used here because there is no other non-volatile location to store a secret key.
 If PUFs were available (either in memory form or fused form), it could become an appealing alternative to hold a device unique fuse key.
-For example, see earlgrey's [OTP controller](../../../top_earlgrey/ip_autogen/otp_ctrl/README.md#secret-vs-non-secret-partitions) for more details.
+For example, see earlgrey's [OTP controller](../../../top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md#secret-vs-non-secret-partitions) for more details.
 
 ### OTP Accessibility Summary and Impact of Life Cycle Signals
 
@@ -314,7 +314,7 @@ Conceptually speaking, the life cycle controller consists of a large  FSM that i
 ![LC Controller Block Diagram](../doc/lc_ctrl_blockdiag.svg)
 
 The main FSM implements a linear state sequence that always moves in one direction for increased glitch resistance.
-I.e., it never returns to the initialization and broadcast states as described in the [life cycle state controller section](#main-fsm).
+I.e., it never returns to the initialization and broadcast states as described in the [life cycle state controller section](#life-cycle-state-controller).
 
 The main FSM state is redundantly encoded, and augmented with the life cycle state.
 That augmented state vector is consumed by three combinational submodules:
@@ -325,7 +325,7 @@ That augmented state vector is consumed by three combinational submodules:
 Note that the two additional life cycle control signals `lc_flash_rma_req_o` and `lc_clk_byp_req_o` are output by the main FSM, since they cannot be derived from the life cycle state alone and are reactive in nature in the sense that there is a corresponding acknowledgement signal.
 
 The life cycle controller contains a JTAG TAP that can be used to access the same CSR space that is accessible via TL-UL.
-In order to write to the CSRs, a [hardware mutex](#hardware-mutex) has to be claimed.
+In order to write to the CSRs, a [hardware mutex](#life-cycle-request-interface) has to be claimed.
 
 The life cycle controller also contains two escalation receivers that are connected to escalation severity 1 and 2 of the alert handler module.
 The actions that are triggered by these escalation receivers are explained in the [escalation handling section](#escalation-handling) below.
@@ -372,7 +372,7 @@ In order to guard against glitch attacks during OTP sense and readout, the OTP c
 I.e., the OTP controller senses and buffers the life cycle in registers in a first readout pass.
 Then, as part of the consistency check mechanism, the OTP controller performs a second and third readout pass to verify whether the buffered life cycle state indeed corresponds to the values stored in OTP.
 The second readout pass uses a linearly increasing address sequence, whereas the third readout pass uses a linearly decreasing address sequence (i.e., reads in reverse order).
-For example, see earlgrey's [consistency check mechanism](../../../top_earlgrey/ip_autogen/otp_ctrl/README.md#storage-consistency).
+For example, see earlgrey's [consistency check mechanism](../../../top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md#storage-consistency).
 
 ### Transition Counter Encoding
 

--- a/hw/ip/lc_ctrl/dv/README.md
+++ b/hw/ip/lc_ctrl/dv/README.md
@@ -49,7 +49,7 @@ TL host interface into LC_CTRL device.
 
 ### JTAG RISCV Agent
 [jtag_riscv_agent](../../../dv/sv/jtag_riscv_agent/README.md) is used to read and write LC_CTRL registers via
-the JTAG interface. It contains an embedded instance of [jtag_agent] ../../../dv/sv/jtag_agent/README.md which
+the JTAG interface. It contains an embedded instance of [jtag_agent](../../../dv/sv/jtag_agent/README.md) which
 uses the jtag_if interface in the testbench.
 
 ### PUSH/PULL Agent

--- a/hw/ip_templates/otp_ctrl/doc/interfaces.md.tpl
+++ b/hw/ip_templates/otp_ctrl/doc/interfaces.md.tpl
@@ -13,7 +13,7 @@ Parameter                   | Default (Max) | Top Earlgrey | Description
 `RndCnstKey`                | (see RTL)     | (see RTL)    | Random scrambling keys for secret partitions, to be used in the [scrambling datapath](#scrambling-datapath).
 `RndCnstDigestConst`        | (see RTL)     | (see RTL)    | Random digest finalization constants, to be used in the [scrambling datapath](#scrambling-datapath).
 `RndCnstDigestIV`           | (see RTL)     | (see RTL)    | Random digest initialization vectors, to be used in the [scrambling datapath](#scrambling-datapath).
-`RndCnstRawUnlockToken`     | (see RTL)     | (see RTL)    | Global RAW unlock token to be used for the first life cycle transition. See also [conditional life cycle transitions](../../../../ip/lc_ctrl/README.md#conditional-transitions).
+`RndCnstRawUnlockToken`     | (see RTL)     | (see RTL)    | Global RAW unlock token to be used for the first life cycle transition. See also [conditional life cycle transitions](../../../../ip/lc_ctrl/doc/theory_of_operation.md#conditional-transitions).
 
 <!-- BEGIN CMDGEN util/regtool.py --interfaces ./hw/top_${topname}/ip_autogen/otp_ctrl/data/otp_ctrl.hjson -->
 <!-- END CMDGEN -->
@@ -107,7 +107,7 @@ The request must remain asserted until the life cycle controller has responded.
 An error is fatal and indicates that the OTP programming operation has failed.
 
 Note that the new state must not clear any bits that have already been programmed to OTP - i.e., the new state must be incrementally programmable on top of the previous state.
-There are hence some implications on the life cycle encoding due to the ECC employed, see [life cycle state encoding](../../../../ip/lc_ctrl/README.md#life-cycle-manufacturing-state-encodings) for details.
+There are hence some implications on the life cycle encoding due to the ECC employed, see [life cycle state encoding](../../../../ip/lc_ctrl/doc/theory_of_operation.md#life-cycle-manufacturing-state-encodings) for details.
 
 Note that the behavior of the `lc_otp_program_i.otp_test_ctrl` signal is vendor-specific, and hence the signal is set to `x` in the timing diagram above.
 The purpose of this signal is to control vendor-specific test mechanisms, and its value will only be forwarded to the OTP macro in RAW, TEST_* and RMA states.

--- a/hw/ip_templates/otp_ctrl/doc/theory_of_operation.md
+++ b/hw/ip_templates/otp_ctrl/doc/theory_of_operation.md
@@ -41,7 +41,7 @@ Thus the security of both volatile (OTP controller) and non-volatile (OTP IP) st
 
 ### Partition Listing and Description
 
-The OTP controller for OpenTitan contains the seven logical partitions shown below.
+The OTP controller for this OpenTitan top-level contains the logical partitions shown below.
 
 {{#include otp_ctrl_partitions.md}}
 
@@ -236,11 +236,11 @@ For more details on how the software programs the OTP, please refer to the [Prog
 
 ### Block Diagram
 
-The following is a high-level block diagram that illustrates everything that has been discussed.
+The following is a high-level block diagram of the Earlygrey OTP that illustrates everything that has been discussed.
 
 ![OTP Controller Block Diagram](otp_ctrl_blockdiag.svg)
 
-Each of the partitions P0-P7 has its [own controller FSM](#partition-implementations) that interacts with the OTP wrapper and the [scrambling datapath](#scrambling-datapath) to fulfil its tasks.
+Each of the partitions (e.g. P0-P7 for Earlgrey) has its [own controller FSM](#partition-implementations) that interacts with the OTP wrapper and the [scrambling datapath](#scrambling-datapath) to fulfil its tasks.
 The partitions expose the address ranges and access control information to the Direct Access Interface (DAI) in order to block accesses that go to locked address ranges.
 Further, the only two blocks that have (conditional) write access to the OTP are the DAI and the Life Cycle Interface (LCI) blocks.
 The partitions can only issue read transactions to the OTP macro.
@@ -248,7 +248,7 @@ Note that the access ranges of the DAI and the LCI are mutually exclusive.
 I.e., the DAI cannot read from nor write to the life cycle partition.
 The LCI cannot read the OTP, but is allowed to write to the life cycle partition.
 
-The CSR node on the left side of this diagram connects to the DAI, the OTP partitions (P0-P7) and the OTP wrapper through a gated TL-UL interface.
+The CSR node on the left side of this diagram connects to the DAI, the OTP partitions (e.g. P0-P7 for Earlgrey) and the OTP wrapper through a gated TL-UL interface.
 All connections from the partitions to the CSR node are read-only, and typically only carry a subset of the information available.
 E.g., the secret partitions only expose their digest value via the CSRs.
 
@@ -427,14 +427,14 @@ They are therefore not further described in this document.
 
 The generalized open-source interface uses a couple of parameters (defaults set for Earlgrey configuration).
 
-Parameter      | Default | Top Earlgrey  | Description
----------------|---------|---------------|---------------
-`Width`        | 16      | 16            | Native OTP word width.
-`Depth`        | 1024    | 1024          | Depth of OTP macro.
-`CmdWidth`     | 7       | 7             | Width of the OTP command.
-`ErrWidth`     | 3       | 3             | Width of error code output signal.
-`PwrSeqWidth`  | 2       | 2             | Width of power sequencing signals to/from AST.
-`SizeWidth`    | 2       | 2             | Width of the size field.
+Parameter      | Default                 | Top Earlgrey            | Description
+---------------|-------------------------|-------------------------|---------------
+`Width`        | 16                      | 16                      | Native OTP word width.
+`Depth`        | 1024                    | 1024                    | Depth of OTP macro.
+`CmdWidth`     | 7                       | 7                       | Width of the OTP command.
+`ErrWidth`     | 3                       | 3                       | Width of error code output signal.
+`PwrSeqWidth`  | 2                       | 2                       | Width of power sequencing signals to/from AST.
+`SizeWidth`    | 2                       | 2                       | Width of the size field.
 `IfWidth`      | 2^`SizeWidth` * `Width` | 2^`SizeWidth` * `Width` | Data interface width.
 
 The generalized open-source interface is a simple command interface with a ready / valid handshake that makes it possible to introduce back pressure if the OTP macro is not able to accept a command due to an ongoing operation.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/interfaces.md
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/interfaces.md
@@ -13,7 +13,7 @@ Parameter                   | Default (Max) | Top Earlgrey | Description
 `RndCnstKey`                | (see RTL)     | (see RTL)    | Random scrambling keys for secret partitions, to be used in the [scrambling datapath](#scrambling-datapath).
 `RndCnstDigestConst`        | (see RTL)     | (see RTL)    | Random digest finalization constants, to be used in the [scrambling datapath](#scrambling-datapath).
 `RndCnstDigestIV`           | (see RTL)     | (see RTL)    | Random digest initialization vectors, to be used in the [scrambling datapath](#scrambling-datapath).
-`RndCnstRawUnlockToken`     | (see RTL)     | (see RTL)    | Global RAW unlock token to be used for the first life cycle transition. See also [conditional life cycle transitions](../../../../ip/lc_ctrl/README.md#conditional-transitions).
+`RndCnstRawUnlockToken`     | (see RTL)     | (see RTL)    | Global RAW unlock token to be used for the first life cycle transition. See also [conditional life cycle transitions](../../../../ip/lc_ctrl/doc/theory_of_operation.md#conditional-transitions).
 
 <!-- BEGIN CMDGEN util/regtool.py --interfaces ./hw/top_darjeeling/ip_autogen/otp_ctrl/data/otp_ctrl.hjson -->
 Referring to the [Comportable guideline for peripheral device functionality](https://opentitan.org/book/doc/contributing/hw/comportability), the module **`otp_ctrl`** has the following hardware interfaces defined
@@ -199,7 +199,7 @@ The request must remain asserted until the life cycle controller has responded.
 An error is fatal and indicates that the OTP programming operation has failed.
 
 Note that the new state must not clear any bits that have already been programmed to OTP - i.e., the new state must be incrementally programmable on top of the previous state.
-There are hence some implications on the life cycle encoding due to the ECC employed, see [life cycle state encoding](../../../../ip/lc_ctrl/README.md#life-cycle-manufacturing-state-encodings) for details.
+There are hence some implications on the life cycle encoding due to the ECC employed, see [life cycle state encoding](../../../../ip/lc_ctrl/doc/theory_of_operation.md#life-cycle-manufacturing-state-encodings) for details.
 
 Note that the behavior of the `lc_otp_program_i.otp_test_ctrl` signal is vendor-specific, and hence the signal is set to `x` in the timing diagram above.
 The purpose of this signal is to control vendor-specific test mechanisms, and its value will only be forwarded to the OTP macro in RAW, TEST_* and RMA states.

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/theory_of_operation.md
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/doc/theory_of_operation.md
@@ -41,7 +41,7 @@ Thus the security of both volatile (OTP controller) and non-volatile (OTP IP) st
 
 ### Partition Listing and Description
 
-The OTP controller for OpenTitan contains the seven logical partitions shown below.
+The OTP controller for this OpenTitan top-level contains the logical partitions shown below.
 
 {{#include otp_ctrl_partitions.md}}
 
@@ -236,11 +236,11 @@ For more details on how the software programs the OTP, please refer to the [Prog
 
 ### Block Diagram
 
-The following is a high-level block diagram that illustrates everything that has been discussed.
+The following is a high-level block diagram of the Earlygrey OTP that illustrates everything that has been discussed.
 
 ![OTP Controller Block Diagram](otp_ctrl_blockdiag.svg)
 
-Each of the partitions P0-P7 has its [own controller FSM](#partition-implementations) that interacts with the OTP wrapper and the [scrambling datapath](#scrambling-datapath) to fulfil its tasks.
+Each of the partitions (e.g. P0-P7 for Earlgrey) has its [own controller FSM](#partition-implementations) that interacts with the OTP wrapper and the [scrambling datapath](#scrambling-datapath) to fulfil its tasks.
 The partitions expose the address ranges and access control information to the Direct Access Interface (DAI) in order to block accesses that go to locked address ranges.
 Further, the only two blocks that have (conditional) write access to the OTP are the DAI and the Life Cycle Interface (LCI) blocks.
 The partitions can only issue read transactions to the OTP macro.
@@ -248,7 +248,7 @@ Note that the access ranges of the DAI and the LCI are mutually exclusive.
 I.e., the DAI cannot read from nor write to the life cycle partition.
 The LCI cannot read the OTP, but is allowed to write to the life cycle partition.
 
-The CSR node on the left side of this diagram connects to the DAI, the OTP partitions (P0-P7) and the OTP wrapper through a gated TL-UL interface.
+The CSR node on the left side of this diagram connects to the DAI, the OTP partitions (e.g. P0-P7 for Earlgrey) and the OTP wrapper through a gated TL-UL interface.
 All connections from the partitions to the CSR node are read-only, and typically only carry a subset of the information available.
 E.g., the secret partitions only expose their digest value via the CSRs.
 
@@ -427,14 +427,14 @@ They are therefore not further described in this document.
 
 The generalized open-source interface uses a couple of parameters (defaults set for Earlgrey configuration).
 
-Parameter      | Default | Top Earlgrey  | Description
----------------|---------|---------------|---------------
-`Width`        | 16      | 16            | Native OTP word width.
-`Depth`        | 1024    | 1024          | Depth of OTP macro.
-`CmdWidth`     | 7       | 7             | Width of the OTP command.
-`ErrWidth`     | 3       | 3             | Width of error code output signal.
-`PwrSeqWidth`  | 2       | 2             | Width of power sequencing signals to/from AST.
-`SizeWidth`    | 2       | 2             | Width of the size field.
+Parameter      | Default                 | Top Earlgrey            | Description
+---------------|-------------------------|-------------------------|---------------
+`Width`        | 16                      | 16                      | Native OTP word width.
+`Depth`        | 1024                    | 1024                    | Depth of OTP macro.
+`CmdWidth`     | 7                       | 7                       | Width of the OTP command.
+`ErrWidth`     | 3                       | 3                       | Width of error code output signal.
+`PwrSeqWidth`  | 2                       | 2                       | Width of power sequencing signals to/from AST.
+`SizeWidth`    | 2                       | 2                       | Width of the size field.
 `IfWidth`      | 2^`SizeWidth` * `Width` | 2^`SizeWidth` * `Width` | Data interface width.
 
 The generalized open-source interface is a simple command interface with a ready / valid handshake that makes it possible to introduce back pressure if the OTP macro is not able to accept a command due to an ongoing operation.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/interfaces.md
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/interfaces.md
@@ -13,7 +13,7 @@ Parameter                   | Default (Max) | Top Earlgrey | Description
 `RndCnstKey`                | (see RTL)     | (see RTL)    | Random scrambling keys for secret partitions, to be used in the [scrambling datapath](#scrambling-datapath).
 `RndCnstDigestConst`        | (see RTL)     | (see RTL)    | Random digest finalization constants, to be used in the [scrambling datapath](#scrambling-datapath).
 `RndCnstDigestIV`           | (see RTL)     | (see RTL)    | Random digest initialization vectors, to be used in the [scrambling datapath](#scrambling-datapath).
-`RndCnstRawUnlockToken`     | (see RTL)     | (see RTL)    | Global RAW unlock token to be used for the first life cycle transition. See also [conditional life cycle transitions](../../../../ip/lc_ctrl/README.md#conditional-transitions).
+`RndCnstRawUnlockToken`     | (see RTL)     | (see RTL)    | Global RAW unlock token to be used for the first life cycle transition. See also [conditional life cycle transitions](../../../../ip/lc_ctrl/doc/theory_of_operation.md#conditional-transitions).
 
 <!-- BEGIN CMDGEN util/regtool.py --interfaces ./hw/top_earlgrey/ip_autogen/otp_ctrl/data/otp_ctrl.hjson -->
 Referring to the [Comportable guideline for peripheral device functionality](https://opentitan.org/book/doc/contributing/hw/comportability), the module **`otp_ctrl`** has the following hardware interfaces defined
@@ -200,7 +200,7 @@ The request must remain asserted until the life cycle controller has responded.
 An error is fatal and indicates that the OTP programming operation has failed.
 
 Note that the new state must not clear any bits that have already been programmed to OTP - i.e., the new state must be incrementally programmable on top of the previous state.
-There are hence some implications on the life cycle encoding due to the ECC employed, see [life cycle state encoding](../../../../ip/lc_ctrl/README.md#life-cycle-manufacturing-state-encodings) for details.
+There are hence some implications on the life cycle encoding due to the ECC employed, see [life cycle state encoding](../../../../ip/lc_ctrl/doc/theory_of_operation.md#life-cycle-manufacturing-state-encodings) for details.
 
 Note that the behavior of the `lc_otp_program_i.otp_test_ctrl` signal is vendor-specific, and hence the signal is set to `x` in the timing diagram above.
 The purpose of this signal is to control vendor-specific test mechanisms, and its value will only be forwarded to the OTP macro in RAW, TEST_* and RMA states.

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/doc/theory_of_operation.md
@@ -41,7 +41,7 @@ Thus the security of both volatile (OTP controller) and non-volatile (OTP IP) st
 
 ### Partition Listing and Description
 
-The OTP controller for OpenTitan contains the seven logical partitions shown below.
+The OTP controller for this OpenTitan top-level contains the logical partitions shown below.
 
 {{#include otp_ctrl_partitions.md}}
 
@@ -236,11 +236,11 @@ For more details on how the software programs the OTP, please refer to the [Prog
 
 ### Block Diagram
 
-The following is a high-level block diagram that illustrates everything that has been discussed.
+The following is a high-level block diagram of the Earlygrey OTP that illustrates everything that has been discussed.
 
 ![OTP Controller Block Diagram](otp_ctrl_blockdiag.svg)
 
-Each of the partitions P0-P7 has its [own controller FSM](#partition-implementations) that interacts with the OTP wrapper and the [scrambling datapath](#scrambling-datapath) to fulfil its tasks.
+Each of the partitions (e.g. P0-P7 for Earlgrey) has its [own controller FSM](#partition-implementations) that interacts with the OTP wrapper and the [scrambling datapath](#scrambling-datapath) to fulfil its tasks.
 The partitions expose the address ranges and access control information to the Direct Access Interface (DAI) in order to block accesses that go to locked address ranges.
 Further, the only two blocks that have (conditional) write access to the OTP are the DAI and the Life Cycle Interface (LCI) blocks.
 The partitions can only issue read transactions to the OTP macro.
@@ -248,7 +248,7 @@ Note that the access ranges of the DAI and the LCI are mutually exclusive.
 I.e., the DAI cannot read from nor write to the life cycle partition.
 The LCI cannot read the OTP, but is allowed to write to the life cycle partition.
 
-The CSR node on the left side of this diagram connects to the DAI, the OTP partitions (P0-P7) and the OTP wrapper through a gated TL-UL interface.
+The CSR node on the left side of this diagram connects to the DAI, the OTP partitions (e.g. P0-P7 for Earlgrey) and the OTP wrapper through a gated TL-UL interface.
 All connections from the partitions to the CSR node are read-only, and typically only carry a subset of the information available.
 E.g., the secret partitions only expose their digest value via the CSRs.
 
@@ -427,14 +427,14 @@ They are therefore not further described in this document.
 
 The generalized open-source interface uses a couple of parameters (defaults set for Earlgrey configuration).
 
-Parameter      | Default | Top Earlgrey  | Description
----------------|---------|---------------|---------------
-`Width`        | 16      | 16            | Native OTP word width.
-`Depth`        | 1024    | 1024          | Depth of OTP macro.
-`CmdWidth`     | 7       | 7             | Width of the OTP command.
-`ErrWidth`     | 3       | 3             | Width of error code output signal.
-`PwrSeqWidth`  | 2       | 2             | Width of power sequencing signals to/from AST.
-`SizeWidth`    | 2       | 2             | Width of the size field.
+Parameter      | Default                 | Top Earlgrey            | Description
+---------------|-------------------------|-------------------------|---------------
+`Width`        | 16                      | 16                      | Native OTP word width.
+`Depth`        | 1024                    | 1024                    | Depth of OTP macro.
+`CmdWidth`     | 7                       | 7                       | Width of the OTP command.
+`ErrWidth`     | 3                       | 3                       | Width of error code output signal.
+`PwrSeqWidth`  | 2                       | 2                       | Width of power sequencing signals to/from AST.
+`SizeWidth`    | 2                       | 2                       | Width of the size field.
 `IfWidth`      | 2^`SizeWidth` * `Width` | 2^`SizeWidth` * `Width` | Data interface width.
 
 The generalized open-source interface is a simple command interface with a ready / valid handshake that makes it possible to introduce back pressure if the OTP macro is not able to accept a command due to an ongoing operation.


### PR DESCRIPTION
One commit is fixing broken links.
The other commit is content tweaks for clarity.