### PR TITLE
[sram_ctrl] Increase width of LFSR used for initialization to 64 bits 

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -64,13 +64,13 @@
     { name:      "RndCnstLfsrSeed",
       desc:      "Compile-time random bits for initial LFSR seed",
       type:      "sram_ctrl_pkg::lfsr_seed_t"
-      randcount: "32",
+      randcount: "64",
       randtype:  "data", // randomize randcount databits
     }
     { name:      "RndCnstLfsrPerm",
       desc:      "Compile-time random permutation for LFSR output",
       type:      "sram_ctrl_pkg::lfsr_perm_t"
-      randcount: "32",
+      randcount: "64",
       randtype:  "perm", // random permutation for randcount elements
     }
     // This parameter is overridden by topgen to set the actual RAM size.

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -172,9 +172,9 @@ module sram_ctrl
   logic [otp_ctrl_pkg::SramNonceWidth-1:0] nonce_d, nonce_q;
 
   // tie-off unused nonce bits
-  if (otp_ctrl_pkg::SramNonceWidth > NonceWidth) begin : gen_nonce_tieoff
+  if (otp_ctrl_pkg::SramNonceWidth > LfsrWidth + NonceWidth) begin : gen_nonce_tieoff
     logic unused_nonce;
-    assign unused_nonce = ^nonce_q[otp_ctrl_pkg::SramNonceWidth-1:NonceWidth];
+    assign unused_nonce = ^nonce_q[otp_ctrl_pkg::SramNonceWidth-1:LfsrWidth + NonceWidth];
   end
 
   //////////////////

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -451,11 +451,11 @@ module sram_ctrl
   // Initialization LFSR //
   /////////////////////////
 
-  logic [LfsrWidth-1:0] lfsr_out;
+  logic [LfsrOutWidth-1:0] lfsr_out;
   prim_lfsr #(
     .LfsrDw      ( LfsrWidth       ),
     .EntropyDw   ( LfsrWidth       ),
-    .StateOutDw  ( LfsrWidth       ),
+    .StateOutDw  ( LfsrOutWidth    ),
     .DefaultSeed ( RndCnstLfsrSeed ),
     .StatePermEn ( 1'b1            ),
     .StatePerm   ( RndCnstLfsrPerm )

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
@@ -23,14 +23,19 @@ package sram_ctrl_pkg;
       128'h22f296f8f95efb84a75cd435a5541e9f;
 
   // These LFSR parameters have been generated with
-  // $ ./util/design/gen-lfsr-seed.py --width 32 --seed 3296833456 --prefix ""
-  parameter int LfsrWidth = 32;
+  // $ ./util/design/gen-lfsr-seed.py --width 64 --seed 3296833456 --prefix ""
+  parameter int LfsrWidth = 64;
   typedef logic [LfsrWidth-1:0] lfsr_seed_t;
   typedef logic [LfsrWidth-1:0][$clog2(LfsrWidth)-1:0] lfsr_perm_t;
-  parameter lfsr_seed_t RndCnstLfsrSeedDefault = 32'h10a81ea5;
+  parameter lfsr_seed_t RndCnstLfsrSeedDefault = 64'hb496209a_10a81ea5;
   parameter lfsr_perm_t RndCnstLfsrPermDefault = {
-    160'h438131ae2cb71ffdd2e4c29a1f412231747cd7b2
+    128'hf7963515_f8af8e60_fbfec4c0_f1edd9e2,
+    256'h41e1c6d4_273d5046_2da7165d_1c1db882_693146c2_a33aa048_43762bed_0ecabea5
   };
+
+  // The LFSR has an internal state width of 64 bits but we just use the lowest 32 bits of the
+  // permuted state for initializing the RAM.
+  parameter int LfsrOutWidth = 32;
 
   //////////////////////
   // Type definitions //

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -1204,7 +1204,7 @@
           randcount: 40
           randtype: data
           name_top: RndCnstOtpCtrlLfsrSeed
-          default: 0x4b9fbde86f
+          default: 0x58fa9063ce
           randwidth: 40
         }
         {
@@ -1214,7 +1214,7 @@
           randcount: 40
           randtype: perm
           name_top: RndCnstOtpCtrlLfsrPerm
-          default: 0x6736539341470210f61f55284b59a44a0c81dd91b0062628d79a014c799
+          default: 0x2dd6809079e67935a195848e7ca5065c47018d980335588c44f1494026c8
           randwidth: 240
         }
         {
@@ -1224,7 +1224,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtpCtrlScrmblKeyInit
-          default: 0xe8f2f8be62fe9d2d4204b2f54be875ae480277680cba442baa3acb9c2a3f40a5
+          default: 0xe34f64ce978305bfc3481a2162ea2792b7508f1eab067af954dda5491439a9dd
           randwidth: 256
         }
       ]
@@ -1809,7 +1809,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0xe816a506c2ab1f4a2f01cbe908a34c2a
+          default: 0xe6320801fdcf25a4fba528399117069e
           randwidth: 128
         }
         {
@@ -1819,7 +1819,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestUnlocked
-          default: 0x20fecda9a5fceba680bbb8e9c0f3699c
+          default: 0x77c887f53dda6fb4ef8758b99027b6aa
           randwidth: 128
         }
         {
@@ -1829,7 +1829,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivDev
-          default: 0xd9803542888fa690c16dd41b3d1fa05f
+          default: 0x7468bc0bd8d70368e7cfb11a99675b14
           randwidth: 128
         }
         {
@@ -1839,7 +1839,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0x7ecc83245ccc8577daafb97c26a70119
+          default: 0x6240619335a9e2d123834d18744778be
           randwidth: 128
         }
         {
@@ -1849,7 +1849,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivRma
-          default: 0x88481250c2c82deb519d69c7051aab9f
+          default: 0x5e63c087e36838b56b1a45f6fd312f53
           randwidth: 128
         }
         {
@@ -1859,7 +1859,7 @@
           randcount: 1024
           randtype: data
           name_top: RndCnstLcCtrlInvalidTokens
-          default: 0xc45a1658fa9063ce216c0b412615d73f476529a96a1a8aca4b0bdcbe6b240c31095162e41bf99b2bc41e9edbb4685f7eb27eb3b35f352752e34f64ce978305bfc3481a2162ea2792b7508f1eab067af954dda5491439a9dde6320801fdcf25a4fba528399117069e77c887f53dda6fb4ef8758b99027b6aa7468bc0bd8d70368
+          default: 0x53fa7b2ce9fc83ddaf1dd8c5a42e2ad24fa02221b6ff5aad7a9c09d5d9fdd1cfcf512835c0cfae2ed0c69fa488685cea9bc1c89bfb7399aef5c6eb5d6e4e23416a0aa6d7ac7ec9c3304470fbe505f9649400ca9864fd4ce49d2cfc6ecc102540ead8734700a5207132689471aa822bc51cdd4d37ac2d246c4264f37ec1982017
           randwidth: 1024
         }
         {
@@ -2461,7 +2461,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0xe7cfb11a
+          default: 0x94adda1b
           randwidth: 32
         }
         {
@@ -2471,7 +2471,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0x7c7f66878056334b97a7d3869812a696d1e12d93
+          default: 0x2c7c7806d8fe46f651c95dc1b36ba44554de4e42
           randwidth: 160
         }
         {
@@ -4405,7 +4405,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0x7b2ce9fc83ddaf1dd8c5a42e2ad24fa0
+          default: 0x21d8cb69d4f3a15faf834cad515d76bd
           randwidth: 128
         }
         {
@@ -4415,28 +4415,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0x2221b6ff5aad7a9c09d5d9fdd1cfcf51
+          default: 0x37c7bec5f33fdca11a72dc05a2313b71
           randwidth: 128
         }
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: sram_ctrl_pkg::lfsr_seed_t
-          randcount: 32
+          randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0x2835c0cf
-          randwidth: 32
+          default: 0x8e6d6dbb8ec647d1
+          randwidth: 64
         }
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: sram_ctrl_pkg::lfsr_perm_t
-          randcount: 32
+          randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0xe87d0cb10f19e4a018824f2ff75b6b6c693c68b5
-          randwidth: 160
+          default: 0xb7742874b52317695c3cdd614d1c1702a7ef13bf561e078a9826ccac36bc9e9b9988623193efc9e7254ed330584bab38
+          randwidth: 384
         }
         {
           name: MemSizeRam
@@ -5284,7 +5284,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x9864fd4ce49d2cfc
+          default: 0x2482cc34468c37bf
           randwidth: 64
         }
         {
@@ -5294,7 +5294,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x8777abc015988e40cfc943a7a17e66b7177d895b35bee482185d1f67bffc2cd4c72a0abe95a338229011736e90244cdb
+          default: 0x57677e4b32baaafaf9e2c13099a62759b8bcfde7f5d219714ce9012293d9a10b8d0095f28d42d18031771fd32d08673b
           randwidth: 384
         }
         {
@@ -5304,7 +5304,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x9aafc50a72f0bbe55fb10265d29883ce15b713d78a1fc6406124646e3ece32d05c1ba3f136f7795384e0ad7a356b2d88
+          default: 0x1c841ed1bb4e7f8222eab3a08f24aadb3adc36f31d67c977e44d069ebc3105365638747a68f8c1949968d9cd5dfd212
           randwidth: 384
         }
         {
@@ -5314,7 +5314,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0xdc0dc524d3b0554603562188552794dd2bebf67f318b5a490e55f7d8b8325652a92482cc
+          default: 0x36270315f91066fb63a6e6eb54493c0631cd3062adf6d00b7e756f81353c10ac316a9c7a
           randwidth: 288
         }
         {
@@ -5324,7 +5324,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0x4a9702757c9b5d49285626121b7769037f89926a8b4d433f7948722f81141f7b5f93007e54632a915336257d71176b5a1e1331955b6e9644607a57809c7655686f3e45276c66860e076d629a4b98583b0f65101974294c8e9e332b11709f1d61992e0b1687518a8d0632390421083d8278418459942009679d85500c4f3842904e3a220523883c64405c3501245e2c8f522d47830d151c18300a1a73378c4634
+          default: 0x9107678e8f0118524a1a5a0e9f544d2a5e69054f5380264171333a0d5f0f7e1b57616a3911970b42566402308c832d6d9d84776c121c3b864b8b731f2e595c48452f3d51407b829b7c080c94278735755b28786595898d8a049368321606179c50253f24317a4e19235d7f72921096902c3e1e6636135815740a1d37476f216260467d44767970853899039a1420986b495522436e004c9e3c81098863292b34
           randwidth: 1280
         }
       ]
@@ -5599,7 +5599,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstKmacLfsrSeed
-          default: 0x813c2b4c006e43bc22b155f9a5ba49b86b3c201409f20381b6ffcba3c838857079768444
+          default: 0xfd7f6334613aa93b656444d70350a89ebc0cfbd0a03925fc80535f277451d2be0c46fdd2
           randwidth: 288
         }
         {
@@ -5609,7 +5609,7 @@
           randcount: 800
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0xb8b04aad5251e951eaac21281068257eeb1066fa05c9b628e30e1cb3b8601de8c42007166c28e1b6b4a34899213ee69626992a4ce56c243402a86ad55505a8471a355369fe3e672ba225160bde87206d08dcdb427dbe26e982af6a564a9b1d7ac506956a136c58883c0515e638a5b5a0055edb8c13812467c015c18d56bd656a24e676d90089334b6ebbd23ac4a0b581ca1b9f584ce0a2c47178b9c522379afd0866a2387fc61a319aae5dd76680939f1bd36ca43fb089011c0315da1abc2deda9e127770cc8a20fa16de81287004fc27c6f1e4367385b94c71a29eaa0969786df9f8b217298c7165ba21b4e4020d46cb9f159ec3f5645527872650370c3115311f42a085e14d15c5473d85190ab79713361555fa0378cda4329bb66fb437101d4ca9c158071cc9cc7602c1e5ff026498271f172fd9a7fd912b6361444148ac104b0ca10fd17ed1b2506aa18681a3f4740f84173a7de78369c4d04c2997d979af93104b621e93adc3c9ad0e9286e219492b6af65288405390469690977c3d7596f68a141492c6c8e159903a947ca4dc3228263166d3ce9a284a27511974d4256a242d1a4994a87e9b1a7918749883511502b07762f62bc69ba84461d4b1144313eb99e5d9778c26d5d5604d73187e07d37a21678c4eaa8e292ab0b5a1255ac5db52ec0ec3291dc2a42f18311287ebe9be4298a49afd2e99951220111d2c7b8d9322c4e3894109e68062b20a6c333572c24980557125701184f1634ae9d4b09212b719e23b1e94d6c6a9d7b194fac19ae7da463be0e498942d49d20ac0240f93e2098947d7be2a48c534fe41ba5bf232439b13c8cadd01abb18afc401c0664f451703c7a929c4f66799d53c70acd0b4c4867f2b76844099d7453a4a1edf396e3c159c121ee475c042812906e500748357e94970809ac088b6ef9352f97e3d54f0f974096fb0d4c1482faf034a77861e036654bfce73ddee85a4b478dc394ff5b58b236fe512ce29c4a33c85161e47c61230e177c2c40f91091091525bcc2a155e5ab876b07424f3c1b40e4d13ae45a36553d563311073022b7b0ba8709aa46a08b0782c5ac04105038d6a5d98b990e726590b2d33a6f7aa93b4eaf37d016945b731ea18ccb6305fe69ddd7e2ad600c92f62037d179d0acad5754048fa3b1b5e9115b22ec167667df24c9b3120132eeee270812f02e1cdda46d3e7dcdd699b081d96248c88dcde1a0a3ae140714b863ef250c2db3d02b319ba5aca585709628fbe62f0a2c80c5d15f20125e80a880d44d95a9184632359e86b6e65752803258d398ea98146a6aa27c643310a02c5ab42ce0a12c2b51acbb5e9d5412a7e672b856e6eded985ba7123bb813d6a30e002cd0811a65c34482837f4ed32f1f45264588993a23943d83b96ed
+          default: 0x62a473f8e39c84bb85a51ae7857664535593e4516657f9ec35bd632631ef05d97c75c393841a787913690b8ac6bed552a47265714badc7b1ed1892fc96d1c0e13443ed20680d63a345d83317a5ec171f8d63da2ede924db3a11fc6c674293c8345955c2b96a797a6893b2cab542781a141921326dce02f0649af9700b98a5e6692fe4ccbf6e414086e9aea195e2f61d857c00759882f61173aa1de7444018291708a407a0cbb836aa8256da7a2416527d27252463420b51e817f0ee2b6700fd166ea85bfe081c587901e2841204e6712962256c49c405b328233f1350627db9463b162d879e1899d28fa3abca6a6e06dbaa2348b0f9205c5f2b343172c2c6e76d3833a3fc4e28615a06a954b73031c0dac649399dfd3e1d59fc24064f4150222d47b57ac22ca056c8b7762d6142f0590471e9a34ac84a5462529ada7c8e649cd2767e1fd9d79d58156b50c552ab5ae53089948d37fef8333179a1457adca42d1d399665589e0098d1b2cdb3eb9a6c865424236066998982aeda1bc61054070decb3eaddb7d2d60da23b43c1dda92085a04820b38fd17e36aed06422f4a6243a4ea403e99c25745ee386713692e806044c8961ab9aa79acae7523144ee4975ea3c8f10eb1573182af1249f30cb42b79840539046a8e1f5f5098443d1a9cf5c5c8c20299a4524b1fa906a171903bc47c5a5bf8a97722826abeb63cd5a710a1580a26256f4fd9489e03509af6a0b4336ae2a14e2c23c461236d4d44540a4f48c518af5f869b5095111e552d861144313f0786e8801a0940283a11dc35cc61f81f4ddcbac1677ee753aaef9b0aa9cd684960e17497266b26ef0d0ec32a34efafb019291297ded7e5f6b6065c392e53d5122011759b11d1a1a80036799322e0f38941139620c0538119a4c42a4a8c278d5c9bf115ae00765909731232df51f5df621285aac3411217ce879424c3ece09dca63551974c1c8840c316bf7a316646abaa4e19350d9b5bdbce9a004f6ac45670487259d7010a04a41ba5c1dba08357ee0af686202b4b3008a8a02a512f9ba8254c34a98096f91a4c1482f91434ac1862e7780d9a72305ba5439cf77ba16a491e994dc394ff5b65662c8da2944c78a7128cf21458791f1848c385df0b003e4425391091525bc0028c855796ae1dbf5d095e4f3c1b40e4d13ae45982d7954f558cc441cc08adec2ea1c26adbbb22c1e0b16b0104140e35ae366263439c9966a50b2013a6d9bdd3b4ea0a7d016945b731eed8ccb6305fe69ddd7e2fa600c92f62037d179d0acb4f025d70a4048fa3a395e9115b22e8ee7667df24c9b3120132ec42270812f02eab0737691b4f9f7375a66c207658923223737b041a0a3ae140b11c52e18f2cd430b71840b1cb259ba5b1a585709628fa762f0a2c8
           randwidth: 8000
         }
         {
@@ -5619,7 +5619,7 @@
           randcount: 800
           randtype: data
           name_top: RndCnstKmacBufferLfsrSeed
-          default: 0x3d1b23e5be54b9c0bf5b2dbd49ab2284a502186c26c4919624eb713bc42ae08eb2a09674c93f8c23868b585534b613e2828b0424f0f9eb900313dcddd6f8207b25a5b5b3f673ba36487d1ecaf61806ccc0803e75180ab65ee3eeeb76afebe2ee4702f603
+          default: 0x82c54e1481730f66854723d00560945b6c126ffec03bf1a985028fae5eca762b77b0aaa69486cff6100543fa654b771979a70dde33ff89cf0ed4d484bcbd6b2ae72e35145b5f97c0e9b65e98cea48c3df219340a563da5b6396fce53002a2961ac84bdda
           randwidth: 800
         }
         {
@@ -5629,7 +5629,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacMsgPerm
-          default: 0x3eb027f1ab166fbbff8a085d67dd189514941382f15c68fa5470b67e621c4c3cb5dc1b45cc9339b8e36991efaa290a30
+          default: 0xc955307f8181637fe30d17bc5fd019b8bd6076649bd903930a1256207cccfaf2aae4da6d6ac9e47223f1ebb968d2b144
           randwidth: 384
         }
       ]
@@ -5823,7 +5823,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0x42246b6c385a5aa3b4fe9c0a8d1f2128e03e0b01632e027e34c81340bcfd0fd5
+          default: 0xa575b899b4caae056cf2b85353e1a33975e7b1209b868a4acd919ed9795d5f51
           randwidth: 256
         }
         {
@@ -5861,7 +5861,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0x3473b5440b76763b45bca8166865fdaf
+          default: 0x9aa8cd47ac68b65650a1bb5a4a6dbf0b
           randwidth: 128
         }
         {
@@ -5871,7 +5871,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0x59f386d5174cc7f5
+          default: 0xc7c1c7af8402bacd
           randwidth: 64
         }
       ]
@@ -6105,7 +6105,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrDpeLfsrSeed
-          default: 0xfd1f544b3a82c54e
+          default: 0x250ed8960c88b4b1
           randwidth: 64
         }
         {
@@ -6115,7 +6115,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrDpeLfsrPerm
-          default: 0xfb391f4f5b077b8a27f6e30998b09a57f362c391ab50ff2f4bb436c6dde929d5e303aa8ec846d69580742118590dc805
+          default: 0xa3fb9af729349f5d820605b362d23a1ac4993dcdd3e0e35de4510af171c08cc5150e2271c0bee942f6fe966ad17a1a9f
           randwidth: 384
         }
         {
@@ -6125,7 +6125,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrDpeRandPerm
-          default: 0x27ee88eb0198f665f5e977a54142ace140acb4f6
+          default: 0x6f92165b3355778fdd0678f9470ba75c8b08809a
           randwidth: 160
         }
         {
@@ -6135,7 +6135,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeRevisionSeed
-          default: 0xc1a496592784ac089e72877bdaf9f7954486164b58ea68f9b7f647cdafc1c9a9
+          default: 0xb6ee6e7ad485ff3ca72c2242223ce6d70f17b4f4b32818aa49d125b4defb1f3c
           randwidth: 256
         }
         {
@@ -6145,7 +6145,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeSoftOutputSeed
-          default: 0x5a7aa52efed17f8efa13e9543502f28c02c460aa8d2a575b899b4caae056cf2
+          default: 0xbe8a29be065c26d23550bbc139ff6461763d7e966a8a7219eb2e8ef9f11a152
           randwidth: 256
         }
         {
@@ -6155,7 +6155,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeHardOutputSeed
-          default: 0xb85353e1a33975e7b1209b868a4acd919ed9795d5f519aa8cd47ac68b65650a1
+          default: 0xe6c71aa23b8864416e750c01a3339c6c7aa11244ecd28a62cb1b851078c2a5f1
           randwidth: 256
         }
         {
@@ -6165,7 +6165,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeAesSeed
-          default: 0xbb5a4a6dbf0bc7c1c7af8402bacd250ed8960c88b4b17ea9867b47ae9a95aaf9
+          default: 0x8eee28d0b562043b7312efad871f92e7527da865d661281fe98dfcd72e3c6d15
           randwidth: 256
         }
         {
@@ -6175,7 +6175,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeKmacSeed
-          default: 0x6dbe43a4472dc0c72f2488d40ccad7575333e5e48f00bbc1f91e5eea7ad029c2
+          default: 0xa85d63009596f7966c5c68caedde4ab7c65fb8d59618284064d7194e4707ada
           randwidth: 256
         }
         {
@@ -6185,7 +6185,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeOtbnSeed
-          default: 0x13141ee86e77b99bf0a1bcd67fb8941c331a44277bc08f711d2d33e72bc40a36
+          default: 0x81f8a6db14ca845beee60798289ad4fb0df1768296390152700e078ec5a951b6
           randwidth: 256
         }
         {
@@ -6195,7 +6195,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrDpeNoneSeed
-          default: 0x399d8364dcd59508d525078e802f91d8583804fde71271f1738c1cac987a6b8a
+          default: 0x27cf2ccd155d84fdaced736e93362c8da83c5f4dd2093e4d2a70dd99dcf4ccac
           randwidth: 256
         }
       ]
@@ -6399,7 +6399,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0x7758b762216edd63070949c7834ab6ee6e7ad485ff3ca72c2242223ce6d70f17b4f4b32818aa49d125b4defb1f3c0be8
+          default: 0x341a2f1a2704f5e21287fa168af251b370d034cda605152662f4d11b3245d5943ea5fd2e4bea016b7911deaf01df7425
           randwidth: 384
         }
         {
@@ -6409,7 +6409,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0xa29be065c26d23550bbc139ff6461763d7e966a8a7219eb2e8ef9f11a152e6c71aa23b8864416e750c01a3339c6c7aa1
+          default: 0x47371445d6e3955145e3074d9ca9e8a4ef06a6f14a5c8fcac0d6396e606a620a9ffb23756bda420a9e7bd1a7c41e3a37
           randwidth: 384
         }
         {
@@ -6753,7 +6753,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0x1244ecd28a62cb1b851078c2a5f18eee
+          default: 0xb747d3d7b758b37d1d1ca19a079c48d7
           randwidth: 128
         }
         {
@@ -6763,28 +6763,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x28d0b562043b7312efad871f92e7527d
+          default: 0xd4e67100a6aaebe45b6f09aefb72895e
           randwidth: 128
         }
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: sram_ctrl_pkg::lfsr_seed_t
-          randcount: 32
+          randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0xa865d661
-          randwidth: 32
+          default: 0xc90d876315db9ad8
+          randwidth: 64
         }
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: sram_ctrl_pkg::lfsr_perm_t
-          randcount: 32
+          randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x9839bf5c89ae64a439947e1763402269ffa8f465
-          randwidth: 160
+          default: 0xd58134893911fa70a6380e0b53a19676dfdf5db42966a81a0c857c16572c376052c077afecadf1f61ae88c9333c8fe6e
+          randwidth: 384
         }
         {
           name: MemSizeRam
@@ -7080,7 +7080,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMboxSramKey
-          default: 0x4d7194e4707ada81f8a6db14ca845bee
+          default: 0xc9adde7bfb79fb9cc4c0b2d1aed6700a
           randwidth: 128
         }
         {
@@ -7090,28 +7090,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMboxSramNonce
-          default: 0xe60798289ad4fb0df176829639015270
+          default: 0x44ea3e7e0610a663d52b082b9aef0e42
           randwidth: 128
         }
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: sram_ctrl_pkg::lfsr_seed_t
-          randcount: 32
+          randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMboxLfsrSeed
-          default: 0xe078ec5
-          randwidth: 32
+          default: 0x6df4866fe88a8baa
+          randwidth: 64
         }
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: sram_ctrl_pkg::lfsr_perm_t
-          randcount: 32
+          randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMboxLfsrPerm
-          default: 0x662343bd21bcc1ce8fc8d1a4d77e0b16cb925955
-          randwidth: 160
+          default: 0x313255020282c197b789fb87992c785a8ea335a9c81b3474bdc76b921daa054cbd103f186e542cecfb75e6917e5cbfce
+          randwidth: 384
         }
         {
           name: MemSizeRam
@@ -7406,7 +7406,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrl0ScrNonce
-          default: 0x2704f5e21287fa16
+          default: 0x37bebb1d8879e257
           randwidth: 64
         }
         {
@@ -7416,7 +7416,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrl0ScrKey
-          default: 0x8af251b370d034cda605152662f4d11b
+          default: 0x23b9d533238865874ef2d375583c209c
           randwidth: 128
         }
         {
@@ -7592,7 +7592,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrl1ScrNonce
-          default: 0x3245d5943ea5fd2e
+          default: 0x27d35c5794f680b
           randwidth: 64
         }
         {
@@ -7602,7 +7602,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrl1ScrKey
-          default: 0x4bea016b7911deaf01df742547371445
+          default: 0x124893c22e6a22f5ad2e7591ecad6cca
           randwidth: 128
         }
         {
@@ -10545,7 +10545,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0xd6e39551
+          default: 0x220de3c0
           randwidth: 32
         }
         {
@@ -10555,7 +10555,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0xb855af9470711fb15b06931a78afd9ed2b348388
+          default: 0x3d1a8b4f92ee1c92c5f55ab77f30c2fe74124060
           randwidth: 160
         }
         {
@@ -10565,7 +10565,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0x47d3d7b758b37d1d1ca19a079c48d7d4
+          default: 0xf2546ea845a7ade1002b84b739380023
           randwidth: 128
         }
         {
@@ -10575,7 +10575,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0xe67100a6aaebe45b
+          default: 0xc25c3deaf38d871a
           randwidth: 64
         }
         {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling_rnd_cnst_pkg.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling_rnd_cnst_pkg.sv
@@ -18,17 +18,17 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter otp_ctrl_top_specific_pkg::lfsr_seed_t RndCnstOtpCtrlLfsrSeed = {
-    40'h4B_9FBDE86F
+    40'h58_FA9063CE
   };
 
   // Compile-time random permutation for LFSR output
   parameter otp_ctrl_top_specific_pkg::lfsr_perm_t RndCnstOtpCtrlLfsrPerm = {
-    240'h0673_65393414_70210F61_F55284B5_9A44A0C8_1DD91B00_62628D79_A014C799
+    240'h2DD6_809079E6_7935A195_848E7CA5_065C4701_8D980335_588C44F1_494026C8
   };
 
   // Compile-time random permutation for scrambling key/nonce register reset value
   parameter otp_ctrl_top_specific_pkg::scrmbl_key_init_t RndCnstOtpCtrlScrmblKeyInit = {
-    256'hE8F2F8BE_62FE9D2D_4204B2F5_4BE875AE_48027768_0CBA442B_AA3ACB9C_2A3F40A5
+    256'hE34F64CE_978305BF_C3481A21_62EA2792_B7508F1E_AB067AF9_54DDA549_1439A9DD
   };
 
   ////////////////////////////////////////////
@@ -36,35 +36,35 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Diversification value used for all invalid life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    128'hE816A506_C2AB1F4A_2F01CBE9_08A34C2A
+    128'hE6320801_FDCF25A4_FBA52839_9117069E
   };
 
   // Diversification value used for the TEST_UNLOCKED* life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestUnlocked = {
-    128'h20FECDA9_A5FCEBA6_80BBB8E9_C0F3699C
+    128'h77C887F5_3DDA6FB4_EF8758B9_9027B6AA
   };
 
   // Diversification value used for the DEV life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivDev = {
-    128'hD9803542_888FA690_C16DD41B_3D1FA05F
+    128'h7468BC0B_D8D70368_E7CFB11A_99675B14
   };
 
   // Diversification value used for the PROD/PROD_END life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    128'h7ECC8324_5CCC8577_DAAFB97C_26A70119
+    128'h62406193_35A9E2D1_23834D18_744778BE
   };
 
   // Diversification value used for the RMA life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivRma = {
-    128'h88481250_C2C82DEB_519D69C7_051AAB9F
+    128'h5E63C087_E36838B5_6B1A45F6_FD312F53
   };
 
   // Compile-time random bits used for invalid tokens in the token mux
   parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
-    256'hC45A1658_FA9063CE_216C0B41_2615D73F_476529A9_6A1A8ACA_4B0BDCBE_6B240C31,
-    256'h095162E4_1BF99B2B_C41E9EDB_B4685F7E_B27EB3B3_5F352752_E34F64CE_978305BF,
-    256'hC3481A21_62EA2792_B7508F1E_AB067AF9_54DDA549_1439A9DD_E6320801_FDCF25A4,
-    256'hFBA52839_9117069E_77C887F5_3DDA6FB4_EF8758B9_9027B6AA_7468BC0B_D8D70368
+    256'h53FA7B2C_E9FC83DD_AF1DD8C5_A42E2AD2_4FA02221_B6FF5AAD_7A9C09D5_D9FDD1CF,
+    256'hCF512835_C0CFAE2E_D0C69FA4_88685CEA_9BC1C89B_FB7399AE_F5C6EB5D_6E4E2341,
+    256'h6A0AA6D7_AC7EC9C3_304470FB_E505F964_9400CA98_64FD4CE4_9D2CFC6E_CC102540,
+    256'hEAD87347_00A52071_32689471_AA822BC5_1CDD4D37_AC2D246C_4264F37E_C1982017
   };
 
   ////////////////////////////////////////////
@@ -72,12 +72,12 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_handler_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'hE7CFB11A
+    32'h94ADDA1B
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_handler_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'h7C7F6687_8056334B_97A7D386_9812A696_D1E12D93
+    160'h2C7C7806_D8FE46F6_51C95DC1_B36BA445_54DE4E42
   };
 
   ////////////////////////////////////////////
@@ -85,22 +85,23 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h7B2CE9FC_83DDAF1D_D8C5A42E_2AD24FA0
+    128'h21D8CB69_D4F3A15F_AF834CAD_515D76BD
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'h2221B6FF_5AAD7A9C_09D5D9FD_D1CFCF51
+    128'h37C7BEC5_F33FDCA1_1A72DC05_A2313B71
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    32'h2835C0CF
+    64'h8E6D6DBB_8EC647D1
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    160'hE87D0CB1_0F19E4A0_18824F2F_F75B6B6C_693C68B5
+    128'hB7742874_B5231769_5C3CDD61_4D1C1702,
+    256'hA7EF13BF_561E078A_9826CCAC_36BC9E9B_99886231_93EFC9E7_254ED330_584BAB38
   };
 
   ////////////////////////////////////////////
@@ -108,34 +109,34 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h9864FD4C_E49D2CFC
+    64'h2482CC34_468C37BF
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h8777ABC0_15988E40_CFC943A7_A17E66B7,
-    256'h177D895B_35BEE482_185D1F67_BFFC2CD4_C72A0ABE_95A33822_9011736E_90244CDB
+    128'h57677E4B_32BAAAFA_F9E2C130_99A62759,
+    256'hB8BCFDE7_F5D21971_4CE90122_93D9A10B_8D0095F2_8D42D180_31771FD3_2D08673B
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h9AAFC50A_72F0BBE5_5FB10265_D29883CE,
-    256'h15B713D7_8A1FC640_6124646E_3ECE32D0_5C1BA3F1_36F77953_84E0AD7A_356B2D88
+    128'h01C841ED_1BB4E7F8_222EAB3A_08F24AAD,
+    256'hB3ADC36F_31D67C97_7E44D069_EBC31053_65638747_A68F8C19_49968D9C_D5DFD212
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    32'hDC0DC524,
-    256'hD3B05546_03562188_552794DD_2BEBF67F_318B5A49_0E55F7D8_B8325652_A92482CC
+    32'h36270315,
+    256'hF91066FB_63A6E6EB_54493C06_31CD3062_ADF6D00B_7E756F81_353C10AC_316A9C7A
   };
 
   // Permutation applied to the output of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h4A970275_7C9B5D49_28562612_1B776903_7F89926A_8B4D433F_7948722F_81141F7B,
-    256'h5F93007E_54632A91_5336257D_71176B5A_1E133195_5B6E9644_607A5780_9C765568,
-    256'h6F3E4527_6C66860E_076D629A_4B98583B_0F651019_74294C8E_9E332B11_709F1D61,
-    256'h992E0B16_87518A8D_06323904_21083D82_78418459_94200967_9D85500C_4F384290,
-    256'h4E3A2205_23883C64_405C3501_245E2C8F_522D4783_0D151C18_300A1A73_378C4634
+    256'h9107678E_8F011852_4A1A5A0E_9F544D2A_5E69054F_53802641_71333A0D_5F0F7E1B,
+    256'h57616A39_11970B42_56640230_8C832D6D_9D84776C_121C3B86_4B8B731F_2E595C48,
+    256'h452F3D51_407B829B_7C080C94_27873575_5B287865_95898D8A_04936832_1606179C,
+    256'h50253F24_317A4E19_235D7F72_92109690_2C3E1E66_36135815_740A1D37_476F2162,
+    256'h60467D44_76797085_3899039A_1420986B_49552243_6E004C9E_3C810988_63292B34
   };
 
   ////////////////////////////////////////////
@@ -143,58 +144,58 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random data for PRNG default seed
   parameter kmac_pkg::lfsr_seed_t RndCnstKmacLfsrSeed = {
-    32'h813C2B4C,
-    256'h006E43BC_22B155F9_A5BA49B8_6B3C2014_09F20381_B6FFCBA3_C8388570_79768444
+    32'hFD7F6334,
+    256'h613AA93B_656444D7_0350A89E_BC0CFBD0_A03925FC_80535F27_7451D2BE_0C46FDD2
   };
 
   // Compile-time random permutation for PRNG output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    64'hB8B04AAD_5251E951,
-    256'hEAAC2128_1068257E_EB1066FA_05C9B628_E30E1CB3_B8601DE8_C4200716_6C28E1B6,
-    256'hB4A34899_213EE696_26992A4C_E56C2434_02A86AD5_5505A847_1A355369_FE3E672B,
-    256'hA225160B_DE87206D_08DCDB42_7DBE26E9_82AF6A56_4A9B1D7A_C506956A_136C5888,
-    256'h3C0515E6_38A5B5A0_055EDB8C_13812467_C015C18D_56BD656A_24E676D9_0089334B,
-    256'h6EBBD23A_C4A0B581_CA1B9F58_4CE0A2C4_7178B9C5_22379AFD_0866A238_7FC61A31,
-    256'h9AAE5DD7_6680939F_1BD36CA4_3FB08901_1C0315DA_1ABC2DED_A9E12777_0CC8A20F,
-    256'hA16DE812_87004FC2_7C6F1E43_67385B94_C71A29EA_A0969786_DF9F8B21_7298C716,
-    256'h5BA21B4E_4020D46C_B9F159EC_3F564552_78726503_70C31153_11F42A08_5E14D15C,
-    256'h5473D851_90AB7971_3361555F_A0378CDA_4329BB66_FB437101_D4CA9C15_8071CC9C,
-    256'hC7602C1E_5FF02649_8271F172_FD9A7FD9_12B63614_44148AC1_04B0CA10_FD17ED1B,
-    256'h2506AA18_681A3F47_40F84173_A7DE7836_9C4D04C2_997D979A_F93104B6_21E93ADC,
-    256'h3C9AD0E9_286E2194_92B6AF65_28840539_04696909_77C3D759_6F68A141_492C6C8E,
-    256'h159903A9_47CA4DC3_22826316_6D3CE9A2_84A27511_974D4256_A242D1A4_994A87E9,
-    256'hB1A79187_49883511_502B0776_2F62BC69_BA84461D_4B114431_3EB99E5D_9778C26D,
-    256'h5D5604D7_3187E07D_37A21678_C4EAA8E2_92AB0B5A_1255AC5D_B52EC0EC_3291DC2A,
-    256'h42F18311_287EBE9B_E4298A49_AFD2E999_51220111_D2C7B8D9_322C4E38_94109E68,
-    256'h062B20A6_C333572C_24980557_12570118_4F1634AE_9D4B0921_2B719E23_B1E94D6C,
-    256'h6A9D7B19_4FAC19AE_7DA463BE_0E498942_D49D20AC_0240F93E_2098947D_7BE2A48C,
-    256'h534FE41B_A5BF2324_39B13C8C_ADD01ABB_18AFC401_C0664F45_1703C7A9_29C4F667,
-    256'h99D53C70_ACD0B4C4_867F2B76_844099D7_453A4A1E_DF396E3C_159C121E_E475C042,
-    256'h812906E5_00748357_E9497080_9AC088B6_EF9352F9_7E3D54F0_F974096F_B0D4C148,
-    256'h2FAF034A_77861E03_6654BFCE_73DDEE85_A4B478DC_394FF5B5_8B236FE5_12CE29C4,
-    256'hA33C8516_1E47C612_30E177C2_C40F9109_1091525B_CC2A155E_5AB876B0_7424F3C1,
-    256'hB40E4D13_AE45A365_53D56331_1073022B_7B0BA870_9AA46A08_B0782C5A_C0410503,
-    256'h8D6A5D98_B990E726_590B2D33_A6F7AA93_B4EAF37D_016945B7_31EA18CC_B6305FE6,
-    256'h9DDD7E2A_D600C92F_62037D17_9D0ACAD5_754048FA_3B1B5E91_15B22EC1_67667DF2,
-    256'h4C9B3120_132EEEE2_70812F02_E1CDDA46_D3E7DCDD_699B081D_96248C88_DCDE1A0A,
-    256'h3AE14071_4B863EF2_50C2DB3D_02B319BA_5ACA5857_09628FBE_62F0A2C8_0C5D15F2,
-    256'h0125E80A_880D44D9_5A918463_2359E86B_6E657528_03258D39_8EA98146_A6AA27C6,
-    256'h43310A02_C5AB42CE_0A12C2B5_1ACBB5E9_D5412A7E_672B856E_6EDED985_BA7123BB,
-    256'h813D6A30_E002CD08_11A65C34_482837F4_ED32F1F4_52645889_93A23943_D83B96ED
+    64'h62A473F8_E39C84BB,
+    256'h85A51AE7_85766453_5593E451_6657F9EC_35BD6326_31EF05D9_7C75C393_841A7879,
+    256'h13690B8A_C6BED552_A4726571_4BADC7B1_ED1892FC_96D1C0E1_3443ED20_680D63A3,
+    256'h45D83317_A5EC171F_8D63DA2E_DE924DB3_A11FC6C6_74293C83_45955C2B_96A797A6,
+    256'h893B2CAB_542781A1_41921326_DCE02F06_49AF9700_B98A5E66_92FE4CCB_F6E41408,
+    256'h6E9AEA19_5E2F61D8_57C00759_882F6117_3AA1DE74_44018291_708A407A_0CBB836A,
+    256'hA8256DA7_A2416527_D2725246_3420B51E_817F0EE2_B6700FD1_66EA85BF_E081C587,
+    256'h901E2841_204E6712_962256C4_9C405B32_8233F135_0627DB94_63B162D8_79E1899D,
+    256'h28FA3ABC_A6A6E06D_BAA2348B_0F9205C5_F2B34317_2C2C6E76_D3833A3F_C4E28615,
+    256'hA06A954B_73031C0D_AC649399_DFD3E1D5_9FC24064_F4150222_D47B57AC_22CA056C,
+    256'h8B7762D6_142F0590_471E9A34_AC84A546_2529ADA7_C8E649CD_2767E1FD_9D79D581,
+    256'h56B50C55_2AB5AE53_089948D3_7FEF8333_179A1457_ADCA42D1_D3996655_89E0098D,
+    256'h1B2CDB3E_B9A6C865_42423606_6998982A_EDA1BC61_054070DE_CB3EADDB_7D2D60DA,
+    256'h23B43C1D_DA92085A_04820B38_FD17E36A_ED06422F_4A6243A4_EA403E99_C25745EE,
+    256'h38671369_2E806044_C8961AB9_AA79ACAE_7523144E_E4975EA3_C8F10EB1_573182AF,
+    256'h1249F30C_B42B7984_0539046A_8E1F5F50_98443D1A_9CF5C5C8_C20299A4_524B1FA9,
+    256'h06A17190_3BC47C5A_5BF8A977_22826ABE_B63CD5A7_10A1580A_26256F4F_D9489E03,
+    256'h509AF6A0_B4336AE2_A14E2C23_C461236D_4D44540A_4F48C518_AF5F869B_5095111E,
+    256'h552D8611_44313F07_86E8801A_0940283A_11DC35CC_61F81F4D_DCBAC167_7EE753AA,
+    256'hEF9B0AA9_CD684960_E1749726_6B26EF0D_0EC32A34_EFAFB019_291297DE_D7E5F6B6,
+    256'h065C392E_53D51220_11759B11_D1A1A800_36799322_E0F38941_139620C0_538119A4,
+    256'hC42A4A8C_278D5C9B_F115AE00_76590973_1232DF51_F5DF6212_85AAC341_1217CE87,
+    256'h9424C3EC_E09DCA63_551974C1_C8840C31_6BF7A316_646ABAA4_E19350D9_B5BDBCE9,
+    256'hA004F6AC_45670487_259D7010_A04A41BA_5C1DBA08_357EE0AF_686202B4_B3008A8A,
+    256'h02A512F9_BA8254C3_4A98096F_91A4C148_2F91434A_C1862E77_80D9A723_05BA5439,
+    256'hCF77BA16_A491E994_DC394FF5_B65662C8_DA2944C7_8A7128CF_21458791_F1848C38,
+    256'h5DF0B003_E4425391_091525BC_0028C855_796AE1DB_F5D095E4_F3C1B40E_4D13AE45,
+    256'h982D7954_F558CC44_1CC08ADE_C2EA1C26_ADBBB22C_1E0B16B0_104140E3_5AE36626,
+    256'h3439C996_6A50B201_3A6D9BDD_3B4EA0A7_D016945B_731EED8C_CB6305FE_69DDD7E2,
+    256'hFA600C92_F62037D1_79D0ACB4_F025D70A_4048FA3A_395E9115_B22E8EE7_667DF24C,
+    256'h9B312013_2EC42270_812F02EA_B0737691_B4F9F737_5A66C207_65892322_3737B041,
+    256'hA0A3AE14_0B11C52E_18F2CD43_0B71840B_1CB259BA_5B1A5857_09628FA7_62F0A2C8
   };
 
   // Compile-time random data for PRNG buffer default seed
   parameter kmac_pkg::buffer_lfsr_seed_t RndCnstKmacBufferLfsrSeed = {
-    32'h3D1B23E5,
-    256'hBE54B9C0_BF5B2DBD_49AB2284_A502186C_26C49196_24EB713B_C42AE08E_B2A09674,
-    256'hC93F8C23_868B5855_34B613E2_828B0424_F0F9EB90_0313DCDD_D6F8207B_25A5B5B3,
-    256'hF673BA36_487D1ECA_F61806CC_C0803E75_180AB65E_E3EEEB76_AFEBE2EE_4702F603
+    32'h82C54E14,
+    256'h81730F66_854723D0_0560945B_6C126FFE_C03BF1A9_85028FAE_5ECA762B_77B0AAA6,
+    256'h9486CFF6_100543FA_654B7719_79A70DDE_33FF89CF_0ED4D484_BCBD6B2A_E72E3514,
+    256'h5B5F97C0_E9B65E98_CEA48C3D_F219340A_563DA5B6_396FCE53_002A2961_AC84BDDA
   };
 
   // Compile-time random permutation for LFSR Message output
   parameter kmac_pkg::msg_perm_t RndCnstKmacMsgPerm = {
-    128'h3EB027F1_AB166FBB_FF8A085D_67DD1895,
-    256'h14941382_F15C68FA_5470B67E_621C4C3C_B5DC1B45_CC9339B8_E36991EF_AA290A30
+    128'hC955307F_8181637F_E30D17BC_5FD019B8,
+    256'hBD607664_9BD90393_0A125620_7CCCFAF2_AAE4DA6D_6AC9E472_23F1EBB9_68D2B144
   };
 
   ////////////////////////////////////////////
@@ -202,17 +203,17 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'h42246B6C_385A5AA3_B4FE9C0A_8D1F2128_E03E0B01_632E027E_34C81340_BCFD0FD5
+    256'hA575B899_B4CAAE05_6CF2B853_53E1A339_75E7B120_9B868A4A_CD919ED9_795D5F51
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'h3473B544_0B76763B_45BCA816_6865FDAF
+    128'h9AA8CD47_AC68B656_50A1BB5A_4A6DBF0B
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'h59F386D5_174CC7F5
+    64'hC7C1C7AF_8402BACD
   };
 
   ////////////////////////////////////////////
@@ -220,53 +221,53 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrDpeLfsrSeed = {
-    64'hFD1F544B_3A82C54E
+    64'h250ED896_0C88B4B1
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrDpeLfsrPerm = {
-    128'hFB391F4F_5B077B8A_27F6E309_98B09A57,
-    256'hF362C391_AB50FF2F_4BB436C6_DDE929D5_E303AA8E_C846D695_80742118_590DC805
+    128'hA3FB9AF7_29349F5D_820605B3_62D23A1A,
+    256'hC4993DCD_D3E0E35D_E4510AF1_71C08CC5_150E2271_C0BEE942_F6FE966A_D17A1A9F
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrDpeRandPerm = {
-    160'h27EE88EB_0198F665_F5E977A5_4142ACE1_40ACB4F6
+    160'h6F92165B_3355778F_DD0678F9_470BA75C_8B08809A
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeRevisionSeed = {
-    256'hC1A49659_2784AC08_9E72877B_DAF9F795_4486164B_58EA68F9_B7F647CD_AFC1C9A9
+    256'hB6EE6E7A_D485FF3C_A72C2242_223CE6D7_0F17B4F4_B32818AA_49D125B4_DEFB1F3C
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeSoftOutputSeed = {
-    256'h05A7AA52_EFED17F8_EFA13E95_43502F28_C02C460A_A8D2A575_B899B4CA_AE056CF2
+    256'h0BE8A29B_E065C26D_23550BBC_139FF646_1763D7E9_66A8A721_9EB2E8EF_9F11A152
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeHardOutputSeed = {
-    256'hB85353E1_A33975E7_B1209B86_8A4ACD91_9ED9795D_5F519AA8_CD47AC68_B65650A1
+    256'hE6C71AA2_3B886441_6E750C01_A3339C6C_7AA11244_ECD28A62_CB1B8510_78C2A5F1
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeAesSeed = {
-    256'hBB5A4A6D_BF0BC7C1_C7AF8402_BACD250E_D8960C88_B4B17EA9_867B47AE_9A95AAF9
+    256'h8EEE28D0_B562043B_7312EFAD_871F92E7_527DA865_D661281F_E98DFCD7_2E3C6D15
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeKmacSeed = {
-    256'h6DBE43A4_472DC0C7_2F2488D4_0CCAD757_5333E5E4_8F00BBC1_F91E5EEA_7AD029C2
+    256'h0A85D630_09596F79_66C5C68C_AEDDE4AB_7C65FB8D_59618284_064D7194_E4707ADA
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeOtbnSeed = {
-    256'h13141EE8_6E77B99B_F0A1BCD6_7FB8941C_331A4427_7BC08F71_1D2D33E7_2BC40A36
+    256'h81F8A6DB_14CA845B_EEE60798_289AD4FB_0DF17682_96390152_700E078E_C5A951B6
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrDpeNoneSeed = {
-    256'h399D8364_DCD59508_D525078E_802F91D8_583804FD_E71271F1_738C1CAC_987A6B8A
+    256'h27CF2CCD_155D84FD_ACED736E_93362C8D_A83C5F4D_D2093E4D_2A70DD99_DCF4CCAC
   };
 
   ////////////////////////////////////////////
@@ -274,14 +275,14 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'h7758B762_216EDD63_070949C7_834AB6EE,
-    256'h6E7AD485_FF3CA72C_2242223C_E6D70F17_B4F4B328_18AA49D1_25B4DEFB_1F3C0BE8
+    128'h341A2F1A_2704F5E2_1287FA16_8AF251B3,
+    256'h70D034CD_A6051526_62F4D11B_3245D594_3EA5FD2E_4BEA016B_7911DEAF_01DF7425
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'hA29BE065_C26D2355_0BBC139F_F6461763,
-    256'hD7E966A8_A7219EB2_E8EF9F11_A152E6C7_1AA23B88_64416E75_0C01A333_9C6C7AA1
+    128'h47371445_D6E39551_45E3074D_9CA9E8A4,
+    256'hEF06A6F1_4A5C8FCA_C0D6396E_606A620A_9FFB2375_6BDA420A_9E7BD1A7_C41E3A37
   };
 
   ////////////////////////////////////////////
@@ -289,22 +290,23 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'h1244ECD2_8A62CB1B_851078C2_A5F18EEE
+    128'hB747D3D7_B758B37D_1D1CA19A_079C48D7
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h28D0B562_043B7312_EFAD871F_92E7527D
+    128'hD4E67100_A6AAEBE4_5B6F09AE_FB72895E
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'hA865D661
+    64'hC90D8763_15DB9AD8
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'h9839BF5C_89AE64A4_39947E17_63402269_FFA8F465
+    128'hD5813489_3911FA70_A6380E0B_53A19676,
+    256'hDFDF5DB4_2966A81A_0C857C16_572C3760_52C077AF_ECADF1F6_1AE88C93_33C8FE6E
   };
 
   ////////////////////////////////////////////
@@ -312,22 +314,23 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMboxSramKey = {
-    128'h4D7194E4_707ADA81_F8A6DB14_CA845BEE
+    128'hC9ADDE7B_FB79FB9C_C4C0B2D1_AED6700A
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMboxSramNonce = {
-    128'hE6079828_9AD4FB0D_F1768296_39015270
+    128'h44EA3E7E_0610A663_D52B082B_9AEF0E42
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMboxLfsrSeed = {
-    32'h0E078EC5
+    64'h6DF4866F_E88A8BAA
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMboxLfsrPerm = {
-    160'h662343BD_21BCC1CE_8FC8D1A4_D77E0B16_CB925955
+    128'h31325502_0282C197_B789FB87_992C785A,
+    256'h8EA335A9_C81B3474_BDC76B92_1DAA054C_BD103F18_6E542CEC_FB75E691_7E5CBFCE
   };
 
   ////////////////////////////////////////////
@@ -335,12 +338,12 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrl0ScrNonce = {
-    64'h2704F5E2_1287FA16
+    64'h37BEBB1D_8879E257
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrl0ScrKey = {
-    128'h8AF251B3_70D034CD_A6051526_62F4D11B
+    128'h23B9D533_23886587_4EF2D375_583C209C
   };
 
   ////////////////////////////////////////////
@@ -348,12 +351,12 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrl1ScrNonce = {
-    64'h3245D594_3EA5FD2E
+    64'h027D35C5_794F680B
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrl1ScrKey = {
-    128'h4BEA016B_7911DEAF_01DF7425_47371445
+    128'h124893C2_2E6A22F5_AD2E7591_ECAD6CCA
   };
 
   ////////////////////////////////////////////
@@ -361,22 +364,22 @@ package top_darjeeling_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'hD6E39551
+    32'h220DE3C0
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'hB855AF94_70711FB1_5B06931A_78AFD9ED_2B348388
+    160'h3D1A8B4F_92EE1C92_C5F55AB7_7F30C2FE_74124060
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'h47D3D7B7_58B37D1D_1CA19A07_9C48D7D4
+    128'hF2546EA8_45A7ADE1_002B84B7_39380023
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'hE67100A6_AAEBE45B
+    64'hC25C3DEA_F38D871A
   };
 
 endpackage : top_darjeeling_rnd_cnst_pkg

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1854,7 +1854,7 @@
           randcount: 40
           randtype: data
           name_top: RndCnstOtpCtrlLfsrSeed
-          default: 0x50c2c82deb
+          default: 0x4f64ce9783
           randwidth: 40
         }
         {
@@ -1864,7 +1864,7 @@
           randcount: 40
           randtype: perm
           name_top: RndCnstOtpCtrlLfsrPerm
-          default: 0x8573e042648a54e4c07e42e770944376231b1c278894d119623156181694
+          default: 0x30e2cd7239915839107536995c511e9e57e00a285b28f0151d4258206481
           randwidth: 240
         }
         {
@@ -1874,7 +1874,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtpCtrlScrmblKeyInit
-          default: 0xdbb4685f7eb27eb3b35f352752e34f64ce978305bfc3481a2162ea2792b7508f
+          default: 0x7468bc0bd8d70368e7cfb11a99675b146240619335a9e2d123834d18744778be
           randwidth: 256
         }
       ]
@@ -2464,7 +2464,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0x1eab067af954dda5491439a9dde63208
+          default: 0x5e63c087e36838b56b1a45f6fd312f53
           randwidth: 128
         }
         {
@@ -2474,7 +2474,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestUnlocked
-          default: 0x1fdcf25a4fba528399117069e77c887
+          default: 0x53fa7b2ce9fc83ddaf1dd8c5a42e2ad2
           randwidth: 128
         }
         {
@@ -2484,7 +2484,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivDev
-          default: 0xf53dda6fb4ef8758b99027b6aa7468bc
+          default: 0x4fa02221b6ff5aad7a9c09d5d9fdd1cf
           randwidth: 128
         }
         {
@@ -2494,7 +2494,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0xbd8d70368e7cfb11a99675b14624061
+          default: 0xcf512835c0cfae2ed0c69fa488685cea
           randwidth: 128
         }
         {
@@ -2504,7 +2504,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivRma
-          default: 0x9335a9e2d123834d18744778be5e63c0
+          default: 0x9bc1c89bfb7399aef5c6eb5d6e4e2341
           randwidth: 128
         }
         {
@@ -2514,7 +2514,7 @@
           randcount: 1024
           randtype: data
           name_top: RndCnstLcCtrlInvalidTokens
-          default: 0x87e36838b56b1a45f6fd312f5353fa7b2ce9fc83ddaf1dd8c5a42e2ad24fa02221b6ff5aad7a9c09d5d9fdd1cfcf512835c0cfae2ed0c69fa488685cea9bc1c89bfb7399aef5c6eb5d6e4e23416a0aa6d7ac7ec9c3304470fbe505f9649400ca9864fd4ce49d2cfc6ecc102540ead8734700a5207132689471aa822bc51cdd4d
+          default: 0x6a0aa6d7ac7ec9c3304470fbe505f9649400ca9864fd4ce49d2cfc6ecc102540ead8734700a5207132689471aa822bc51cdd4d37ac2d246c4264f37ec198201794adda1b16929df5e06a56aaded443259ffb5736dd6801215b98e162dcc09e31e8382e46e4fecfda2375a6147421d8cb69d4f3a15faf834cad515d76bd37c7be
           randwidth: 1024
         }
         {
@@ -3124,7 +3124,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0x37ac2d24
+          default: 0xc5f33fdc
           randwidth: 32
         }
         {
@@ -3134,7 +3134,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0x83a2b09fb9d7006b1534f2bf7d8eb2112787b10d
+          default: 0xc65720dc8f9a845f6a1c62516ab63d39be0db874
           randwidth: 160
         }
         {
@@ -5876,7 +5876,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0x46e4fecfda2375a6147421d8cb69d4f3
+          default: 0x4b6a0cd066336e9b0bdf6a55f0d23bb7
           randwidth: 128
         }
         {
@@ -5886,28 +5886,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0xa15faf834cad515d76bd37c7bec5f33f
+          default: 0xdc0dc524d3b0554603562188552794dd
           randwidth: 128
         }
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: sram_ctrl_pkg::lfsr_seed_t
-          randcount: 32
+          randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0xdca11a72
-          randwidth: 32
+          default: 0x2bebf67f318b5a49
+          randwidth: 64
         }
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: sram_ctrl_pkg::lfsr_perm_t
-          randcount: 32
+          randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0x848bcb54640ebabb89f357fcc4a3386c5c73501b
-          randwidth: 160
+          default: 0xe4e6d896c3e8066ed32909f049e11da6bc488997f75a101af179382f2d7f147b7a08672fd2344dce026a53e32edbd543
+          randwidth: 384
         }
         {
           name: MemSizeRam
@@ -6209,7 +6209,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0xcd066336e9b0bdf6a55f0d23bb7dc0d
+          default: 0xf0ef478248447b11420873650cbc6aee
           randwidth: 128
         }
         {
@@ -6219,7 +6219,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0xc524d3b0554603562188552794dd2beb
+          default: 0xa2c8ee2de417e3d05d145c3a684922f7
           randwidth: 128
         }
         {
@@ -6229,7 +6229,7 @@
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
-          default: 0xf67f318b5a490e55f7d8b8325652a92482cc34468c37bfee731a0ab430181cde15f40d83472dd252e38f2c5e24d201bdb435d5cff95c40a1643cc8f540230522
+          default: 0xdc57cc668c58f099531a3221a2eddca41f778dde61de9734b7ecdec517110ed2ceb31d789f996bcd43ba4fb06b9ea47dbf441aa625f5ddf2dcb03c2b867024d5
           randwidth: 512
         }
         {
@@ -6239,7 +6239,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0xd33a4ea4
+          default: 0x4654c6e6
           randwidth: 32
         }
         {
@@ -6249,7 +6249,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0xb16325f54d0ed9e31c04c3eb9d5f88127f41cdd0
+          default: 0x50fc8f9fb826e306841c34eda63a45a5d79155e9
           randwidth: 160
         }
         {
@@ -7198,7 +7198,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x4922f7dc57cc668c
+          default: 0xd00b7e756f81353c
           randwidth: 64
         }
         {
@@ -7208,7 +7208,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x5d2732570001b22c5987ad3e90b08f80ae6f3b8babff36ea27b45fd9341af677b50c416d365623747a77a08306526f16
+          default: 0x530a34a8127f92f0c6d8bb5c8c7e515bded975795fea686c3b5bb317ec7c4a954841b013dcf8028b263828d7a768cac4
           randwidth: 384
         }
         {
@@ -7218,7 +7218,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x386fa8411f6af130d92e9b5c863cb0c54916b17226009147bf88b694ab9e9dadf513b3606dd7c2d2b63fccc04f495eb9
+          default: 0x8ac7aa1a9fc8115f247475a6fb7c4f2a0acd73596fb7ac97b9315a27051bf408d00428516730cbe68e1f4b660e9fbd0c
           randwidth: 384
         }
         {
@@ -7228,7 +7228,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0x4660c443df8e6e3a14e92af0b0266dcd3de77d58929920453cedc4bb4632d2ee9d3b62da
+          default: 0x51a50ac312c182822cf6ad12452480a61092e8a80cdf267889e06a8a1ab5f6db8158aa7c
           randwidth: 288
         }
         {
@@ -7238,7 +7238,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0x486579742011b2324800a7a7215902b345b2662581c0c510f680b9d4a1e389c1f6d5f070247307332431d33173620926778039e8c3d4d8f6b843b55897d0e967631747c19692e7e29915e631a8a4c3e2c5d9a4535853c139454496f834077226656166493600961055228755a2153952a442539795988128b3f5c829970379b7b8e816e117110184e4f146a2798506c3a008d4106088746652d0d2f9f4b7f48
+          default: 0x377a4a727e8f357024262156918e494c104f305d366b186a1583878a758b882d5e0a972f082b0b8429400792763e22901f0412474e46854371963c414d09116802935b1b58949f0d146d01551e57277b541c1766787d8660732a67482079623877336f99196c312c3d162e0f4b513f8142450e059a741d597c23069c699e8c135f53809b390c50034464653b3a619d637f5a8d89321a5c6e9552002582342898
           randwidth: 1280
         }
       ]
@@ -7499,7 +7499,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstKmacLfsrSeed
-          default: 0x4fe255b13d5003ae3828ee1a34f865c10b37a68df5d1293205f54724a965ab81ca6c3169
+          default: 0xd58dc810dd8eb1225d79f3ec320bb4d2d4692b1f9d1645f037d9dc83e4b7b7d0e5638801
           randwidth: 288
         }
         {
@@ -7509,7 +7509,7 @@
           randcount: 800
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0xa111496869a41cc0bf1badf1c3c4f89d1806dd5434eeb721ab6cb04035b8112ff4494614f0e622acb24f636e878961b92d2026e1fbdae2341255b2288ee7921d6585df741eb12b0b0b1098a4d6125f1e9ab15a59f1b72ee1e9017063e9591888de690e31af9c7b76325a4629cd5651e198cea1068d10041735c00635435bc83ac150bd20c49265abdf4c1c931ddb53198f332d531c355668b6599c60466439d111b02965fe516d33e9cd27d72a889517dde26ab54641c8f700a7ad78fe54611b3408a2c7d5747daa4a2770e1f530ceca6c29108a1b42bdaa5867240aa251a5448001acc4aa0b488361ccb32d4e409538c66884b490486f8336b64c9ee0d05544e517dab42303f71ad883a673fe354f5396edcb84496ba94f42ae09126f91579089d7924bdc35272fd93508542f8e55499775a3476d2c89e2c73d74a756a168b2474882999fac8211c97e2954c6a1046d15372ac57c8fc3d27da991cacc18554571d5c00f8e78c21340ecd121903f94819ec70c5766f0e2174030aa7a902725c050053052adba8aed46528d8192e32eb86746b2e41f69860871ed9baf783540098a87ad3b7e66bbe41eb9dfc904162e98b932db8d8745e987049af3d55da1830986df9b4da738ddbcc24a053404d36a0dc30444c848fb42e2e3387b7406d2a6e1136a470ae480d1bb99beb2094c06260566608e5bb3c0b1b0c08502c81c1b20aaa45d636b6cbc58339197b970ca1ba398106f42481526fe678519a47945a8f6300f7567c9280c216c09c03b6159bc417d434d837e188aa989a2764005e2770b85b14801a9c22ba24647160e0c2aa3961ffa44a7219b12e1f00e98922b185f2bf6555cb96206e5666467f90ae3804afb490c7f65d885ac4ae22589054d4ea561e8b39e11f5e5a80f93c0523c9c43b60213910c49235116da2aca3cc78c75a707711455e0a540947ab9825dc2eefb60c65666641866c105a10a0e82121d95ee93be485688e28db0a707c3994bb5b0f2dda24c4392d911bc108c32bb7910faa070b46ae4196027294579d3934eba69bfc0c405fec67ecee68c5b6683c5c6bc18ed91a1b6324debf21a538e11fc028b6f2316387768e15a15a4a710644a765d45dc5c3668052a8250526988f7321ef5e2e8534c4124d23f42b2d306b686a77cbc3083d7ccd5948326968c02092aad642b4070dcb1282c24e9e24dd6b93a1e266fa3525378eec660aab0c8f7693eb04e37a84f59ef111e7e2ba7504309192ed3a4d67e317305d889260a7d6e6084b039296f49e22d5b09d73bf5ec64a7ba16977164f1da556825e74aa75a2507a58a7e805234cf98f135d53c0118eb7a0f1647e6902e79c898e8438dd33841ae82a5fa655f4fc2d8162fbd6a5ab4718f0a44c31a82020372ef8a4454be78
+          default: 0xc75c2a171038e805291da85db7ed8e8aaaf49e5d2515b5eda1a9a3cbc41852d1146c5e481bb54af80463e0cd78b8b1f84c97222d9533022aaf44494db94418feb56c610b1d15831aac2d0c3beb7189341e475ac45cb7cce2cad3c72cf378500ac8c5c2bd60642b406e90d5590575068921c435aa973748193b86d5fa111c2b890143b590a19c434e30d682273a1f2264950be4a7aca887e8f826835197f9729f45a958dcbfba5a3a60fe36cdd8163860db8a64542b5a505dca164651a1657116c26c762a6c3c46ef3aa0f04da95595e0b8639d40bb35c04881fae71b27250341843b0f91af1e7f0d4aa28da29ce7723196d860b67871c2264b09180245459b4f226bf8b3afcdf3f2d29609fab84864ee37515815ea49bd9ca6976609de6be64086761cb1a6657a3e0a5888b7c39efa4825506f5b98f40e11f0d8a49a87b8b6a92108e6cb0f035f72404b10006a3a3d82c6967a9da40491363a1149316c476b64992e299fdb5144dac05352e47aacc272d67a079260c9c8112bb7a9fd9c26c23d4579d1ca8e36af9181fd397a64769055be831bdef259997c31da92296746b043e0361c5d3319fa9d3d63c741f90b57652399b67da0e009e21b31438a3570d6487a0db1a7d360660ec982aeb41bc61056ed0dcaf3e8c855ed44b5ff7e8ed0f17488d599dc821681281c20c566eb82d16285f7867131906420bc5cb059f9cbc480fa2d40719cd5f273b1536a1ec186c4c97e8163272656ec676252baab86ae744dcca70033ca190ea794ddd69a6978a196af0b853a74a800539046ba14fb61097943d1aa2f6e971c5cd77b429798524b1d8b7168c0c4f40c421f16928e5a5dc8a9ae66bfcf35690028560289895bd3f65206a11f96894202b042c0b4336146c27c542e4c66086a014a0a8634d2b2252522c862794798ab261667bcdae634fd0fcf1c59d5099cf551b92ed2e4cc7719123c62c249224932348c9bf32967ae823b297d01ea2275c5139620c0538119a4c42a4a8c278d5c939615ae0076590a6d0232df51f5df6224d4a16ac2904485f3b266da20fb38294918a63551974c1c8840c317067a2da646f0bb8e1a2700436ac6f481b78013dafc159c121c9675c042812906edb9841d8ec8357d01baac8202f9c4e7b022c080ad79a12fab6c454c3497aeb025be46930520be450d2c22188b9e0366e18c16e950e73ddee85ad547a91994dc394ff5b65662c8db31440a0a7128cfa4c851629e791f1848c385df0c1c3e442cb94e44245496f000a32155e5ab876ce699d095e4f3c1b4ad839344eb91660882553d563311073022b7b0ba8709a2b1328b0782c5ac04105038d6bda39662fb98d0e72659a942c804e945c734ed3a829f405a516dcc76ce332d8c17f9a7b76fd775f84f980324bd
           randwidth: 8000
         }
         {
@@ -7519,7 +7519,7 @@
           randcount: 800
           randtype: data
           name_top: RndCnstKmacBufferLfsrSeed
-          default: 0xb6396fce53002a2961ac84bdda1315add2f8a394a094c63c8af070919cd8b168cab6a734a2a92b34ba17c531911e20c1a496592784ac089e72877bdaf9f7954486164b58ea68f9b7f647cdafc1c9a905a7aa52efed17f8efa13e9543502f28c02c460aa8
+          default: 0x75e7b1209b868a4acd919ed9795d5f519aa8cd47ac68b65650a1bb5a4a6dbf0bc7c1c7af8402bacd250ed8960c88b4b17ea9867b47ae9a95aaf96dbe43a4472dc0c72f2488d40ccad7575333e5e48f00bbc1f91e5eea7ad029c213141ee86e77b99bf0a1
           randwidth: 800
         }
         {
@@ -7529,7 +7529,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacMsgPerm
-          default: 0x8cc0f8c760851b07167c7d4a3d3a9910042f637e4d24b960f95691cfa5de9e44a287b22cf4ea3f53c6c1af2b66b9da74
+          default: 0xf24f6a4181572048be494e1dfe16a8b0f4d50f76eb9b20315b4a73076b7b6609ce3422b92fa723c1e25118c1e5b9fd6f
           randwidth: 384
         }
       ]
@@ -7723,7 +7723,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0x88d40ccad7575333e5e48f00bbc1f91e5eea7ad029c213141ee86e77b99bf0a1
+          default: 0x3ca72c2242223ce6d70f17b4f4b32818aa49d125b4defb1f3c0be8a29be065c2
           randwidth: 256
         }
         {
@@ -7761,7 +7761,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0xbcd67fb8941c331a44277bc08f711d2d
+          default: 0x6d23550bbc139ff6461763d7e966a8a7
           randwidth: 128
         }
         {
@@ -7771,7 +7771,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0x33e72bc40a36399d
+          default: 0x219eb2e8ef9f11a1
           randwidth: 64
         }
       ]
@@ -8006,7 +8006,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0x8364dcd59508d525
+          default: 0x52e6c71aa23b8864
           randwidth: 64
         }
         {
@@ -8016,7 +8016,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0x30dc4f457678d15f06b4a0334e7243865c2c7e9e8553242ebe8efd482dea6c863976269e9ab1fed5c13f396da42e08c1
+          default: 0x4bbde0996949e0fa88cad4ec5cb570ff508dafd933f05e5a65f507bee70e0712a3a76d2119889113a7be9cca000dd6d0
           randwidth: 384
         }
         {
@@ -8026,7 +8026,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0xa1eddaca974af0044d9e1c6af0b1699295ff74c
+          default: 0x6c74abd4c4b30fdc0fe8d84b302f22a41fee49c9
           randwidth: 160
         }
         {
@@ -8036,7 +8036,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0xcb1b851078c2a5f18eee28d0b562043b7312efad871f92e7527da865d661281f
+          default: 0x2ccd155d84fdaced736e93362c8da83c5f4dd2093e4d2a70dd99dcf4ccac341a
           randwidth: 256
         }
         {
@@ -8046,7 +8046,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0xe98dfcd72e3c6d150a85d63009596f7966c5c68caedde4ab7c65fb8d59618284
+          default: 0x2f1a2704f5e21287fa168af251b370d034cda605152662f4d11b3245d5943ea5
           randwidth: 256
         }
         {
@@ -8056,7 +8056,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0x64d7194e4707ada81f8a6db14ca845beee60798289ad4fb0df1768296390152
+          default: 0xfd2e4bea016b7911deaf01df742547371445d6e3955145e3074d9ca9e8a4ef06
           randwidth: 256
         }
         {
@@ -8066,7 +8066,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0x700e078ec5a951b627cf2ccd155d84fdaced736e93362c8da83c5f4dd2093e4d
+          default: 0xa6f14a5c8fcac0d6396e606a620a9ffb23756bda420a9e7bd1a7c41e3a37b747
           randwidth: 256
         }
         {
@@ -8076,7 +8076,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0x2a70dd99dcf4ccac341a2f1a2704f5e21287fa168af251b370d034cda6051526
+          default: 0xd3d7b758b37d1d1ca19a079c48d7d4e67100a6aaebe45b6f09aefb72895ec90d
           randwidth: 256
         }
         {
@@ -8086,7 +8086,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0x62f4d11b3245d5943ea5fd2e4bea016b7911deaf01df742547371445d6e39551
+          default: 0x876315db9ad8bbe63ecace31278da3acfc873ec5a22829bd781efe2b4b06f4b3
           randwidth: 256
         }
         {
@@ -8096,7 +8096,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0x45e3074d9ca9e8a4ef06a6f14a5c8fcac0d6396e606a620a9ffb23756bda420a
+          default: 0x49e0372b7394d415d937f3578cc1200dd1fb1d0ecf948594bc831c3e0e1f33c9
           randwidth: 256
         }
         {
@@ -8106,7 +8106,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0x9e7bd1a7c41e3a37b747d3d7b758b37d1d1ca19a079c48d7d4e67100a6aaebe4
+          default: 0x98cabd61dac609b5dd0e0c602aef2e932b1fb8fb631dd82de6c9adde7bfb79fb
           randwidth: 256
         }
         {
@@ -8116,7 +8116,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOtbnSeed
-          default: 0x5b6f09aefb72895ec90d876315db9ad8bbe63ecace31278da3acfc873ec5a228
+          default: 0x9cc4c0b2d1aed6700a44ea3e7e0610a663d52b082b9aef0e426df4866fe88a8b
           randwidth: 256
         }
         {
@@ -8126,7 +8126,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCdi
-          default: 0x29bd781efe2b4b06f4b349e0372b7394d415d937f3578cc1200dd1fb1d0ecf94
+          default: 0xaa3b3b2f5e3917a7a7d4b5e53c38b3cedc40946cf3635f0c112f435205ef40d4
           randwidth: 256
         }
         {
@@ -8136,7 +8136,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0x8594bc831c3e0e1f33c998cabd61dac609b5dd0e0c602aef2e932b1fb8fb631d
+          default: 0xb50cbd86b4932d75cebe7060738efa2035418082cfe96e5cc1280fbe2f2e3236
           randwidth: 256
         }
       ]
@@ -8350,7 +8350,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0xd82de6c9adde7bfb79fb9cc4c0b2d1aed6700a44ea3e7e0610a663d52b082b9aef0e426df4866fe88a8baa3b3b2f5e39
+          default: 0x88bcc7ecbb1a7db7be4ccaf27d6eb83fd28156d9cb50075d6af437bebb1d8879e25723b9d533238865874ef2d375583c
           randwidth: 384
         }
         {
@@ -8360,7 +8360,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0x17a7a7d4b5e53c38b3cedc40946cf3635f0c112f435205ef40d4b50cbd86b4932d75cebe7060738efa2035418082cfe9
+          default: 0x209c027d35c5794f680b124893c22e6a22f5ad2e7591ecad6cca220de3c0051a862508d4ce0015f9376719bd15980c9e
           randwidth: 384
         }
         {
@@ -8880,7 +8880,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0x6e5cc1280fbe2f2e323688bcc7ecbb1a
+          default: 0x525dcbc7a2e75c94580bc5da0a20865a
           randwidth: 128
         }
         {
@@ -8890,28 +8890,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x7db7be4ccaf27d6eb83fd28156d9cb50
+          default: 0x9b36b012f2546ea845a7ade1002b84b7
           randwidth: 128
         }
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: sram_ctrl_pkg::lfsr_seed_t
-          randcount: 32
+          randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0x75d6af4
-          randwidth: 32
+          default: 0x39380023c25c3dea
+          randwidth: 64
         }
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: sram_ctrl_pkg::lfsr_perm_t
-          randcount: 32
+          randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0xad901d2e6dcc8e0a0b857260cde3fd229f11fae6
-          randwidth: 160
+          default: 0x5c16b58efd74310e6cb4648037d4969e379ce946fa13f676ca49d1eaba2b24fb07c256582de3adbb30b60450f1a18fc
+          randwidth: 384
         }
         {
           name: MemSizeRam
@@ -9205,7 +9205,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0x2e6a22f5ad2e7591
+          default: 0x86282b72c315dc48
           randwidth: 64
         }
         {
@@ -9215,7 +9215,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0xecad6cca220de3c0051a862508d4ce00
+          default: 0x76f6acfa65e2f3fff25369dff7245670
           randwidth: 128
         }
         {
@@ -9424,7 +9424,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x15f93767
+          default: 0x4342d7cd
           randwidth: 32
         }
         {
@@ -9434,7 +9434,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0x439bd600f9899f5f7d258135bb4b145ab8198ae3
+          default: 0x8a44441e74cc34a083fb359f5e5fb8933c56adc3
           randwidth: 160
         }
         {
@@ -9444,7 +9444,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0x380023c25c3deaf38d871a3c5213602c
+          default: 0xa6bfbfb2eb0038e80868a59e9dd11bbf
           randwidth: 128
         }
         {
@@ -9454,7 +9454,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0x32e73d3051db61b7
+          default: 0x7449121cdefc0bd7
           randwidth: 64
         }
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -18,17 +18,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter otp_ctrl_top_specific_pkg::lfsr_seed_t RndCnstOtpCtrlLfsrSeed = {
-    40'h50_C2C82DEB
+    40'h4F_64CE9783
   };
 
   // Compile-time random permutation for LFSR output
   parameter otp_ctrl_top_specific_pkg::lfsr_perm_t RndCnstOtpCtrlLfsrPerm = {
-    240'h8573_E042648A_54E4C07E_42E77094_4376231B_1C278894_D1196231_56181694
+    240'h30E2_CD723991_58391075_36995C51_1E9E57E0_0A285B28_F0151D42_58206481
   };
 
   // Compile-time random permutation for scrambling key/nonce register reset value
   parameter otp_ctrl_top_specific_pkg::scrmbl_key_init_t RndCnstOtpCtrlScrmblKeyInit = {
-    256'hDBB4685F_7EB27EB3_B35F3527_52E34F64_CE978305_BFC3481A_2162EA27_92B7508F
+    256'h7468BC0B_D8D70368_E7CFB11A_99675B14_62406193_35A9E2D1_23834D18_744778BE
   };
 
   ////////////////////////////////////////////
@@ -36,35 +36,35 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Diversification value used for all invalid life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    128'h1EAB067A_F954DDA5_491439A9_DDE63208
+    128'h5E63C087_E36838B5_6B1A45F6_FD312F53
   };
 
   // Diversification value used for the TEST_UNLOCKED* life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestUnlocked = {
-    128'h01FDCF25_A4FBA528_39911706_9E77C887
+    128'h53FA7B2C_E9FC83DD_AF1DD8C5_A42E2AD2
   };
 
   // Diversification value used for the DEV life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivDev = {
-    128'hF53DDA6F_B4EF8758_B99027B6_AA7468BC
+    128'h4FA02221_B6FF5AAD_7A9C09D5_D9FDD1CF
   };
 
   // Diversification value used for the PROD/PROD_END life cycle states.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    128'h0BD8D703_68E7CFB1_1A99675B_14624061
+    128'hCF512835_C0CFAE2E_D0C69FA4_88685CEA
   };
 
   // Diversification value used for the RMA life cycle state.
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivRma = {
-    128'h9335A9E2_D123834D_18744778_BE5E63C0
+    128'h9BC1C89B_FB7399AE_F5C6EB5D_6E4E2341
   };
 
   // Compile-time random bits used for invalid tokens in the token mux
   parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
-    256'h87E36838_B56B1A45_F6FD312F_5353FA7B_2CE9FC83_DDAF1DD8_C5A42E2A_D24FA022,
-    256'h21B6FF5A_AD7A9C09_D5D9FDD1_CFCF5128_35C0CFAE_2ED0C69F_A488685C_EA9BC1C8,
-    256'h9BFB7399_AEF5C6EB_5D6E4E23_416A0AA6_D7AC7EC9_C3304470_FBE505F9_649400CA,
-    256'h9864FD4C_E49D2CFC_6ECC1025_40EAD873_4700A520_71326894_71AA822B_C51CDD4D
+    256'h6A0AA6D7_AC7EC9C3_304470FB_E505F964_9400CA98_64FD4CE4_9D2CFC6E_CC102540,
+    256'hEAD87347_00A52071_32689471_AA822BC5_1CDD4D37_AC2D246C_4264F37E_C1982017,
+    256'h94ADDA1B_16929DF5_E06A56AA_DED44325_9FFB5736_DD680121_5B98E162_DCC09E31,
+    256'hE8382E46_E4FECFDA_2375A614_7421D8CB_69D4F3A1_5FAF834C_AD515D76_BD37C7BE
   };
 
   ////////////////////////////////////////////
@@ -72,12 +72,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_handler_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'h37AC2D24
+    32'hC5F33FDC
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_handler_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'h83A2B09F_B9D7006B_1534F2BF_7D8EB211_2787B10D
+    160'hC65720DC_8F9A845F_6A1C6251_6AB63D39_BE0DB874
   };
 
   ////////////////////////////////////////////
@@ -85,22 +85,23 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h46E4FECF_DA2375A6_147421D8_CB69D4F3
+    128'h4B6A0CD0_66336E9B_0BDF6A55_F0D23BB7
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'hA15FAF83_4CAD515D_76BD37C7_BEC5F33F
+    128'hDC0DC524_D3B05546_03562188_552794DD
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    32'hDCA11A72
+    64'h2BEBF67F_318B5A49
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    160'h848BCB54_640EBABB_89F357FC_C4A3386C_5C73501B
+    128'hE4E6D896_C3E8066E_D32909F0_49E11DA6,
+    256'hBC488997_F75A101A_F179382F_2D7F147B_7A08672F_D2344DCE_026A53E3_2EDBD543
   };
 
   ////////////////////////////////////////////
@@ -108,28 +109,28 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'h0CD06633_6E9B0BDF_6A55F0D2_3BB7DC0D
+    128'hF0EF4782_48447B11_42087365_0CBC6AEE
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'hC524D3B0_55460356_21885527_94DD2BEB
+    128'hA2C8EE2D_E417E3D0_5D145C3A_684922F7
   };
 
   // Compile-time random bits for default seeds
   parameter flash_ctrl_top_specific_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
-    256'hF67F318B_5A490E55_F7D8B832_5652A924_82CC3446_8C37BFEE_731A0AB4_30181CDE,
-    256'h15F40D83_472DD252_E38F2C5E_24D201BD_B435D5CF_F95C40A1_643CC8F5_40230522
+    256'hDC57CC66_8C58F099_531A3221_A2EDDCA4_1F778DDE_61DE9734_B7ECDEC5_17110ED2,
+    256'hCEB31D78_9F996BCD_43BA4FB0_6B9EA47D_BF441AA6_25F5DDF2_DCB03C2B_867024D5
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_top_specific_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'hD33A4EA4
+    32'h4654C6E6
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_top_specific_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'hB16325F5_4D0ED9E3_1C04C3EB_9D5F8812_7F41CDD0
+    160'h50FC8F9F_B826E306_841C34ED_A63A45A5_D79155E9
   };
 
   ////////////////////////////////////////////
@@ -137,34 +138,34 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h4922F7DC_57CC668C
+    64'hD00B7E75_6F81353C
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h5D273257_0001B22C_5987AD3E_90B08F80,
-    256'hAE6F3B8B_ABFF36EA_27B45FD9_341AF677_B50C416D_36562374_7A77A083_06526F16
+    128'h530A34A8_127F92F0_C6D8BB5C_8C7E515B,
+    256'hDED97579_5FEA686C_3B5BB317_EC7C4A95_4841B013_DCF8028B_263828D7_A768CAC4
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h386FA841_1F6AF130_D92E9B5C_863CB0C5,
-    256'h4916B172_26009147_BF88B694_AB9E9DAD_F513B360_6DD7C2D2_B63FCCC0_4F495EB9
+    128'h8AC7AA1A_9FC8115F_247475A6_FB7C4F2A,
+    256'h0ACD7359_6FB7AC97_B9315A27_051BF408_D0042851_6730CBE6_8E1F4B66_0E9FBD0C
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    32'h4660C443,
-    256'hDF8E6E3A_14E92AF0_B0266DCD_3DE77D58_92992045_3CEDC4BB_4632D2EE_9D3B62DA
+    32'h51A50AC3,
+    256'h12C18282_2CF6AD12_452480A6_1092E8A8_0CDF2678_89E06A8A_1AB5F6DB_8158AA7C
   };
 
   // Permutation applied to the output of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h04865797_42011B23_24800A7A_7215902B_345B2662_581C0C51_0F680B9D_4A1E389C,
-    256'h1F6D5F07_02473073_32431D33_17362092_6778039E_8C3D4D8F_6B843B55_897D0E96,
-    256'h7631747C_19692E7E_29915E63_1A8A4C3E_2C5D9A45_35853C13_9454496F_83407722,
-    256'h66561664_93600961_05522875_5A215395_2A442539_79598812_8B3F5C82_9970379B,
-    256'h7B8E816E_11711018_4E4F146A_2798506C_3A008D41_06088746_652D0D2F_9F4B7F48
+    256'h377A4A72_7E8F3570_24262156_918E494C_104F305D_366B186A_1583878A_758B882D,
+    256'h5E0A972F_082B0B84_29400792_763E2290_1F041247_4E468543_71963C41_4D091168,
+    256'h02935B1B_58949F0D_146D0155_1E57277B_541C1766_787D8660_732A6748_20796238,
+    256'h77336F99_196C312C_3D162E0F_4B513F81_42450E05_9A741D59_7C23069C_699E8C13,
+    256'h5F53809B_390C5003_4464653B_3A619D63_7F5A8D89_321A5C6E_95520025_82342898
   };
 
   ////////////////////////////////////////////
@@ -172,58 +173,58 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random data for PRNG default seed
   parameter kmac_pkg::lfsr_seed_t RndCnstKmacLfsrSeed = {
-    32'h4FE255B1,
-    256'h3D5003AE_3828EE1A_34F865C1_0B37A68D_F5D12932_05F54724_A965AB81_CA6C3169
+    32'hD58DC810,
+    256'hDD8EB122_5D79F3EC_320BB4D2_D4692B1F_9D1645F0_37D9DC83_E4B7B7D0_E5638801
   };
 
   // Compile-time random permutation for PRNG output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    64'hA1114968_69A41CC0,
-    256'hBF1BADF1_C3C4F89D_1806DD54_34EEB721_AB6CB040_35B8112F_F4494614_F0E622AC,
-    256'hB24F636E_878961B9_2D2026E1_FBDAE234_1255B228_8EE7921D_6585DF74_1EB12B0B,
-    256'h0B1098A4_D6125F1E_9AB15A59_F1B72EE1_E9017063_E9591888_DE690E31_AF9C7B76,
-    256'h325A4629_CD5651E1_98CEA106_8D100417_35C00635_435BC83A_C150BD20_C49265AB,
-    256'hDF4C1C93_1DDB5319_8F332D53_1C355668_B6599C60_466439D1_11B02965_FE516D33,
-    256'hE9CD27D7_2A889517_DDE26AB5_4641C8F7_00A7AD78_FE54611B_3408A2C7_D5747DAA,
-    256'h4A2770E1_F530CECA_6C29108A_1B42BDAA_5867240A_A251A544_8001ACC4_AA0B4883,
-    256'h61CCB32D_4E409538_C66884B4_90486F83_36B64C9E_E0D05544_E517DAB4_2303F71A,
-    256'hD883A673_FE354F53_96EDCB84_496BA94F_42AE0912_6F915790_89D7924B_DC35272F,
-    256'hD9350854_2F8E5549_9775A347_6D2C89E2_C73D74A7_56A168B2_47488299_9FAC8211,
-    256'hC97E2954_C6A1046D_15372AC5_7C8FC3D2_7DA991CA_CC185545_71D5C00F_8E78C213,
-    256'h40ECD121_903F9481_9EC70C57_66F0E217_4030AA7A_902725C0_50053052_ADBA8AED,
-    256'h46528D81_92E32EB8_6746B2E4_1F698608_71ED9BAF_78354009_8A87AD3B_7E66BBE4,
-    256'h1EB9DFC9_04162E98_B932DB8D_8745E987_049AF3D5_5DA18309_86DF9B4D_A738DDBC,
-    256'hC24A0534_04D36A0D_C30444C8_48FB42E2_E3387B74_06D2A6E1_136A470A_E480D1BB,
-    256'h99BEB209_4C062605_66608E5B_B3C0B1B0_C08502C8_1C1B20AA_A45D636B_6CBC5833,
-    256'h9197B970_CA1BA398_106F4248_1526FE67_8519A479_45A8F630_0F7567C9_280C216C,
-    256'h09C03B61_59BC417D_434D837E_188AA989_A2764005_E2770B85_B14801A9_C22BA246,
-    256'h47160E0C_2AA3961F_FA44A721_9B12E1F0_0E98922B_185F2BF6_555CB962_06E56664,
-    256'h67F90AE3_804AFB49_0C7F65D8_85AC4AE2_2589054D_4EA561E8_B39E11F5_E5A80F93,
-    256'hC0523C9C_43B60213_910C4923_5116DA2A_CA3CC78C_75A70771_1455E0A5_40947AB9,
-    256'h825DC2EE_FB60C656_66641866_C105A10A_0E82121D_95EE93BE_485688E2_8DB0A707,
-    256'hC3994BB5_B0F2DDA2_4C4392D9_11BC108C_32BB7910_FAA070B4_6AE41960_27294579,
-    256'hD3934EBA_69BFC0C4_05FEC67E_CEE68C5B_6683C5C6_BC18ED91_A1B6324D_EBF21A53,
-    256'h8E11FC02_8B6F2316_387768E1_5A15A4A7_10644A76_5D45DC5C_3668052A_82505269,
-    256'h88F7321E_F5E2E853_4C4124D2_3F42B2D3_06B686A7_7CBC3083_D7CCD594_8326968C,
-    256'h02092AAD_642B4070_DCB1282C_24E9E24D_D6B93A1E_266FA352_5378EEC6_60AAB0C8,
-    256'hF7693EB0_4E37A84F_59EF111E_7E2BA750_4309192E_D3A4D67E_317305D8_89260A7D,
-    256'h6E6084B0_39296F49_E22D5B09_D73BF5EC_64A7BA16_977164F1_DA556825_E74AA75A,
-    256'h2507A58A_7E805234_CF98F135_D53C0118_EB7A0F16_47E6902E_79C898E8_438DD338,
-    256'h41AE82A5_FA655F4F_C2D8162F_BD6A5AB4_718F0A44_C31A8202_0372EF8A_4454BE78
+    64'hC75C2A17_1038E805,
+    256'h291DA85D_B7ED8E8A_AAF49E5D_2515B5ED_A1A9A3CB_C41852D1_146C5E48_1BB54AF8,
+    256'h0463E0CD_78B8B1F8_4C97222D_9533022A_AF44494D_B94418FE_B56C610B_1D15831A,
+    256'hAC2D0C3B_EB718934_1E475AC4_5CB7CCE2_CAD3C72C_F378500A_C8C5C2BD_60642B40,
+    256'h6E90D559_05750689_21C435AA_97374819_3B86D5FA_111C2B89_0143B590_A19C434E,
+    256'h30D68227_3A1F2264_950BE4A7_ACA887E8_F8268351_97F9729F_45A958DC_BFBA5A3A,
+    256'h60FE36CD_D8163860_DB8A6454_2B5A505D_CA164651_A1657116_C26C762A_6C3C46EF,
+    256'h3AA0F04D_A95595E0_B8639D40_BB35C048_81FAE71B_27250341_843B0F91_AF1E7F0D,
+    256'h4AA28DA2_9CE77231_96D860B6_7871C226_4B091802_45459B4F_226BF8B3_AFCDF3F2,
+    256'hD29609FA_B84864EE_37515815_EA49BD9C_A6976609_DE6BE640_86761CB1_A6657A3E,
+    256'h0A5888B7_C39EFA48_25506F5B_98F40E11_F0D8A49A_87B8B6A9_2108E6CB_0F035F72,
+    256'h404B1000_6A3A3D82_C6967A9D_A4049136_3A114931_6C476B64_992E299F_DB5144DA,
+    256'hC05352E4_7AACC272_D67A0792_60C9C811_2BB7A9FD_9C26C23D_4579D1CA_8E36AF91,
+    256'h81FD397A_64769055_BE831BDE_F259997C_31DA9229_6746B043_E0361C5D_3319FA9D,
+    256'h3D63C741_F90B5765_2399B67D_A0E009E2_1B31438A_3570D648_7A0DB1A7_D360660E,
+    256'hC982AEB4_1BC61056_ED0DCAF3_E8C855ED_44B5FF7E_8ED0F174_88D599DC_82168128,
+    256'h1C20C566_EB82D162_85F78671_31906420_BC5CB059_F9CBC480_FA2D4071_9CD5F273,
+    256'hB1536A1E_C186C4C9_7E816327_2656EC67_6252BAAB_86AE744D_CCA70033_CA190EA7,
+    256'h94DDD69A_6978A196_AF0B853A_74A80053_9046BA14_FB610979_43D1AA2F_6E971C5C,
+    256'hD77B4297_98524B1D_8B7168C0_C4F40C42_1F16928E_5A5DC8A9_AE66BFCF_35690028,
+    256'h56028989_5BD3F652_06A11F96_894202B0_42C0B433_6146C27C_542E4C66_086A014A,
+    256'h0A8634D2_B2252522_C8627947_98AB2616_67BCDAE6_34FD0FCF_1C59D509_9CF551B9,
+    256'h2ED2E4CC_7719123C_62C24922_4932348C_9BF32967_AE823B29_7D01EA22_75C51396,
+    256'h20C05381_19A4C42A_4A8C278D_5C939615_AE007659_0A6D0232_DF51F5DF_6224D4A1,
+    256'h6AC29044_85F3B266_DA20FB38_294918A6_3551974C_1C8840C3_17067A2D_A646F0BB,
+    256'h8E1A2700_436AC6F4_81B78013_DAFC159C_121C9675_C0428129_06EDB984_1D8EC835,
+    256'h7D01BAAC_8202F9C4_E7B022C0_80AD79A1_2FAB6C45_4C3497AE_B025BE46_930520BE,
+    256'h450D2C22_188B9E03_66E18C16_E950E73D_DEE85AD5_47A91994_DC394FF5_B65662C8,
+    256'hDB31440A_0A7128CF_A4C85162_9E791F18_48C385DF_0C1C3E44_2CB94E44_245496F0,
+    256'h00A32155_E5AB876C_E699D095_E4F3C1B4_AD839344_EB916608_82553D56_33110730,
+    256'h22B7B0BA_8709A2B1_328B0782_C5AC0410_5038D6BD_A39662FB_98D0E726_59A942C8,
+    256'h04E945C7_34ED3A82_9F405A51_6DCC76CE_332D8C17_F9A7B76F_D775F84F_980324BD
   };
 
   // Compile-time random data for PRNG buffer default seed
   parameter kmac_pkg::buffer_lfsr_seed_t RndCnstKmacBufferLfsrSeed = {
-    32'hB6396FCE,
-    256'h53002A29_61AC84BD_DA1315AD_D2F8A394_A094C63C_8AF07091_9CD8B168_CAB6A734,
-    256'hA2A92B34_BA17C531_911E20C1_A4965927_84AC089E_72877BDA_F9F79544_86164B58,
-    256'hEA68F9B7_F647CDAF_C1C9A905_A7AA52EF_ED17F8EF_A13E9543_502F28C0_2C460AA8
+    32'h75E7B120,
+    256'h9B868A4A_CD919ED9_795D5F51_9AA8CD47_AC68B656_50A1BB5A_4A6DBF0B_C7C1C7AF,
+    256'h8402BACD_250ED896_0C88B4B1_7EA9867B_47AE9A95_AAF96DBE_43A4472D_C0C72F24,
+    256'h88D40CCA_D7575333_E5E48F00_BBC1F91E_5EEA7AD0_29C21314_1EE86E77_B99BF0A1
   };
 
   // Compile-time random permutation for LFSR Message output
   parameter kmac_pkg::msg_perm_t RndCnstKmacMsgPerm = {
-    128'h8CC0F8C7_60851B07_167C7D4A_3D3A9910,
-    256'h042F637E_4D24B960_F95691CF_A5DE9E44_A287B22C_F4EA3F53_C6C1AF2B_66B9DA74
+    128'hF24F6A41_81572048_BE494E1D_FE16A8B0,
+    256'hF4D50F76_EB9B2031_5B4A7307_6B7B6609_CE3422B9_2FA723C1_E25118C1_E5B9FD6F
   };
 
   ////////////////////////////////////////////
@@ -231,17 +232,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'h88D40CCA_D7575333_E5E48F00_BBC1F91E_5EEA7AD0_29C21314_1EE86E77_B99BF0A1
+    256'h3CA72C22_42223CE6_D70F17B4_F4B32818_AA49D125_B4DEFB1F_3C0BE8A2_9BE065C2
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'hBCD67FB8_941C331A_44277BC0_8F711D2D
+    128'h6D23550B_BC139FF6_461763D7_E966A8A7
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'h33E72BC4_0A36399D
+    64'h219EB2E8_EF9F11A1
   };
 
   ////////////////////////////////////////////
@@ -249,73 +250,73 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'h8364DCD5_9508D525
+    64'h52E6C71A_A23B8864
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'h30DC4F45_7678D15F_06B4A033_4E724386,
-    256'h5C2C7E9E_8553242E_BE8EFD48_2DEA6C86_3976269E_9AB1FED5_C13F396D_A42E08C1
+    128'h4BBDE099_6949E0FA_88CAD4EC_5CB570FF,
+    256'h508DAFD9_33F05E5A_65F507BE_E70E0712_A3A76D21_19889113_A7BE9CCA_000DD6D0
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'h0A1EDDAC_A974AF00_44D9E1C6_AF0B1699_295FF74C
+    160'h6C74ABD4_C4B30FDC_0FE8D84B_302F22A4_1FEE49C9
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'hCB1B8510_78C2A5F1_8EEE28D0_B562043B_7312EFAD_871F92E7_527DA865_D661281F
+    256'h2CCD155D_84FDACED_736E9336_2C8DA83C_5F4DD209_3E4D2A70_DD99DCF4_CCAC341A
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'hE98DFCD7_2E3C6D15_0A85D630_09596F79_66C5C68C_AEDDE4AB_7C65FB8D_59618284
+    256'h2F1A2704_F5E21287_FA168AF2_51B370D0_34CDA605_152662F4_D11B3245_D5943EA5
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'h064D7194_E4707ADA_81F8A6DB_14CA845B_EEE60798_289AD4FB_0DF17682_96390152
+    256'hFD2E4BEA_016B7911_DEAF01DF_74254737_1445D6E3_955145E3_074D9CA9_E8A4EF06
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'h700E078E_C5A951B6_27CF2CCD_155D84FD_ACED736E_93362C8D_A83C5F4D_D2093E4D
+    256'hA6F14A5C_8FCAC0D6_396E606A_620A9FFB_23756BDA_420A9E7B_D1A7C41E_3A37B747
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'h2A70DD99_DCF4CCAC_341A2F1A_2704F5E2_1287FA16_8AF251B3_70D034CD_A6051526
+    256'hD3D7B758_B37D1D1C_A19A079C_48D7D4E6_7100A6AA_EBE45B6F_09AEFB72_895EC90D
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'h62F4D11B_3245D594_3EA5FD2E_4BEA016B_7911DEAF_01DF7425_47371445_D6E39551
+    256'h876315DB_9AD8BBE6_3ECACE31_278DA3AC_FC873EC5_A22829BD_781EFE2B_4B06F4B3
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'h45E3074D_9CA9E8A4_EF06A6F1_4A5C8FCA_C0D6396E_606A620A_9FFB2375_6BDA420A
+    256'h49E0372B_7394D415_D937F357_8CC1200D_D1FB1D0E_CF948594_BC831C3E_0E1F33C9
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'h9E7BD1A7_C41E3A37_B747D3D7_B758B37D_1D1CA19A_079C48D7_D4E67100_A6AAEBE4
+    256'h98CABD61_DAC609B5_DD0E0C60_2AEF2E93_2B1FB8FB_631DD82D_E6C9ADDE_7BFB79FB
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrOtbnSeed = {
-    256'h5B6F09AE_FB72895E_C90D8763_15DB9AD8_BBE63ECA_CE31278D_A3ACFC87_3EC5A228
+    256'h9CC4C0B2_D1AED670_0A44EA3E_7E0610A6_63D52B08_2B9AEF0E_426DF486_6FE88A8B
   };
 
   // Compile-time random bits for generation seed when no CDI is selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrCdi = {
-    256'h29BD781E_FE2B4B06_F4B349E0_372B7394_D415D937_F3578CC1_200DD1FB_1D0ECF94
+    256'hAA3B3B2F_5E3917A7_A7D4B5E5_3C38B3CE_DC40946C_F3635F0C_112F4352_05EF40D4
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'h8594BC83_1C3E0E1F_33C998CA_BD61DAC6_09B5DD0E_0C602AEF_2E932B1F_B8FB631D
+    256'hB50CBD86_B4932D75_CEBE7060_738EFA20_35418082_CFE96E5C_C1280FBE_2F2E3236
   };
 
   ////////////////////////////////////////////
@@ -323,14 +324,14 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'hD82DE6C9_ADDE7BFB_79FB9CC4_C0B2D1AE,
-    256'hD6700A44_EA3E7E06_10A663D5_2B082B9A_EF0E426D_F4866FE8_8A8BAA3B_3B2F5E39
+    128'h88BCC7EC_BB1A7DB7_BE4CCAF2_7D6EB83F,
+    256'hD28156D9_CB50075D_6AF437BE_BB1D8879_E25723B9_D5332388_65874EF2_D375583C
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'h17A7A7D4_B5E53C38_B3CEDC40_946CF363,
-    256'h5F0C112F_435205EF_40D4B50C_BD86B493_2D75CEBE_7060738E_FA203541_8082CFE9
+    128'h209C027D_35C5794F_680B1248_93C22E6A,
+    256'h22F5AD2E_7591ECAD_6CCA220D_E3C0051A_862508D4_CE0015F9_376719BD_15980C9E
   };
 
   ////////////////////////////////////////////
@@ -338,22 +339,23 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'h6E5CC128_0FBE2F2E_323688BC_C7ECBB1A
+    128'h525DCBC7_A2E75C94_580BC5DA_0A20865A
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h7DB7BE4C_CAF27D6E_B83FD281_56D9CB50
+    128'h9B36B012_F2546EA8_45A7ADE1_002B84B7
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'h075D6AF4
+    64'h39380023_C25C3DEA
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'hAD901D2E_6DCC8E0A_0B857260_CDE3FD22_9F11FAE6
+    128'h05C16B58_EFD74310_E6CB4648_037D4969,
+    256'hE379CE94_6FA13F67_6CA49D1E_ABA2B24F_B07C2565_82DE3ADB_B30B6045_0F1A18FC
   };
 
   ////////////////////////////////////////////
@@ -361,12 +363,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'h2E6A22F5_AD2E7591
+    64'h86282B72_C315DC48
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'hECAD6CCA_220DE3C0_051A8625_08D4CE00
+    128'h76F6ACFA_65E2F3FF_F25369DF_F7245670
   };
 
   ////////////////////////////////////////////
@@ -374,22 +376,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h15F93767
+    32'h4342D7CD
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'h439BD600_F9899F5F_7D258135_BB4B145A_B8198AE3
+    160'h8A44441E_74CC34A0_83FB359F_5E5FB893_3C56ADC3
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'h380023C2_5C3DEAF3_8D871A3C_5213602C
+    128'hA6BFBFB2_EB0038E8_0868A59E_9DD11BBF
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'h32E73D30_51DB61B7
+    64'h7449121C_DEFC0BD7
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
+++ b/hw/top_englishbreakfast/data/autogen/top_englishbreakfast.gen.hjson
@@ -3083,7 +3083,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0x7befa2eaca5e9e86b268b82b10ea8e91
+          default: 0x2d2caf521284d078b2442c4dcdfffc13
           randwidth: 128
         }
         {
@@ -3093,7 +3093,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0x3c65a10e10daa910cd93e9e8dde03e8a
+          default: 0x6eaed4bf1a600233980bc4cf2116db51
           randwidth: 128
         }
         {
@@ -3103,7 +3103,7 @@
           randcount: 512
           randtype: data
           name_top: RndCnstFlashCtrlAllSeeds
-          default: 0xb0f1f4225b70de66ae2a2d2caf521284d078b2442c4dcdfffc136eaed4bf1a600233980bc4cf2116db51ec10b747b9011d99f556b893842a91cafc63cb10b944
+          default: 0xec10b747b9011d99f556b893842a91cafc63cb10b944601633a421ace20b50ec6ba7624a9f75ee12041d292c75940b51257e2224bb78951511213905e9cb853b
           randwidth: 512
         }
         {
@@ -3113,7 +3113,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x601633a4
+          default: 0xc8e152be
           randwidth: 32
         }
         {
@@ -3123,7 +3123,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0xea0dbd7e58f2df985ae78946013a69651aa0f2a4
+          default: 0x88b3d46355372701a8fefa572238366dca06536f
           randwidth: 160
         }
         {
@@ -3626,7 +3626,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x5e9cb853bc8e152
+          default: 0x654d0f66fb6fc362
           randwidth: 64
         }
         {
@@ -3636,7 +3636,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x8541885e2ad14f7138023a9568a1503e71fb372fb0f3d9a0e6560ea0331dd1e4b55a4bac25cc730ad6ff2c1e99a767ef
+          default: 0x322bdce48cfadc95b2069b2b82303e2dd1d39ed35a15819b97fa26f4ee10675ab6d04791f035d490254ac617fbbb048f
           randwidth: 384
         }
         {
@@ -3646,7 +3646,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x10546c53c047bb1aa7b4d4a9ee362242b54a0af7ff4dd5f2eb321a7060245a0e668496cbc0cf65a0f675e37f9ed0e0f6
+          default: 0xea6d01ec7ce3b436aa6c951645d1b7b8c97f4efe0d417018a1f3acf446614b2c4ba7e78222092bc3c8a7db5e4a3d5705
           randwidth: 384
         }
         {
@@ -3656,7 +3656,7 @@
           randcount: 288
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0xc880914b8567e2fb12ce5455e5387cc149c106bd836a7311d59def2e2061b6069e362fb5
+          default: 0x46437ea19c961290cc380044b6a20a920684bc784b3c5ec3f27bd1b3f4ff8071c1b01ad2
           randwidth: 288
         }
         {
@@ -3666,7 +3666,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0x46c591b8e1e6f5887256151158d60027a8b0953562e404f68754d2967053193812226302b6920831d98657c8c1128105c48336a64909491073a9b89885b3f8a2374187257634139863e457f661f70213d6d37548f142c0e329d49132777420b3479629f039c1c762a01952f555a0f5f476e827d0d241799354a190c92524c3b851a96807b5e3c4b78849a0a440038127e9e464e5d1671735036066b9708432d
+          default: 0x29308660712032248352973f099a2f2a8a787389614c6e4b04626f8e0588878d673a42081564006613441b565701113806287a46935d0b4a7f772b7b3425720a989e36167935439d404d51026831705f5c94812250754e5b80908b6a928219270c7c230d9b0f0e2d41589c3c543e85453b531c1f47213d493774917e63127d14591d6510264f6d8417695a07399655032c9f1e8f1a482e6c6b9533188c99765e
           randwidth: 1280
         }
       ]
@@ -3804,7 +3804,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xf8b34d3a036354a7212f4ab685058803
+          default: 0x31494f63e5134a004e3c988a62c28a30
           randwidth: 128
         }
         {
@@ -3814,28 +3814,28 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0xba2f9679ea4623137127ec6ee39aa98b
+          default: 0xe3a475991516636bf59db68ccd043d5f
           randwidth: 128
         }
         {
           name: RndCnstLfsrSeed
           desc: Compile-time random bits for initial LFSR seed
           type: sram_ctrl_pkg::lfsr_seed_t
-          randcount: 32
+          randcount: 64
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0x7f39f9dd
-          randwidth: 32
+          default: 0x2df70b7b0547c824
+          randwidth: 64
         }
         {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: sram_ctrl_pkg::lfsr_perm_t
-          randcount: 32
+          randcount: 64
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x9aec76abf040d80bf3b8ca4db75044f45e50d65a
-          randwidth: 160
+          default: 0x2da689f828ee6ef81cafebf59c8dd9b4ae5358b064f78736883d19316477d0335830883f4955e0bcd9b2d4ec4485a97
+          randwidth: 384
         }
         {
           name: MemSizeRam
@@ -4121,7 +4121,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0x991516636bf59db6
+          default: 0xb3c1a26d4faa85ee
           randwidth: 64
         }
         {
@@ -4131,7 +4131,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0x8ccd043d5f2df70b7b0547c8245da916
+          default: 0x5f205825cac1c3fda717137880b3d785
           randwidth: 128
         }
         {
@@ -4311,7 +4311,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x4b111053
+          default: 0xdc68b5ad
           randwidth: 32
         }
         {
@@ -4321,7 +4321,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0xc506042fee9caa765fb937a168e84453c29db785
+          default: 0xdd7df168a4066ea79e114b714b3b9d0c8c89ac6c
           randwidth: 160
         }
         {
@@ -4331,7 +4331,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRvCoreIbexIbexKeyDefault
-          default: 0xf341d8f69ffaf435e5d3c0ecdd694b90
+          default: 0x5153fdd9691fdd7a990894e5ff39211e
           randwidth: 128
         }
         {
@@ -4341,7 +4341,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRvCoreIbexIbexNonceDefault
-          default: 0xd7fb1168378c3136
+          default: 0x8a4528ee6f4a10b8
           randwidth: 64
         }
         {

--- a/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_rnd_cnst_pkg.sv
+++ b/hw/top_englishbreakfast/rtl/autogen/top_englishbreakfast_rnd_cnst_pkg.sv
@@ -18,28 +18,28 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'h7BEFA2EA_CA5E9E86_B268B82B_10EA8E91
+    128'h2D2CAF52_1284D078_B2442C4D_CDFFFC13
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'h3C65A10E_10DAA910_CD93E9E8_DDE03E8A
+    128'h6EAED4BF_1A600233_980BC4CF_2116DB51
   };
 
   // Compile-time random bits for default seeds
   parameter flash_ctrl_top_specific_pkg::all_seeds_t RndCnstFlashCtrlAllSeeds = {
-    256'hB0F1F422_5B70DE66_AE2A2D2C_AF521284_D078B244_2C4DCDFF_FC136EAE_D4BF1A60,
-    256'h0233980B_C4CF2116_DB51EC10_B747B901_1D99F556_B893842A_91CAFC63_CB10B944
+    256'hEC10B747_B9011D99_F556B893_842A91CA_FC63CB10_B9446016_33A421AC_E20B50EC,
+    256'h6BA7624A_9F75EE12_041D292C_75940B51_257E2224_BB789515_11213905_E9CB853B
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_top_specific_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h601633A4
+    32'hC8E152BE
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_top_specific_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'hEA0DBD7E_58F2DF98_5AE78946_013A6965_1AA0F2A4
+    160'h88B3D463_55372701_A8FEFA57_2238366D_CA06536F
   };
 
   ////////////////////////////////////////////
@@ -47,34 +47,34 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h05E9CB85_3BC8E152
+    64'h654D0F66_FB6FC362
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h8541885E_2AD14F71_38023A95_68A1503E,
-    256'h71FB372F_B0F3D9A0_E6560EA0_331DD1E4_B55A4BAC_25CC730A_D6FF2C1E_99A767EF
+    128'h322BDCE4_8CFADC95_B2069B2B_82303E2D,
+    256'hD1D39ED3_5A15819B_97FA26F4_EE10675A_B6D04791_F035D490_254AC617_FBBB048F
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h10546C53_C047BB1A_A7B4D4A9_EE362242,
-    256'hB54A0AF7_FF4DD5F2_EB321A70_60245A0E_668496CB_C0CF65A0_F675E37F_9ED0E0F6
+    128'hEA6D01EC_7CE3B436_AA6C9516_45D1B7B8,
+    256'hC97F4EFE_0D417018_A1F3ACF4_46614B2C_4BA7E782_22092BC3_C8A7DB5E_4A3D5705
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    32'hC880914B,
-    256'h8567E2FB_12CE5455_E5387CC1_49C106BD_836A7311_D59DEF2E_2061B606_9E362FB5
+    32'h46437EA1,
+    256'h9C961290_CC380044_B6A20A92_0684BC78_4B3C5EC3_F27BD1B3_F4FF8071_C1B01AD2
   };
 
   // Permutation applied to the output of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h046C591B_8E1E6F58_87256151_158D6002_7A8B0953_562E404F_68754D29_67053193,
-    256'h81222630_2B692083_1D98657C_8C112810_5C48336A_64909491_073A9B89_885B3F8A,
-    256'h23741872_57634139_863E457F_661F7021_3D6D3754_8F142C0E_329D4913_2777420B,
-    256'h3479629F_039C1C76_2A01952F_555A0F5F_476E827D_0D241799_354A190C_92524C3B,
-    256'h851A9680_7B5E3C4B_78849A0A_44003812_7E9E464E_5D167173_5036066B_9708432D
+    256'h29308660_71203224_8352973F_099A2F2A_8A787389_614C6E4B_04626F8E_0588878D,
+    256'h673A4208_15640066_13441B56_57011138_06287A46_935D0B4A_7F772B7B_3425720A,
+    256'h989E3616_7935439D_404D5102_6831705F_5C948122_50754E5B_80908B6A_92821927,
+    256'h0C7C230D_9B0F0E2D_41589C3C_543E8545_3B531C1F_47213D49_3774917E_63127D14,
+    256'h591D6510_264F6D84_17695A07_39965503_2C9F1E8F_1A482E6C_6B953318_8C99765E
   };
 
   ////////////////////////////////////////////
@@ -82,22 +82,23 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hF8B34D3A_036354A7_212F4AB6_85058803
+    128'h31494F63_E5134A00_4E3C988A_62C28A30
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'hBA2F9679_EA462313_7127EC6E_E39AA98B
+    128'hE3A47599_1516636B_F59DB68C_CD043D5F
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'h7F39F9DD
+    64'h2DF70B7B_0547C824
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'h9AEC76AB_F040D80B_F3B8CA4D_B75044F4_5E50D65A
+    128'h02DA689F_828EE6EF_81CAFEBF_59C8DD9B,
+    256'h4AE5358B_064F7873_6883D193_16477D03_35830883_F4955E0B_CD9B2D4E_C4485A97
   };
 
   ////////////////////////////////////////////
@@ -105,12 +106,12 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'h99151663_6BF59DB6
+    64'hB3C1A26D_4FAA85EE
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'h8CCD043D_5F2DF70B_7B0547C8_245DA916
+    128'h5F205825_CAC1C3FD_A7171378_80B3D785
   };
 
   ////////////////////////////////////////////
@@ -118,22 +119,22 @@ package top_englishbreakfast_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h4B111053
+    32'hDC68B5AD
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'hC506042F_EE9CAA76_5FB937A1_68E84453_C29DB785
+    160'hDD7DF168_A4066EA7_9E114B71_4B3B9D0C_8C89AC6C
   };
 
   // Default icache scrambling key
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstRvCoreIbexIbexKeyDefault = {
-    128'hF341D8F6_9FFAF435_E5D3C0EC_DD694B90
+    128'h5153FDD9_691FDD7A_990894E5_FF39211E
   };
 
   // Default icache scrambling nonce
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstRvCoreIbexIbexNonceDefault = {
-    64'hD7FB1168_378C3136
+    64'h8A4528EE_6F4A10B8
   };
 
 endpackage : top_englishbreakfast_rnd_cnst_pkg


### PR DESCRIPTION
Previously, this LFSR just used a width of 32 which - depending on how the module is used - may not be ideal. This commit thus increases the width of this LFSR to 64 bits, while the output width, i.e., the number of bits used per cycle, remains at 32 bits. To seed the additional 32 state bits, the previously unused upper 32 bits of the nonce obtained from OTP_CTRL are used.

This is related to https://github.com/lowRISC/opentitan/issues/27381.