### PR TITLE
[bazel] Ensure Bazel cache is clean before airgap test

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,3 +3,4 @@ build
 hw/ip/prim/util/vendor/google_verible_verilog_syntax_py
 sw/vendor/google_googletest
 util/lowrisc_misc-linters
+bazel-airgapped

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,10 +38,11 @@ bazel_dep(
     name = "lowrisc_misc_linters",
     dev_dependency = True,
 )
-git_override(
+archive_override(
     module_name = "lowrisc_misc_linters",
-    commit = "556bd3cf7e730a70f76e2a13f624b633deda6ef6",
-    remote = "https://github.com/lowRISC/misc-linters",
+    integrity = "sha256-eRFiSjD638NuOjDDScMuEKVYpmotDY0yX3jxYL/d3ac=",
+    strip_prefix = "misc-linters-20250217_01",
+    urls = ["https://github.com/lowRISC/misc-linters/archive/refs/tags/20250217_01.tar.gz"],
 )
 
 # Includes:

--- a/ci/scripts/check-bazel-banned-rules.sh
+++ b/ci/scripts/check-bazel-banned-rules.sh
@@ -9,8 +9,8 @@ set -e
 REPO_TOP="$(git rev-parse --show-toplevel)"
 cd "$REPO_TOP"
 
-if grep -r --include '*.bzl' git_repository; then
-  echo "Bazel's 'git_repository' rule is insecure and incompatible with OpenTitan's airgapping strategy."
-  echo "Please replace $GIT_REPOS with 'http_archive' rule and set a sha256 so it can be canonically reproducible."
+if grep -r --include '*MODULE.bazel' git_override; then
+  echo "Bazel's 'git_override' method is incompatible with OpenTitan's airgapping strategy." >&2
+  echo "Please replace all instances with 'archive_override' method and set an 'integrity' so it can be canonically reproducible." >&2
   exit 1
 fi

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -11,6 +11,9 @@ if [ ! -d bazel-airgapped ]; then
   util/prep-bazel-airgapped-build.sh -f
 fi
 
+# Clean out bazel cache so no remnants exist for test.
+"${PWD}/bazel-airgapped/bazel" clean --expunge
+
 # Remove the airgapped network namespace.
 remove_airgapped_netns() {
   sudo ip netns delete airgapped

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -30,7 +30,7 @@ sudo ip netns exec airgapped sudo -u "$USER" \
     BITSTREAM="--offline latest"                                     \
   "${PWD}/bazel-airgapped/bazel" build                               \
     --distdir="${PWD}/bazel-airgapped/bazel-distdir"                 \
-    --repository_cache="${PWD}/bazel-airgapped/bazel-cache"          \
+    --vendor_dir="${PWD}/bazel-airgapped/bazel-vendor"               \
     --define DISABLE_VERILATOR_BUILD=true                            \
     //sw/device/silicon_creator/rom:mask_rom
 

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 : "${BAZEL_AIRGAPPED_DIR:=bazel-airgapped}"
 : "${BAZEL_DISTDIR:=bazel-distdir}"
 : "${BAZEL_CACHEDIR:=bazel-cache}"
+: "${BAZEL_VENDORDIR:=bazel-vendor}"
 : "${BAZEL_BITSTREAMS_CACHE:=bitstreams-cache}"
 : "${BAZEL_BITSTREAMS_CACHEDIR:=${BAZEL_BITSTREAMS_CACHE}/cache}"
 : "${BAZEL_BITSTREAMS_REPO:=bitstreams}"
@@ -137,13 +138,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR}
   # Make bazel forget everything it knows, then download everything.
   ${BAZELISK} clean --expunge
-  ${BAZELISK} fetch \
-    --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} \
-    //... \
-    @lowrisc_rv32imcb_toolchain//... \
-    @local_config_platform//... \
-    @riscv-compliance//... \
-    @rules_foreign_cc//toolchains/... \
+  ${BAZELISK} vendor --vendor_dir="${BAZEL_AIRGAPPED_DIR}/${BAZEL_VENDORDIR}" //...
   # We don't need all bitstreams in the cache, we just need the latest one so
   # that the cache is "initialized" and "offline" mode will work correctly.
   mkdir -p ${BAZEL_AIRGAPPED_DIR}/${BAZEL_BITSTREAMS_CACHEDIR}
@@ -168,5 +163,5 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" ]]; then
   echo $LINE_SEP
   echo "To perform an airgapped build, ship the contents of ${BAZEL_AIRGAPPED_DIR} to your airgapped environment and then:"
   echo ""
-  echo "bazel build --distdir=${BAZEL_AIRGAPPED_DIR}/${BAZEL_DISTDIR} --repository_cache=${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR} <label>"
+  echo "bazel build --distdir=${BAZEL_AIRGAPPED_DIR}/${BAZEL_DISTDIR} --vendor_dir=${BAZEL_AIRGAPPED_DIR}/${BAZEL_VENDORDIR} <label>"
 fi


### PR DESCRIPTION
This PR backports a commit from https://github.com/lowRISC/opentitan/pull/26092 which ensures the Bazel cache outside of the airgap directory is cleaned before running the test.

Requires a change to how we override `misc-linters` since Git downloads aren't cached properly by Bazel at the moment.