### PR TITLE
[prim] removing prim_legacy from partner file list

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -13,7 +13,6 @@ filesets:
       - lowrisc:earlgrey_ip:flash_ctrl_prim_reg_top
       - "fileset_partner ? (partner:systems:top_earlgrey_ast)"
       - "fileset_partner ? (partner:systems:top_earlgrey_scan_role_pkg)"
-      - "fileset_partner ? (partner:prim:prim_legacy_pkg)"
       - "fileset_partner ? (partner:prim_tech:all)"
       - "fileset_partner ? (partner:prim_tech:flash)"
       - "!fileset_partner ? (lowrisc:systems:top_earlgrey_ast)"


### PR DESCRIPTION
[prim] removing prim_legacy from partner file list

With the above change, partner side compiles successfully :)