### PR TITLE
[lib][drivers] Inital draft for change

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -14,6 +14,7 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_CW340_TEST_ENVS",
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
     "fpga_params",
@@ -230,7 +231,10 @@ cc_test(
 opentitan_test(
     name = "hmac_functest",
     srcs = ["hmac_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -369,7 +373,10 @@ cc_test(
 opentitan_test(
     name = "kmac_functest",
     srcs = ["kmac_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdalign.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -19,16 +20,17 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-enum {
-  kSha256BlockBits = 512,
-  kSha256BlockBytes = kSha256BlockBits / 8,
-};
-
 // From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
-static const char kGettysburgPrelude[] =
+static alignas(uint32_t) const char kGettysburgPrelude[] =
     "Four score and seven years ago our fathers brought forth on this "
     "continent, a new nation, conceived in Liberty, and dedicated to the "
     "proposition that all men are created equal.";
+
+enum {
+  kSha256BlockBits = 512,
+  kSha256BlockBytes = kSha256BlockBits / 8,
+  kGettysburgPreludeSize = sizeof(kGettysburgPrelude),
+};
 
 // The following shell command will produce the sha256sum and convert the
 // digest into valid C hexadecimal constants:
@@ -88,9 +90,39 @@ static const uint32_t kGettysburgHmacSha256Digest[] = {
     0xb54e0af5, 0x9d85e15b, 0xa9a3bafe, 0x9d115197,
 };
 
+// The unaligned version of the kGettysburgPrelude is used to test
+typedef struct unalignedhash {
+  char unused;
+  const char payload[kGettysburgPreludeSize];
+} unalignedhash_t;
+
+// This structure is used to ensure that the kGettysburgPrelude is not aligned
+// on a 4-byte boundary
+static const alignas(uint32_t) unalignedhash_t kGettysburgPreludeUnaligned = {
+    .payload =
+        "Four score and seven years ago our fathers brought forth on this "
+        "continent, a new nation, conceived in Liberty, and dedicated to the "
+        "proposition that all men are created equal.",
+};
+
 rom_error_t hmac_hmac_sha256_test(void) {
   hmac_digest_t digest;
   hmac_hmac_sha256(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1, kHmacKey,
+                   /*big_endian_digest=*/false, &digest);
+  const size_t len = ARRAYSIZE(digest.digest);
+  for (int i = 0; i < len; ++i) {
+    LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);
+    if (digest.digest[i] != kGettysburgHmacSha256Digest[i]) {
+      return kErrorUnknown;
+    }
+  }
+  return kErrorOk;
+}
+
+rom_error_t hmac_hmac_sha256_unaligned_test(void) {
+  hmac_digest_t digest;
+  hmac_hmac_sha256(kGettysburgPreludeUnaligned.payload,
+                   sizeof(kGettysburgPreludeUnaligned.payload) - 1, kHmacKey,
                    /*big_endian_digest=*/false, &digest);
   const size_t len = ARRAYSIZE(digest.digest);
   for (int i = 0; i < len; ++i) {
@@ -291,6 +323,7 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, hmac_sha256_test);
+  EXECUTE_TEST(result, hmac_hmac_sha256_unaligned_test);
   EXECUTE_TEST(result, hmac_hmac_sha256_test);
   EXECUTE_TEST(result, hmac_process_nowait_test);
   EXECUTE_TEST(result, hmac_process_wait_test);


### PR DESCRIPTION
feat:  Add a test that can hash256 unaligned inputs

As defined by the HMAC/KMAC specs, the hashing algorithm should be able to reproduce a digest that is identical to an aligned/unaligned input. 

Test:
Device under test: cw340 w/ HyperDebugger
CMD: bazel test --test_output=streamed --cache_test_results=no //sw/device/silicon_creator/lib/drivers:kmac_functest_fpga_cw340_rom_with_fake_keys

tested git hash: 81e4bb698ffd45469fe10a70086a6f49074fc97b
KMAC
[test.log](https://github.com/user-attachments/files/20892449/test.log)
HMAC
[test.log](https://github.com/user-attachments/files/20892480/test.log)



