### PR TITLE
[flash_ctrl/dv] Fix path used in FI tests

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -61,7 +61,7 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
               ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
       {"tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd",
               ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
-      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_normal_fifo.storage_rdata[39:0]"
+      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_singleton_fifo.rdata_int[39:0]"
     };
     if (common_seq_type == "") void'($value$plusargs("run_%0s", common_seq_type));
     if (common_seq_type == "sec_cm_fi") begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -61,7 +61,7 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
               ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
       {"tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd",
               ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
-      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_normal_fifo.storage_rdata[39:0]"
+      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_singleton_fifo.rdata_int[39:0]"
     };
     if (common_seq_type == "") void'($value$plusargs("run_%0s", common_seq_type));
     if (common_seq_type == "sec_cm_fi") begin

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -61,7 +61,7 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
               ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
       {"tb.dut.u_eflash.gen_flash_cores[1].u_core.u_rd",
               ".u_rd_storage.gen_normal_fifo.storage_rdata[74:0]"},
-      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_normal_fifo.storage_rdata[39:0]"
+      "tb.dut.u_to_rd_fifo.u_rspfifo.gen_singleton_fifo.rdata_int[39:0]"
     };
     if (common_seq_type == "") void'($value$plusargs("run_%0s", common_seq_type));
     if (common_seq_type == "sec_cm_fi") begin


### PR DESCRIPTION
The path previously referred to a generate case in which the FIFO would have more than one entry, but `u_rspfifo` has as many entries as the value of the `Outstanding` parameter of `tlul_adapter_sram`, which is not set for the `u_to_rd_fifo` instance in `flash_ctrl`, hence the default is 1 entry.  This caused the `flash_ctrl_sec_cm` test to fail.

This commit fixes the path to be correct for the singleton FIFO.  The `flash_ctrl_sec_cm` test passes again.