### PR TITLE
[pentest] Extend FI and SCA tests

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -504,6 +504,8 @@ status_t handle_crypto_fi_sha256(ujson_t *uj) {
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
+  // Get fatal and recoverable AST alerts from sensor controller.
+  pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -514,6 +516,8 @@ status_t handle_crypto_fi_sha256(ujson_t *uj) {
   uj_output.err_status = codes;
   memcpy(uj_output.tag, digest.digest, sizeof(uj_output.tag));
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  memcpy(uj_output.ast_alerts, sensor_alerts.alerts,
+         sizeof(sensor_alerts.alerts));
   RESP_OK(ujson_serialize_crypto_fi_hmac_tag_t, uj, &uj_output);
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/crypto_fi.c
@@ -254,11 +254,12 @@ status_t handle_crypto_fi_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Init the AES block.
   TRY(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.c
@@ -3843,11 +3843,12 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Enable the flash.
   flash_info = dif_flash_ctrl_get_device_info();

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -32,11 +32,12 @@ status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -1254,11 +1254,12 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
   ;
 
   // The load integrity, key sideloading, and char_mem tests get initialized at

--- a/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otp_fi.c
@@ -175,11 +175,12 @@ status_t handle_otp_fi_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   TRY(dif_otp_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -401,11 +401,12 @@ status_t handle_rng_fi_edn_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(
@@ -619,11 +620,12 @@ status_t handle_rng_fi_csrng_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(

--- a/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rom_fi.c
@@ -90,11 +90,12 @@ status_t handle_rom_fi_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Initialize rom_ctrl.
   mmio_region_t rom_ctrl_reg =

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -89,6 +89,16 @@ enum {
    */
   kRvTimerComparator = 0,
   kRvTimerHart = kTopEarlgreyPlicTargetIbex0,
+  /**
+   * CSR_REG_CPUCTRL[0] is the iCache configuration field.
+   */
+  kCpuctrlICacheIdx = 0,
+  kCpuctrlICacheMask = (1 << kCpuctrlICacheIdx),
+  /**
+   * CSR_REG_CPUCTRL[2] is the dummy instruction enable configuration field.
+   */
+  kCpuctrlDummyInstrEnIdx = 2,
+  kCpuctrlDummyInstrEnMask = (1 << kCpuctrlDummyInstrEnIdx),
 };
 
 // By default, we use the precise, hardware-gated capture trigger.
@@ -335,27 +345,41 @@ status_t pentest_read_device_id(uint32_t device_id[]) {
 }
 
 status_t pentest_configure_cpu(
-    bool disable_icache, bool disable_dummy_instr, bool enable_jittery_clock,
-    bool enable_sram_readback, bool *clock_jitter_locked, bool *clock_jitter_en,
+    bool enable_icache, bool *icache_en, bool enable_dummy_instr,
+    bool *dummy_instr_en, bool enable_jittery_clock, bool enable_sram_readback,
+    bool *clock_jitter_locked, bool *clock_jitter_en,
     bool *sram_main_readback_locked, bool *sram_ret_readback_locked,
     bool *sram_main_readback_en, bool *sram_ret_readback_en) {
-  uint32_t cpuctrl_csr;
-  // Get current config.
-  CSR_READ(CSR_REG_CPUCTRL, &cpuctrl_csr);
-  // Disable the iCache.
-  if (disable_icache) {
-    cpuctrl_csr = bitfield_field32_write(
-        cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 0}, 0);
+  // Enable/disable the iCache.
+  if (enable_icache) {
+    // Set CSR_REG_CPUCTRL[0].
+    CSR_SET_BITS(CSR_REG_CPUCTRL, kCpuctrlICacheMask);
+  } else {
+    // Set CSR_REG_CPUCTRL[0].
+    CSR_CLEAR_BITS(CSR_REG_CPUCTRL, kCpuctrlICacheMask);
+  }
+  *icache_en = false;
+  // Read back the config stored in CSR_REG_CPUCTRL[0].
+  uint32_t csr;
+  CSR_READ(CSR_REG_CPUCTRL, &csr);
+  if (((csr & kCpuctrlICacheMask) >> kCpuctrlICacheIdx) == 1) {
+    *icache_en = true;
   }
 
-  // Disable dummy instructions.
-  if (disable_dummy_instr) {
-    cpuctrl_csr = bitfield_field32_write(
-        cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 2}, 0);
+  // Enable/disable dummy instructions.
+  if (enable_dummy_instr) {
+    // Set CSR_REG_CPUCTRL[2].
+    CSR_SET_BITS(CSR_REG_CPUCTRL, kCpuctrlDummyInstrEnMask);
+  } else {
+    // Clear CSR_REG_CPUCTRL[2].
+    CSR_CLEAR_BITS(CSR_REG_CPUCTRL, kCpuctrlDummyInstrEnMask);
   }
-
-  // Write back config.
-  CSR_WRITE(CSR_REG_CPUCTRL, cpuctrl_csr);
+  *dummy_instr_en = false;
+  // Read back the config stored in CSR_REG_CPUCTRL[2].
+  CSR_READ(CSR_REG_CPUCTRL, &csr);
+  if (((csr & kCpuctrlDummyInstrEnMask) >> kCpuctrlDummyInstrEnIdx) == 1) {
+    *dummy_instr_en = true;
+  }
 
   // Enable or disable the jittery clock.
   dif_clkmgr_t clkmgr;

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h
@@ -277,8 +277,9 @@ status_t pentest_read_device_id(uint32_t device_id[]);
  * @return OK or error.
  */
 status_t pentest_configure_cpu(
-    bool disable_icache, bool disable_dummy_instr, bool enable_jittery_clock,
-    bool enable_sram_readback, bool *clock_jitter_locked, bool *clock_jitter_en,
+    bool enable_icache, bool *icache_en, bool enable_dummy_instr,
+    bool *dummy_instr_en, bool enable_jittery_clock, bool enable_sram_readback,
+    bool *clock_jitter_locked, bool *clock_jitter_en,
     bool *sram_main_readback_locked, bool *sram_ret_readback_locked,
     bool *sram_main_readback_en, bool *sram_ret_readback_en);
 

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -619,7 +619,8 @@ status_t handle_aes_pentest_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_icache, &uj_output.icache_en,
+      uj_cpuctrl.enable_dummy_instr, &uj_output.dummy_instr_en,
       uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
       &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
       &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
@@ -130,11 +130,12 @@ status_t handle_edn_sca_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for SCA attacks.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Configure Ibex to allow reading ERR_STATUS register.
   TRY(dif_rv_core_ibex_init(

--- a/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/hmac_sca.c
@@ -115,11 +115,12 @@ status_t handle_hmac_pentest_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for SCA.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
   TRY(dif_hmac_init(base_addr, &hmac));

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -149,11 +149,12 @@ status_t handle_ibex_pentest_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for SCA.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Key manager not initialized for the handle_ibex_sca_key_sideloading test.
   key_manager_init = false;

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -191,7 +191,7 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
   if (trigger & kCombiOpsTriggerXor) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "xor x13, x5, x12\n"
                  "xor x14, x5, x12\n"
@@ -205,14 +205,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "xor x31, x5, x12\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     asm volatile("sw x13, (%0)" ::"r"(&result[0]));
   }
 
   if (trigger & kCombiOpsTriggerAdd) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "add x13, x5, x12\n"
                  "add x14, x5, x12\n"
@@ -226,14 +226,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "add x31, x5, x12\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     asm volatile("sw x13, (%0)" ::"r"(&result[1]));
   }
 
   if (trigger & kCombiOpsTriggerSub) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "sub x13, x5, x12\n"
                  "sub x14, x5, x12\n"
@@ -247,14 +247,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "sub x31, x5, x12\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     asm volatile("sw x13, (%0)" ::"r"(&result[2]));
   }
 
   if (trigger & kCombiOpsTriggerShift) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "rol x13, x5, x12\n"
                  "rol x14, x5, x12\n"
@@ -268,14 +268,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "rol x31, x5, x12\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     asm volatile("sw x13, (%0)" ::"r"(&result[3]));
   }
 
   if (trigger & kCombiOpsTriggerMul) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "mul x13, x5, x12\n"
                  "mul x14, x5, x12\n"
@@ -289,14 +289,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "mul x31, x5, x12\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     asm volatile("sw x13, (%0)" ::"r"(&result[4]));
   }
 
   if (trigger & kCombiOpsTriggerDiv) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "div x13, x5, x12\n"
                  "div x14, x5, x12\n"
@@ -310,14 +310,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "div x31, x5, x12\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     asm volatile("sw x13, (%0)" ::"r"(&result[5]));
   }
 
   if (trigger & kCombiOpsTriggerLw) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "lw x13, (%0)\n"
                  "lw x14, (%0)\n"
@@ -331,14 +331,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "lw x31, (%0)\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     result[6] = value1;
   }
 
   if (trigger & kCombiOpsTriggerSw) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "sw x5, (%0)\n"
                  "sw x5, (%0)\n"
@@ -352,14 +352,14 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "sw x5, (%0)\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     result[7] = value1;
   }
 
   if (trigger & kCombiOpsTriggerCp) {
     init_registers(value1, value2, 0, 0, 0, 0);
 
-    pentest_set_trigger_high();
+    PENTEST_ASM_TRIGGER_HIGH
     asm volatile(NOP30
                  "sw x5, (%1)\n"
                  "sw x12, (%0)\n"
@@ -373,7 +373,7 @@ static status_t trigger_ibex_sca_combi_operations(uint32_t value1,
                  "sw x12, (%0)\n" NOP30
                  :
                  : "r"(&value1), "r"(&value2));
-    pentest_set_trigger_low();
+    PENTEST_ASM_TRIGGER_LOW
     result[8] = value1;
   }
 

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -478,7 +478,8 @@ status_t handle_kmac_pentest_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_icache, &uj_output.icache_en,
+      uj_cpuctrl.enable_dummy_instr, &uj_output.dummy_instr_en,
       uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
       &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
       &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
@@ -494,11 +494,12 @@ status_t handle_otbn_pentest_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_data.icache_disable, uj_data.dummy_instr_disable,
-      uj_data.enable_jittery_clock, uj_data.enable_sram_readback,
-      &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
-      &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,
-      &uj_output.sram_main_readback_en, &uj_output.sram_ret_readback_en));
+      uj_data.enable_icache, &uj_output.icache_en, uj_data.enable_dummy_instr,
+      &uj_output.dummy_instr_en, uj_data.enable_jittery_clock,
+      uj_data.enable_sram_readback, &uj_output.clock_jitter_locked,
+      &uj_output.clock_jitter_en, &uj_output.sram_main_readback_locked,
+      &uj_output.sram_ret_readback_locked, &uj_output.sram_main_readback_en,
+      &uj_output.sram_ret_readback_en));
 
   // Read device ID and return to host.
   TRY(pentest_read_device_id(uj_output.device_id));

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -608,7 +608,8 @@ status_t handle_sha3_pentest_init(ujson_t *uj) {
   // Configure the CPU for the pentest.
   penetrationtest_device_info_t uj_output;
   TRY(pentest_configure_cpu(
-      uj_cpuctrl.icache_disable, uj_cpuctrl.dummy_instr_disable,
+      uj_cpuctrl.enable_icache, &uj_output.icache_en,
+      uj_cpuctrl.enable_dummy_instr, &uj_output.dummy_instr_en,
       uj_cpuctrl.enable_jittery_clock, uj_cpuctrl.enable_sram_readback,
       &uj_output.clock_jitter_locked, &uj_output.clock_jitter_en,
       &uj_output.sram_main_readback_locked, &uj_output.sram_ret_readback_locked,

--- a/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/crypto_fi_commands.h
@@ -78,7 +78,8 @@ UJSON_SERDE_STRUCT(FiHmacMessage, crypto_fi_hmac_message_t, CRYPTOFI_HMAC_MESSAG
 #define CRYPTOFI_HMAC_TAG(field, string) \
     field(tag, uint32_t, CRYPTOFI_HMAC_CMD_MAX_TAG_WORDS) \
     field(alerts, uint32_t, 3) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(ast_alerts, uint32_t, 2)
 UJSON_SERDE_STRUCT(FiHmacTag, crypto_fi_hmac_tag_t, CRYPTOFI_HMAC_TAG);
 
 #define CRYPTOFI_HMAC_MODE(field, string) \

--- a/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/pentest_lib_commands.h
@@ -17,6 +17,8 @@ extern "C" {
 
 #define PENETRATIONTEST_DEVICE_INFO(field, string) \
     field(device_id, uint32_t, 8) \
+    field(icache_en, bool) \
+    field(dummy_instr_en, bool) \
     field(clock_jitter_locked, bool) \
     field(clock_jitter_en, bool) \
     field(sram_main_readback_locked, bool) \
@@ -26,8 +28,8 @@ extern "C" {
 UJSON_SERDE_STRUCT(PenetrationtestDeviceInfo, penetrationtest_device_info_t, PENETRATIONTEST_DEVICE_INFO);
 
 #define PENETRATIONTEST_CPUCTRL(field, string) \
-    field(icache_disable, bool) \
-    field(dummy_instr_disable, bool) \
+    field(enable_icache, bool) \
+    field(enable_dummy_instr, bool) \
     field(enable_jittery_clock, bool) \
     field(enable_sram_readback, bool)
 UJSON_SERDE_STRUCT(PenetrationtesCpuctrl, penetrationtest_cpuctrl_t, PENETRATIONTEST_CPUCTRL);

--- a/sw/host/penetrationtests/testvectors/data/fi_crypto.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_crypto.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/fi_ibex.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_ibex.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/fi_lc_ctrl.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_lc_ctrl.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/fi_otbn.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_otbn.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/fi_otp.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_otp.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/fi_rng.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_rng.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "CsrngInit",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/fi_rom.json
+++ b/sw/host/penetrationtests/testvectors/data/fi_rom.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_aes.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_aes.json
@@ -3,9 +3,9 @@
     "test_case_id": 1,
     "command": "Init",
     "mode": "{\"fpga_mode\": 0}",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_edn.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_edn.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_hmac.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_hmac.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_ibex.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_ibex.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_kmac.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_kmac.json
@@ -3,9 +3,9 @@
     "test_case_id": 1,
     "command": "Init",
     "mode": "{\"fpga_mode\": 0}",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_otbn.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_otbn.json
@@ -2,9 +2,9 @@
   {
     "test_case_id": 1,
     "command": "Init",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",

--- a/sw/host/penetrationtests/testvectors/data/sca_sha3.json
+++ b/sw/host/penetrationtests/testvectors/data/sca_sha3.json
@@ -3,9 +3,9 @@
     "test_case_id": 1,
     "command": "Init",
     "mode": "{\"fpga_mode\": 0}",
-    "input": "{\"icache_disable\": true,\"dummy_instr_disable\": true,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
+    "input": "{\"enable_icache\": false,\"enable_dummy_instr\": false,\"enable_jittery_clock\": false,\"enable_sram_readback\": false}",
     "expected_output": [
-      "{\"device_id\":[0,0,0,0,0,0,0,0],\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
+      "{\"device_id\":[0,0,0,0,0,0,0,0],\"icache_en\":false,\"dummy_instr_en\":false,\"clock_jitter_locked\":false,\"clock_jitter_en\":false,\"sram_main_readback_locked\":false,\"sram_main_readback_en\":false,\"sram_ret_readback_locked\":false,\"sram_ret_readback_en\":false}",
       "{\"config_version\":1,\"sram_exec_mode\":0,\"ownership_key_alg\":0,\"update_mode\":0,\"min_security_version_bl0\":0,\"lock_constraint\":0}",
       "{\"digest\":[0,0,0,0,0,0,0,0],\"identifier\":0,\"scm_revision_low\":0,\"scm_revision_high\":0,\"rom_ext_slot\":0,\"rom_ext_major\":0,\"rom_ext_minor\":1,\"rom_ext_size\":0,\"bl0_slot\":0,\"ownership_state\":0,\"ownership_transfers\":0,\"rom_ext_min_sec_ver\":0,\"bl0_min_sec_ver\":0,\"primary_bl0_slot\":16000078145,\"retention_ram_initialized\":0}",
       "{\"bl0\":[0,0,0,0,0,0,0,0],\"rom_ext\":[0,0,0,0,0,0,0,0]}",


### PR DESCRIPTION
This PR consists of three different commits:
- Return the AST alerts for the Sha256 FI tests as this was missing
- Switch to the assembly-based trigger for IbexSca tests
- Streamline the iCache and dummy instruction behavior