### PR TITLE
[rom_ext,rescue] Fix allowlist for reboot mode

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -214,10 +214,20 @@ exitproc:
 }
 
 rom_error_t rescue_send_handler(rescue_state_t *state) {
-  if (state->mode == kRescueModeNoOp) {
-    // The No-Op mode is always allowed and does nothing.
-    return kErrorOk;
+  // The following commands are always allowed and are not subject to
+  // the "command allowed" check.
+  switch (state->mode) {
+    case kRescueModeReboot:
+      // If a reboot was requested, return an error and go through the normal
+      // shutdown process.
+      return kErrorRescueReboot;
+    case kRescueModeNoOp:
+      // The No-Op mode is always allowed and does nothing.
+      return kErrorOk;
+    default:
+        /* do nothing */;
   }
+
   hardened_bool_t allow =
       owner_rescue_command_allowed(state->config, state->mode);
   if (allow != kHardenedBoolTrue) {
@@ -255,10 +265,6 @@ rom_error_t rescue_send_handler(rescue_state_t *state) {
     case kRescueModeFirmwareSlotB:
       // Nothing to do for receive modes.
       return kErrorOk;
-    case kRescueModeReboot:
-      // If a reboot was requested, return an error and go through the normal
-      // shutdown process.
-      return kErrorRescueReboot;
     default:
       // This state should be impossible.
       return kErrorRescueBadMode;

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -443,6 +443,8 @@ opentitan_test(
             --exec="rescue get-device-id --reboot=false"
             # Try the `RESQ` mode and make sure we get an error message.
             --exec="console --non-interactive --send='RESQ\r' --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+            # Try the `REBO` mode and make sure we reboot without crash.
+            --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
     ),


### PR DESCRIPTION
The reboot mode is always allowed in `rescue_validate_mode`. However, the rescue protocol will still crash with `kErrorRescueBadMode` when the reboot command is not allowed.

This commit fixes this issue by moving those special commands before the `owner_rescue_command_allowed` checks.