### PR TITLE
[manuf] set DIN to all 1s for FPGA devices

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/individualize.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize.c
@@ -115,13 +115,15 @@ status_t manuf_individualize_device_hw_cfg(
     }
 
     // On non-silicon targets, we expect the CP device ID from flash to be
-    // empty. In this case we set the HW origin portion of the CP device ID to
-    // all 1s to indicate this is an FPGA/Sim generated device ID.
+    // empty. In this case we set the HW origin and DIN portions of the CP
+    // device ID to all 1s to indicate this is an FPGA/Sim generated device ID.
     // Otherwise, we expect the CP device ID to be present and non-zero.
     if (flash_cp_device_id_empty) {
       if (kDeviceType != kDeviceSilicon && kDeviceType != kDeviceSimDV) {
         memset(&cp_device_id, 0, sizeof(cp_device_id));
         cp_device_id[0] = UINT32_MAX;
+        cp_device_id[1] = UINT32_MAX;
+        cp_device_id[2] = UINT32_MAX;
       } else {
         return NOT_FOUND();
       }

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -83,12 +83,19 @@ class DeviceIdentificationNumber:
 
     @staticmethod
     def from_int(din: int) -> "DeviceIdentificationNumber":
-        year = util.bcd_decode(din & 0xF)
-        week = util.bcd_decode((din >> 4) & 0xFF)
-        lot = util.bcd_decode((din >> 12) & 0xFFF)
-        wafer = util.bcd_decode((din >> 24) & 0xFF)
-        wafer_x_coord = util.bcd_decode((din >> 32) & 0xFFF)
-        wafer_y_coord = util.bcd_decode((din >> 44) & 0xFFF)
+        year = -1
+        week = -1
+        lot = -1
+        wafer = -1
+        wafer_x_coord = -1
+        wafer_y_coord = -1
+        if din != 0xFFFFFFFFFFFFFFFF:
+            year = util.bcd_decode(din & 0xF)
+            week = util.bcd_decode((din >> 4) & 0xFF)
+            lot = util.bcd_decode((din >> 12) & 0xFFF)
+            wafer = util.bcd_decode((din >> 24) & 0xFF)
+            wafer_x_coord = util.bcd_decode((din >> 32) & 0xFFF)
+            wafer_y_coord = util.bcd_decode((din >> 44) & 0xFFF)
         return DeviceIdentificationNumber(year=year,
                                           week=week,
                                           lot=lot,


### PR DESCRIPTION
This updates the DIN to be set to all 1s for FPGA emulated devices to enable test owner firmware images to bind to this invalid device ID.