### PR TITLE
[perso] log perso firmware has in the perso blob

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -198,18 +198,22 @@ OT_WEAK rom_error_t sku_creator_owner_init(boot_data_t *bootdata) {
   return kErrorOk;
 }
 
-static void log_self_hash(void) {
-  // clang-format off
-  base_printf("Personalization Firmware Hash: 0x%08x%08x%08x%08x%08x%08x%08x%08x\n",
-           boot_measurements.rom_ext.data[7],
-           boot_measurements.rom_ext.data[6],
-           boot_measurements.rom_ext.data[5],
-           boot_measurements.rom_ext.data[4],
-           boot_measurements.rom_ext.data[3],
-           boot_measurements.rom_ext.data[2],
-           boot_measurements.rom_ext.data[1],
-           boot_measurements.rom_ext.data[0]);
-  // clang-format on
+/**
+ * Pushes the hash of the personalization firmware to the perso blob.
+ */
+static status_t log_self_hash(perso_blob_t *perso_blob_to_host) {
+  perso_tlv_object_header_t tlv_header = 0;
+  PERSO_TLV_SET_FIELD(Objh, Type, tlv_header, kPersoObjectTypePersoSha256Hash);
+  PERSO_TLV_SET_FIELD(
+      Objh, Size, tlv_header,
+      sizeof(perso_tlv_object_header_t) + sizeof(keymgr_binding_value_t));
+  TRY(perso_tlv_push_to_perso_blob(
+      &tlv_header, sizeof(perso_tlv_object_header_t), perso_blob_to_host));
+  TRY(perso_tlv_push_to_perso_blob(boot_measurements.rom_ext.data,
+                                   sizeof(keymgr_binding_value_t),
+                                   perso_blob_to_host));
+  perso_blob_to_host->num_objs++;
+  return OK_STATUS();
 }
 
 /*
@@ -373,7 +377,6 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
   // Provision OTP Secret2 partition and flash info pages 1, 2, and 4 (keymgr
   // and DICE keygen seeds).
   if (!status_ok(manuf_personalize_device_secrets_check(&otp_ctrl))) {
-    log_self_hash();
     lc_token_hash_t token_hash;
     // Wait for the host to send the RMA unlock token hash over the console.
     base_printf("Waiting For RMA Unlock Token Hash ...\n");
@@ -1121,6 +1124,7 @@ static status_t provision(ujson_t *uj) {
           &otp_rot_creator_auth_state_measurement};
   TRY(personalize_extension_pre_cert_endorse(&pre_endorse));
   TRY(compute_tbs_was_hmac(pre_endorse.perso_blob_to_host));
+  TRY(log_self_hash(pre_endorse.perso_blob_to_host));
 
   // Endorse TBS certs and install in flash.
   TRY(personalize_endorse_certificates(uj));

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -56,9 +56,13 @@ typedef enum perso_tlv_object_type {
    */
   kPersoObjectTypeDeviceId = 5,
   /**
-   * Generic purpose seed
+   * Generic seed.
    */
   kPersoObjectTypeGenericSeed = 6,
+  /**
+   * Personalization firmware SHA256 Hash.
+   */
+  kPersoObjectTypePersoSha256Hash = 7,
 } perso_tlv_object_type_t;
 
 typedef uint16_t perso_tlv_object_header_t;

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -437,6 +437,16 @@ fn provision_certificates(
                 generic_seed_id += 1;
                 continue;
             }
+            ObjType::PersoSha256Hash => {
+                let hash_size = header.obj_size - obj_header_size;
+                let hash = &perso_blob.body[start..start + hash_size];
+                log::info!(
+                    "Personalization firmware SHA256 hash: {}",
+                    hex::encode(hash)
+                );
+                start += hash_size;
+                continue;
+            }
         }
 
         // The next object is a cert, let's retrieve its properties (name, needs
@@ -485,7 +495,8 @@ fn provision_certificates(
                 ObjType::WasTbsHmac
                 | ObjType::DeviceId
                 | ObjType::DevSeed
-                | ObjType::GenericSeed => unreachable!(),
+                | ObjType::GenericSeed
+                | ObjType::PersoSha256Hash => unreachable!(),
             };
 
             let ec = EndorsedCert {
@@ -631,8 +642,6 @@ pub fn run_ft_personalize(
     init.bootstrap.load(transport, &second_bootstrap)?;
     spi_console.reset_frame_counter();
     response.stats.log_elapsed_time("second-bootstrap", t0);
-
-    let _ = UartConsole::wait_for(spi_console, r"Personalization Firmware Hash:", timeout)?;
 
     // Send RMA unlock token digest to device.
     let second_t0 = Instant::now();

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -15,6 +15,8 @@ pub enum ObjType {
     WasTbsHmac = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeWasTbsHmac as isize,
     DeviceId = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDeviceId as isize,
     GenericSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeGenericSeed as isize,
+    PersoSha256Hash =
+        perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypePersoSha256Hash as isize,
 }
 
 impl ObjType {
@@ -27,6 +29,7 @@ impl ObjType {
             4 => Ok(ObjType::WasTbsHmac),
             5 => Ok(ObjType::DeviceId),
             6 => Ok(ObjType::GenericSeed),
+            7 => Ok(ObjType::PersoSha256Hash),
             _ => bail!("incorrect input value of {value} for ObjType"),
         }
     }


### PR DESCRIPTION
Prior to this change, the personalization firmware (self) hash was logged to the console as text. This updates the flow to push it into the perso TLV structure (i.e., perso blob) so it can be sent to the provisioning registry.