### PR TITLE
[rom_ext] Boot services refactor and unit tests

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -253,10 +253,18 @@ cc_library(
 
 cc_test(
     name = "dbg_print_unittest",
-    srcs = ["dbg_print_unittest.cc"],
+    srcs = [
+        "dbg_print.c",
+        "dbg_print.h",
+        "dbg_print_unittest.cc",
+    ],
+    local_defines = ["DBG_PRINT_UNIT_TEST_"],
     deps = [
-        ":dbg_print",
+        ":epmp_defs",
         ":error",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:uart",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -16,6 +16,7 @@ dual_cc_library(
         host = ["mock_boot_svc_header.h"],
         shared = ["boot_svc_header.h"],
     ),
+    visibility = ["//visibility:public"],
     deps = dual_inputs(
         host = [
             "//sw/device/lib/base:global_mock",

--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -9,6 +9,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifndef OT_PLATFORM_RV32
+#include <stdio.h>
+#endif
+
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
@@ -16,6 +20,7 @@
 
 static const char kHexTable[16] = "0123456789abcdef";
 
+#if defined(OT_PLATFORM_RV32) || defined(DBG_PRINT_UNIT_TEST_)
 static void print_integer(unsigned value, bool is_signed) {
   char buf[12];
   char *b = buf + sizeof(buf);
@@ -110,6 +115,19 @@ void dbg_printf(const char *format, ...) {
   }
   va_end(args);
 }
+
+#else  // defined(OT_PLATFORM_RV32) || defined(DBG_PRINT_UNIT_TEST_)
+
+void dbg_puts(const char *str) { puts(str); }
+
+void dbg_printf(const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
+}
+
+#endif  // defined(OT_PLATFORM_RV32) || defined(DBG_PRINT_UNIT_TEST_)
 
 void dbg_print_epmp(void) {
   uint32_t pmpaddr[16];

--- a/sw/device/silicon_creator/lib/mock_manifest.cc
+++ b/sw/device/silicon_creator/lib/mock_manifest.cc
@@ -22,5 +22,22 @@ epmp_region_t manifest_code_region_get(const manifest_t *manifest) {
 uintptr_t manifest_entry_point_get(const manifest_t *manifest) {
   return MockManifest::Instance().EntryPoint(manifest);
 }
+
+rom_error_t manifest_ext_get_spx_key(const manifest_t *manifest,
+                                     const manifest_ext_spx_key_t **spx_key) {
+  return MockManifest::Instance().SpxKey(manifest, spx_key);
+}
+
+rom_error_t manifest_ext_get_spx_signature(
+    const manifest_t *manifest,
+    const manifest_ext_spx_signature_t **spx_signature) {
+  return MockManifest::Instance().SpxSignature(manifest, spx_signature);
+}
+
+rom_error_t manifest_ext_get_isfb(const manifest_t *manifest,
+                                  const manifest_ext_isfb_t **isfb) {
+  return MockManifest::Instance().Isfb(manifest, isfb);
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/mock_manifest.h
+++ b/sw/device/silicon_creator/lib/mock_manifest.h
@@ -21,6 +21,13 @@ class MockManifest : public global_mock::GlobalMock<MockManifest> {
   MOCK_METHOD(manifest_digest_region_t, DigestRegion, (const manifest_t *));
   MOCK_METHOD(epmp_region_t, CodeRegion, (const manifest_t *));
   MOCK_METHOD(uintptr_t, EntryPoint, (const manifest_t *));
+  MOCK_METHOD(rom_error_t, SpxKey,
+              (const manifest_t *, const manifest_ext_spx_key_t **spx_key));
+  MOCK_METHOD(rom_error_t, SpxSignature,
+              (const manifest_t *,
+               const manifest_ext_spx_signature_t **spx_signature));
+  MOCK_METHOD(rom_error_t, Isfb,
+              (const manifest_t *, const manifest_ext_isfb_t **isfb));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -74,6 +74,7 @@ dual_cc_library(
     deps = dual_inputs(
         device = [
             ":owner_verify",
+            "//sw/device/lib/arch:device",
             "//sw/device/lib/base:memory",
             "//sw/device/lib/base:hardened_memory",
             "//sw/device/silicon_creator/lib/drivers:keymgr",
@@ -256,15 +257,30 @@ cc_library(
     for name, param in TEST_OWNER_CONFIGS.items()
 ]
 
-cc_library(
+dual_cc_library(
     name = "owner_verify",
-    srcs = ["owner_verify.c"],
-    hdrs = ["owner_verify.h"],
-    deps = [
-        ":datatypes",
-        "//sw/device/silicon_creator/lib:error",
-        "//sw/device/silicon_creator/lib/base:util",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/device/silicon_creator/lib/sigverify",
-    ],
+    srcs = dual_inputs(
+        device = ["owner_verify.c"],
+        host = ["mock_owner_verify.cc"],
+    ),
+    hdrs = dual_inputs(
+        host = ["mock_owner_verify.h"],
+        shared = ["owner_verify.h"],
+    ),
+    deps = dual_inputs(
+        device = [
+            "//sw/device/silicon_creator/lib/sigverify",
+        ],
+        host = [
+            "//sw/device/lib/base:global_mock",
+            "//sw/device/silicon_creator/testing:rom_test",
+            "@googletest//:gtest",
+        ],
+        shared = [
+            ":datatypes",
+            "//sw/device/silicon_creator/lib/base:util",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+            "//sw/device/silicon_creator/lib:error",
+        ],
+    ),
 )

--- a/sw/device/silicon_creator/lib/ownership/isfb.c
+++ b/sw/device/silicon_creator/lib/ownership/isfb.c
@@ -185,3 +185,5 @@ rom_error_t isfb_info_flash_erase_policy_get(
 
   return kErrorOk;
 }
+
+extern uint32_t isfb_expected_count_get(const manifest_ext_isfb_t *ext);

--- a/sw/device/silicon_creator/lib/ownership/mock_owner_verify.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_owner_verify.cc
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/ownership/mock_owner_verify.h"
+
+namespace rom_test {
+extern "C" {
+
+rom_error_t owner_verify(uint32_t key_alg, const owner_keydata_t *key,
+                         const ecdsa_p256_signature_t *ecdsa_sig,
+                         const sigverify_spx_signature_t *spx_sig,
+                         const void *msg_prefix_1, size_t msg_prefix_1_len,
+                         const void *msg_prefix_2, size_t msg_prefix_2_len,
+                         const void *msg, size_t msg_len,
+                         const hmac_digest_t *digest, uint32_t *flash_exec) {
+  return MockOwnerVerify::Instance().verify(
+      key_alg, key, ecdsa_sig, spx_sig, msg_prefix_1, msg_prefix_1_len,
+      msg_prefix_2, msg_prefix_2_len, msg, msg_len, digest, flash_exec);
+}
+
+}  // extern "C"
+}  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/mock_owner_verify.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_owner_verify.h
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_MOCK_OWNER_VERIFY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_MOCK_OWNER_VERIFY_H_
+
+#include "sw/device/lib/base/global_mock.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_verify.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace rom_test {
+namespace internal {
+
+/**
+ * Mock class for owner_verify.c.
+ */
+class MockOwnerVerify : public global_mock::GlobalMock<MockOwnerVerify> {
+ public:
+  MOCK_METHOD(rom_error_t, verify,
+              (uint32_t, const owner_keydata_t *,
+               const ecdsa_p256_signature_t *,
+               const sigverify_spx_signature_t *, const void *, size_t,
+               const void *, size_t, const void *, size_t,
+               const hmac_digest_t *, uint32_t *));
+};
+
+}  // namespace internal
+
+using MockOwnerVerify = testing::StrictMock<internal::MockOwnerVerify>;
+
+}  // namespace rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_MOCK_OWNER_VERIFY_H_

--- a/sw/device/silicon_creator/lib/ownership/owner_verify.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_verify.h
@@ -8,7 +8,8 @@
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
-#include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/lib/sigverify/spx_key.h"
 
 /**
  * Verify data using an owner key or owner application key.

--- a/sw/device/silicon_creator/lib/rescue/BUILD
+++ b/sw/device/silicon_creator/lib/rescue/BUILD
@@ -136,3 +136,11 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:usb",
     ],
 )
+
+cc_library(
+    name = "rescue_null",
+    srcs = ["rescue_null.c"],
+    deps = [
+        ":rescue",
+    ],
+)

--- a/sw/device/silicon_creator/lib/rescue/rescue_null.c
+++ b/sw/device/silicon_creator/lib/rescue/rescue_null.c
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+const uint32_t rescue_type = 0;

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:const.bzl", "CONST", "hex")
-load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
@@ -109,6 +109,18 @@ cc_library(
         "//sw/device/silicon_creator/lib/ownership:ownership_activate",
         "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
         "//sw/device/silicon_creator/lib/rescue",
+    ],
+)
+
+cc_test(
+    name = "rom_ext_boot_services_unittest",
+    srcs = ["rom_ext_boot_services_unittest.cc"],
+    deps = [
+        ":rom_ext_boot_services",
+        dual_cc_device_library_of("//sw/device/silicon_creator/lib/boot_svc:boot_svc_header"),
+        "//sw/device/silicon_creator/lib/rescue:rescue_null",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -94,6 +94,25 @@ cc_test(
 )
 
 cc_library(
+    name = "rom_ext_boot_services",
+    srcs = ["rom_ext_boot_services.c"],
+    hdrs = ["rom_ext_boot_services.h"],
+    deps = [
+        ":rom_ext_boot_policy",
+        ":rom_ext_verify",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:manifest",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/ownership:ownership_activate",
+        "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
+        "//sw/device/silicon_creator/lib/rescue",
+    ],
+)
+
+cc_library(
     name = "rom_ext_isrs",
     srcs = [
         "rom_ext_isrs.c",
@@ -111,6 +130,24 @@ cc_library(
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+cc_library(
+    name = "rom_ext_verify",
+    srcs = ["rom_ext_verify.c"],
+    hdrs = ["rom_ext_verify.h"],
+    deps = [
+        ":rom_ext_boot_policy",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:manifest",
+        "//sw/device/silicon_creator/lib/base:boot_measurements",
+        "//sw/device/silicon_creator/lib/ownership:isfb",
+        "//sw/device/silicon_creator/lib/ownership:owner_block",
+        "//sw/device/silicon_creator/lib/ownership:owner_verify",
+        "//sw/device/silicon_creator/lib/sigverify:usage_constraints",
     ],
 )
 
@@ -163,6 +200,7 @@ ld_library(
         deps = [
             ":rom_ext_boot_policy",
             ":rom_ext_boot_policy_ptrs",
+            ":rom_ext_boot_services",
             ":rom_ext_isrs",
             ":rom_ext_manifest",
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -52,7 +52,9 @@
 #include "sw/device/silicon_creator/rom_ext/imm_section/imm_section_version.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_boot_services.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_manifest.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_verify.h"
 
 #include "flash_ctrl_regs.h"                          // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
@@ -202,92 +204,6 @@ void rom_ext_sram_exec(owner_sram_exec_mode_t mode) {
                        0);
       break;
   }
-}
-
-OT_WARN_UNUSED_RESULT
-static rom_error_t rom_ext_verify(const manifest_t *manifest,
-                                  const boot_data_t *boot_data,
-                                  uint32_t *flash_exec) {
-  RETURN_IF_ERROR(rom_ext_boot_policy_manifest_check(manifest, boot_data));
-
-  uint32_t key_id =
-      sigverify_ecdsa_p256_key_id_get(&manifest->ecdsa_public_key);
-  // Check if there is an SPX+ key.
-  const manifest_ext_spx_key_t *ext_spx_key;
-  const manifest_ext_spx_signature_t *ext_spx_signature;
-  rom_error_t spx_err = manifest_ext_get_spx_key(manifest, &ext_spx_key);
-  spx_err += manifest_ext_get_spx_signature(manifest, &ext_spx_signature);
-  switch ((uint32_t)spx_err) {
-    case kErrorOk * 2:
-      // Both extensions present: valid SPX+ signature.
-      key_id ^= sigverify_spx_key_id_get(&ext_spx_key->key);
-      break;
-    case kErrorManifestBadExtension * 2:
-      // Both extensions absent: ECDSA only.
-      break;
-    default:
-      // One present, one absent: bad configuration.
-      return kErrorManifestBadExtension;
-  }
-
-  RETURN_IF_ERROR(owner_keyring_find_key(&keyring, key_id, &verify_key));
-  uint32_t key_alg = keyring.key[verify_key]->key_alg;
-
-  dbg_printf("verify: key%u;%C;%C\r\n", verify_key, key_alg,
-             keyring.key[verify_key]->key_domain);
-
-  memset(boot_measurements.bl0.data, (int)rnd_uint32(),
-         sizeof(boot_measurements.bl0.data));
-
-  hmac_sha256_init();
-  // Hash usage constraints.
-  manifest_usage_constraints_t usage_constraints_from_hw;
-  sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits |
-                                      keyring.key[verify_key]->usage_constraint,
-                                  &usage_constraints_from_hw);
-  hmac_sha256_update(&usage_constraints_from_hw,
-                     sizeof(usage_constraints_from_hw));
-  // Hash the remaining part of the image.
-  manifest_digest_region_t digest_region = manifest_digest_region_get(manifest);
-  hmac_sha256_update(digest_region.start, digest_region.length);
-  // TODO(#19596): add owner configuration block to measurement.
-  // Verify signature
-  hmac_sha256_process();
-  hmac_digest_t act_digest;
-  hmac_sha256_final(&act_digest);
-
-  static_assert(sizeof(boot_measurements.bl0) == sizeof(act_digest),
-                "Unexpected BL0 digest size.");
-  memcpy(&boot_measurements.bl0, &act_digest, sizeof(boot_measurements.bl0));
-
-  RETURN_IF_ERROR(owner_verify(
-      key_alg, &keyring.key[verify_key]->data, &manifest->ecdsa_signature,
-      &ext_spx_signature->signature, &usage_constraints_from_hw,
-      sizeof(usage_constraints_from_hw), NULL, 0, digest_region.start,
-      digest_region.length, &act_digest, flash_exec));
-
-  // Perform ISFB checks if the extension is present.
-  if ((hardened_bool_t)owner_config.isfb != kHardenedBoolFalse) {
-    const manifest_ext_isfb_t *ext_isfb;
-    rom_error_t error = manifest_ext_get_isfb(manifest, &ext_isfb);
-    if (error == kErrorOk) {
-      isfb_check_count = kHardenedBoolFalse;
-      RETURN_IF_ERROR(isfb_boot_request_process(ext_isfb, &owner_config,
-                                                &isfb_check_count));
-      // The previous function returns `kErrorOwnershipISFBFailed` if the strike
-      // check or product expression check fails. The following check is to
-      // detect any faults.
-      HARDENED_CHECK_EQ(isfb_check_count, isfb_expected_count_get(ext_isfb));
-    } else {
-      HARDENED_CHECK_NE(error, kErrorOk);
-    }
-  }
-
-  // This is given that we are expected to perform redundant checks on
-  // `flash_exec` and `isfb_check_count`. This is also the reason why don't use
-  // `HARDENED_RETURN_IF_ERROR` in the `owner_verify` and `isfb_boot_request`
-  // calls.
-  return kErrorOk;
 }
 
 /**
@@ -474,159 +390,6 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
 }
 
 OT_WARN_UNUSED_RESULT
-static rom_error_t boot_svc_next_boot_bl0_slot_handler(
-    boot_svc_msg_t *boot_svc_msg, boot_data_t *boot_data,
-    boot_log_t *boot_log) {
-  uint32_t active_slot = boot_data->primary_bl0_slot;
-  uint32_t primary_slot = boot_svc_msg->next_boot_bl0_slot_req.primary_bl0_slot;
-  rom_error_t error = kErrorOk;
-
-  // If the requested primary slot is the same as the active slot, this request
-  // is a no-op.
-  if (active_slot != primary_slot) {
-    switch (primary_slot) {
-      case kBootSlotA:
-      case kBootSlotB:
-        boot_data->primary_bl0_slot = primary_slot;
-        // Write boot data, updating relevant fields and recomputing the digest.
-        HARDENED_RETURN_IF_ERROR(boot_data_write(boot_data));
-        // Read the boot data back to ensure the correct slot is booted this
-        // time.
-        HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, boot_data));
-        // Update the boot log.
-        boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
-        break;
-      case kBootSlotUnspecified:
-        // Do nothing.
-        break;
-      default:
-        error = kErrorBootSvcBadSlot;
-    }
-  }
-
-  // Record the new primary slot for use in the response message.
-  active_slot = boot_data->primary_bl0_slot;
-
-  uint32_t next_slot = boot_svc_msg->next_boot_bl0_slot_req.next_bl0_slot;
-  switch (launder32(next_slot)) {
-    case kBootSlotA:
-    case kBootSlotB:
-      // We overwrite the RAM copy of the primary slot to the requested next
-      // slot. This will cause a one-time boot of the requested side.
-      boot_data->primary_bl0_slot = next_slot;
-      break;
-    case kBootSlotUnspecified:
-      // Do nothing.
-      break;
-    default:
-      error = kErrorBootSvcBadSlot;
-  }
-
-  boot_svc_next_boot_bl0_slot_res_init(error, active_slot,
-                                       &boot_svc_msg->next_boot_bl0_slot_res);
-  // We always return OK here because we've logged any error status in the boot
-  // services response message and we want the boot flow to continue.
-  return kErrorOk;
-}
-
-OT_WARN_UNUSED_RESULT
-static rom_error_t boot_svc_min_sec_ver_handler(boot_svc_msg_t *boot_svc_msg,
-                                                boot_data_t *boot_data) {
-  const uint32_t current_min_sec_ver = boot_data->min_security_version_bl0;
-  const uint32_t requested_min_sec_ver =
-      boot_svc_msg->next_boot_bl0_slot_req.next_bl0_slot;
-
-  // Ensure the requested minimum security version isn't lower than the current
-  // minimum security version.
-  if (launder32(requested_min_sec_ver) > current_min_sec_ver) {
-    HARDENED_CHECK_GT(requested_min_sec_ver, current_min_sec_ver);
-    uint32_t max_sec_ver = current_min_sec_ver;
-
-    // Check the two flash slots for valid manifests and determine the maximum
-    // value of the new minimum_security_version.  This prevents a malicious
-    // MinBl0SecVer request from making the chip un-bootable.
-    const manifest_t *manifest = rom_ext_boot_policy_manifest_a_get();
-    uint32_t flash_exec = 0;
-    rom_error_t error = rom_ext_verify(manifest, boot_data, &flash_exec);
-    if (error == kErrorOk && manifest->security_version > max_sec_ver) {
-      max_sec_ver = manifest->security_version;
-    }
-    manifest = rom_ext_boot_policy_manifest_b_get();
-    error = rom_ext_verify(manifest, boot_data, &flash_exec);
-    if (error == kErrorOk && manifest->security_version > max_sec_ver) {
-      max_sec_ver = manifest->security_version;
-    }
-
-    if (requested_min_sec_ver <= max_sec_ver) {
-      HARDENED_CHECK_LE(requested_min_sec_ver, max_sec_ver);
-      // Update boot data to the requested minimum BL0 security version.
-      boot_data->min_security_version_bl0 = requested_min_sec_ver;
-
-      // Write boot data, updating relevant fields and recomputing the digest.
-      HARDENED_RETURN_IF_ERROR(boot_data_write(boot_data));
-      // Read the boot data back to ensure the correct policy is used this boot.
-      HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, boot_data));
-
-      boot_svc_min_bl0_sec_ver_res_init(boot_data->min_security_version_bl0,
-                                        kErrorOk,
-                                        &boot_svc_msg->min_bl0_sec_ver_res);
-
-      HARDENED_CHECK_EQ(requested_min_sec_ver,
-                        boot_data->min_security_version_bl0);
-      return kErrorOk;
-    }
-  }
-  boot_svc_min_bl0_sec_ver_res_init(current_min_sec_ver, kErrorBootSvcBadSecVer,
-                                    &boot_svc_msg->min_bl0_sec_ver_res);
-  return kErrorOk;
-}
-
-OT_WARN_UNUSED_RESULT
-static rom_error_t handle_boot_svc(boot_data_t *boot_data,
-                                   boot_log_t *boot_log) {
-  boot_svc_msg_t *boot_svc_msg = &retention_sram_get()->creator.boot_svc_msg;
-  // TODO(lowRISC#22387): Examine the boot_svc code paths for boot loops.
-  if (boot_svc_msg->header.identifier == kBootSvcIdentifier) {
-    HARDENED_RETURN_IF_ERROR(boot_svc_header_check(&boot_svc_msg->header));
-    uint32_t msg_type = boot_svc_msg->header.type;
-    switch (launder32(msg_type)) {
-      case kBootSvcEmptyReqType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcEmptyReqType);
-        boot_svc_empty_res_init(&boot_svc_msg->empty);
-        break;
-      case kBootSvcEnterRescueReqType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcEnterRescueReqType);
-        return rescue_enter_handler(boot_svc_msg);
-      case kBootSvcNextBl0SlotReqType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcNextBl0SlotReqType);
-        return boot_svc_next_boot_bl0_slot_handler(boot_svc_msg, boot_data,
-                                                   boot_log);
-      case kBootSvcMinBl0SecVerReqType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcMinBl0SecVerReqType);
-        return boot_svc_min_sec_ver_handler(boot_svc_msg, boot_data);
-      case kBootSvcOwnershipUnlockReqType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipUnlockReqType);
-        return ownership_unlock_handler(boot_svc_msg, boot_data);
-      case kBootSvcOwnershipActivateReqType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipActivateReqType);
-        return ownership_activate_handler(boot_svc_msg, boot_data);
-      case kBootSvcEmptyResType:
-      case kBootSvcEnterRescueResType:
-      case kBootSvcNextBl0SlotResType:
-      case kBootSvcMinBl0SecVerResType:
-      case kBootSvcOwnershipUnlockResType:
-      case kBootSvcOwnershipActivateResType:
-        // For response messages left in ret-ram we do nothing.
-        break;
-      default:
-          // For messages with an unknown msg_type, we do nothing.
-          ;
-    }
-  }
-  return kErrorOk;
-}
-
-OT_WARN_UNUSED_RESULT
 static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
                                           boot_log_t *boot_log) {
   rom_ext_boot_policy_manifests_t manifests =
@@ -635,7 +398,9 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data,
   rom_error_t slot[2] = {0, 0};
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
     uint32_t flash_exec = 0;
-    error = rom_ext_verify(manifests.ordered[i], boot_data, &flash_exec);
+    error =
+        rom_ext_verify(manifests.ordered[i], boot_data, &flash_exec, &keyring,
+                       &verify_key, &owner_config, &isfb_check_count);
     slot[i] = error;
     if (error != kErrorOk) {
       continue;
@@ -801,7 +566,10 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 
   // We don't want to execute boot_svc requests if this is a low-power wakeup.
   if (waking_from_low_power != kHardenedBoolTrue) {
-    error = handle_boot_svc(boot_data, boot_log);
+    boot_svc_msg_t *boot_svc_msg = &retention_sram_get()->creator.boot_svc_msg;
+    error =
+        boot_svc_handler(boot_svc_msg, boot_data, boot_log, lc_state, &keyring,
+                         &verify_key, &owner_config, &isfb_check_count);
     if (error == kErrorWriteBootdataThenReboot) {
       // Boot services reports errors by writing a status code into the reply
       // messages.  Regardless of whether a boot service request produced an

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.c
@@ -1,0 +1,181 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_ext/rom_ext_boot_services.h"
+
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership_activate.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership_unlock.h"
+#include "sw/device/silicon_creator/lib/rescue/rescue.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
+
+OT_WARN_UNUSED_RESULT
+static rom_error_t boot_svc_next_boot_bl0_slot_handler(
+    boot_svc_msg_t *boot_svc_msg, boot_data_t *boot_data, boot_log_t *boot_log,
+    lifecycle_state_t lc_state) {
+  uint32_t active_slot = boot_data->primary_bl0_slot;
+  uint32_t primary_slot = boot_svc_msg->next_boot_bl0_slot_req.primary_bl0_slot;
+  rom_error_t error = kErrorOk;
+
+  // If the requested primary slot is the same as the active slot, this request
+  // is a no-op.
+  if (active_slot != primary_slot) {
+    switch (primary_slot) {
+      case kBootSlotA:
+      case kBootSlotB:
+        boot_data->primary_bl0_slot = primary_slot;
+        // Write boot data, updating relevant fields and recomputing the digest.
+        HARDENED_RETURN_IF_ERROR(boot_data_write(boot_data));
+        // Read the boot data back to ensure the correct slot is booted this
+        // time.
+        HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, boot_data));
+        // Update the boot log.
+        boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
+        break;
+      case kBootSlotUnspecified:
+        // Do nothing.
+        break;
+      default:
+        error = kErrorBootSvcBadSlot;
+    }
+  }
+
+  // Record the new primary slot for use in the response message.
+  active_slot = boot_data->primary_bl0_slot;
+
+  uint32_t next_slot = boot_svc_msg->next_boot_bl0_slot_req.next_bl0_slot;
+  switch (launder32(next_slot)) {
+    case kBootSlotA:
+    case kBootSlotB:
+      // We overwrite the RAM copy of the primary slot to the requested next
+      // slot. This will cause a one-time boot of the requested side.
+      boot_data->primary_bl0_slot = next_slot;
+      break;
+    case kBootSlotUnspecified:
+      // Do nothing.
+      break;
+    default:
+      error = kErrorBootSvcBadSlot;
+  }
+
+  boot_svc_next_boot_bl0_slot_res_init(error, active_slot,
+                                       &boot_svc_msg->next_boot_bl0_slot_res);
+  // We always return OK here because we've logged any error status in the boot
+  // services response message and we want the boot flow to continue.
+  return kErrorOk;
+}
+
+OT_WARN_UNUSED_RESULT
+static rom_error_t boot_svc_min_sec_ver_handler(
+    boot_svc_msg_t *boot_svc_msg, boot_data_t *boot_data,
+    lifecycle_state_t lc_state, owner_application_keyring_t *keyring,
+    size_t *verify_key, owner_config_t *owner_config,
+    uint32_t *isfb_check_count) {
+  const uint32_t current_min_sec_ver = boot_data->min_security_version_bl0;
+  const uint32_t requested_min_sec_ver =
+      boot_svc_msg->next_boot_bl0_slot_req.next_bl0_slot;
+
+  // Ensure the requested minimum security version isn't lower than the current
+  // minimum security version.
+  if (launder32(requested_min_sec_ver) > current_min_sec_ver) {
+    HARDENED_CHECK_GT(requested_min_sec_ver, current_min_sec_ver);
+    uint32_t max_sec_ver = current_min_sec_ver;
+
+    // Check the two flash slots for valid manifests and determine the maximum
+    // value of the new minimum_security_version.  This prevents a malicious
+    // MinBl0SecVer request from making the chip un-bootable.
+    const manifest_t *manifest = rom_ext_boot_policy_manifest_a_get();
+    uint32_t flash_exec = 0;
+    rom_error_t error =
+        rom_ext_verify(manifest, boot_data, &flash_exec, keyring, verify_key,
+                       owner_config, isfb_check_count);
+    if (error == kErrorOk && manifest->security_version > max_sec_ver) {
+      max_sec_ver = manifest->security_version;
+    }
+    manifest = rom_ext_boot_policy_manifest_b_get();
+    error = rom_ext_verify(manifest, boot_data, &flash_exec, keyring,
+                           verify_key, owner_config, isfb_check_count);
+    if (error == kErrorOk && manifest->security_version > max_sec_ver) {
+      max_sec_ver = manifest->security_version;
+    }
+
+    if (requested_min_sec_ver <= max_sec_ver) {
+      HARDENED_CHECK_LE(requested_min_sec_ver, max_sec_ver);
+      // Update boot data to the requested minimum BL0 security version.
+      boot_data->min_security_version_bl0 = requested_min_sec_ver;
+
+      // Write boot data, updating relevant fields and recomputing the digest.
+      HARDENED_RETURN_IF_ERROR(boot_data_write(boot_data));
+      // Read the boot data back to ensure the correct policy is used this boot.
+      HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, boot_data));
+
+      boot_svc_min_bl0_sec_ver_res_init(boot_data->min_security_version_bl0,
+                                        kErrorOk,
+                                        &boot_svc_msg->min_bl0_sec_ver_res);
+
+      HARDENED_CHECK_EQ(requested_min_sec_ver,
+                        boot_data->min_security_version_bl0);
+      return kErrorOk;
+    }
+  }
+  boot_svc_min_bl0_sec_ver_res_init(current_min_sec_ver, kErrorBootSvcBadSecVer,
+                                    &boot_svc_msg->min_bl0_sec_ver_res);
+  return kErrorOk;
+}
+
+OT_WARN_UNUSED_RESULT
+rom_error_t boot_svc_handler(boot_svc_msg_t *boot_svc_msg,
+                             boot_data_t *boot_data, boot_log_t *boot_log,
+                             lifecycle_state_t lc_state,
+                             owner_application_keyring_t *keyring,
+                             size_t *verify_key, owner_config_t *owner_config,
+                             uint32_t *isfb_check_count) {
+  // TODO(lowRISC#22387): Examine the boot_svc code paths for boot loops.
+  if (boot_svc_msg->header.identifier == kBootSvcIdentifier) {
+    HARDENED_RETURN_IF_ERROR(boot_svc_header_check(&boot_svc_msg->header));
+    uint32_t msg_type = boot_svc_msg->header.type;
+    switch (launder32(msg_type)) {
+      case kBootSvcEmptyReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcEmptyReqType);
+        boot_svc_empty_res_init(&boot_svc_msg->empty);
+        break;
+      case kBootSvcEnterRescueReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcEnterRescueReqType);
+        return rescue_enter_handler(boot_svc_msg);
+      case kBootSvcNextBl0SlotReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcNextBl0SlotReqType);
+        return boot_svc_next_boot_bl0_slot_handler(boot_svc_msg, boot_data,
+                                                   boot_log, lc_state);
+      case kBootSvcMinBl0SecVerReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcMinBl0SecVerReqType);
+        return boot_svc_min_sec_ver_handler(boot_svc_msg, boot_data, lc_state,
+                                            keyring, verify_key, owner_config,
+                                            isfb_check_count);
+      case kBootSvcOwnershipUnlockReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipUnlockReqType);
+        return ownership_unlock_handler(boot_svc_msg, boot_data);
+      case kBootSvcOwnershipActivateReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipActivateReqType);
+        return ownership_activate_handler(boot_svc_msg, boot_data);
+      case kBootSvcEmptyResType:
+      case kBootSvcEnterRescueResType:
+      case kBootSvcNextBl0SlotResType:
+      case kBootSvcMinBl0SecVerResType:
+      case kBootSvcOwnershipUnlockResType:
+      case kBootSvcOwnershipActivateResType:
+        // For response messages left in ret-ram we do nothing.
+        break;
+      default:
+          // For messages with an unknown msg_type, we do nothing.
+          ;
+    }
+  }
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services.h
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_SERVICES_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_SERVICES_H_
+
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_verify.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+OT_WARN_UNUSED_RESULT
+rom_error_t boot_svc_handler(boot_svc_msg_t *boot_svc_msg,
+                             boot_data_t *boot_data, boot_log_t *boot_log,
+                             lifecycle_state_t lc_state,
+                             owner_application_keyring_t *keyring,
+                             size_t *verify_key, owner_config_t *owner_config,
+                             uint32_t *isfb_check_count);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_SERVICES_H_

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -1,0 +1,262 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_ext/rom_ext_boot_services.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
+#include "sw/device/silicon_creator/lib/mock_boot_data.h"
+#include "sw/device/silicon_creator/lib/mock_manifest.h"
+#include "sw/device/silicon_creator/lib/ownership/mock_owner_verify.h"
+#include "sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace boot_services_unittest {
+namespace {
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::DoAll;
+using ::testing::Each;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+class RomExtBootServicesTest : public rom_test::RomTest {
+ protected:
+  boot_svc_msg_t boot_svc_msg{};
+  boot_data_t boot_data{};
+  boot_log_t boot_log{};
+  lifecycle_state_t lc_state{};
+  owner_application_keyring_t keyring{};
+  size_t verify_key;
+  owner_config_t owner_config{};
+  uint32_t isfb_check_count;
+
+  rom_test::MockHmac mock_hmac_;
+  rom_test::MockRomExtBootPolicyPtrs rom_ext_boot_policy_ptrs_;
+  rom_test::MockManifest mock_manifest_;
+  rom_test::MockBootData mock_boot_data_;
+  rom_test::MockRnd mock_rnd_;
+  rom_test::MockLifecycle mock_lifecycle_;
+  rom_test::MockOtp mock_otp_;
+  rom_test::MockOwnerVerify mock_owner_verify_;
+};
+
+TEST_F(RomExtBootServicesTest, BootSvcDefault) {
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.header.type, 0);
+}
+
+TEST_F(RomExtBootServicesTest, BootSvcEmpty) {
+  boot_svc_msg.header.identifier = kBootSvcIdentifier;
+  boot_svc_msg.header.type = kBootSvcEmptyReqType;
+  boot_svc_msg.header.length = sizeof(boot_svc_empty_t);
+  boot_svc_msg.header.digest = hmac_digest_t{0x1234};
+
+  EXPECT_CALL(mock_hmac_, sha256)
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+
+  EXPECT_CALL(mock_hmac_, sha256)
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.empty.header.identifier, kBootSvcIdentifier);
+  EXPECT_EQ(boot_svc_msg.empty.header.type, kBootSvcEmptyResType);
+
+  EXPECT_THAT(boot_svc_msg.empty.payload, Each(0));
+}
+
+TEST_F(RomExtBootServicesTest, BootSvcEnterRescue) {
+  boot_svc_msg.header.type = kBootSvcEnterRescueReqType;
+
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.enter_rescue_res.status, kErrorOk);
+}
+
+TEST_F(RomExtBootServicesTest, BootSvcNextBl0Slot) {
+  boot_svc_msg.header.identifier = kBootSvcIdentifier;
+  boot_svc_msg.header.type = kBootSvcNextBl0SlotReqType;
+  boot_svc_msg.header.length = sizeof(boot_svc_next_boot_bl0_slot_req_t);
+  boot_svc_msg.header.digest = hmac_digest_t{0x1234};
+
+  boot_svc_msg.next_boot_bl0_slot_req.primary_bl0_slot = kBootSlotA;
+
+  boot_svc_msg.next_boot_bl0_slot_req.next_bl0_slot = kBootSlotB;
+
+  boot_data.primary_bl0_slot = kBootSlotB;
+
+  EXPECT_CALL(mock_hmac_, sha256)
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+
+  EXPECT_CALL(mock_boot_data_, Write).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(mock_boot_data_, Read).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(mock_hmac_, sha256)
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.next_boot_bl0_slot_res.header.identifier,
+            kBootSvcIdentifier);
+  EXPECT_EQ(boot_svc_msg.next_boot_bl0_slot_res.header.type,
+            kBootSvcNextBl0SlotResType);
+
+  EXPECT_EQ(boot_svc_msg.next_boot_bl0_slot_res.status, kErrorOk);
+}
+
+TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVer) {
+  boot_svc_msg.header.identifier = kBootSvcIdentifier;
+  boot_svc_msg.header.type = kBootSvcMinBl0SecVerReqType;
+  boot_svc_msg.header.length = sizeof(boot_svc_next_boot_bl0_slot_req_t);
+  boot_svc_msg.header.digest = hmac_digest_t{0x1234};
+
+  boot_svc_msg.next_boot_bl0_slot_req.next_bl0_slot = 2;
+
+  boot_data.min_security_version_bl0 = 1;
+
+  owner_config.isfb = (owner_isfb_config_t *)kHardenedBoolFalse;
+
+  owner_application_key_t key = {
+      .header =
+          {
+              .tag = kTlvTagApplicationKey,
+              .length = sizeof(owner_application_key_t),
+          },
+      .key_alg = kOwnershipKeyAlgEcdsaP256,
+  };
+
+  keyring.length = 1;
+  keyring.key[0] = &key;
+
+  manifest_ext_spx_key_t spx_key = {.key{.data = {0}}};
+
+  manifest_t manifest_a{};
+  manifest_t manifest_b{};
+
+  manifest_a.identifier = CHIP_BL0_IDENTIFIER;
+  manifest_a.length = CHIP_BL0_SIZE_MIN;
+  manifest_a.security_version = 2;
+  manifest_a.manifest_version.major = kManifestVersionMajor2;
+  manifest_a.length = sizeof(manifest_t) + 0x1000;
+  manifest_a.signed_region_end = sizeof(manifest_t) + 0x900;
+  manifest_a.code_start = sizeof(manifest_t);
+  manifest_a.code_end = sizeof(manifest_t) + 0x800;
+  manifest_a.entry_point = 0x500;
+  manifest_a.ecdsa_public_key.x[0] = 0;
+
+  manifest_b.identifier = CHIP_BL0_IDENTIFIER;
+  manifest_b.length = CHIP_BL0_SIZE_MIN;
+  manifest_b.security_version = 3;
+  manifest_b.manifest_version.major = kManifestVersionMajor2;
+  manifest_b.length = sizeof(manifest_t) + 0x1000;
+  manifest_b.signed_region_end = sizeof(manifest_t) + 0x900;
+  manifest_b.code_start = sizeof(manifest_t);
+  manifest_b.code_end = sizeof(manifest_t) + 0x800;
+  manifest_b.entry_point = 0x500;
+  manifest_b.ecdsa_public_key.x[0] = 0;
+
+  EXPECT_CALL(mock_hmac_, sha256)
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA)
+      .WillOnce(Return(&manifest_a));
+  EXPECT_CALL(mock_manifest_, SpxKey)
+      .WillOnce(DoAll(SetArgPointee<1>(&spx_key), Return(kErrorOk)));
+  EXPECT_CALL(mock_manifest_, SpxSignature).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(mock_rnd_, Uint32);
+  EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_lifecycle_, DeviceId);
+  EXPECT_CALL(mock_otp_, read32);
+  EXPECT_CALL(mock_otp_, read32);
+  EXPECT_CALL(mock_lifecycle_, State);
+  EXPECT_CALL(mock_hmac_, sha256_update);
+  EXPECT_CALL(mock_manifest_, DigestRegion);
+  EXPECT_CALL(mock_hmac_, sha256_update);
+  EXPECT_CALL(mock_hmac_, sha256_process);
+  EXPECT_CALL(mock_hmac_, sha256_final);
+
+  EXPECT_CALL(mock_owner_verify_, verify).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB)
+      .WillOnce(Return(&manifest_b));
+  EXPECT_CALL(mock_manifest_, SpxKey)
+      .WillOnce(DoAll(SetArgPointee<1>(&spx_key), Return(kErrorOk)));
+  EXPECT_CALL(mock_manifest_, SpxSignature).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(mock_rnd_, Uint32);
+  EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_lifecycle_, DeviceId);
+  EXPECT_CALL(mock_otp_, read32);
+  EXPECT_CALL(mock_otp_, read32);
+  EXPECT_CALL(mock_lifecycle_, State);
+  EXPECT_CALL(mock_hmac_, sha256_update);
+  EXPECT_CALL(mock_manifest_, DigestRegion);
+  EXPECT_CALL(mock_hmac_, sha256_update);
+  EXPECT_CALL(mock_hmac_, sha256_process);
+  EXPECT_CALL(mock_hmac_, sha256_final);
+
+  EXPECT_CALL(mock_owner_verify_, verify).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(mock_boot_data_, Write).WillOnce(Return(kErrorOk));
+  EXPECT_CALL(mock_boot_data_, Read).WillOnce(Return(kErrorOk));
+
+  EXPECT_CALL(mock_hmac_, sha256)
+      .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
+
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.min_bl0_sec_ver_res.header.identifier,
+            kBootSvcIdentifier);
+  EXPECT_EQ(boot_svc_msg.min_bl0_sec_ver_res.header.type,
+            kBootSvcMinBl0SecVerResType);
+
+  EXPECT_EQ(boot_svc_msg.min_bl0_sec_ver_res.status, kErrorOk);
+}
+
+TEST_F(RomExtBootServicesTest, BootSvcOwnershipUnlock) {
+  boot_svc_msg.header.type = kBootSvcOwnershipUnlockReqType;
+
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.ownership_unlock_res.status, kErrorOk);
+}
+
+TEST_F(RomExtBootServicesTest, BootSvcOwnershipActivate) {
+  boot_svc_msg.header.type = kBootSvcOwnershipActivateReqType;
+
+  EXPECT_EQ(
+      boot_svc_handler(&boot_svc_msg, &boot_data, &boot_log, lc_state, &keyring,
+                      &verify_key, &owner_config, &isfb_check_count),
+      kErrorOk);
+
+  EXPECT_EQ(boot_svc_msg.ownership_activate_res.status, kErrorOk);
+}
+
+}  // namespace
+}  // namespace boot_services_unittest

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.c
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_ext/rom_ext_verify.h"
+
+#include <string.h>
+
+#include "sw/device/silicon_creator/lib/base/boot_measurements.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+#include "sw/device/silicon_creator/lib/ownership/isfb.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_verify.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/lib/sigverify/usage_constraints.h"
+#include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
+
+OT_WARN_UNUSED_RESULT
+rom_error_t rom_ext_verify(const manifest_t *manifest,
+                           const boot_data_t *boot_data, uint32_t *flash_exec,
+                           owner_application_keyring_t *keyring,
+                           size_t *verify_key, owner_config_t *owner_config,
+                           uint32_t *isfb_check_count) {
+  RETURN_IF_ERROR(rom_ext_boot_policy_manifest_check(manifest, boot_data));
+
+  uint32_t key_id =
+      sigverify_ecdsa_p256_key_id_get(&manifest->ecdsa_public_key);
+  // Check if there is an SPX+ key.
+  const manifest_ext_spx_key_t *ext_spx_key;
+  const manifest_ext_spx_signature_t *ext_spx_signature;
+  rom_error_t spx_err = manifest_ext_get_spx_key(manifest, &ext_spx_key);
+  spx_err += manifest_ext_get_spx_signature(manifest, &ext_spx_signature);
+  switch ((uint32_t)spx_err) {
+    case kErrorOk * 2:
+      // Both extensions present: valid SPX+ signature.
+      key_id ^= sigverify_spx_key_id_get(&ext_spx_key->key);
+      break;
+    case kErrorManifestBadExtension * 2:
+      // Both extensions absent: ECDSA only.
+      break;
+    default:
+      // One present, one absent: bad configuration.
+      return kErrorManifestBadExtension;
+  }
+
+  RETURN_IF_ERROR(owner_keyring_find_key(keyring, key_id, verify_key));
+  uint32_t key_alg = keyring->key[*verify_key]->key_alg;
+
+  dbg_printf("verify: key%u;%C;%C\r\n", (uint32_t)*verify_key, key_alg,
+             keyring->key[*verify_key]->key_domain);
+
+  memset(boot_measurements.bl0.data, (int)rnd_uint32(),
+         sizeof(boot_measurements.bl0.data));
+
+  hmac_sha256_init();
+  // Hash usage constraints.
+  manifest_usage_constraints_t usage_constraints_from_hw;
+  sigverify_usage_constraints_get(
+      manifest->usage_constraints.selector_bits |
+          keyring->key[*verify_key]->usage_constraint,
+      &usage_constraints_from_hw);
+  hmac_sha256_update(&usage_constraints_from_hw,
+                     sizeof(usage_constraints_from_hw));
+  // Hash the remaining part of the image.
+  manifest_digest_region_t digest_region = manifest_digest_region_get(manifest);
+  hmac_sha256_update(digest_region.start, digest_region.length);
+  // TODO(#19596): add owner configuration block to measurement.
+  // Verify signature
+  hmac_sha256_process();
+  hmac_digest_t act_digest;
+  hmac_sha256_final(&act_digest);
+
+  static_assert(sizeof(boot_measurements.bl0) == sizeof(act_digest),
+                "Unexpected BL0 digest size.");
+  memcpy(&boot_measurements.bl0, &act_digest, sizeof(boot_measurements.bl0));
+
+  RETURN_IF_ERROR(owner_verify(
+      key_alg, &keyring->key[*verify_key]->data, &manifest->ecdsa_signature,
+      &ext_spx_signature->signature, &usage_constraints_from_hw,
+      sizeof(usage_constraints_from_hw), NULL, 0, digest_region.start,
+      digest_region.length, &act_digest, flash_exec));
+
+  // Perform ISFB checks if the extension is present.
+  if ((hardened_bool_t)owner_config->isfb != kHardenedBoolFalse) {
+    const manifest_ext_isfb_t *ext_isfb;
+    rom_error_t error = manifest_ext_get_isfb(manifest, &ext_isfb);
+    if (error == kErrorOk) {
+      *isfb_check_count = kHardenedBoolFalse;
+      RETURN_IF_ERROR(
+          isfb_boot_request_process(ext_isfb, owner_config, isfb_check_count));
+      // The previous function returns `kErrorOwnershipISFBFailed` if the strike
+      // check or product expression check fails. The following check is to
+      // detect any faults.
+      HARDENED_CHECK_EQ(*isfb_check_count, isfb_expected_count_get(ext_isfb));
+    } else {
+      HARDENED_CHECK_NE(error, kErrorOk);
+    }
+  }
+
+  // This is given that we are expected to perform redundant checks on
+  // `flash_exec` and `isfb_check_count`. This is also the reason why don't use
+  // `HARDENED_RETURN_IF_ERROR` in the `owner_verify` and `isfb_boot_request`
+  // calls.
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_verify.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_verify.h
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_VERIFY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_VERIFY_H_
+
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+OT_WARN_UNUSED_RESULT
+rom_error_t rom_ext_verify(const manifest_t *manifest,
+                           const boot_data_t *boot_data, uint32_t *flash_exec,
+                           owner_application_keyring_t *keyring,
+                           size_t *verify_key, owner_config_t *owner_config,
+                           uint32_t *isfb_check_count);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_VERIFY_H_


### PR DESCRIPTION
These changes refactor the `handle_boot_svc` method and several related methods out of `rom_ext.c` into separate libraries - `rom_ext_boot_services.c` and `rom_ext_verify.c`. This enables standalone unit tests to be written for boot services (and shortly, fuzzing for boot services).

Unit tests were added for each action handled in `handle_boot_svc`. Mocks and conditional compilation were added where necessary to support on-host tests for `rom_ext`.