### PR TITLE
[adc_ctrl, verissimo][UVM69] UVM new() functions

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
@@ -81,7 +81,7 @@ class adc_ctrl_env_cov extends cip_base_env_cov #(
       [ADC_CTRL_CHANNELS] [ADC_CTRL_NUM_FILTERS];
 
 
-  function new(string name = "adc_ctrl_env_cov", uvm_component parent = null);
+  function new(string name, uvm_component parent = null);
     super.new(name, parent);
     adc_ctrl_testmode_cg = new();
   endfunction


### PR DESCRIPTION
Verissimo complains:
The class 'adc_ctrl_env_pkg::adc_ctrl_env_cov' constructor's argument 'name' default value is not an empty string!

We create the class object through the create call which creates the object as well as register it to UVM factory. So, leaving the name argument empty inside the constructor will not affect any functionality.