### PR TITLE
[top_earlgrey] Remove duplicated entropy_src intersignal

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -1189,7 +1189,6 @@
       'rom_ctrl.keymgr_data'    : ['keymgr.rom_digest'],
       'flash_ctrl.keymgr'       : ['keymgr.flash'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
-      'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
 
       // LC RMA req/ack interface: LC --> Flash -> LC
       //                              |-> OTBN  -> LC


### PR DESCRIPTION
This line already exists above. Remove the duplicated entry.