### PR TITLE
[ottf] Add OTTF option to configure and catch alerts

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -190,7 +190,13 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
-    ],
+    ] + select({
+        "//sw/device:is_english_breakfast": [],
+        "//conditions:default": [
+            "//hw/top_earlgrey:alert_handler_c_regs",
+            "//sw/device/lib/dif:alert_handler",
+        ],
+    }),
 )
 
 # This target provides start files without providing the full OTTF, and can be

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -182,6 +182,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":check",
+        ":ottf_test_config",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
@@ -287,7 +288,10 @@ cc_library(
         "//sw/device/lib/testing:rand_testutils",
         "//third_party/freertos",
         "@manufacturer_test_hooks//:test_hooks",
-    ],
+    ] + select({
+        "//sw/device:is_english_breakfast": [],
+        "//conditions:default": [":ottf_alerts"],
+    }),
     # `:ottf` depends on `:ottf_start`, but `:ottf_start` gets its main function
     # from `:ottf`. Thus we need to include all of the objects in `:ottf`
     # unconditionally so that the linker can find the symbol later.

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -245,6 +245,25 @@ cc_library(
 )
 
 cc_library(
+    name = "ottf_alerts",
+    srcs = ["ottf_alerts.c"],
+    hdrs = ["ottf_alerts.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey:alert_handler_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+    ],
+)
+
+cc_library(
     name = "ottf_main",
     srcs = ["ottf_main.c"],
     hdrs = ["ottf_main.h"],

--- a/sw/device/lib/testing/test_framework/ottf_alerts.c
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.c
@@ -26,6 +26,13 @@ status_t ottf_alerts_enable_all(void) {
   for (dif_alert_handler_alert_t i = 0; i < ARRAYSIZE(alerts); i++) {
     alerts[i] = i;
     alert_classes[i] = kDifAlertHandlerClassD;
+
+    // Temporarily skip alert 37 (`flash_ctrl_fatal_err`) on FPGAs and sims at
+    // the owner stage since flash will not be provisioned with expected data.
+    // See #23038.
+    if (kDeviceType != kDeviceSilicon) {
+      alerts[i] = 0;
+    }
   }
 
   dif_alert_handler_escalation_phase_t esc_phases[] = {

--- a/sw/device/lib/testing/test_framework/ottf_alerts.c
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.c
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
+
+#include "sw/device/lib/arch/boot_stage.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+
+#include "alert_handler_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+status_t ottf_alerts_enable_all(void) {
+  dif_alert_handler_t alert_handler;
+  TRY(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  dif_alert_handler_alert_t alerts[ALERT_HANDLER_PARAM_N_ALERTS];
+  dif_alert_handler_class_t alert_classes[ARRAYSIZE(alerts)];
+  for (dif_alert_handler_alert_t i = 0; i < ARRAYSIZE(alerts); i++) {
+    alerts[i] = i;
+    alert_classes[i] = kDifAlertHandlerClassD;
+  }
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles = 2000}};
+  dif_alert_handler_class_config_t class_config = {
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = UINT16_MAX,
+      .irq_deadline_cycles = UINT32_MAX,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+  };
+  dif_alert_handler_class_config_t class_configs[] = {class_config};
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassD};
+
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .classes = classes,
+      .class_configs = class_configs,
+      .classes_len = ARRAYSIZE(class_configs),
+      .ping_timeout = UINT16_MAX,
+  };
+  TRY(alert_handler_testutils_configure_all(&alert_handler, config,
+                                            kDifToggleDisabled));
+
+  TRY(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassd, kDifToggleEnabled));
+
+  dif_rv_plic_t rv_plic;
+  TRY(dif_rv_plic_init(mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR),
+                       &rv_plic));
+
+  TRY(dif_rv_plic_irq_set_priority(&rv_plic,
+                                   kTopEarlgreyPlicIrqIdAlertHandlerClassd,
+                                   kDifRvPlicMaxPriority));
+  TRY(dif_rv_plic_irq_set_enabled(
+      &rv_plic, kTopEarlgreyPlicIrqIdAlertHandlerClassd,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
+  TRY(dif_rv_plic_target_set_threshold(&rv_plic, kTopEarlgreyPlicTargetIbex0,
+                                       kDifRvPlicMinPriority));
+
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/test_framework/ottf_alerts.h
+++ b/sw/device/lib/testing/test_framework/ottf_alerts.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_ALERTS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_ALERTS_H_
+
+#include "sw/device/lib/base/status.h"
+
+/**
+ * Configure and enable all alerts.
+ *
+ * Alerts are configured for class D which is configured for signal 0.
+ * The ping and IRQ deadline timers are set to their maximums.
+ * OTTF is expected to handle the class D IRQ before the alert escalates.
+ *
+ * The alert handler config is not locked and can be changed by tests.
+ *
+ * Note that this function enables external IRQs for Ibex.
+ */
+status_t ottf_alerts_enable_all(void);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_ALERTS_H_

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -242,7 +242,7 @@ void ottf_external_isr(uint32_t *exc_info) {
     return;
 #if !OT_IS_ENGLISH_BREAKFAST
   } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler &&
-             kOttfTestConfig.catch_alerts) {
+             !kOttfTestConfig.ignore_alerts) {
     ottf_alert_isr(exc_info);
     // Complete the IRQ at PLIC.
     CHECK_DIF_OK(

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -14,6 +14,12 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 
+#if !OT_IS_ENGLISH_BREAKFAST
+#include "sw/device/lib/dif/dif_alert_handler.h"
+
+#include "alert_handler_regs.h"
+#endif  // !OT_IS_ENGLISH_BREAKFAST
+
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 dif_rv_plic_t ottf_plic;
@@ -194,7 +200,24 @@ OT_WEAK
 bool ottf_console_flow_control_isr(uint32_t *exc_info) { return false; }
 
 OT_WEAK
-bool ottf_alert_isr(uint32_t *exc_info) {
+void ottf_alert_isr(uint32_t *exc_info) {
+#if !OT_IS_ENGLISH_BREAKFAST
+  dif_alert_handler_t alert_handler;
+  CHECK_DIF_OK(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  // Log all asserted alerts.
+  for (dif_alert_handler_alert_t alert = 0;
+       alert < ALERT_HANDLER_PARAM_N_ALERTS; alert++) {
+    bool is_cause = false;
+    CHECK_DIF_OK(
+        dif_alert_handler_alert_is_cause(&alert_handler, alert, &is_cause));
+    if (is_cause) {
+      LOG_ERROR("INFO: Alert %d is asserted", alert);
+    }
+  }
+
   ottf_generic_fault_print(exc_info, "Alert IRQ", ibex_mcause_read());
   abort();
 #else

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -28,6 +28,10 @@
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 
+#if !OT_IS_ENGLISH_BREAKFAST
+#include "sw/device/lib/testing/test_framework/ottf_alerts.h"
+#endif  // !OT_IS_ENGLISH_BREAKFAST
+
 // TODO: make this toplevel agnostic.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -169,6 +173,12 @@ void _ottf_main(void) {
       LOG_INFO("Running %s", kOttfTestConfig.file);
     }
   }
+
+#if !OT_IS_ENGLISH_BREAKFAST
+  if (kOttfTestConfig.catch_alerts) {
+    CHECK_STATUS_OK(ottf_alerts_enable_all());
+  }
+#endif  // !OT_IS_ENGLISH_BREAKFAST
 
   // Initialize a global random number generator testutil context to provide
   // tests with a source of entropy for randomizing test behaviors.

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -175,7 +175,7 @@ void _ottf_main(void) {
   }
 
 #if !OT_IS_ENGLISH_BREAKFAST
-  if (kOttfTestConfig.catch_alerts) {
+  if (!kOttfTestConfig.ignore_alerts) {
     CHECK_STATUS_OK(ottf_alerts_enable_all());
   }
 #endif  // !OT_IS_ENGLISH_BREAKFAST

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -125,6 +125,17 @@ typedef struct ottf_test_config {
    * this will be the file that defines `test_main()`.
    */
   const char *file;
+
+  /**
+   * If true, OTTF will enable all alerts configured for alert class D which
+   * will escalate with signal 0. OTTF will handle IRQs for class D before they
+   * escalate and abort the test.
+   *
+   * The alert handler configuration is not locked and can be modified further
+   * by the test. The ISR for class D can also be overridden by defining the
+   * symbol `ottf_alert_isr` in the test.
+   */
+  bool catch_alerts;
 } ottf_test_config_t;
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -135,7 +135,7 @@ typedef struct ottf_test_config {
    * by the test. The ISR for class D can also be overridden by defining the
    * symbol `ottf_alert_isr` in the test.
    */
-  bool catch_alerts;
+  bool ignore_alerts;
 } ottf_test_config_t;
 
 /**

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/chip_specific_startup.c
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/chip_specific_startup.c
@@ -27,7 +27,7 @@
 #include "otp_ctrl_regs.h"
 #include "sensor_ctrl_regs.h"
 
-OTTF_DEFINE_TEST_CONFIG();
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 enum {
   kAstInitEnOffset = OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET -

--- a/sw/device/silicon_creator/rom/e2e/shutdown_alert/rom_e2e_alert_config_test.c
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_alert/rom_e2e_alert_config_test.c
@@ -10,7 +10,7 @@
 
 #include "otp_ctrl_regs.h"
 
-OTTF_DEFINE_TEST_CONFIG();
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 /**
  * Check that the alert_handler register CRC32 matches OTP value.

--- a/sw/device/silicon_creator/rom/e2e/shutdown_alert/rom_e2e_shutdown_alert_config_test.c
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_alert/rom_e2e_shutdown_alert_config_test.c
@@ -11,7 +11,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "uart_regs.h"
 
-OTTF_DEFINE_TEST_CONFIG();
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 enum {
   /**

--- a/sw/device/tests/chip_power_sleep_load_test.c
+++ b/sw/device/tests/chip_power_sleep_load_test.c
@@ -59,7 +59,7 @@ static volatile const bool kDeepSleep = false;
 
 static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
 
-OTTF_DEFINE_TEST_CONFIG();
+OTTF_DEFINE_TEST_CONFIG(.ignore_alerts = true);
 
 void ottf_external_isr(uint32_t *exc_info) {
   LOG_INFO("got external IRQ");


### PR DESCRIPTION
Allows tests to configure that OTTF should catch and fail the test if any alerts trigger. I've made it opt-in for now.

Tests may set `.catch_alerts` in `OTTF_DEFINE_TEST_CONFIG` to cause OTTF to configure all alerts as enabled in class D. OTTF will catch class D interrupst and fail the test.

---

You can test this by forcing an alert, for example in `uart_smoketest`:

```diff
--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -14,12 +14,17 @@
 static const uint8_t kSendData[] = "Smoke test!";
 
 OTTF_DEFINE_TEST_CONFIG(.enable_concurrency = false,
                         .console.test_may_clobber = true, );
 
 bool test_main(void) {
   dif_uart_t uart;
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
+
+  LOG_INFO("Forcing alert...");
+  CHECK_DIF_OK(dif_uart_alert_force(&uart, kDifUartAlertFatalFault));
+  LOG_INFO("done");
+
   CHECK(kUartBaudrate <= UINT32_MAX, "kUartBaudrate must fit in uint32_t");
   CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
         "kClockFreqPeripheralHz must fit in uint32_t");
```