### PR TITLE
[rom_ext,rescue] Fix rescue rx when triggered by boot svc

### DIFF
--- a/sw/device/silicon_creator/lib/rescue/rescue.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue.c
@@ -409,7 +409,6 @@ hardened_bool_t rescue_detect_entry(const owner_rescue_config_t *config) {
     case kRescueDetectBreak:
       if (uart_break_detect(kRescueDetectTime) == kHardenedBoolTrue) {
         dbg_printf("rescue:1.0 remember to clear break\r\n");
-        uart_enable_receiver();
         return kHardenedBoolTrue;
       }
       break;

--- a/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_xmodem.c
@@ -154,6 +154,7 @@ rom_error_t rescue_protocol(boot_data_t *bootdata, boot_log_t *boot_log,
                             const owner_rescue_config_t *config) {
   rescue_state_t rescue_state;
   rescue_state_init(&rescue_state, bootdata, boot_log, config);
+  uart_enable_receiver();
   rom_error_t result = protocol(&rescue_state);
   if (result == kErrorRescueReboot) {
     rstmgr_reboot();

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -71,6 +71,15 @@ opentitan_test(
         assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
         exit_failure = "BFV|PASS|FAIL",
         exit_success = "mode: RESQ\r\n",
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+            # Try the `REBO` mode and make sure it works.
+            --exec="rescue no-op --reset-target=reboot"
+            no-op
+        """,
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [


### PR DESCRIPTION
When rescue mode is initiated by OwnerSW via the boot service, the UART RX is not active. This prevents it from receiving commands after displaying "RESQ".