### PR TITLE
[perso] start versioning perso firmware

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -286,7 +286,8 @@ manifest(d = {
     "manuf_state_creator": hex(CONST.MANUF_STATE.PERSO_INITIAL),
     "visibility": ["//visibility:private"],
     "version_major": ROM_EXT_VERSION.MAJOR,
-    "version_minor": ROM_EXT_VERSION.MINOR,
+    # Release: 2025-06-18-RC00
+    "version_minor": "2025061800",
     "security_version": "0xFFFFFFFF",
 })
 


### PR DESCRIPTION
This sets the perso firmware version to an integer that represents the following format for a given release candidate:
\<year\>\<month\>\<day\>\<release candidate\>.

The perso firmware version will no longer be match the ROM_EXT version.