### PR TITLE
[perso] send CRC with the RMA unlock token hash UJSON payload

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -378,7 +378,7 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
     // Wait for the host to send the RMA unlock token hash over the console.
     base_printf("Waiting For RMA Unlock Token Hash ...\n");
     TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, true));
-    TRY(ujson_deserialize_lc_token_hash_t(uj, &token_hash));
+    TRY(UJSON_WITH_CRC(ujson_deserialize_lc_token_hash_t, uj, &token_hash));
     TRY(dif_gpio_write(&gpio, kGpioPinSpiConsoleRxReady, false));
 
     TRY(manuf_personalize_device_secrets(&flash_ctrl_state, &lc_ctrl, &otp_ctrl,

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -223,7 +223,11 @@ fn send_rma_unlock_token_hash(
     )?;
     ujson_payloads.dut_in.insert(
         "FT_PERSO_RMA_TOKEN_HASH".to_string(),
-        rma_token_hash.send_with_padding(spi_console, LC_TOKEN_HASH_SERIALIZED_MAX_SIZE)?,
+        rma_token_hash.send_with_padding_and_crc(
+            spi_console,
+            LC_TOKEN_HASH_SERIALIZED_MAX_SIZE,
+            /*quiet=*/ true,
+        )?,
     );
     Ok(())
 }


### PR DESCRIPTION
This updates the perso firmware, and benchtop provisioning flow, to send a CRC with the RMA unlock token hash as this is the only asset provisioned during the entire provisioning flow that is not also tested during the flow.