### PR TITLE
[bazel] fix/add patches to enable downstream builds

### DIFF
--- a/third_party/rust/patches/rules_rust.experimental.patch
+++ b/third_party/rust/patches/rules_rust.experimental.patch
@@ -1,0 +1,15 @@
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+--- rust/private/rustc.bzl
++++ rust/private/rustc.bzl
+@@ -1518,11 +1518,6 @@ def rustc_compile_action(
+         "source_attributes": ["srcs"],
+     }
+ 
+-    if experimental_use_coverage_metadata_files:
+-        instrumented_files_kwargs.update({
+-            "metadata_files": coverage_runfiles + [executable] if executable else [],
+-        })
+-
+     providers = [
+         DefaultInfo(
+             # nb. This field is required for cc_library to depend on our output.

--- a/third_party/rust/patches/rules_rust.transition.patch
+++ b/third_party/rust/patches/rules_rust.transition.patch
@@ -1,0 +1,13 @@
+diff --git a/extensions/bindgen/private/llvm_utils.bzl b/extensions/bindgen/private/llvm_utils.bzl
+--- private/llvm_utils.bzl
++++ private/llvm_utils.bzl
+@@ -42,6 +42,9 @@ _COMMON_ATTRS = {
+         doc = "The target to transition.",
+         mandatory = True,
+     ),
++    "_allowlist_function_transition": attr.label(
++        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
++    ),
+ }
+ 
+ def _cc_stdcc17_transitioned_target_impl(ctx):

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -97,7 +97,10 @@ def rust_repos(rules_rust = None, serde_annotate = None, rules_rust_bindgen = No
         local = rules_rust,
         integrity = "sha256-CeF7R8AVBGVjGqMZ8nQnYKQ+3tqy6cAS+R0K4u/wImg=",
         urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.59.2/rules_rust-0.59.2.tar.gz"],
-        patches = ["//third_party/rust/patches:rules_rust.extra_rustc_toolchain_dirs.patch"],
+        patches = [
+            "@lowrisc_opentitan//third_party/rust/patches:rules_rust.extra_rustc_toolchain_dirs.patch",
+            "@lowrisc_opentitan//third_party/rust/patches:rules_rust.experimental.patch",
+        ],
     )
 
     http_archive_or_local(
@@ -106,7 +109,10 @@ def rust_repos(rules_rust = None, serde_annotate = None, rules_rust_bindgen = No
         integrity = "sha256-CeF7R8AVBGVjGqMZ8nQnYKQ+3tqy6cAS+R0K4u/wImg=",
         strip_prefix = "extensions/bindgen",
         urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.59.2/rules_rust-0.59.2.tar.gz"],
-        patches = ["//third_party/rust/patches:rules_rust.bindgen_static_lib.patch"],
+        patches = [
+            "@lowrisc_opentitan//third_party/rust/patches:rules_rust.bindgen_static_lib.patch",
+            "@lowrisc_opentitan//third_party/rust/patches:rules_rust.transition.patch",
+        ],
     )
 
     http_archive_or_local(


### PR DESCRIPTION
The opentitan-provisioning loads this repo as a bazel dependency to build opentitanlib. Minor updates to rules rust in this repo broke builds downstream. This should fix them.