### PR TITLE
[dvsim,hjson] Remove all dead code 'design_level' references/overrides

### DIFF
--- a/hw/cdc/tools/dvsim/common_cdc_cfg.hjson
+++ b/hw/cdc/tools/dvsim/common_cdc_cfg.hjson
@@ -31,7 +31,6 @@
                        "{fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/syn-icarus"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
-  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 
   // Determines which message severities to print into report summaries.
   report_severities: ["review", "warning", "error"]

--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -41,7 +41,4 @@
               printf "<br>$REV_STR_FOUNDRY"; \
             fi
             '''
-
-  // The current design level
-  design_level:  "ip"
 }

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -13,8 +13,7 @@
                      "{dv_root}/tools/dvsim/bazel.hjson",
                      "{dv_root}/tools/dvsim/{tool}.hjson"]
 
-  sv_flist_gen_flags: ["--flag=fileset_{design_level}",
-                       "--mapping=lowrisc:prim_generic:all:0.1"]
+  sv_flist_gen_flags: ["--mapping=lowrisc:prim_generic:all:0.1"]
 
   // Default directory structure for the output
   build_dir:          "{scratch_path}/{build_mode}"

--- a/hw/dv/tools/dvsim/fusesoc.hjson
+++ b/hw/dv/tools/dvsim/fusesoc.hjson
@@ -13,5 +13,4 @@
   fusesoc_cores_root_dirs: ["--cores-root {proj_root}/hw"]
   sv_flist_gen_dir:   "{build_dir}/fusesoc-work"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
-  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 }

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -51,8 +51,7 @@
   // TODO: Verilator has a few useful build switches. Need to figure out how to
   // pass them via FuseSoC.
 
-  build_opts: ["--flag=fileset_{design_level}",
-               "--target=sim",
+  build_opts: ["--target=sim",
                "--build-root={build_dir}",
                "--setup",
                "--build",

--- a/hw/formal/tools/dvsim/common_conn_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_conn_cfg.hjson
@@ -12,12 +12,6 @@
   ]
 
   overrides: [
-    // Connectivity test should all be in top_level design
-    {
-      name:  design_level
-      value: "top"
-    }
-
     // Connectivity test won't run any assertions, so here we use default RTL target
     {
       name:  fusesoc_target

--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -30,8 +30,7 @@
                       "--work-root={build_dir}/fusesoc-work",
                       "--setup {fusesoc_core}"]
   sv_flist_gen_dir:  "{build_dir}/fusesoc-work"
-  sv_flist_gen_flags: ["--flag=fileset_{design_level}",
-                       "--mapping=lowrisc:prim_generic:all:0.1"]
+  sv_flist_gen_flags: ["--mapping=lowrisc:prim_generic:all:0.1"]
 
   report_cmd:  "python3 {formal_root}/tools/{tool}/parse-formal-report.py"
   report_opts: ["--logpath={build_log}",

--- a/hw/ip/lc_ctrl/syn/lc_ctrl_gtech_syn_cfg.hjson
+++ b/hw/ip/lc_ctrl/syn/lc_ctrl_gtech_syn_cfg.hjson
@@ -12,10 +12,6 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]
 
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     { // Deletes black-boxed hierarchies before writing out the unmapped netlist
       name: post_elab_script
       value: "{proj_root}/hw/ip/{name}/syn/post_elab_gtech.tcl"

--- a/hw/ip/lc_ctrl/syn/lc_ctrl_syn_cfg.hjson
+++ b/hw/ip/lc_ctrl/syn/lc_ctrl_syn_cfg.hjson
@@ -11,13 +11,6 @@
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/ip/{name}/syn/constraints.sdc"
 

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson.tpl
@@ -36,10 +36,6 @@
   // Flash references pwrmgr directly, need to reference the top version
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: "timescale"
       value: "1ns/100ps"
     }

--- a/hw/ip_templates/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson.tpl
@@ -12,10 +12,6 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]
 
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     { // Deletes black-boxed hierarchies before writing out the unmapped netlist
       name: post_elab_script
       value: "{proj_root}/hw/top_${topname}/ip_autogen/{name}/syn/post_elab_gtech.tcl"

--- a/hw/ip_templates/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson.tpl
+++ b/hw/ip_templates/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson.tpl
@@ -11,13 +11,6 @@
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/top_${topname}/ip_autogen/{name}/syn/constraints.sdc"
 

--- a/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson.tpl
@@ -35,10 +35,6 @@
 
   // Overrides
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     // Handle generated coverage exclusion.
     {
       name: default_vcs_cov_cfg_file

--- a/hw/ip_templates/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson.tpl
@@ -47,11 +47,4 @@
       tests: ["rstmgr_cnsty_chk_test"]
     }
   ]
-  overrides: [
-    // This override is in order to pick the autogen rstmgr packages.
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
 }

--- a/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
+++ b/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson.tpl
@@ -43,10 +43,6 @@
   // Overrides
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }

--- a/hw/lint/tools/dvsim/common_lint_cfg.hjson
+++ b/hw/lint/tools/dvsim/common_lint_cfg.hjson
@@ -22,7 +22,6 @@
   build_cmd:  "{job_prefix} fusesoc"
   build_opts: ["--cores-root {proj_root}/hw",
                "run",
-               "--flag=fileset_{design_level}",
                "--target={flow}",
                "--tool={tool}",
                "--work-root={build_dir}/fusesoc-work",

--- a/hw/rdc/tools/dvsim/common_rdc_cfg.hjson
+++ b/hw/rdc/tools/dvsim/common_rdc_cfg.hjson
@@ -31,7 +31,6 @@
                        "{fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/syn-icarus"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
-  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 
   // Determines which message severities to print into report summaries.
   report_severities: ["review", "warning", "error"]

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -41,7 +41,6 @@
                        "{fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/syn-icarus"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
-  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 
   // Can be used to hook in an additional post elab scripting step.
   post_elab_script: ""

--- a/hw/top_darjeeling/data/chip_cfg.hjson
+++ b/hw/top_darjeeling/data/chip_cfg.hjson
@@ -15,9 +15,5 @@
               "--cores-root {proj_root}/hw/vendor",
               "--cores-root {proj_root}/hw/top_darjeeling"]
     }
-    {
-      name: design_level
-      value: "top"
-    }
   ]
 }

--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -59,7 +59,6 @@
                 "{proj_root}/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson",
                 "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
                 "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
-                // This defines the design_level: "top" key
 //                "{proj_root}/hw/{top_chip}/data/chip_cfg.hjson",
                 "{top_dv_path}/chip_smoketests.hjson",
                 "{top_dv_path}/chip_rom_tests.hjson",

--- a/hw/top_darjeeling/formal/top_darjeeling_fpv_ip_cfgs.hjson
+++ b/hw/top_darjeeling/formal/top_darjeeling_fpv_ip_cfgs.hjson
@@ -40,12 +40,6 @@
                defines: "FPV_ALERT_NO_SIGINT_ERR"
                cov: true
                exp_fail_hjson: "{proj_root}/hw/{top_chip}/ip/pinmux/fpv/pinmux_expected_failure.hjson"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
              }
 
              {
@@ -56,12 +50,6 @@
                rel_path: "hw/{top_chip}/ip_autogen/rv_plic/{sub_flow}/{tool}"
                cov: true
                exp_fail_hjson: "{proj_root}/hw/{top_chip}/ip_autogen/rv_plic/fpv/rv_plic_expected_failure.hjson"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
              }
             ]
 }

--- a/hw/top_darjeeling/formal/top_darjeeling_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_darjeeling/formal/top_darjeeling_fpv_sec_cm_cfgs.hjson
@@ -82,12 +82,6 @@
                fusesoc_core: lowrisc:dv:top_darjeeling_flash_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/flash_ctrl/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                stopats: ["*u_state_regs.state_o", "*u_rma_state_regs.state_o"]
                task: "FpvSecCm"
              }
@@ -145,12 +139,6 @@
                fusesoc_core: lowrisc:dv:top_darjeeling_pwrmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pwrmgr/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                stopats: ["*u_state_regs.state_o"]
                task: "FpvSecCm"
              }
@@ -169,12 +157,6 @@
                fusesoc_core: lowrisc:dv:top_darjeeling_rstmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/rstmgr/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                stopats: ["*u_state_regs.state_o"]
                task: "FpvSecCm"
              }
@@ -210,12 +192,6 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip/pinmux/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"
-               overrides: [
-                 {
-                    name:  design_level
-                    value: "top"
-                 }
-               ]
               }
               {
                name: rv_plic_sec_cm
@@ -224,12 +200,6 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/{top_chip}/ip/rv_plic/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"
-               overrides: [
-                  {
-                    name:  design_level
-                    value: "top"
-                  }
-               ]
               }
 
              // Other non-standard countermeasure checks.
@@ -273,12 +243,6 @@
                fusesoc_core: lowrisc:dv:top_darjeeling_pwrmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pwrmgr/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                task: "PwrmgrSecCmEsc"
              }
             ]

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
@@ -12,10 +12,6 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]
 
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     { // Deletes black-boxed hierarchies before writing out the unmapped netlist
       name: post_elab_script
       value: "{proj_root}/hw/top_darjeeling/ip_autogen/{name}/syn/post_elab_gtech.tcl"

--- a/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
@@ -11,13 +11,6 @@
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/top_darjeeling/ip_autogen/{name}/syn/constraints.sdc"
 

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -35,10 +35,6 @@
 
   // Overrides
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     // Handle generated coverage exclusion.
     {
       name: default_vcs_cov_cfg_file

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -47,11 +47,4 @@
       tests: ["rstmgr_cnsty_chk_test"]
     }
   ]
-  overrides: [
-    // This override is in order to pick the autogen rstmgr packages.
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
 }

--- a/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -43,10 +43,6 @@
   // Overrides
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }

--- a/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
@@ -214,12 +214,6 @@
           //         fusesoc_core: lowrisc:dv:top_darjeeling_chip_sim
           //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
           //         rel_path: "hw/top_darjeeling/dv/lint/{tool}"
-          //         overrides: [
-          //           {
-          //             name: design_level
-          //             value: "top"
-          //           }
-          //         ]
           //    },
             ]
 }

--- a/hw/top_darjeeling/lint/top_darjeeling_fpga_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_fpga_lint_cfgs.hjson
@@ -24,12 +24,6 @@
             //       fusesoc_core: lowrisc:systems:chip_darjeeling_cw310
             //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
             //       rel_path: "hw/chip_darjeeling_asic/lint/{tool}"
-            //       overrides: [
-            //         {
-            //           name: design_level
-            //           value: "top"
-            //         }
-            //       ]
             //  },
             ]
 

--- a/hw/top_earlgrey/cdc/chip_earlgrey_asic_cdc_cfg.hjson
+++ b/hw/top_earlgrey/cdc/chip_earlgrey_asic_cdc_cfg.hjson
@@ -13,14 +13,6 @@
 
   tool: meridiancdc
 
-  // Overrides
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
   // Timing constraints for this module
   sdc_file: [
     "{proj_root}/hw/top_earlgrey/syn/ot.sdc_setup.tcl",

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -104,11 +104,6 @@
       name: vcs_xprop_cfg_file
       value: "{top_dv_path}/vcs_xprop.cfg"
     }
-    // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`.
-    {
-      name: design_level
-      value: "top"
-    }
     // The jtag agent requires the data and bytenable widths to be increased.
     {
       name: tl_dw

--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -40,12 +40,6 @@
       name: sv_flist_gen_dir
       value: "{build_dir}"
     }
-    // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`. Override
-    // since we are building the top level.
-    {
-      name: design_level
-      value: top
-    }
   ]
 
   // Common run parameters. Each test entry can override any of these as needed.

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_ip_cfgs.hjson
@@ -53,12 +53,6 @@
                exp_fail_hjson: "{proj_root}/hw/top_earlgrey/ip_autogen/rv_plic/fpv/rv_plic_expected_failure.hjson"
                after_load: ["{proj_root}/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/waivers.tcl",
                             "{proj_root}/hw/top_earlgrey/ip_autogen/rv_plic/fpv/tb/coverage_waivers.tcl"]
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
              }
             ]
 }

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_sec_cm_cfgs.hjson
@@ -91,12 +91,6 @@
                fusesoc_core: lowrisc:earlgrey_dv:flash_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/flash_ctrl/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                stopats: ["*u_state_regs.state_o", "*u_rma_state_regs.state_o"]
                task: "FpvSecCm"
              }
@@ -154,12 +148,6 @@
                fusesoc_core: lowrisc:earlgrey_dv:pwrmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pwrmgr/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                stopats: ["*u_state_regs.state_o"]
                task: "FpvSecCm"
              }
@@ -178,12 +166,6 @@
                fusesoc_core: lowrisc:earlgrey_dv:rstmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/rstmgr/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                stopats: ["*u_state_regs.state_o"]
                task: "FpvSecCm"
              }
@@ -219,12 +201,6 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pinmux/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"
-               overrides: [
-                 {
-                    name:  design_level
-                    value: "top"
-                 }
-               ]
               }
               {
                name: rv_plic_sec_cm
@@ -233,12 +209,6 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip/rv_plic/{sub_flow}/{tool}/sec_cm"
                task: "FpvSecCm"
-               overrides: [
-                  {
-                    name:  design_level
-                    value: "top"
-                  }
-               ]
               }
 
              // Other non-standard countermeasure checks.
@@ -282,12 +252,6 @@
                fusesoc_core: lowrisc:earlgrey_dv:pwrmgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip_autogen/pwrmgr/{sub_flow}/{tool}"
-               overrides: [
-                 {
-                   name:  design_level
-                   value: "top"
-                 }
-               ]
                task: "PwrmgrSecCmEsc"
              }
             ]

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -36,10 +36,6 @@
   // Flash references pwrmgr directly, need to reference the top version
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: "timescale"
       value: "1ns/100ps"
     }

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_gtech_syn_cfg.hjson
@@ -12,10 +12,6 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]
 
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     { // Deletes black-boxed hierarchies before writing out the unmapped netlist
       name: post_elab_script
       value: "{proj_root}/hw/top_earlgrey/ip_autogen/{name}/syn/post_elab_gtech.tcl"

--- a/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/otp_ctrl/syn/otp_ctrl_syn_cfg.hjson
@@ -11,13 +11,6 @@
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/top_earlgrey/ip_autogen/{name}/syn/constraints.sdc"
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -35,10 +35,6 @@
 
   // Overrides
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     // Handle generated coverage exclusion.
     {
       name: default_vcs_cov_cfg_file

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -47,11 +47,4 @@
       tests: ["rstmgr_cnsty_chk_test"]
     }
   ]
-  overrides: [
-    // This override is in order to pick the autogen rstmgr packages.
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
 }

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -43,10 +43,6 @@
   // Overrides
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -235,12 +235,6 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   additional_fusesoc_argument: "--mapping=lowrisc:systems:top_earlgrey:0.1"
                   rel_path: "hw/top_earlgrey/dv/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
             ]
 }

--- a/hw/top_earlgrey/lint/top_earlgrey_fpga_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_fpga_lint_cfgs.hjson
@@ -23,12 +23,6 @@
                   fusesoc_core: lowrisc:systems:chip_earlgrey_cw310
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/chip_earlgrey_asic/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
             ]
 

--- a/hw/top_earlgrey/rdc/chip_earlgrey_asic_rdc_cfg.hjson
+++ b/hw/top_earlgrey/rdc/chip_earlgrey_asic_rdc_cfg.hjson
@@ -13,14 +13,6 @@
 
   tool: meridianrdc
 
-  // Overrides
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc"
 

--- a/hw/top_earlgrey/syn/chip_earlgrey_asic_syn_cfg.hjson
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic_syn_cfg.hjson
@@ -13,10 +13,6 @@
 
   // Overrides
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     // Since this synthesizes the design at chip level,
     // we need to instruct the parser script to explicitly
     // expand the top_earlgrey submodule.

--- a/hw/top_earlgrey/syn/top_earlgrey_gtech_syn_cfg.hjson
+++ b/hw/top_earlgrey/syn/top_earlgrey_gtech_syn_cfg.hjson
@@ -12,10 +12,6 @@
                 "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]
 
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     { // Deletes black-boxed hierarchies before writing out the unmapped netlist
       name: post_elab_script
       value: "{proj_root}/hw/top_earlgrey/syn/post_elab_gtech.tcl"

--- a/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -36,10 +36,6 @@
   // Flash references pwrmgr directly, need to reference the top version
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: "timescale"
       value: "1ns/100ps"
     }

--- a/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -35,10 +35,6 @@
 
   // Overrides
   overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
     // Handle generated coverage exclusion.
     {
       name: default_vcs_cov_cfg_file

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson
@@ -47,11 +47,4 @@
       tests: ["rstmgr_cnsty_chk_test"]
     }
   ]
-  overrides: [
-    // This override is in order to pick the autogen rstmgr packages.
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
 }

--- a/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_englishbreakfast/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -43,10 +43,6 @@
   // Overrides
   overrides: [
     {
-      name: design_level
-      value: "top"
-    }
-    {
       name: default_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }

--- a/hw/top_englishbreakfast/lint/top_englishbreakfast_lint_cfgs.hjson
+++ b/hw/top_englishbreakfast/lint/top_englishbreakfast_lint_cfgs.hjson
@@ -22,45 +22,21 @@
                   fusesoc_core: lowrisc:englishbreakfast_ip:flash_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/flash_ctrl/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
              {    name: otp_ctrl
                   fusesoc_core: lowrisc:englishbreakfast_ip:otp_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/otp_ctrl/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
              {    name: pwrmgr
                   fusesoc_core: lowrisc:englishbreakfast_ip:pwrmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/ip/pwrmgr/lint/{tool}",
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
              {    name: rstmgr
                   fusesoc_core: lowrisc:englishbreakfast_ip:rstmgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
                   rel_path: "hw/ip/rstmgr/lint/{tool}",
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
              {    name: sensor_ctrl
                   fusesoc_core: lowrisc:systems:top_earlgrey_sensor_ctrl
@@ -71,12 +47,6 @@
                   fusesoc_core: lowrisc:systems:top_englishbreakfast
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/top_englishbreakfast/lint/{tool}"
-                  overrides: [
-                    {
-                      name: design_level
-                      value: "top"
-                    }
-                  ]
              },
             ]
 }


### PR DESCRIPTION
> As of the completed migration to ipgen, we no longer make use of the
> '--flag=fileset_X' selectors to switch out filesets between ip-level and
> top-level. (e.g. `fileset_top`)
> Hence, this code is now dead, and can be removed.
>
> Note. that there are still example uses of 'fileset_partner' as a suggestion for how
> integrators can use this mechanism to swap out filesets. There is nothing
> stopping downstream users from continuing to swap-out core filesets using this
> mechanism and passing flags via the 'sv_flist_gen_flags' hjson variable.
> However, the documentation should be updated to suggest the use of fusesoc
> virtual cores as a preferred solution to this problem.

https://github.com/lowRISC/opentitan/pull/23555#discussion_r2109789131 I'd suggest that we remove the 'fileset_partner' examples once the documentation for how integrators can make use of virtual cores has been written, and notice / opportunity has been given for partners and integrators to migrate.

Related #25747 #27477 
Related #23555 
