### PR TITLE
[flash] Move assertion from `flash_ctrl` to `prim_flash`

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_flash.sv
@@ -142,5 +142,7 @@ module prim_flash #(
   assign unused_obs = |obs_ctrl_i;
   assign fla_obs_o = '0;
 
+  `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
+      u_reg_top, flash_ctrl.alert_tx_o[3])
 
 endmodule // prim_flash

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
@@ -1488,13 +1488,4 @@ module flash_ctrl
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
 
-  // Assertions for countermeasures inside prim_flash
-  `ifndef PRIM_DEFAULT_IMPL
-    `define PRIM_DEFAULT_IMPL prim_pkg::ImplGeneric
-  `endif
-  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_reg_we_assert_generic
-    `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
-        u_eflash.u_flash.u_reg_top, alert_tx_o[3])
-  end
-
 endmodule

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -1489,13 +1489,4 @@ module flash_ctrl
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
 
-  // Assertions for countermeasures inside prim_flash
-  `ifndef PRIM_DEFAULT_IMPL
-    `define PRIM_DEFAULT_IMPL prim_pkg::ImplGeneric
-  `endif
-  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_reg_we_assert_generic
-    `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
-        u_eflash.u_flash.u_reg_top, alert_tx_o[3])
-  end
-
 endmodule

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -1489,13 +1489,4 @@ module flash_ctrl
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg_core, alert_tx_o[1])
 
-  // Assertions for countermeasures inside prim_flash
-  `ifndef PRIM_DEFAULT_IMPL
-    `define PRIM_DEFAULT_IMPL prim_pkg::ImplGeneric
-  `endif
-  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_reg_we_assert_generic
-    `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(PrimRegWeOnehotCheck_A,
-        u_eflash.u_flash.u_reg_top, alert_tx_o[3])
-  end
-
 endmodule


### PR DESCRIPTION
This allows to get rid of `prim_pkg` in RTL code.