### PR TITLE
[racl_ctrl] Fix alert order and order of IsFatal.

### DIFF
--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -73,10 +73,13 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   logic [NumAlerts-1:0] alert_test, alert;
 
 % if enable_shadow_reg:
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1, 1'b0};
+  localparam logic [NumAlerts-1:0] IsFatal = {
+    1'b0, // [1] recov_ctrl_update_err
+    1'b1  // [0] fatal_fault
+  };
 
-  assign alert[0]  = shadowed_update_err;
-  assign alert[1]  = reg_intg_error | shadowed_storage_err;
+  assign alert[0]  = reg_intg_error | shadowed_storage_err; // fatal_fault
+  assign alert[1]  = shadowed_update_err;                   // recov_ctrl_update_err
 
   assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
   assign alert_test[1] = reg2hw.alert_test.recov_ctrl_update_err.q &

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -62,10 +62,13 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   //////////////////////////////////////////////////////////////////////////////////////////////////
   logic [NumAlerts-1:0] alert_test, alert;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1, 1'b0};
+  localparam logic [NumAlerts-1:0] IsFatal = {
+    1'b0, // [1] recov_ctrl_update_err
+    1'b1  // [0] fatal_fault
+  };
 
-  assign alert[0]  = shadowed_update_err;
-  assign alert[1]  = reg_intg_error | shadowed_storage_err;
+  assign alert[0]  = reg_intg_error | shadowed_storage_err; // fatal_fault
+  assign alert[1]  = shadowed_update_err;                   // recov_ctrl_update_err
 
   assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
   assign alert_test[1] = reg2hw.alert_test.recov_ctrl_update_err.q &


### PR DESCRIPTION
The alert order in racl_ctrl has been mixed previously and #27390 has only partially corrected it.

In racl_ctrl.hjson the alerts are specified as
```
[0] fatal_fault (isFatal=1)
[1] recov_ctrl_update_err (if enable_shadow_reg) (isFatal=0)
```
This PR changes the order of the alerts and the IsFatal to be aligned with alert_test and the data in the hjson file.