### PR TITLE
[pentest] Add tests to CI

### DIFF
--- a/sw/device/tests/penetrationtests/BUILD
+++ b/sw/device/tests/penetrationtests/BUILD
@@ -17,7 +17,6 @@ IBEX_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi_ibex(
     name = "fi_ibex",
-    slow_test = False,
     test_args = IBEX_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_ibex:harness",
     test_vectors = IBEX_FI_TESTVECTOR_TARGETS,
@@ -34,7 +33,6 @@ CRYPTO_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi(
     name = "fi_crypto",
-    slow_test = True,
     test_args = CRYPTO_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_crypto:harness",
     test_vectors = CRYPTO_FI_TESTVECTOR_TARGETS,
@@ -51,7 +49,6 @@ LCCTRL_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi(
     name = "fi_lc_ctrl",
-    slow_test = True,
     test_args = LCCTRL_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_lc_ctrl:harness",
     test_vectors = LCCTRL_FI_TESTVECTOR_TARGETS,
@@ -68,7 +65,6 @@ OTP_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi(
     name = "fi_otp",
-    slow_test = True,
     test_args = OTP_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_otp:harness",
     test_vectors = OTP_FI_TESTVECTOR_TARGETS,
@@ -85,7 +81,6 @@ RNG_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi(
     name = "fi_rng",
-    slow_test = True,
     test_args = RNG_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_rng:harness",
     test_vectors = RNG_FI_TESTVECTOR_TARGETS,
@@ -102,7 +97,6 @@ ROM_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi(
     name = "fi_rom",
-    slow_test = True,
     test_args = ROM_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_rom:harness",
     test_vectors = ROM_FI_TESTVECTOR_TARGETS,
@@ -119,7 +113,6 @@ OTBN_FI_TESTVECTOR_ARGS = " ".join([
 
 pentest_fi_otbn(
     name = "fi_otbn",
-    slow_test = True,
     test_args = OTBN_FI_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/fi_otbn:harness",
     test_vectors = OTBN_FI_TESTVECTOR_TARGETS,
@@ -136,7 +129,6 @@ AES_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_aes",
-    slow_test = True,
     test_args = AES_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_aes:harness",
     test_vectors = AES_SCA_TESTVECTOR_TARGETS,
@@ -153,7 +145,6 @@ EDN_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_edn",
-    slow_test = True,
     test_args = EDN_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_edn:harness",
     test_vectors = EDN_SCA_TESTVECTOR_TARGETS,
@@ -170,7 +161,6 @@ HMAC_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_hmac",
-    slow_test = True,
     test_args = HMAC_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_hmac:harness",
     test_vectors = HMAC_SCA_TESTVECTOR_TARGETS,
@@ -187,7 +177,6 @@ IBEX_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_ibex",
-    slow_test = True,
     test_args = IBEX_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_ibex:harness",
     test_vectors = IBEX_SCA_TESTVECTOR_TARGETS,
@@ -204,7 +193,6 @@ KMAC_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_kmac",
-    slow_test = True,
     test_args = KMAC_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_kmac:harness",
     test_vectors = KMAC_SCA_TESTVECTOR_TARGETS,
@@ -221,7 +209,6 @@ OTBN_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_otbn",
-    slow_test = True,
     test_args = OTBN_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_otbn:harness",
     test_vectors = OTBN_SCA_TESTVECTOR_TARGETS,
@@ -238,7 +225,6 @@ SHA3_SCA_TESTVECTOR_ARGS = " ".join([
 
 pentest_sca(
     name = "sca_sha3",
-    slow_test = True,
     test_args = SHA3_SCA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/penetrationtests/sca_sha3:harness",
     test_vectors = SHA3_SCA_TESTVECTOR_TARGETS,

--- a/sw/device/tests/penetrationtests/pentest.bzl
+++ b/sw/device/tests/penetrationtests/pentest.bzl
@@ -168,7 +168,7 @@ FIRMWARE_DEPS_CRYPTOLIB_SCA_ASYM = [
     "//sw/device/tests/penetrationtests/json:commands",
 ]
 
-def pentest_fi(name, test_vectors, test_args, test_harness, slow_test = False):
+def pentest_fi(name, test_vectors, test_args, test_harness):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -176,14 +176,13 @@ def pentest_fi(name, test_vectors, test_args, test_harness, slow_test = False):
         test_vectors: the test vectors to use.
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
-        slow_test: indicate if the test should be run in the nightly CI.
     """
-    tags = ["slow_test"] if slow_test else []
+    tags = []
     opentitan_test(
         name = name,
         srcs = ["//sw/device/tests/penetrationtests/firmware:firmware_fi.c"],
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             data = test_vectors,
             tags = tags,
             test_cmd = """
@@ -192,7 +191,7 @@ def pentest_fi(name, test_vectors, test_args, test_harness, slow_test = False):
             test_harness = test_harness,
         ),
         fpga_cw340 = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             tags = tags,
             data = test_vectors,
             test_cmd = """
@@ -213,7 +212,7 @@ def pentest_fi(name, test_vectors, test_args, test_harness, slow_test = False):
         deps = FIRMWARE_DEPS_FI,
     )
 
-def pentest_fi_ibex(name, test_vectors, test_args, test_harness, slow_test = False):
+def pentest_fi_ibex(name, test_vectors, test_args, test_harness):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -221,14 +220,13 @@ def pentest_fi_ibex(name, test_vectors, test_args, test_harness, slow_test = Fal
         test_vectors: the test vectors to use.
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
-        slow_test: indicate if the test should be run in the nightly CI.
     """
-    tags = ["slow_test"] if slow_test else []
+    tags = []
     opentitan_test(
         name = name,
         srcs = ["//sw/device/tests/penetrationtests/firmware:firmware_fi_ibex.c"],
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             data = test_vectors,
             tags = tags,
             test_cmd = """
@@ -237,7 +235,7 @@ def pentest_fi_ibex(name, test_vectors, test_args, test_harness, slow_test = Fal
             test_harness = test_harness,
         ),
         fpga_cw340 = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             tags = tags,
             data = test_vectors,
             test_cmd = """
@@ -258,7 +256,7 @@ def pentest_fi_ibex(name, test_vectors, test_args, test_harness, slow_test = Fal
         deps = FIRMWARE_DEPS_FI_IBEX,
     )
 
-def pentest_fi_otbn(name, test_vectors, test_args, test_harness, slow_test = False):
+def pentest_fi_otbn(name, test_vectors, test_args, test_harness):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -266,14 +264,13 @@ def pentest_fi_otbn(name, test_vectors, test_args, test_harness, slow_test = Fal
         test_vectors: the test vectors to use.
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
-        slow_test: indicate if the test should be run in the nightly CI.
     """
-    tags = ["slow_test"] if slow_test else []
+    tags = []
     opentitan_test(
         name = name,
         srcs = ["//sw/device/tests/penetrationtests/firmware:firmware_fi_otbn.c"],
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             data = test_vectors,
             tags = tags,
             test_cmd = """
@@ -282,7 +279,7 @@ def pentest_fi_otbn(name, test_vectors, test_args, test_harness, slow_test = Fal
             test_harness = test_harness,
         ),
         fpga_cw340 = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             tags = tags,
             data = test_vectors,
             test_cmd = """
@@ -303,7 +300,7 @@ def pentest_fi_otbn(name, test_vectors, test_args, test_harness, slow_test = Fal
         deps = FIRMWARE_DEPS_FI_OTBN,
     )
 
-def pentest_sca(name, test_vectors, test_args, test_harness, slow_test = False):
+def pentest_sca(name, test_vectors, test_args, test_harness):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -311,14 +308,13 @@ def pentest_sca(name, test_vectors, test_args, test_harness, slow_test = False):
         test_vectors: the test vectors to use.
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
-        slow_test: indicate if the test should be run in the nightly CI.
     """
-    tags = ["slow_test"] if slow_test else []
+    tags = []
     opentitan_test(
         name = name,
         srcs = ["//sw/device/tests/penetrationtests/firmware:firmware_sca.c"],
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             data = test_vectors,
             tags = tags,
             test_cmd = """
@@ -327,7 +323,7 @@ def pentest_sca(name, test_vectors, test_args, test_harness, slow_test = False):
             test_harness = test_harness,
         ),
         fpga_cw340 = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             tags = tags,
             data = test_vectors,
             test_cmd = """


### PR DESCRIPTION
This commit puts the tests for the pentest framework into CI by setting the timeout to moderate instead to long.