### PR TITLE
[rv_plic, fpv] Removed alert related FPV 

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -48,35 +48,10 @@ check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
  code block}
 
-# Below task acts as an isolated container for the following assertion and stopat.
-task -create FSMParasiticState
-
-# Drives any possible value to state_q.
-stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
-
-# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
-# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
-# checker coverage for the default case.
-assert -name FSMParasiticState::AlertSenderFSMParasiticState_A\
- {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside\
-  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->\
-  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\
  {dut.u_reg.u_reg_if.u_rsp_intg_gen} -comment {Rsp and Data Intg will always be zero}
-
-# For now, waiving this coverage is the sensible step. prim_diff_decode FSM would get stuck into
-# faulty state unless reset happens. So, even if we add a stopat on state_q, the default case would
-# ask for an assertion to cover missing checker coverage.
-check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv}\
- -start_line 153 -end_line 153 -type {branch} -comment {Unreachable without FI}
-
-# To support the waiver above, this assertion makes sure that state_q can never transition to a
-# parasitic state. If that is no longer the case, this assertion will fail.
-assert -name PrimDiffDecodeNoParasiticState_A\
- {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
 
 # Waiving all the alert instances for coverage.
 foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {

--- a/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/ip_templates/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -77,3 +77,9 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_
 # parasitic state. If that is no longer the case, this assertion will fail.
 assert -name PrimDiffDecodeNoParasiticState_A\
  {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
+
+# Waiving all the alert instances for coverage.
+foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {
+  check_cov -waiver -add -instance "$alert_sender_inst"\
+    -comment {FPV for Alerts has already been done elsewhere}
+}

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -48,35 +48,10 @@ check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
  code block}
 
-# Below task acts as an isolated container for the following assertion and stopat.
-task -create FSMParasiticState
-
-# Drives any possible value to state_q.
-stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
-
-# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
-# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
-# checker coverage for the default case.
-assert -name FSMParasiticState::AlertSenderFSMParasiticState_A\
- {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside\
-  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->\
-  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\
  {dut.u_reg.u_reg_if.u_rsp_intg_gen} -comment {Rsp and Data Intg will always be zero}
-
-# For now, waiving this coverage is the sensible step. prim_diff_decode FSM would get stuck into
-# faulty state unless reset happens. So, even if we add a stopat on state_q, the default case would
-# ask for an assertion to cover missing checker coverage.
-check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv}\
- -start_line 153 -end_line 153 -type {branch} -comment {Unreachable without FI}
-
-# To support the waiver above, this assertion makes sure that state_q can never transition to a
-# parasitic state. If that is no longer the case, this assertion will fail.
-assert -name PrimDiffDecodeNoParasiticState_A\
- {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
 
 # Waiving all the alert instances for coverage.
 foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {

--- a/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_darjeeling/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -77,3 +77,9 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_
 # parasitic state. If that is no longer the case, this assertion will fail.
 assert -name PrimDiffDecodeNoParasiticState_A\
  {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
+
+# Waiving all the alert instances for coverage.
+foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {
+  check_cov -waiver -add -instance "$alert_sender_inst"\
+    -comment {FPV for Alerts has already been done elsewhere}
+}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -48,35 +48,10 @@ check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
  code block}
 
-# Below task acts as an isolated container for the following assertion and stopat.
-task -create FSMParasiticState
-
-# Drives any possible value to state_q.
-stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
-
-# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
-# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
-# checker coverage for the default case.
-assert -name FSMParasiticState::AlertSenderFSMParasiticState_A\
- {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside\
-  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->\
-  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\
  {dut.u_reg.u_reg_if.u_rsp_intg_gen} -comment {Rsp and Data Intg will always be zero}
-
-# For now, waiving this coverage is the sensible step. prim_diff_decode FSM would get stuck into
-# faulty state unless reset happens. So, even if we add a stopat on state_q, the default case would
-# ask for an assertion to cover missing checker coverage.
-check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv}\
- -start_line 153 -end_line 153 -type {branch} -comment {Unreachable without FI}
-
-# To support the waiver above, this assertion makes sure that state_q can never transition to a
-# parasitic state. If that is no longer the case, this assertion will fail.
-assert -name PrimDiffDecodeNoParasiticState_A\
- {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
 
 # Waiving all the alert instances for coverage.
 foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -77,3 +77,9 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_
 # parasitic state. If that is no longer the case, this assertion will fail.
 assert -name PrimDiffDecodeNoParasiticState_A\
  {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
+
+# Waiving all the alert instances for coverage.
+foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {
+  check_cov -waiver -add -instance "$alert_sender_inst"\
+    -comment {FPV for Alerts has already been done elsewhere}
+}

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -48,35 +48,10 @@ check_cov -waiver -add -start_line 397 -end_line 417 -instance {prim_mubi_pkg} -
 check_cov -waiver -add -start_line 536 -end_line 556 -instance {prim_mubi_pkg} -comment {Unused\
  code block}
 
-# Below task acts as an isolated container for the following assertion and stopat.
-task -create FSMParasiticState
-
-# Drives any possible value to state_q.
-stopat -task FSMParasiticState "dut.gen_alert_tx\[0\].u_prim_alert_sender.state_q"
-
-# If some silly state has been injected in state_q then the FSM will always comes back to Idle in
-# the next state as the FSM treats the unrecognized state as Idle. This assertion also covers the
-# checker coverage for the default case.
-assert -name FSMParasiticState::AlertSenderFSMParasiticState_A\
- {!(dut.gen_alert_tx[0].u_prim_alert_sender.state_q inside\
-  {Idle, AlertHsPhase1, AlertHsPhase2, PingHsPhase1, PingHsPhase2, Pause0, Pause1}) ->\
-  dut.gen_alert_tx[0].u_prim_alert_sender.state_d == Idle}
-
 # These two blocking assignment appear as undetectable and making an assertion for them looks
 # unreasonable as for this particular instance, they will always be generated as zero.
 check_cov -waiver -add -start_line 67 -end_line 68 -type {statement} -instance\
  {dut.u_reg.u_reg_if.u_rsp_intg_gen} -comment {Rsp and Data Intg will always be zero}
-
-# For now, waiving this coverage is the sensible step. prim_diff_decode FSM would get stuck into
-# faulty state unless reset happens. So, even if we add a stopat on state_q, the default case would
-# ask for an assertion to cover missing checker coverage.
-check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv}\
- -start_line 153 -end_line 153 -type {branch} -comment {Unreachable without FI}
-
-# To support the waiver above, this assertion makes sure that state_q can never transition to a
-# parasitic state. If that is no longer the case, this assertion will fail.
-assert -name PrimDiffDecodeNoParasiticState_A\
- {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
 
 # Waiving all the alert instances for coverage.
 foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {

--- a/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
+++ b/hw/top_englishbreakfast/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl
@@ -77,3 +77,9 @@ check_cov -waiver -add -source_file {../src/lowrisc_prim_diff_decode_0/rtl/prim_
 # parasitic state. If that is no longer the case, this assertion will fail.
 assert -name PrimDiffDecodeNoParasiticState_A\
  {dut.gen_alert_tx[0].u_prim_alert_sender.u_decode_ping.gen_async.state_q < 3}
+
+# Waiving all the alert instances for coverage.
+foreach alert_sender_inst [get_design_info -list instance -filter "prim_alert_sender$" -regexp] {
+  check_cov -waiver -add -instance "$alert_sender_inst"\
+    -comment {FPV for Alerts has already been done elsewhere}
+}


### PR DESCRIPTION
The FPV for alerts is already been done separately. It would makes sense to migrate the coverage closure work done for alerts while doing FPV on rv_plic to the alert FPV world.