### PR TITLE
[dv, alert_handler] Remove `illegal_bins` where not needed

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv.tpl
@@ -76,11 +76,9 @@ class ${module_instance_name}_env_cov extends cip_base_env_cov #(.CFG_T(${module
   covergroup alert_cause_cg with function sample(int alert_index, int class_index);
     alert_cause_cp: coverpoint alert_index {
       bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     alert_cause_cross_class_index: cross alert_cause_cp, class_index_cp;
   endgroup
@@ -91,15 +89,12 @@ class ${module_instance_name}_env_cov extends cip_base_env_cov #(.CFG_T(${module
     loc_alert_cause_cp: coverpoint local_alert {
       bins alert_ping_fail = {LocalAlertPingFail};
       bins alert_integrity_fail = {LocalAlertIntFail};
-      illegal_bins il = default;
     }
     alert_index_cp: coverpoint alert_index {
       bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, alert_index_cp;
     loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_index_cp;
@@ -111,15 +106,12 @@ class ${module_instance_name}_env_cov extends cip_base_env_cov #(.CFG_T(${module
     loc_alert_cause_cp: coverpoint local_alert {
       bins esc_ping_fail = {LocalEscPingFail};
       bins esc_integrity_fail = {LocalEscIntFail};
-      illegal_bins il = default;
     }
     esc_index_cp: coverpoint esc_index {
       bins alert[NUM_ESCS] = {[0:NUM_ESCS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, esc_index_cp;
     loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_index_cp;

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv.tpl
@@ -215,19 +215,27 @@ class ${module_instance_name}_scoreboard extends cip_base_scoreboard #(
           if (!is_int_err) begin
             class_i = `gmv(ral.alert_class_shadowed[alert_i]);
             void'(ral.alert_cause[alert_i].predict(1));
-            if (cfg.en_cov) cov.alert_cause_cg.sample(alert_i, class_i);
+            if (cfg.en_cov) begin
+              cov.alert_cause_cg.sample(alert_i, class_i);
+            end
           end else begin
             class_i = `gmv(ral.loc_alert_class_shadowed[int'(local_alert_type)]);
             void'(ral.loc_alert_cause[int'(local_alert_type)].predict(
                 .value(1), .kind(UVM_PREDICT_READ)));
-            if (cfg.en_cov) begin
-              if (local_alert_type inside {LocalAlertPingFail, LocalAlertIntFail}) begin
+            if (local_alert_type inside {LocalAlertPingFail, LocalAlertIntFail}) begin
+              if (cfg.en_cov) begin
                 cov.alert_loc_alert_cause_cg.sample(local_alert_type, alert_i, class_i);
-              end else begin
+              end
+            end else begin
+              // Check the local alert type equals to the ones defined in the CG:
+              `DV_CHECK(local_alert_type inside {LocalEscPingFail, LocalEscIntFail})
+              if (cfg.en_cov) begin
                 cov.esc_loc_alert_cause_cg.sample(local_alert_type, alert_i, class_i);
               end
             end
           end
+          // Check to ensure alert_i and class_i is within bounds
+          `DV_CHECK(alert_i < NUM_ALERTS && class_i < NUM_ALERT_CLASSES)
 
           intr_state_field = intr_state_fields[class_i];
           void'(intr_state_field.predict(.value(1), .kind(UVM_PREDICT_READ)));

--- a/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_darjeeling/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -76,11 +76,9 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
   covergroup alert_cause_cg with function sample(int alert_index, int class_index);
     alert_cause_cp: coverpoint alert_index {
       bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     alert_cause_cross_class_index: cross alert_cause_cp, class_index_cp;
   endgroup
@@ -91,15 +89,12 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     loc_alert_cause_cp: coverpoint local_alert {
       bins alert_ping_fail = {LocalAlertPingFail};
       bins alert_integrity_fail = {LocalAlertIntFail};
-      illegal_bins il = default;
     }
     alert_index_cp: coverpoint alert_index {
       bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, alert_index_cp;
     loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_index_cp;
@@ -111,15 +106,12 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     loc_alert_cause_cp: coverpoint local_alert {
       bins esc_ping_fail = {LocalEscPingFail};
       bins esc_integrity_fail = {LocalEscIntFail};
-      illegal_bins il = default;
     }
     esc_index_cp: coverpoint esc_index {
       bins alert[NUM_ESCS] = {[0:NUM_ESCS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, esc_index_cp;
     loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_index_cp;

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -76,11 +76,9 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
   covergroup alert_cause_cg with function sample(int alert_index, int class_index);
     alert_cause_cp: coverpoint alert_index {
       bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     alert_cause_cross_class_index: cross alert_cause_cp, class_index_cp;
   endgroup
@@ -91,15 +89,12 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     loc_alert_cause_cp: coverpoint local_alert {
       bins alert_ping_fail = {LocalAlertPingFail};
       bins alert_integrity_fail = {LocalAlertIntFail};
-      illegal_bins il = default;
     }
     alert_index_cp: coverpoint alert_index {
       bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, alert_index_cp;
     loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_index_cp;
@@ -111,15 +106,12 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     loc_alert_cause_cp: coverpoint local_alert {
       bins esc_ping_fail = {LocalEscPingFail};
       bins esc_integrity_fail = {LocalEscIntFail};
-      illegal_bins il = default;
     }
     esc_index_cp: coverpoint esc_index {
       bins alert[NUM_ESCS] = {[0:NUM_ESCS-1]};
-      illegal_bins il = default;
     }
     class_index_cp: coverpoint class_index {
       bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
-      illegal_bins il = default;
     }
     loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, esc_index_cp;
     loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_index_cp;


### PR DESCRIPTION
Alert handler defines specific bins for the coverpoints. So when X-coverage takes place, only the explicitly defined bins will be crossed, and hence the illegal_bins won't influence the cross.

A check has been moved the the SCB to be active regardless of whether coverage collection is enabled or not. These checks just ensure the TB is configured within the design bounds by making sure the analysis imports for alert and esc are within the design bounds.