### PR TITLE
[reggen] Switch to using dataclasses

### DIFF
--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
 
 from design.mubi import prim_mubi
 
@@ -61,25 +62,23 @@ OPTIONAL_FIELDS = {
 }
 
 
+@dataclass
 class Field:
+    name: str
+    alias_target: str | None
+    desc: str | None
+    tags: list[str]
+    swaccess: SWAccess
+    hwaccess: HWAccess
+    hwqe: bool
+    bits: Bits
+    resval: int | None
+    enum: list[EnumEntry] | None
+    mubi: bool
+    auto_split: bool
 
-    def __init__(self, name: str, alias_target: Optional[str],
-                 desc: Optional[str], tags: List[str], swaccess: SWAccess,
-                 hwaccess: HWAccess, hwqe: bool, bits: Bits,
-                 resval: Optional[int], enum: Optional[List[EnumEntry]],
-                 mubi: bool, auto_split: bool):
-        self.name = name
-        self.alias_target = alias_target
-        self.desc = desc
-        self.tags = tags
-        self.swaccess = swaccess
-        self.hwaccess = hwaccess
-        self.hwqe = hwqe
-        self.bits = bits
-        self.resval = resval
-        self.enum = enum
-        self.mubi = mubi
-        self.auto_split = auto_split
+    def __hash__(self) -> int:
+        return hash(self.name)
 
     @staticmethod
     def resval_from_raw(field_bits: Bits,

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -112,10 +112,10 @@ class MultiRegister(RegBase):
         # This only makes sense if all the pseudo-registers are "compatible".
         # This means:
         #
-        # - They should have the same associated clocks (async_name, async_clk,
-        #   sync_name, sync_clk). We expect that to be checked in the caller
-        #   (probably MultiRegister.from_raw), so can check it with just an
-        #   assertion here.
+        # - They should have the same associated clocks (async and sync). We
+        #   expect that to be checked in the caller (probably
+        #   MultiRegister.from_raw), so can check it with just an assertion
+        #   here.
         #
         # - They should either all have homogeneous fields or none of them
         #   should have them.
@@ -125,16 +125,13 @@ class MultiRegister(RegBase):
         homogeneous = pregs[0].is_homogeneous()
         needs_qe = False
         for preg in pregs[1:]:
-            assert preg.async_name == pregs[0].async_name
             assert preg.async_clk == pregs[0].async_clk
-            assert preg.sync_name == pregs[0].sync_name
             assert preg.sync_clk == pregs[0].sync_clk
             assert preg.is_homogeneous() == homogeneous
             needs_qe |= preg.needs_qe()
 
         super().__init__(name, offset,
-                         pregs[0].async_name, pregs[0].async_clk,
-                         pregs[0].sync_name, pregs[0].sync_clk, alias_target)
+                         pregs[0].async_clk, pregs[0].sync_clk, alias_target)
         self.pregs = pregs
         self.cname = cname
         self.regwen_multi = regwen_multi
@@ -353,8 +350,7 @@ class MultiRegister(RegBase):
         '''
         # Attributes to be crosschecked
         attrs = [
-            'async_name', 'async_clk', 'sync_name', 'sync_clk', 'count',
-            'regwen_multi', 'compact'
+            'async_clk', 'sync_clk', 'count', 'regwen_multi', 'compact'
         ]
         for attr in attrs:
             if getattr(self, attr) != getattr(alias_reg, attr):

--- a/util/reggen/reg_base.py
+++ b/util/reggen/reg_base.py
@@ -2,60 +2,50 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
+from dataclasses import dataclass
 
 from reggen.clocking import ClockingItem
 from reggen.field import Field
 
 
+@dataclass
 class RegBase:
     '''An abstract class inherited by Register and MultiRegister
 
     This represents a block of one or more registers with a base address.
-
-    Instance variables:
-
-      name       The name of the register/multiregister
-
-      offset     The offset or address of the register. For a MultiRegister,
-                 this gives the address of the first concrete register in the
-                 expansion.
-
-      async_name The name of an asynchronous clock used for the data backing
-                 the register/multiregister.
-
-      async_clk  The clocking item named by async_name
-
-      sync_name  The name of a synchronous clock used for the data backing the
-                 register/multiregister. Unlike an asynchronous clock, there is
-                 no CDC needed between the main clock and the clock used by the
-                 register.
-
-      sync_clk   The clocking item named by sync_name
-
-      alias_target The name of an analogous register/multiregister that we are
-                   going to override. This is used when building closed source
-                   components which override a generic register/multiregister
-                   implementation with extra fields/flags etc.
     '''
+    name: str
+    '''The name of the register/multiregister'''
 
-    def __init__(self,
-                 name: str,
-                 offset: int,
-                 async_name: Optional[str], async_clk: Optional[ClockingItem],
-                 sync_name: Optional[str], sync_clk: Optional[ClockingItem],
-                 alias_target: Optional[str]):
-        self.name = name
-        self.offset = offset
+    offset: int
+    '''The offset or address of the register. For a MultiRegister, this gives
+    the address of the first concrete register in the expansion.'''
 
-        self.async_name = async_name
-        self.async_clk = async_clk
-        self.sync_name = sync_name
-        self.sync_clk = sync_clk
+    async_name: str | None
+    '''The name of an asynchronous clock used for the data backing the
+    register/multiregister.'''
 
-        self.alias_target = alias_target
+    async_clk: ClockingItem | None
+    '''The clocking item named by async_name'''
 
-    def get_n_bits(self, bittype: List[str]) -> int:
+    sync_name: str | None
+    '''The name of a synchronous clock used for the data backing the
+    register/multiregister. Unlike an asynchronous clock, there is no CDC
+    needed between the main clock and the clock used by the register.'''
+
+    sync_clk: ClockingItem | None
+    '''The clocking item named by sync_name'''
+
+    alias_target: str | None
+    '''The name of an analogous register/multiregister that we are going to
+    override. This is used when building closed source components which
+    override a generic register/multiregister implementation with extra
+    fields/flags etc.'''
+
+    def __hash__(self) -> int:
+        return hash((self.offset, self.name))
+
+    def get_n_bits(self, bittype: list[str]) -> int:
         '''Get the size of this register / these registers in bits
 
         See Field.get_n_bits() for the precise meaning of bittype.
@@ -63,7 +53,7 @@ class RegBase:
         '''
         raise NotImplementedError()
 
-    def get_field_list(self) -> List[Field]:
+    def get_field_list(self) -> list[Field]:
         '''Get an ordered list of the fields in the register(s)
 
         Registers are ordered from low to high address. Within a register,

--- a/util/reggen/reg_base.py
+++ b/util/reggen/reg_base.py
@@ -21,20 +21,14 @@ class RegBase:
     '''The offset or address of the register. For a MultiRegister, this gives
     the address of the first concrete register in the expansion.'''
 
-    async_name: str | None
-    '''The name of an asynchronous clock used for the data backing the
+    async_clk: tuple[str, ClockingItem] | None
+    '''An optional asynchronous clock used for the data backing the
     register/multiregister.'''
 
-    async_clk: ClockingItem | None
-    '''The clocking item named by async_name'''
-
-    sync_name: str | None
-    '''The name of a synchronous clock used for the data backing the
+    sync_clk: tuple[str, ClockingItem] | None
+    '''An optional asynchronous clock used for the data backing the
     register/multiregister. Unlike an asynchronous clock, there is no CDC
     needed between the main clock and the clock used by the register.'''
-
-    sync_clk: ClockingItem | None
-    '''The clocking item named by sync_name'''
 
     alias_target: str | None
     '''The name of an analogous register/multiregister that we are going to

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -468,25 +468,16 @@ class RegBlock:
                     mubi=False,
                     auto_split=False))
 
-        reg = Register(
-            self.offset,
-            reg_name,
-            None,  # no alias target
-            reg_desc,
-            async_clk=None,
-            sync_clk=None,
-            hwext=is_testreg,
-            hwqe=is_testreg,
-            hwre=False,
-            regwen=None,
-            tags=reg_tags,
-            resval=None,
-            shadowed=False,
-            fields=fields,
-            update_err_alert=None,
-            storage_err_alert=None,
-            writes_ignore_errors=False)
-        self.add_register(reg)
+        self.add_register(Register(reg_name,
+                                   self.offset,
+                                   async_clk=None,
+                                   sync_clk=None,
+                                   alias_target=None,
+                                   desc=reg_desc,
+                                   fields=fields,
+                                   hwext=is_testreg,
+                                   hwqe=is_testreg,
+                                   tags=reg_tags))
 
     def make_intr_regs(self, interrupts: Sequence[Interrupt]) -> None:
         """Create INTR_STATE, INTR_ENABLE, INTR_TEST CSRs.
@@ -546,16 +537,13 @@ class RegBlock:
 
         self.add_register(
             Register(
-                self.offset,
                 'INTR_STATE',
-                None,  # no alias target
-                'Interrupt State Register',
+                self.offset,
                 async_clk=None,
                 sync_clk=None,
-                hwext=False,
-                hwqe=False,
-                hwre=False,
-                regwen=None,
+                alias_target=None,
+                desc='Interrupt State Register',
+                fields=fields,
                 # Some POR routines have the potential to unpredictably set
                 # some `intr_state` fields for various IPs, so we exclude all
                 # `intr_state` accesses from CSR checks to prevent this from
@@ -563,13 +551,7 @@ class RegBlock:
                 #
                 # An example of an `intr_state` mismatch error occurring due to
                 # a POR routine can be seen in issue #6888.
-                tags=["excl:CsrAllTests:CsrExclAll"],
-                resval=None,
-                shadowed=False,
-                fields=fields,
-                update_err_alert=None,
-                storage_err_alert=None,
-                writes_ignore_errors=False))
+                tags=["excl:CsrAllTests:CsrExclAll"]))
 
         self._add_intr_alert_reg(
             interrupts, 'INTR_ENABLE', 'Interrupt Enable Register',

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -117,7 +117,7 @@
           else:
             fsig_name = '{}.{}'.format(fsig_pfx, fld_name)
 
-        finst_names[field] = (fsig_name, finst_name)
+        finst_names[(sr, field)] = (fsig_name, finst_name)
 
 %>
 `include "prim_assert.sv"
@@ -659,7 +659,7 @@ ${reg_hdr}
       % for fidx, field in enumerate(sr.fields):
 <%
           fld_name = field.name.lower()
-          fsig_name, finst_name = finst_names[field]
+          fsig_name, finst_name = finst_names[(sr, field)]
 %>\
         % if len(sr.fields) > 1:
   //   F[${fld_name}]: ${field.bits.msb}:${field.bits.lsb}
@@ -885,7 +885,7 @@ ${rdata_gen(f, r.name.lower() + "_" + f.name.lower())}\
 
       for sr in srs:
         for field in sr.fields:
-          _, pfx = finst_names[field]
+          _, pfx = finst_names[(sr, field)]
           shadowed_field_pfxs.append(pfx)
 %>\
   assign shadowed_storage_err_o = |{

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -453,7 +453,7 @@ ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
   % for r in regs_flat:
     % if r.async_clk:
 <%
-  base_name = r.async_clk.clock_base_name
+  base_name = r.async_clk[1].clock_base_name
   r_name = r.name.lower()
   comb_name = f"{base_name}_{r_name}"
   src_we_expr = f"{r_name}_we" if r.needs_we() else "'0"
@@ -538,8 +538,8 @@ ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
   ) u_${r_name}_cdc (
     .clk_src_i    (${reg_clk_expr}),
     .rst_src_ni   (${reg_rst_expr}),
-    .clk_dst_i    (${r.async_clk.clock}),
-    .rst_dst_ni   (${r.async_clk.reset}),
+    .clk_dst_i    (${r.async_clk[1].clock}),
+    .rst_dst_ni   (${r.async_clk[1].reset}),
     .src_regwen_i (${src_regwen_expr}),
     .src_we_i     (${src_we_expr}),
     .src_re_i     (${src_re_expr}),
@@ -576,8 +576,8 @@ ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
                      f'  // R[{sr_name}]: V({sr.hwext})')
         else:
           reg_hdr = (f'  // R[{sr_name}]: V({sr.hwext})')
-        clk_expr = sr.async_clk.clock if sr.async_clk else reg_clk_expr
-        rst_expr = sr.async_clk.reset if sr.async_clk else reg_rst_expr
+        clk_expr = sr.async_clk[1].clock if sr.async_clk else reg_clk_expr
+        rst_expr = sr.async_clk[1].reset if sr.async_clk else reg_rst_expr
 %>\
 ${reg_hdr}
       % if sr.needs_qe():
@@ -623,7 +623,7 @@ ${reg_hdr}
 <%
   # We usually use the REG_we signal, but use REG_re for RC fields
   # (which get updated on a read, not a write)
-  clk_base_name = f"{sr.async_clk.clock_base_name}_" if sr.async_clk else ""
+  clk_base_name = f"{sr.async_clk[1].clock_base_name}_" if sr.async_clk else ""
   we_suffix = 're' if field.swaccess.swrd() == SwRdAccess.RC else 'we'
   we_signal = f'{clk_base_name}{sr_name}_{we_suffix}'
 
@@ -998,10 +998,10 @@ ${bits.msb}\
 <%def name="finst_gen(reg, field, finst_name, fsig_name, fidx)">\
 <%
 
-    clk_base_name = f"{reg.async_clk.clock_base_name}_" if reg.async_clk else ""
+    clk_base_name = f"{reg.async_clk[1].clock_base_name}_" if reg.async_clk else ""
     reg_name = reg.name.lower()
-    clk_expr = reg.async_clk.clock if reg.async_clk else reg_clk_expr
-    rst_expr = reg.async_clk.reset if reg.async_clk else reg_rst_expr
+    clk_expr = reg.async_clk[1].clock if reg.async_clk else reg_clk_expr
+    rst_expr = reg.async_clk[1].reset if reg.async_clk else reg_rst_expr
     re_expr = f'{clk_base_name}{reg_name}_re' if field.swaccess.allows_read() or reg.shadowed else "1'b0"
 
     # software inputs to field instance, write enable, read enable, write data
@@ -1110,8 +1110,8 @@ ${bits.msb}\
 
   // update error is transient and must be immediately captured
   prim_pulse_sync u_${finst_name}_err_update_sync (
-    .clk_src_i(${reg.async_clk.clock}),
-    .rst_src_ni(${reg.async_clk.reset}),
+    .clk_src_i(${reg.async_clk[1].clock}),
+    .rst_src_ni(${reg.async_clk[1].reset}),
     .src_pulse_i(async_${finst_name}_err_update),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
@@ -1126,8 +1126,8 @@ ${bits.msb}\
   ) u_${finst_name} (
       % if reg.sync_clk:
     // sync clock and reset required for this register
-    .clk_i   (${reg.sync_clk.clock}),
-    .rst_ni  (${reg.sync_clk.reset}),
+    .clk_i   (${reg.sync_clk[1].clock}),
+    .rst_ni  (${reg.sync_clk[1].reset}),
       % else:
     .clk_i   (${clk_expr}),
     .rst_ni  (${rst_expr}),


### PR DESCRIPTION
This was inspired by a [review comment](https://github.com/lowRISC/opentitan/pull/27289#discussion_r2137884087) in #27289. The changes here switch to using `@dataclass` in the Python classes. It's rather nicer! I've never used this before, but I'm very impressed.
