### PR TITLE
[sival, kdf] Compare derived keys in kdf_kmac_sideload_functest

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -519,6 +519,7 @@ opentitan_test(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:kmac_kdf",
         "//sw/device/lib/dif:keymgr",
         "//sw/device/lib/dif:kmac",


### PR DESCRIPTION
The `kdf_kmac_sideload_functest` computes two blinded keys using KDF with sideloaded keys from the keymgr, but directly compares the output blinded keyblobs, which will each contain two masked keyshares. KMAC masking is disabled on CW310 due to FPGA limitations, but in other execution environments we would not expect the two keyblobs to be the same as a result of KMAC masking.

To fix this, correct the test logic to export and unmask both derived blinded keys, and directly compare the contents of the unmasked keys instead. This should allow the test to pass in environments that have KMAC masking enabled. I've also created issue #27463 to track the ability to run KMAC tests on CW340, to prevent similar issues appearing in the future.

CC @moidx